### PR TITLE
added .env.docker for the docker default build

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,136 @@
+# ============================================
+# OPENNVR - DOCKER QUICK START CONFIGURATION
+# ============================================
+# 
+# 🚀 QUICK START GUIDE:
+# 1. Copy this file:    cp .env.docker .env
+# 2. Start application: docker compose up -d
+# 3. Access at:         http://localhost:8000
+# 4. Login with:        admin / SecurePass123!
+#
+# ⚠️ DEVELOPMENT USE ONLY ⚠️
+# These are WORKING defaults for local testing.
+# For production, generate secure secrets:
+#   ./scripts/generate-secrets.ps1  (Windows)
+#   ./scripts/generate-secrets.sh   (Linux/Mac)
+#
+# ============================================
+
+# ============================================
+# DATABASE CONFIGURATION
+# ============================================
+POSTGRES_USER=opennvr_user
+POSTGRES_PASSWORD=dev_postgres_pass_2024
+POSTGRES_DB=opennvr_db
+
+# ============================================
+# SECURITY & AUTHENTICATION
+# ============================================
+# ⚠️ DEVELOPMENT SECRETS - DO NOT USE IN PRODUCTION!
+
+# JWT Secret Key (for token signing)
+SECRET_KEY=dev_jwt_secret_key_f8a4b2c9e1d7a5f3b8c4e2a9d6f1b7c3
+
+# Fernet Key (for camera credential encryption)
+# Generated with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+CREDENTIAL_ENCRYPTION_KEY=CKLghtP4rWz8J9vN2xQ5mT7yU8kF6bD3eH1aG4cS0wE=
+
+# Internal API Key (for service-to-service auth)
+INTERNAL_API_KEY=dev_internal_api_key_h9j2k5l8m3n6p1q4
+
+# MediaMTX Webhook Secret
+MEDIAMTX_SECRET=dev_mediamtx_webhook_secret_x7y2z5a8b3c6d1e4
+
+# JWT Settings
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
+
+# ============================================
+# APPLICATION SETTINGS
+# ============================================
+DEBUG=False
+HOST=0.0.0.0
+PORT=8000
+APPLICATION_URL=http://localhost:8000
+API_PREFIX=/api/v1
+
+# ============================================
+# MEDIAMTX STREAMING SERVER
+# ============================================
+MEDIAMTX_BASE_URL=http://localhost:8889
+MEDIAMTX_ADMIN_API=http://localhost:9997/v3
+MEDIAMTX_API_URL=http://localhost:9997
+MEDIAMTX_HLS_URL=http://localhost:8888
+MEDIAMTX_RTSP_URL=rtsp://localhost:8554
+MEDIAMTX_PLAYBACK_URL=http://localhost:9996
+
+# MediaMTX Configuration
+MEDIAMTX_STREAM_PREFIX=cam-
+MEDIAMTX_PATH_MODE=id
+MEDIAMTX_AUTO_PROVISION=True
+
+# ============================================
+# DOCKER-SPECIFIC SETTINGS
+# ============================================
+# Recording storage path (adjust for your OS)
+# Windows: D:/Recordings or C:/opennvr-recordings
+# Linux:   /var/lib/opennvr/recordings
+# macOS:   /Users/Shared/opennvr-recordings
+RECORDINGS_PATH=./Recordings
+
+# Backend service networking
+BACKEND_HOST=opennvr_core
+BACKEND_PORT=8000
+
+# ============================================
+# AI INFERENCE CONFIGURATION
+# ============================================
+# KAI-C runs inside opennvr-core container on port 8100
+# It then forwards requests to AI Adapters on port 9100
+KAI_C_URL=http://127.0.0.1:8100
+KAI_C_IP=127.0.0.1
+
+# ============================================
+# RECORDING SETTINGS
+# ============================================
+RECORDINGS_BASE_PATH=/app/recordings
+
+# Docker volume mount path mapping (set automatically by docker-compose.yml)
+# RECORDINGS_HOST_BASE is set to ${RECORDINGS_PATH} in docker-compose.yml
+# RECORDINGS_CONTAINER_BASE is set to /app/recordings in docker-compose.yml
+# These are used for path mapping between host and container filesystems
+
+# ============================================
+# DEFAULT ADMIN USER
+# ============================================
+# ⚠️ CHANGE PASSWORD AFTER FIRST LOGIN!
+DEFAULT_ADMIN_USERNAME=admin
+DEFAULT_ADMIN_PASSWORD=SecurePass123!
+DEFAULT_ADMIN_EMAIL=admin@opennvr.local
+DEFAULT_ADMIN_FIRST_NAME=System
+DEFAULT_ADMIN_LAST_NAME=Administrator
+
+# ============================================
+# LOGGING CONFIGURATION
+# ============================================
+LOG_LEVEL=INFO
+LOG_FILE_ENABLED=True
+LOG_FILE_PATH=logs/server.log
+LOG_FILE_MAX_SIZE_MB=50
+LOG_FILE_BACKUP_COUNT=10
+LOG_CONSOLE_ENABLED=True
+LOG_JSON_FORMAT=False
+
+# ============================================
+# PRODUCTION DEPLOYMENT CHECKLIST
+# ============================================
+# Before deploying to production:
+# [ ] Generate new secrets with ./scripts/generate-secrets.ps1
+# [ ] Change DEFAULT_ADMIN_PASSWORD to a strong password
+# [ ] Update RECORDINGS_PATH to persistent storage location
+# [ ] Set DEBUG=False (already set above)
+# [ ] Review all security settings in docker-compose.yml
+# [ ] Enable HTTPS/TLS for external access
+# [ ] Restrict network access with firewall rules
+# [ ] Enable backup for opennvr_db_data volume
+# ============================================

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 .env
 .env.*
 !.env.example
-!.env.docker  # Default Docker environment template
+!.env.docker
+# Default Docker environment template
 !env.example
 
 # Cryptographic keys and certificates


### PR DESCRIPTION
Fix .env.docker being ignored

Problem
.env.docker was unintentionally ignored due to the .env.* rule in .gitignore.

Solution
Updated the .gitignore to correctly allow .env.docker to be tracked.

Impact

Enables Docker environment template to be committed
Improves developer onboarding
No breaking changes