### PR TITLE
AI-A1: AI Adapter Contract v1 — design doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,8 @@ test_*.py
 server/test_*.py
 !server/tests/test_*.py
 !server/tests/**/test_*.py
+# KAI-C's pytest suite (A2.4): same negation pattern as server/tests/.
+!kai-c/test/test_*.py
 server/scripts/check_*.py
 server/scripts/get_*.py
 server/scripts/delete_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ server/test_*.py
 !server/tests/**/test_*.py
 # KAI-C's pytest suite (A2.4): same negation pattern as server/tests/.
 !kai-c/test/test_*.py
+# Example-app pytest suites (A2.5+): each example/{slug}/tests/ is part
+# of the shipped artifact and must be tracked.
+!examples/**/tests/test_*.py
 server/scripts/check_*.py
 server/scripts/get_*.py
 server/scripts/delete_*.py

--- a/docs/AI_ADAPTER_CONTRACT.md
+++ b/docs/AI_ADAPTER_CONTRACT.md
@@ -1,0 +1,1257 @@
+# AI Adapter Contract — design (A1)
+
+> **Status.** Draft for review. Locks the HTTP/WebSocket surface every
+> AI Adapter must implement so OpenNVR / KAI-C / example apps can speak
+> to any model — first-party or community-contributed — without
+> coordinating on a per-model basis. No code in this revision is wired
+> up; this document is the load-bearing artefact reviewers should
+> critique before any adapter migration begins.
+>
+> **What lives outside this doc.** NATS event bus (B1), Redis caches
+> (B2), MCP server (D1), pgvector + RAG (D2/D3), example apps
+> (C1/C2). Each is named in the milestone plan and will get its own
+> design doc when its turn comes.
+
+---
+
+## 0. TL;DR — what every reader gets in one screen
+
+**If you're an operator/org:** existing cameras (Hikvision, Dahua,
+Axis, Reolink, generic ONVIF / RTSP) integrate via the OpenNVR
+camera wizard — auto-discovery, transport-security probe, one stable
+UUID per camera that adapters and apps will use forever (§12.1).
+Every adapter declares permissions up front (GPU? Network egress?
+Filesystem paths?), needs your approval on first registration, runs
+inside a sandbox that enforces the approved list, and writes an
+immutable audit trail of every inference and every policy refusal
+that you can search from the UI and forward to your Splunk/ELK/Syslog
+(§11.2). The narrower subset that needs human attention — sovereignty
+refusals, fingerprint mismatches, app-fired "person in restricted
+zone" — routes to UI badges, Slack, Discord, PagerDuty, email
+(§11.5). If a model gets swapped under you, KAI-C tells you. If
+sovereignty says "local_only", no adapter that declared network
+egress can register. This is the single trust contract.
+
+**If you're a developer:** you implement six HTTP endpoints (with one
+WebSocket) and you get sandboxing, fair queuing per camera, audit
+logging, sovereignty enforcement, blue-green deploys, alerting
+plumbing, and operator UX for free. The minimum viable adapter is
+~30 lines of FastAPI (§3.7); a production adapter adds bearer-token
+auth in another ~10 lines (§3.8). Point the conformance kit at your
+service; if green, KAI-C accepts it (§11.4). Two SDKs are shipped:
+`opennvr-adapter-sdk` for wrapping a model, `opennvr-app-sdk` for
+*using* adapters to build an app (camera discovery, inference
+streaming, alert emission). The contract is intentionally weakly
+typed where it can be (free-form `tasks_advertised`, free-form
+`result` shapes) so you're never bottlenecked on us. Adapters and
+apps can live in your own repos — the community catalogue (§12.4)
+lists conforming entries; you keep ownership and get a "Conforming
+to OpenNVR Adapter Contract v1" badge.
+
+**If you're a security reviewer:** §3.8 (auth + correlation),
+§8 (permissions + sandbox), §11.1 (sovereignty enforcement),
+§11.2 (audit trail + SIEM export), §11.3 (capability drift), and
+§11.5 (alert routing) are the six contracts that turn "an adapter
+ran" into "and here is who let it run, what it asked for, what it
+actually did, and how the operator was notified." Hash-chained
+audit integrity is v1.5.
+
+**If you're an organization planning a deployment:** the use-case
+catalogue in §12.2 lists 12 named examples covering intrusion
+detection, package theft, LPR, loitering, PPE compliance, fall
+detection, fire/smoke, crowd counting, camera health, forensic
+search, and the watchman voice agent. C1/C2 ship first; the rest
+are the contribution roadmap.
+
+---
+
+## 1. The bet
+
+The single architectural bet we are making is: **one adapter wraps one
+model and exposes that model's capabilities as a stable HTTP/WebSocket
+surface.** Anyone — Anthropic, a research lab, a community hobbyist —
+who can write a FastAPI service (or a Go service, or a Rust service)
+can author an adapter. The contract is the only thing that binds them.
+
+What is *not* in this bet: where the model runs, who hosts it, which
+framework, what hardware. The HuggingFace adapter that proxies to a
+remote endpoint, a YOLO adapter that loads weights into local GPU
+memory, and a hypothetical Triton sidecar that fronts a 70B model on a
+remote GPU server are all conformant adapters as long as their HTTP
+surface is the same. Their internals are not our concern.
+
+What we get for accepting this constraint: a single integration point
+between OpenNVR and any model, a clear contribution lane for the
+community, and a stable target that example apps can build against.
+What we give up: the fastest possible inference path for in-process
+plugin models. The shared-memory fast path described in §6 buys most
+of that performance back when the adapter is co-located with its
+caller.
+
+## 2. Layers (mental model)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Example apps & agents                         │
+│      Each one is a separate program in examples/. They           │
+│      consume adapter HTTP/WS, NATS subjects, and NVR APIs.       │
+└──────────────┬──────────────────────────────┬───────────────────┘
+               │                              │
+       ┌───────▼──────────┐         ┌────────▼─────────┐
+       │  OpenNVR backend │         │   MCP server     │
+       │   + KAI-C        │◀────────│   (in-process    │
+       │  (registry +     │         │    with backend) │
+       │  policy + cache) │         └──────────────────┘
+       └───────┬──────────┘
+               │
+       HTTP control plane (mandatory)        ┌───────────────┐
+       WebSocket streaming  (mandatory)      │  NATS event   │
+       Shared-memory frame transport         │  bus (B1)     │
+        (optional, negotiated)               │  detections,  │
+               │                             │  commands     │
+   ┌───────────▼──────────────────────────┐  └───────────────┘
+   │   AI Adapters                         │
+   │  one model each; HTTP+WS contract;    │
+   │  self-hosted local OR cloud-proxy     │
+   │  OR service-mesh fan-out;             │
+   │  language-agnostic by contract        │
+   └───────────────────────────────────────┘
+```
+
+## 3. The contract — mandatory endpoints
+
+Every adapter MUST expose the following HTTP endpoints. The shapes
+below are the v1 wire format; later revisions of this contract will
+bump a version number and adapters can advertise which versions they
+speak (see §10).
+
+### 3.1 `GET /health`
+
+Liveness + identity. No auth. Adapter is expected to return a 200
+within 1 second of being asked.
+
+```json
+{
+  "status": "ok",
+  "adapter_name": "yolov8-person-detection",
+  "adapter_version": "1.4.0",
+  "model_name": "yolov8n.onnx",
+  "model_version": "8.0.196",
+  "started_at": "2026-05-18T03:00:00Z",
+  "uptime_seconds": 12345
+}
+```
+
+Status values: `ok`, `degraded` (working but slow / partial), `loading`
+(model loading, not ready yet), `error` (alive but broken).
+
+### 3.2 `GET /capabilities`
+
+The most important endpoint. What this adapter *can do*, structured
+enough for KAI-C and OpenNVR UI to render, free-form enough for exotic
+models to fit. See §4 for the full shape.
+
+### 3.3 `GET /hardware/evaluation`
+
+Verdict + reasoning for "can this adapter serve from where it is
+deployed". The adapter decides how to compute the verdict — local
+hardware probe, ping a cloud endpoint, check service-mesh health,
+look at its own model load status. The contract only standardizes the
+response shape.
+
+```json
+{
+  "verdict": "ok",                  // "ok" | "warn" | "blocked"
+  "reasoning": "GPU detected, model loaded, 4.2GB VRAM free",
+  "checked_at": "2026-05-18T03:00:00Z",
+  "details": {
+    "gpu_available": true,
+    "gpu_name": "NVIDIA RTX 3060",
+    "vram_total_mb": 12288,
+    "vram_free_mb": 4307,
+    "cuda_version": "12.1"
+  }
+}
+```
+
+The `details` field is free-form per adapter. A cloud-proxying adapter
+would put `endpoint_reachable`, `auth_valid`, `measured_latency_ms`,
+`rate_limit_headroom_pct` there. OpenNVR UI shows `verdict` +
+`reasoning` to the operator and only drills into `details` on request.
+
+### 3.4 `GET /metrics`
+
+Prometheus exposition format. Mandatory because we should never have
+to retrofit observability. Minimum baseline metrics:
+
+- `adapter_infer_total{outcome}` (`outcome ∈ {ok, model_error, provider_error, transport_error, refused}`)
+- `adapter_infer_latency_seconds` (histogram)
+- `adapter_model_loaded` (gauge, 0/1)
+- `adapter_stream_connections_active` (gauge)
+- `adapter_inflight_requests` (gauge)
+- `adapter_queue_depth` (gauge) — number of requests waiting for the model
+
+Adapter-specific metrics are encouraged. KAI-C will scrape from each
+registered adapter; OpenNVR-side dashboards aggregate.
+
+### 3.5 `POST /infer`
+
+Single-shot inference, request/response. Default content-type:
+`multipart/form-data` because most inference inputs include binary
+data (images, audio).
+
+```
+POST /infer
+Content-Type: multipart/form-data; boundary=...
+
+--...
+Content-Disposition: form-data; name="frame"; filename="capture.jpg"
+Content-Type: image/jpeg
+
+<bytes>
+--...
+Content-Disposition: form-data; name="params"
+Content-Type: application/json
+
+{
+  "confidence_threshold": 0.45,
+  "classes": ["person", "vehicle"]
+}
+--...
+```
+
+Adapters MAY additionally accept `application/json` with base64-encoded
+binary fields for clients that can't do multipart. They MUST accept
+multipart.
+
+Response is always JSON. Successful shape:
+
+```json
+{
+  "status": "ok",
+  "model_name": "yolov8n",
+  "model_version": "8.0.196",
+  "inference_ms": 23,
+  "result": { /* free-form per adapter, see §5 for guidance */ }
+}
+```
+
+Error shape: see §7 (failure envelope).
+
+### 3.6 `POST /infer/stream` (WebSocket)
+
+Continuous bidirectional inference for camera feeds / audio streams /
+LLM token streaming. Required because the agent and intrusion-detection
+example apps depend on it; adapters whose models genuinely don't
+support streaming MUST refuse the WebSocket upgrade with HTTP 501
+(*before* the socket opens) and MUST declare
+`endpoints.infer_stream.supported = false` in `/capabilities`. The
+4xxx close codes in §6.5 apply only to adapters that *accepted* the
+upgrade and are terminating mid-stream.
+
+See §6 for the full protocol including the optional shared-memory
+fast path.
+
+### 3.7 Minimum viable adapter
+
+The smallest legal adapter is ~30 lines. Drop this into any FastAPI
+project and you have something KAI-C will accept:
+
+```python
+# my_adapter.py
+from datetime import datetime, timezone
+from fastapi import FastAPI
+
+app = FastAPI()
+STARTED_AT = datetime.now(timezone.utc)
+
+@app.get("/health")
+def health():
+    return {
+        "status": "ok",
+        "adapter_name": "hello-adapter",
+        "adapter_version": "0.1.0",
+        "model_name": "hello-echo",
+        "model_version": "1",
+        "started_at": STARTED_AT.isoformat(),
+        "uptime_seconds": int((datetime.now(timezone.utc) - STARTED_AT).total_seconds()),
+    }
+
+@app.get("/capabilities")
+def capabilities():
+    return {
+      "adapter": {"name": "hello-adapter", "version": "0.1.0",
+                  "vendor": "you", "license": "MIT",
+                  "supported_contract_versions": ["1"]},
+      "model":   {"name": "hello-echo", "version": "1",
+                  "framework": "none", "modalities_in": ["text"],
+                  "modalities_out": ["text"]},
+      "endpoints": {
+        "infer":        {"supported": True,
+                         "input_content_types": ["application/json"]},
+        "infer_stream": {"supported": False, "max_concurrent_streams": 0},
+      },
+      "tasks_advertised": ["echo"],
+      "scheduling": {"max_inflight": 1},
+    }
+
+@app.get("/hardware/evaluation")
+def hwe():
+    return {"verdict": "ok", "reasoning": "no hardware required",
+            "checked_at": datetime.now(timezone.utc).isoformat(), "details": {}}
+
+@app.get("/metrics")
+def metrics():
+    return "adapter_infer_total 0\nadapter_model_loaded 1\n"
+
+@app.post("/infer")
+def infer(payload: dict):
+    return {"status": "ok", "model_name": "hello-echo", "model_version": "1",
+            "inference_ms": 0, "result": {"echoed": payload}}
+```
+
+Everything else (permissions, cost, fair queuing, streaming) you opt
+*into* — defaults are safe. Streaming is unsupported here by design;
+KAI-C accepts it.
+
+### 3.8 Authentication + correlation_id
+
+**Authentication.** Every HTTP request from KAI-C carries an
+`Authorization: Bearer <token>` header. The token is minted by KAI-C
+at adapter registration and rotated on operator request. Adapters
+MUST validate the token on `/infer`, `/infer/stream`, and `/metrics`
+and MAY skip it on `/health` (so KAI-C can probe liveness before
+re-issuing a token). `/capabilities` and `/hardware/evaluation` MUST
+accept *either* the registered token *or* an unauthenticated probe
+during the initial registration window (5 minutes after the adapter
+URL first becomes reachable). After the window closes, all endpoints
+except `/health` require the token.
+
+The minimum viable adapter in §3.7 omits auth for brevity. A
+production adapter looks like:
+
+```python
+from fastapi import Depends, Header, HTTPException
+
+EXPECTED_TOKEN = os.environ["OPENNVR_ADAPTER_TOKEN"]  # set by KAI-C
+
+def require_token(authorization: str = Header(None)):
+    if authorization != f"Bearer {EXPECTED_TOKEN}":
+        raise HTTPException(401, "invalid token")
+
+@app.post("/infer", dependencies=[Depends(require_token)])
+def infer(...): ...
+```
+
+KAI-C delivers the token to the adapter container via the
+environment variable `OPENNVR_ADAPTER_TOKEN`. Adapters that prefer
+mTLS over bearer tokens MAY declare
+`adapter.auth = "mtls"` in capabilities; the KAI-C registry flow
+provisions a per-adapter client certificate.
+
+**correlation_id wire spec.** Every request from KAI-C carries an
+`X-Correlation-Id: <uuid>` header (HTTP) or `correlation_id` field
+(WebSocket handshake). The adapter:
+
+- Echoes the value in every response (HTTP response header or
+  per-message field in WS `result`/`result_ack`/`close`).
+- Logs the value with every internal log line tied to that request.
+- If propagating downstream (e.g., cloud-fronting adapter making
+  outbound calls), passes it through.
+
+This is the single identifier that joins audit-log lines across
+KAI-C, the adapter, NATS subscribers, and example apps. Without it
+the §11.2 audit story is unimplementable.
+
+**Body/frame size limits.** Default request body limit is 32 MiB for
+`/infer` and 8 MiB per WS frame. Adapters MAY advertise lower
+limits via `endpoints.infer.max_body_bytes` and
+`endpoints.infer_stream.max_frame_bytes`; KAI-C enforces.
+
+## 4. The `/capabilities` shape
+
+This is the only endpoint reviewers should scrutinize hardest, because
+it is what every consumer learns the adapter from. The shape needs to
+be expressive enough for exotic models, structured enough for the UI.
+
+```json
+{
+  "adapter": {
+    "name": "yolov8-person-detection",
+    "version": "1.4.0",
+    "vendor": "open-nvr",
+    "license": "AGPL-3.0",
+    "model_card_url": "https://github.com/ultralytics/ultralytics",
+    "supported_contract_versions": ["1"]
+  },
+  "model": {
+    "name": "yolov8n",
+    "version": "8.0.196",
+    "framework": "ultralytics",
+    "size_mb": 6.2,
+    "modalities_in": ["image"],
+    "modalities_out": ["bbox_classes"],
+    "fingerprint": "sha256:c4f3a1...e7"   // optional but strongly recommended
+  },
+  "endpoints": {
+    "infer": {
+      "supported": true,
+      "input_content_types": ["multipart/form-data", "application/json"],
+      "input_schema_ref": "/schema/infer",
+      "output_schema_ref": "/schema/infer/response"
+    },
+    "infer_stream": {
+      "supported": true,
+      "max_concurrent_streams": 16,
+      "supports_shared_memory": true,
+      "shared_memory_protocol_version": 1
+    },
+    "extra": [
+      { "path": "/track", "method": "POST",  "purpose": "multi-object tracking across frames" },
+      { "path": "/classes", "method": "GET", "purpose": "list known class labels" }
+    ]
+  },
+  "tasks_advertised": ["object_detection"],
+  "permissions": {
+    "gpu": true,
+    "network_egress": [],
+    "host_filesystem": [],
+    "shared_memory_paths": ["/dev/shm/opennvr/frames"]
+  },
+  "scheduling": {
+    "max_inflight": 8,
+    "preferred_batch_size": 4,
+    "fair_queuing": "per_camera"
+  },
+  "cost": {
+    "currency": "USD",
+    "estimated_per_call": 0.0,
+    "estimated_per_hour": 0.0,
+    "rate_limit_per_minute": null,
+    "is_metered": false
+  }
+}
+```
+
+A cloud-fronted adapter would look the same shape with values that
+reflect its reality:
+
+```json
+"permissions": {
+  "gpu": false,
+  "network_egress": ["api-inference.huggingface.co"],
+  "host_filesystem": [],
+  "shared_memory_paths": []
+},
+"cost": {
+  "currency": "USD",
+  "estimated_per_call": 0.0008,
+  "rate_limit_per_minute": 60,
+  "is_metered": true
+}
+```
+
+A few notes on the shape:
+
+- `tasks_advertised` is the closest thing to a "Task enum" — a small,
+  optional, free-text vocabulary so consumers can answer "I want
+  any adapter that does X." It's intentionally weak typing: an adapter
+  can declare a brand-new task name that nobody has heard of, and the
+  UI just renders it. We do not constrain the vocabulary in v1. If
+  the community converges on common names, we can canonicalize them
+  later.
+- `permissions` is the **sandboxing declaration** (§8). KAI-C reads
+  this and applies the declared scope as container constraints when
+  managing the adapter's lifecycle.
+- `scheduling.fair_queuing: "per_camera"` opts the adapter in to
+  KAI-C's per-camera fair-queuing (§9). Default `"none"` lets KAI-C
+  forward requests as fast as they arrive; `"per_camera"` makes KAI-C
+  apply a token bucket per camera_id header.
+- `cost` lets OpenNVR show a running estimate of cloud-adapter spend
+  to the operator and refuse to schedule inference when a budget is
+  exhausted. `null` rate-limit means "unlimited / unknown". For
+  free / local adapters everything is zero.
+- `model.fingerprint` is an opaque adapter-chosen string (typically
+  a content hash of the weights file like `sha256:...`). If the
+  adapter advertises one, KAI-C records it at registration and on
+  every subsequent `/capabilities` poll. A mismatch is a **tamper
+  signal** — KAI-C alerts the operator and records the change to the
+  audit log (§10.5). Adapters that can't compute a meaningful
+  fingerprint (e.g., cloud-fronting adapters) omit the field; KAI-C
+  surfaces "model identity not verifiable" in the UI rather than
+  silently trusting.
+
+## 5. Inference output — guidance, not strict schema
+
+Different models return different shapes. We do not try to standardize
+the *content* of the `result` field. We do strongly recommend the
+following conventions for the four most common modalities, so that
+consumers (UI, agents, downstream adapters) can reason about results
+without per-adapter parsers:
+
+### 5.1 Detection (bounding boxes)
+
+```json
+{
+  "detections": [
+    {
+      "label": "person",
+      "confidence": 0.92,
+      "bbox": { "x": 0.21, "y": 0.34, "w": 0.18, "h": 0.55 },
+      "track_id": null,
+      "attributes": {}
+    }
+  ],
+  "frame_dimensions": { "w": 1920, "h": 1080 }
+}
+```
+
+`bbox` coordinates are normalized [0,1] (resolution-independent).
+`track_id` is null unless a tracking-capable adapter set it.
+
+### 5.2 Classification
+
+```json
+{
+  "predictions": [
+    { "label": "cat",   "confidence": 0.81 },
+    { "label": "dog",   "confidence": 0.12 }
+  ]
+}
+```
+
+### 5.3 ASR
+
+```json
+{
+  "transcript": "the room is clear",
+  "language": "en",
+  "segments": [ { "start_ms": 0, "end_ms": 1800, "text": "the room is clear" } ]
+}
+```
+
+### 5.4 LLM chat
+
+```json
+{
+  "completion": "I see one person near the gate.",
+  "finish_reason": "stop",
+  "usage": { "prompt_tokens": 24, "completion_tokens": 9 }
+}
+```
+
+These are conventions for consistency. An adapter that needs to deviate
+should — for example, an OCR adapter would return polygons not boxes,
+and that's fine. The contract is the envelope (§3.5), not the content.
+
+## 6. Streaming protocol
+
+`POST /infer/stream` opens a WebSocket. The protocol is JSON-framed
+control messages with optional binary frame payloads. Every connection
+opens with a `handshake` exchange that negotiates:
+
+- which inputs the client will send (frames, audio, JSON)
+- whether shared-memory frame transport is in play
+- per-client inflight limits
+- whether the adapter should publish results to NATS (B1) instead of
+  back over the socket
+
+### 6.1 Handshake
+
+Client → Adapter (first WS message):
+
+```json
+{
+  "type": "handshake",
+  "client_id": "opennvr-core-1",
+  "camera_id": "cam-7",
+  "frame_transport": "websocket",   // or "shared_memory"
+  "shared_memory_root": "/dev/shm/opennvr/frames/cam-7",
+  "result_sink": "websocket",       // or "nats:detections.cam-7.object_detection"
+  "expected_input_rate_hz": 15
+}
+```
+
+Adapter → Client:
+
+```json
+{
+  "type": "handshake_ack",
+  "frame_transport": "shared_memory",   // accepted offer; falls back if can't
+  "result_sink": "websocket",
+  "max_inflight": 8,
+  "session_id": "ws-9f3e..."
+}
+```
+
+### 6.2 Frame messages
+
+If `frame_transport == "websocket"`, the client sends:
+
+```json
+{ "type": "frame", "seq": 142, "ts_ms": 1716000000123,
+  "content_type": "image/jpeg" }
+<binary frame bytes immediately follow as the next WS message>
+```
+
+If `frame_transport == "shared_memory"`, the client writes the frame
+into the negotiated shared-memory path and sends only metadata:
+
+```json
+{ "type": "frame_ref", "seq": 142, "ts_ms": 1716000000123,
+  "shm_path": "/dev/shm/opennvr/frames/cam-7/000142.bin",
+  "content_type": "image/jpeg", "size_bytes": 87432 }
+```
+
+The adapter reads from the shared-memory path, runs inference, and the
+client is responsible for unlinking the file (or wrapping in a ring
+buffer — implementation-defined, documented).
+
+### 6.3 Result messages
+
+Adapter → Client (for each completed inference):
+
+```json
+{
+  "type": "result",
+  "seq": 142,                            // echoes the frame seq
+  "ts_ms": 1716000000123,
+  "inference_ms": 18,
+  "result": { /* per §5 */ }
+}
+```
+
+If `result_sink` was set to a NATS subject in the handshake, the
+adapter publishes the same payload to that subject and the WebSocket
+sees only periodic `result_ack` heartbeats. This is the path the
+agent layer will use — the agent subscribes to NATS for detections
+without holding open one WebSocket per camera.
+
+### 6.4 Control messages
+
+Either side can send:
+
+- `{"type": "pause"}` / `{"type": "resume"}` — flow control
+- `{"type": "stats"}` → result includes inflight, queue depth, fps
+- `{"type": "close", "reason": "..."}` — graceful shutdown
+
+### 6.5 Close codes
+
+Beyond the standard 1000 close, the adapter uses:
+
+- `4001` policy refused (sovereignty / permissions / etc.)
+- `4002` model error (OOM, weights missing, runtime crash)
+- `4003` provider error (cloud endpoint failure for proxy adapters)
+- `4004` overloaded (back off and retry)
+
+## 7. Failure envelope
+
+Every error response — `/infer`, `/infer/stream`, `/health`,
+`/capabilities` — uses the same JSON shape:
+
+```json
+{
+  "status": "error",
+  "error": {
+    "category": "model_error",         // see below
+    "code": "out_of_memory",
+    "message": "GPU OOM at batch size 4",
+    "transient": false,
+    "retry_after_ms": null,
+    "details": {}
+  }
+}
+```
+
+Categories:
+
+| Category | Meaning | Example |
+|---|---|---|
+| `model_error` | Inference itself failed | OOM, bad weights, NaN output |
+| `provider_error` | Upstream / cloud failure | HF 429, OpenAI 503, auth expired |
+| `transport_error` | Network or framing | Truncated multipart, malformed JSON |
+| `permission_denied` | Sandbox or policy refused | Tried to write outside declared paths |
+| `not_supported` | Endpoint not implemented | Adapter doesn't do streaming |
+| `overloaded` | Backpressure | Queue full, ask later |
+
+Consumers (KAI-C, agents) use `category` to decide retry policy —
+`transient: true` errors are safe to retry with backoff;
+`transient: false` are operator-actionable.
+
+### 7.1 Canonical error codes
+
+`error.code` is a stable adapter-chosen identifier. To keep audit
+logs searchable across adapters we canonicalize the most common ones
+— adapters SHOULD use these names where applicable and MAY define
+new ones for adapter-specific failures (`my_adapter.weights_corrupt`
+prefix-namespacing is encouraged for non-canonical codes).
+
+| Code | Category | Meaning |
+|---|---|---|
+| `out_of_memory` | model_error | GPU/CPU OOM |
+| `weights_missing` | model_error | Adapter started without weights present |
+| `inference_runtime_crash` | model_error | Model produced NaN, crashed, or hard-faulted |
+| `quota_exceeded` | provider_error | Cloud provider rate/quota hit |
+| `auth_expired` | provider_error | Cloud credential rotated / expired |
+| `provider_unavailable` | provider_error | Cloud endpoint 5xx |
+| `malformed_input` | transport_error | Multipart truncated, JSON invalid |
+| `unsupported_content_type` | transport_error | Adapter doesn't accept this MIME |
+| `permission_egress_denied` | permission_denied | Adapter tried to call out outside declared egress list |
+| `permission_path_denied` | permission_denied | Adapter tried to read/write outside declared filesystem scope |
+| `stream_not_supported` | not_supported | WS upgrade refused (alias for HTTP 501) |
+| `queue_full` | overloaded | KAI-C inflight cap hit (transient: true) |
+| `backpressure` | overloaded | Adapter signalled overload mid-stream |
+
+## 8. Permission declaration + sandbox enforcement
+
+Adapters declare what they need in `/capabilities.permissions`. KAI-C
+reads this on adapter registration and applies the declared scope as
+container constraints. The operator sees the requested permissions
+before enabling the adapter — like an app-store permission prompt.
+
+| Permission | Enforcement |
+|---|---|
+| `gpu: true` | Container gets GPU device passthrough; if false, denied |
+| `network_egress: ["host", ...]` | nftables rule limiting egress to listed hosts; empty = no internet |
+| `host_filesystem: ["/path", ...]` | Bind-mounts limited to listed paths; default deny |
+| `shared_memory_paths: ["/path"]` | tmpfs mount writable only at listed paths |
+| `host_metadata: false` | Block AWS/GCP/Azure IMDS endpoints + `/proc/host*` |
+
+**Operator approval is mandatory** for any permission outside the
+safe-by-default set. Specifically, KAI-C MUST refuse to register an
+adapter that declares any of the following until the operator
+explicitly approves it from the OpenNVR UI:
+
+- `gpu: true`
+- `network_egress` non-empty
+- `host_filesystem` non-empty
+- `shared_memory_paths` non-empty
+- `host_metadata: true`
+
+The UI prompt looks like an app-store permission dialog: the operator
+sees the adapter name, version, fingerprint (§4), declared permission
+list, and a single approve/reject button per permission. Approvals
+are recorded to the audit log (§10.5) with a stable
+`adapter_grant_id` so a future incident review can answer "who
+approved this adapter to call out to api.openai.com on 2026-04-12."
+
+This is the **biggest security upgrade** the contract delivers and the
+single best argument for why HTTP-adapter-per-container beats
+in-process plugins for community-contributed code.
+
+## 9. Fair queuing inside KAI-C
+
+When multiple cameras want the same adapter, fairness matters. If
+camera 1 is publishing 30fps continuous inference and camera 2 wants
+one ad-hoc call, camera 2 should not wait behind 30 frames every
+second.
+
+KAI-C implements a per-camera token bucket for any adapter that
+declares `scheduling.fair_queuing: "per_camera"` in its capabilities.
+The bucket is sized from `scheduling.max_inflight` and refilled at
+the adapter's measured `inference_ms` rate. Adapters that declare
+`fair_queuing: "none"` get FIFO — useful for cloud adapters where
+backpressure happens at the provider.
+
+The fair-queuing layer also enforces a **global max-inflight per
+adapter** so KAI-C never opens more concurrent requests than the
+adapter advertised. Adapters can rely on never seeing more than N
+inflight, no matter how many cameras are pushing.
+
+## 10. Versioning + blue-green
+
+Adapters declare which contract versions they speak:
+
+```json
+"adapter": {
+  ...
+  "supported_contract_versions": ["1", "2"]
+}
+```
+
+KAI-C uses this to route requests. The contract itself is versioned at
+the document level (this is v1). Breaking changes bump the version;
+adapters can declare support for multiple versions for a transition
+period.
+
+Adapter *implementations* are also versioned. Operators can register
+two versions of the same adapter (`face_recognition:v1.2` and
+`face_recognition:v1.3`) side-by-side. KAI-C routes new traffic to the
+newer version, drains the old, retires it. Versions are part of the
+adapter URL in the registry (`/api/v1/adapters/face_recognition/v1.3`).
+
+This sounds heavy but it falls out almost for free if we plan for it
+now and is painful to retrofit. Implementation lands in milestone B
+or later.
+
+## 11. KAI-C aggregator behaviour
+
+KAI-C polls each registered adapter's `/capabilities` and
+`/hardware/evaluation` on:
+
+- adapter registration
+- every 60s thereafter (configurable)
+- on demand via `POST /kaic/refresh`
+
+It maintains an in-memory + Redis-backed cache of:
+
+- adapter → capabilities (latest)
+- adapter → health (latest)
+- task → list of adapters that advertise it (derived index)
+- adapter → permissions granted (declared at registration)
+
+OpenNVR backend gets a single aggregated view via
+`GET /api/v1/ai/capabilities` (which KAI-C serves) so the UI never
+fans out across N adapter calls.
+
+### 11.1 Sovereignty enforcement
+
+KAI-C is also the sovereignty enforcement point (V-022 from the
+security work). The existing `ai_sovereignty` setting still applies:
+
+- `local_only` — KAI-C refuses to register any adapter whose
+  registration URL is non-loopback AND any adapter whose declared
+  `permissions.network_egress` is non-empty (because that's a
+  cloud-proxy adapter). This is stricter than the current V-022
+  check, which only looked at the URL.
+- `federated` — adapters may have egress to declared peer endpoints,
+  but `permissions.network_egress` must list them explicitly; KAI-C
+  refuses wildcards.
+- `cloud_allowed` — anything goes.
+
+**For adapter authors:** to be sovereignty-clean for `local_only`
+deployments, advertise `permissions.network_egress: []` and bind your
+HTTP server on loopback. If your adapter is a cloud-proxy by nature
+(HuggingFace, OpenAI, etc.), declare every egress host you'll call
+out to in `network_egress` — KAI-C will admit you under `federated`
+or `cloud_allowed` and reject under `local_only`. The adapter
+declaration is the source of truth; KAI-C will not infer.
+
+This is a meaningful tightening of V-022 and lands in milestone B
+when KAI-C is rewritten as the registry. Until then, the existing
+loopback check stays in place as a baseline.
+
+### 11.2 Audit trail
+
+Audit logging is the load-bearing trust contract. KAI-C writes an
+append-only audit record to OpenNVR's audit log (V-013 store)
+for every event below. The log is queryable from the OpenNVR UI by
+time range, adapter, camera, outcome, and category — that's the
+"audit any breach" affordance the platform promises to operators.
+
+| Event | When | Fields recorded |
+|---|---|---|
+| `adapter.registered` | Adapter passes registration checks | adapter_name, adapter_version, model_name, model_version, model_fingerprint, declared_permissions, registration_url, contract_version |
+| `adapter.permission_granted` | Operator approves a non-default permission (§8) | adapter_grant_id, adapter_name, permission_kind, permission_value, operator_user_id |
+| `adapter.permission_revoked` | Operator or system revokes a grant | adapter_grant_id, reason |
+| `adapter.deregistered` | Adapter removed (operator action / drift / shutdown) | reason |
+| `adapter.capability_drift` | `/capabilities` poll shows changed values (§11.3) | field_path, previous_value, current_value, action_taken |
+| `adapter.fingerprint_mismatch` | `model.fingerprint` changed between polls | previous_fingerprint, current_fingerprint |
+| `inference.completed` | Every successful `/infer` or per-frame stream result | correlation_id, adapter, camera_id, model_version, request_received_at, response_sent_at, inference_ms, result_size_bytes |
+| `inference.failed` | Every error envelope returned | correlation_id, adapter, camera_id, error.category, error.code, transient |
+| `inference.refused_sovereignty` | Sovereignty policy rejected the call | correlation_id, adapter, sovereignty_mode, refusal_reason |
+| `inference.refused_permission` | Sandbox denied an attempted side-effect | correlation_id, adapter, permission_kind, attempted_value |
+| `inference.refused_budget` | Cost budget exhausted | correlation_id, adapter, budget_window, spend_at_refusal |
+| `stream.opened` / `stream.closed` | WS lifecycle | session_id, adapter, camera_id, close_code, reason |
+
+`correlation_id` is the stable UUID defined in §3.8. KAI-C mints it
+at request-receive time and threads it through every layer: the
+adapter, the audit log, NATS subjects (B1), and any example app
+that subscribes. A single correlation_id lets an incident reviewer
+pull the full causal chain — "this 3am alert came from app `X`,
+which called adapter `Y` v1.4, which got a stream frame from camera
+`cam-7` at 03:04:17" — out of a single audit query.
+
+Retention defaults to 90 days; operators can extend via the existing
+audit-log retention settings.
+
+**SIEM / external forwarding.** The audit log is append-only inside
+OpenNVR and additionally MAY be forwarded to external sinks
+configured by the operator:
+
+| Sink | Format | Notes |
+|---|---|---|
+| `syslog` | RFC 5424 JSON | Default-available for any org running a Splunk/ELK/Sumo collector |
+| `webhook` | POST `application/json` per event | Generic — useful for Slack/Discord/PagerDuty via existing receivers |
+| `file` | JSON Lines, rotating | Local audit archive for air-gapped deployments |
+| `splunk_hec` | Splunk HTTP Event Collector | v1.5 |
+| `datadog` | Datadog Logs API | v1.5 |
+
+Operators configure the sink in OpenNVR settings. Forwarding is
+best-effort; failures to forward are themselves audited
+(`audit.export_failed`) but do not block the local append-only
+write — local audit is the source of truth.
+
+**Integrity.** v1 audit log is append-only via the existing
+OpenNVR audit store. v1.5 will add hash-chained integrity (each
+record's hash includes the previous record's hash) so tampering is
+detectable. Tracked as a security roadmap item.
+
+### 11.3 Capability drift detection
+
+`/capabilities` is polled on the cadence in §11. Drift between two
+polls is treated as follows:
+
+| Field that changed | Action |
+|---|---|
+| `adapter.version` or `adapter.name` | Treat as new adapter; require re-registration. Old registration de-registered. |
+| `model.fingerprint` | Audit `adapter.fingerprint_mismatch`. Alert operator. Keep serving (operator may decide it's a legitimate update); UI offers "re-approve" + "de-register" actions. |
+| `model.version` | Audit `adapter.capability_drift`. Inform operator. Keep serving. |
+| `permissions.*` adding a new permission | **Blocking.** De-register adapter. Operator must re-approve from registration flow. |
+| `permissions.*` removing a permission | Allow; record audit event. |
+| `endpoints.*` | Audit; no action. |
+| `scheduling.*` | Apply new values on next request. No audit. |
+| `cost.*` | Apply; recompute budget. |
+
+Drift in `tasks_advertised` is benign (just updates the index).
+
+### 11.4 Conformance kit + SDKs
+
+Three artefacts ship alongside the KAI-C registry to make the
+contract easy to adopt:
+
+**1. `opennvr-adapter-conformance`** (Python CLI). Point it at any
+adapter URL; it exercises every endpoint, asserts wire shapes
+(using the Pydantic models in
+`ai-adapter/app/interfaces/contract.py`), runs a streaming
+roundtrip, and reports pass/fail/warn:
+
+```bash
+pip install opennvr-adapter-conformance
+opennvr-adapter-conformance http://localhost:9001
+```
+
+Green run = KAI-C will accept. Community contributors run locally
+before opening a PR; CI runs it on every reference adapter.
+
+**2. `opennvr-adapter-sdk`** (Python). For *adapter authors* — a
+minimal FastAPI starter that wires up `/health`, `/capabilities`,
+`/hardware/evaluation`, `/metrics`, bearer-token validation,
+correlation_id plumbing, and the WS protocol skeleton. Author
+implements only the `infer()` method:
+
+```python
+from opennvr_adapter_sdk import Adapter, infer
+
+adapter = Adapter(
+    name="my-detector", version="0.1.0",
+    model_name="my-model", model_version="1",
+    tasks=["object_detection"],
+)
+
+@adapter.infer
+async def detect(image_bytes, params, correlation_id):
+    ...
+    return {"detections": [...]}
+
+adapter.run()  # starts FastAPI on $ADAPTER_PORT
+```
+
+**3. `opennvr-app-sdk`** (Python + TypeScript). For *example-app
+authors* — wraps adapter discovery, invocation, camera lookup,
+recording trigger, and alert emission. Generated from the same
+Pydantic contract so types stay in sync:
+
+```python
+from opennvr_app_sdk import OpenNVR
+
+nvr = OpenNVR()  # auto-discovers from env
+
+# Find an adapter that does object detection
+adapter = await nvr.adapters.find(task="object_detection")
+
+# Stream camera 7 through it; alert if person in zone
+async with adapter.stream(camera_id="cam-7") as session:
+    async for result in session:
+        for det in result["detections"]:
+            if det["label"] == "person" and in_zone(det["bbox"]):
+                await nvr.alerts.fire(
+                    title="Person in restricted zone",
+                    camera_id="cam-7",
+                    severity="high",
+                )
+```
+
+Both SDKs ship in A2 alongside the conformance kit. They are the
+single biggest lever for "popular": writing an adapter or an app
+becomes a 30-line affair, not a contract-reading exercise.
+
+### 11.5 Alerts
+
+Audit logging is "always on, always recorded." Alerting is the
+narrower set of events that *demand operator attention right now*.
+Both flow through KAI-C; alerts are a strict subset of the audit
+stream tagged for routing.
+
+**Built-in system alerts** (KAI-C emits these without operator
+configuration):
+
+| Trigger | Severity | Default channels |
+|---|---|---|
+| `adapter.unavailable` (≥ 3 consecutive `/health` failures) | high | UI + webhook |
+| `adapter.fingerprint_mismatch` | critical | UI + webhook + email |
+| `adapter.permission_drift_blocking` | critical | UI + webhook + email |
+| `inference.refused_sovereignty` (any) | high | UI + webhook |
+| `inference.refused_permission` (≥ 5/min from one adapter) | high | UI + webhook |
+| `inference.refused_budget` (any) | medium | UI |
+| `audit.export_failed` (≥ 1/min) | medium | UI |
+
+**App-emitted alerts** (example apps call
+`nvr.alerts.fire(...)` via the SDK):
+
+```python
+await nvr.alerts.fire(
+    title="Person in restricted zone",
+    description="Detected at gate camera, after-hours.",
+    camera_id="cam-7",
+    severity="high",          # low | medium | high | critical
+    correlation_id=session.correlation_id,
+    evidence={
+        "snapshot_uri": "opennvr://snapshots/...",
+        "recording_clip_uri": "opennvr://recordings/...",
+        "detection": det.dict(),
+    },
+    tags=["intrusion", "after-hours"],
+)
+```
+
+The alert shape on the wire:
+
+```json
+{
+  "alert_id": "alrt_...",
+  "fired_at": "2026-05-18T03:04:17Z",
+  "title": "Person in restricted zone",
+  "description": "...",
+  "severity": "high",
+  "source": {
+    "kind": "app|adapter|kai-c",
+    "name": "intrusion-detection",
+    "version": "1.2.0"
+  },
+  "camera_id": "cam-7",
+  "correlation_id": "<uuid>",
+  "evidence": { ... },
+  "tags": ["intrusion", "after-hours"]
+}
+```
+
+**Alert channels** (configured per-deployment by the operator from
+the OpenNVR UI):
+
+| Channel | Notes |
+|---|---|
+| UI badge | Always-on; in-app inbox with ack/resolve |
+| Webhook (POST JSON) | Generic; works for Slack/Discord/Teams/PagerDuty via their incoming-webhook endpoints |
+| Email (SMTP) | Configured at OpenNVR install time |
+| Slack incoming-webhook | First-class with severity → colour mapping |
+| Discord incoming-webhook | Same |
+| Native push | Mobile app (B+) |
+| PagerDuty Events API | Direct integration (v1.5) |
+
+**Routing rules** are operator-defined: "alerts of severity ≥ high
+go to PagerDuty + UI; severity = medium go to Slack only; severity =
+low go to UI only." Default rules ship with a sensible profile so
+day-one operators get useful pings without configuration.
+
+**Acknowledge / resolve flow** is operator-facing in the UI: each
+alert is a row that can be acked (snoozes channel re-fires for 1h),
+resolved (closes the alert), or escalated (re-fires on the
+next-severity-up channel).
+
+**Audit relationship**: every alert is also an audit event
+(`alert.fired`, `alert.acked`, `alert.resolved`). The audit log
+remains the source of truth; alerts are the *delivery mechanism*
+for the subset that needs immediate human attention.
+
+## 12. Examples + the integration contract for app authors
+
+This section is the **app developer's manual.** Adapter authors can
+skim; example-app authors live here.
+
+### 12.1 Camera identifiers — how to integrate existing cameras
+
+Operators register cameras once in OpenNVR (via UI or
+`POST /api/v1/cameras`). OpenNVR talks to existing cameras over
+RTSP/RTSPS/ONVIF through MediaMTX; common vendors are supported
+out-of-the-box (Hikvision, Dahua, Axis, Reolink, Amcrest, Foscam,
+Uniview, plus any generic ONVIF / RTSP source). Once registered, a
+camera has a stable UUID — `camera_id` — that flows through every
+adapter call and audit event.
+
+**App author discovery flow:**
+
+```python
+# 1. List cameras visible to this app's role
+cameras = await nvr.cameras.list()
+# → [{"id": "cam-7", "name": "Front gate", "manufacturer": "Hikvision",
+#     "resolution": [1920, 1080], "fps": 15, "has_audio": true,
+#     "rtsp_internal": "rtsps://mediamtx:8322/cam-7", "tags": ["outdoor"]}]
+
+# 2. Open a stream through any object-detection adapter
+adapter = await nvr.adapters.find(task="object_detection")
+async with adapter.stream(camera_id="cam-7") as session:
+    async for result in session:
+        ...
+```
+
+**Important guarantees for app authors:**
+
+- The `camera_id` is stable across reboots, IP changes, and credential
+  rotations. An app written today still works when the camera moves
+  to a new VLAN tomorrow.
+- The app never sees raw RTSP URLs or camera credentials. KAI-C
+  fetches frames; the app sees decoded, pre-processed frames over WS.
+- Camera capabilities (resolution, fps, audio, PTZ, two-way audio)
+  are queryable via `nvr.cameras.get(camera_id)`; an app can refuse
+  to run if a camera lacks audio.
+- New camera registration triggers `camera.registered` audit event;
+  apps that auto-attach to new cameras can subscribe via NATS (B1).
+
+**For new-camera onboarding (operator UX):** the OpenNVR UI's
+"Add camera" wizard auto-discovers ONVIF devices on the LAN,
+probes transport security (M1c work), and gives the operator
+defaults for username/password and resolution. Apps don't see this
+flow — they only see the resulting stable `camera_id`.
+
+### 12.2 Use-case catalog (what we plan to ship)
+
+The intent is: by milestone end, OpenNVR ships with 6–8 first-party
+examples covering the most-asked-for NVR + AI use cases. Each is a
+template community contributors can copy. The full target catalogue:
+
+| Slug | Use case | Adapters needed | Status |
+|---|---|---|---|
+| `intrusion-detection` | Person/vehicle in zone after-hours | object_detection | **C1 (first to ship)** |
+| `watchman-agent` | Voice-interactive watchman ("what's at the gate?") | ASR + TTS + LLM | **C2** |
+| `package-detect` | Porch package arrival + theft detection | object_detection + classification | A3 candidate |
+| `camera-health` | Detect blurry/obstructed/offline cameras | classification | A3 candidate |
+| `lpr` | License-plate recognition (whitelist / denylist) | LPR adapter (new) | B |
+| `loitering` | Person stays in zone > N minutes | object_detection + tracking | B |
+| `crowd-count` | Headcount in zone (retail, public safety) | counting | B |
+| `ppe-compliance` | Hardhat/vest detection (construction sites) | classification | B |
+| `fall-detect` | Slip-and-fall (elder care, retail) | pose | B+ |
+| `fire-smoke` | Early fire/smoke warning | classification | B+ |
+| `forensic-search` | "Show me everyone in red between 2-4pm" | CLIP + pgvector | D3 |
+| `audit-replay` | Semantic search across recorded events | embeddings + RAG | D3 |
+
+Each example ships as a runnable Docker container with a README and
+screenshots. Community contributors fill the gaps — an example
+becomes "first-party" only after it passes the conformance kit and
+ships with tests.
+
+### 12.3 Example app structure
+
+```
+examples/intrusion-detection/
+├── README.md           ← problem + screenshots + how to run
+├── Dockerfile          ← drop-in run-this
+├── pyproject.toml      ← or package.json / Cargo.toml
+├── intrusion_detection.py
+├── config.example.yml  ← what an operator configures
+└── tests/
+```
+
+Examples consume:
+
+- Adapter HTTP/WS contract (this doc) — for inference
+- OpenNVR REST APIs — for cameras, recordings, alerts
+- NATS subjects (once B1 ships) — for detection-event streams
+- `opennvr-app-sdk` (§11.4) — wraps the above
+
+Each example's README answers: "what problem does this solve, what
+adapters does it need, how do I run it, what's the operator UX." No
+special integration with OpenNVR core — examples are first-class
+clients.
+
+### 12.4 Publishing your own adapter or app (community flow)
+
+The contract is designed for community contribution. Three lanes:
+
+**1. Adapter in your own repo.** An adapter only needs to be a
+reachable HTTPS endpoint that passes the conformance kit. Host it
+wherever — your GitHub repo, your own Docker registry, your laptop.
+KAI-C registers any URL. To get *listed* in the OpenNVR community
+catalogue (UI marketplace surface, planned B+), submit a one-line PR
+to `open-nvr/community/adapters.yml` with your name + repo + image
+URL + conformance-kit run output.
+
+**2. Example app in your own repo.** Same model — host wherever,
+submit to `open-nvr/community/apps.yml`. The catalogue listing
+links to your repo; you keep ownership.
+
+**3. Reference adapter / first-party example.** PR directly into
+`ai-adapter/app/adapters/` or `open-nvr/examples/`. Must pass
+conformance kit + have tests + be maintained. Reserved for adapters
+that solve a foundational need (the existing 8) or examples that
+fill a high-priority slot in the catalogue.
+
+**Recognition.** First-party authors are credited in the example's
+README + the community catalogue. Adapter and app authors who pass
+conformance get a "Conforming to OpenNVR Adapter Contract v1" badge
+they can show on their repo.
+
+**Version safety.** Contract versions are forward-compatible within
+a major. An adapter built against v1 keeps working through v1.x;
+v2 will bump only after a deprecation window. The
+`supported_contract_versions` field lets adapters declare which
+versions they accept so KAI-C can route correctly during transitions.
+
+## 13. Migration matrix — the 8 existing adapters
+
+Each adapter in `ai-adapter/app/adapters/` needs to be brought up to
+the contract. Ordered by complexity (simplest first to validate the
+design with low risk):
+
+| Adapter | `/health` | `/capabilities` | `/hardware/evaluation` | `/infer` | `/infer/stream` | `/metrics` | Notes |
+|---|---|---|---|---|---|---|---|
+| PiperAdapter (TTS) | partial | needs full | new | partial | optional (not real-time) | new | Smallest model, simplest endpoints. **First migration.** |
+| WhisperAdapter (ASR) | partial | needs full | new | yes | new (real-time ASR) | new | Streaming valuable. |
+| YOLOv8Adapter | partial | needs full | new | yes | new (continuous detection) | new | **Most impactful** — shared-memory fast path makes most sense here. |
+| YOLOv11Adapter | partial | needs full | new | yes | new | new | Same as YOLOv8. |
+| BLIPAdapter (caption) | partial | needs full | new | yes | optional | new | One-shot per frame; streaming optional. |
+| InsightFaceAdapter | partial | needs full | new | yes | new | new | Face DB needs to move to pgvector later (D2). |
+| HuggingFaceAdapter (vision) | partial | needs full | needs cloud-aware verdict | yes | new | new | First cloud-proxying adapter; reference for cost/quota fields. |
+| OllamaAdapter (LLM) | partial | needs full | new | yes | yes (LLM streaming is natural) | new | Token streaming over WS. |
+
+Migration order (one commit per adapter): **Piper → Whisper → YOLOv8 → YOLOv11 → BLIP → InsightFace → HuggingFace → Ollama.** Each lands behind a feature flag (`ENABLE_CONTRACT_V1`) so we can roll back if a migration breaks something.
+
+## 14. What is intentionally NOT in v1
+
+Each of these will get its own design doc when its milestone arrives.
+
+- **NATS event bus.** Adapters publish detection events as
+  `result_sink: "nats:..."` in streaming handshakes, but the bus
+  itself, JetStream persistence, and subject naming come in B1.
+- **Redis cache layer.** The capability cache + idempotency cache
+  are KAI-C concerns that ride alongside the contract; B2.
+- **MCP server.** Tools to expose, auth shape, and rate-limiting
+  in D1.
+- **pgvector + RAG.** D2/D3. The face DB migration off the
+  in-memory dict is the trigger.
+- **Triton-style multi-model inference servers.** Not ruled out —
+  a Triton-fronting adapter is a perfectly valid contract
+  implementation — but not in v1's reference set.
+- **Adapter image signing + SBOM.** Tracked under the V-011 security
+  roadmap; lands in parallel.
+
+## 15. Open questions for reviewer
+
+1. Is the `tasks_advertised` field too weak (free-text strings, no
+   canonical vocabulary)? My take: leave it weak for v1, formalize
+   only if the community converges on names organically.
+2. Does the shared-memory protocol need a per-frame lifecycle owner
+   (who unlinks)? My take: client owns it (the side that wrote it),
+   adapter reads and acks. Document explicitly so adapter authors
+   don't try to clean up.
+3. Should `permissions` be declarative-only, or should KAI-C
+   *enforce* it as a v1 requirement? My take: declarative only in
+   the contract spec, enforcement is a v1.5 KAI-C feature. Otherwise
+   we can't ship the contract without finishing the sandbox plumbing.
+
+## 16. References
+
+- Zenodo paper, DOI [10.5281/zenodo.17261761](https://doi.org/10.5281/zenodo.17261761) — §3.4 / §4.1 customer-sovereignty principles inform §8 and §11.1.
+- Existing adapter implementations: `/Users/varunpratapsingh/cv/ai-adapter/app/adapters/`.
+- KAI-C registry behaviour today: `/Users/varunpratapsingh/cv/open-nvr/kai-c/main.py`.
+- OpenNVR security architecture: [docs/SECURITY_ARCHITECTURE.md](./SECURITY_ARCHITECTURE.md), §2.4 V-022 row covers the sovereignty interaction.

--- a/examples/intrusion-detection/Dockerfile
+++ b/examples/intrusion-detection/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+# Intrusion-detection example app.
+#
+# Build:
+#   docker build -f examples/intrusion-detection/Dockerfile -t opennvr/example-intrusion-detection:1.0.0 .
+#
+# Run (sidecar to KAI-C and OpenNVR backend on the same host):
+#   docker run --rm \
+#     -v $(pwd)/examples/intrusion-detection/config.yml:/app/config.yml:ro \
+#     --network host \
+#     opennvr/example-intrusion-detection:1.0.0
+
+FROM python:3.11-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Minimal runtime deps — httpx for KAI-C calls and snapshot fetches,
+# PyYAML for the config file. No cv2/PIL — frames go through KAI-C
+# as base64 JSON without any local image processing in this example.
+RUN pip install --no-cache-dir \
+        "httpx>=0.27,<1.0" \
+        "PyYAML>=6.0,<7.0"
+
+COPY examples/intrusion-detection/intrusion_detection.py ./intrusion_detection.py
+COPY examples/intrusion-detection/zone.py                ./zone.py
+COPY examples/intrusion-detection/alerts.py              ./alerts.py
+COPY examples/intrusion-detection/frame_sources.py       ./frame_sources.py
+
+ENV PYTHONPATH=/app
+
+ENTRYPOINT ["python", "intrusion_detection.py", "--config", "/app/config.yml"]

--- a/examples/intrusion-detection/README.md
+++ b/examples/intrusion-detection/README.md
@@ -1,0 +1,160 @@
+# Intrusion-detection example app
+
+The first first-party OpenNVR example app per §12 of the [AI Adapter Contract](../../docs/AI_ADAPTER_CONTRACT.md). Watches one or more cameras for persons/vehicles entering operator-defined restricted zones during operator-defined restricted hours, and fires alerts to stdout and (optionally) a webhook.
+
+This is also the canonical **consumer-side** validation of the contract: every previous milestone built producer-side surface (adapters, KAI-C registry, audit, sovereignty). This example proves the whole chain works end-to-end as an operator-facing artifact.
+
+## What it does
+
+```
+┌──────────┐  every poll_interval_seconds
+│  Camera  │ ─────────────────────────────┐
+└──────────┘                              │
+                                          ▼
+                              ┌──────────────────────┐
+                              │ frame_sources.fetch  │  file:// or http(s)://
+                              └──────────┬───────────┘
+                                         │ raw JPEG bytes
+                                         ▼
+                              ┌──────────────────────┐
+                              │   KaicClient         │  base64 frame
+                              │   POST /api/v1/      │  X-Correlation-Id
+                              │   infer/{adapter}    │  X-Internal-Api-Key
+                              └──────────┬───────────┘
+                                         │ §5.1 DetectionResult
+                                         ▼
+                              ┌──────────────────────┐
+                              │ filter watch_labels  │
+                              │ → bbox_center        │
+                              │ → zone.contains?     │
+                              │ → restricted_hours?  │
+                              └──────────┬───────────┘
+                                         │ yes
+                                         ▼
+                              ┌──────────────────────┐
+                              │  AlertDispatcher     │  stdout (always)
+                              │                      │  + webhook (optional)
+                              └──────────────────────┘
+```
+
+Every alert carries a `correlation_id` that joins back to KAI-C's audit log — an operator investigating an incident can pull the full causal chain: the alert → the KAI-C inference event → the adapter's audit line.
+
+## Operational notes
+
+**Polling is serial across cameras.** With N cameras and per-camera inference latency L, the cycle takes ~N×L. If `request_timeout_seconds` (default 30s) is much greater than `poll_interval_seconds` (default 1s), one slow inference blocks the whole loop for the timeout. For N > ~10 cameras or when sub-second responsiveness matters, parallel polling lands in A2.5b.
+
+**Fail-fast on bad camera URLs.** `IntrusionDetector.__init__` raises on the first unsupported `frame_url`, so a single typo aborts startup before any detection runs. Operator notices the typo immediately rather than silently losing one camera in a fleet of ten — but the trade-off is real, so review the full config before deploying.
+
+**Restricted hours use the host timezone.** `datetime.now()` picks up the host TZ. DST transitions can cause one duplicated or skipped hour per year — operators in TZ-sensitive deployments should pin the container to UTC and translate their restricted-hours window accordingly.
+
+**Webhook payloads include topology metadata.** The §11.5 alert shape carries `correlation_id`, adapter name, model version, and camera_id. If the webhook URL is compromised (or pointed at an untrusted destination via config tampering), the attacker learns internal deployment topology. Treat the config file as a sensitive secret; restrict its filesystem permissions accordingly.
+
+## What's NOT in v1
+
+- **RTSP stream input** — only HTTP snapshot polling. RTSP needs an ffmpeg subprocess; lands in A2.5b.
+- **WebSocket streaming through KAI-C** — KAI-C's WS proxy isn't built yet (A2.4b). HTTP polling at 1 fps is sufficient for most security-camera use cases.
+- **Tracking / persistence across frames** — every cycle is independent. Same person standing in a zone for 60s fires 60 alerts (unless you ack/snooze in the receiving system).
+- **Adapter discovery / multi-camera-per-adapter routing** — `kaic_adapter_name` is single-valued in config. Multi-adapter fanout lands as a follow-up.
+- **OpenNVR alerts API integration** — webhook + stdout for v1. Native OpenNVR alerts-inbox integration lands alongside the operator-UI alerts work in A2.5b.
+
+## Quick start
+
+```bash
+# 1. Build & run the YOLOv8 adapter (the example talks to it via KAI-C).
+#    A2.2 ships the Dockerfile in ai-adapter/adapters/yolov8/.
+cd ai-adapter
+docker build -f adapters/yolov8/Dockerfile -t opennvr/yolov8-adapter:local .
+docker run --rm -d --name yolov8 -p 9002:9002 \
+  -e OPENNVR_ADAPTER_TOKEN=$(openssl rand -hex 16) \
+  -v $(pwd)/model_weights:/weights:ro \
+  opennvr/yolov8-adapter:local
+
+# 2. Run KAI-C from source (A2.4 doesn't ship a versioned image yet —
+#    that's a follow-up). Either `python -m uvicorn main:app --port 8100`
+#    from the kai-c/ directory, or build a local image from kai-c/Dockerfile.
+cd ../open-nvr/kai-c
+export INTERNAL_API_KEY=$(openssl rand -hex 32)
+AI_SOVEREIGNTY=local_only INTERNAL_API_KEY=$INTERNAL_API_KEY \
+  python -m uvicorn main:app --host 0.0.0.0 --port 8100 &
+
+# 3. Register the adapter with KAI-C
+curl -X POST http://localhost:8100/api/v1/adapters/register \
+  -H "X-Internal-Api-Key: $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"yolov8","url":"http://127.0.0.1:9002"}'
+
+# 4. Configure + run the intrusion detector
+cd ../examples/intrusion-detection
+cp config.example.yml config.yml
+# edit config.yml: kaic_api_key, camera frame_url, zone, restricted_hours
+python intrusion_detection.py --config config.yml
+```
+
+You'll see lines like:
+
+```
+2026-05-19T14:32:18+00:00 INFO intrusion-detection: intrusion-detection started: 2 cameras, poll=1.0s, watch=['person', 'car'], hours=22:00:00-06:00:00
+ALERT [HIGH] 2026-05-19T22:14:07+00:00 camera=cam-front-gate title='Person in restricted zone \'front-yard-restricted\'' correlation_id=a4f1b... alert_id=alrt_8c2d31
+```
+
+## Config
+
+Copy `config.example.yml` and edit. Required: `kaic_url`, `cameras` (with `camera_id`, `frame_url`, `zone`). See the config file's inline comments for every field.
+
+## Operate
+
+| Mode | Command |
+|---|---|
+| Daemon (production) | `python intrusion_detection.py --config config.yml` |
+| One cycle per camera then exit (testing) | `python intrusion_detection.py --config config.yml --once` |
+| Verbose | `python intrusion_detection.py --config config.yml --log-level DEBUG` |
+
+Send `SIGINT` (Ctrl-C) or `SIGTERM` to stop cleanly — the detector finishes its current cycle and exits.
+
+## Layout
+
+```
+examples/intrusion-detection/
+├── intrusion_detection.py  Main loop + IntrusionDetector class + CLI
+├── zone.py                 Point-in-polygon (ray-cast) + bbox_center
+├── alerts.py               Alert dataclass + stdout/webhook channels
+├── frame_sources.py        file://, http(s):// — pluggable
+├── config.example.yml      Sample config with every option
+├── Dockerfile              Drop-in run-this
+├── pyproject.toml          Minimal deps (httpx, PyYAML)
+├── README.md               you are here
+└── tests/
+    ├── test_zone.py            (11 tests)
+    ├── test_alerts.py          (12 tests)
+    ├── test_frame_sources.py   (14 tests)
+    └── test_intrusion_detection.py  (16 tests)
+```
+
+## Tests
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest tests/
+```
+
+53 tests total. Coverage: zone math (convex + concave + edge cases), alert routing (stdout + webhook + failure isolation), frame sources (file + HTTP + transport errors + unsupported schemes), and the full `IntrusionDetector.step()` loop with a stubbed KAI-C (alert paths, no-alert paths, restricted-hours edges, KAI-C errors, correlation_id threading).
+
+## Why this is a template
+
+If you want to build a new monitoring app for OpenNVR — package detection, loitering detection, PPE compliance, fall detection, fire/smoke — copy this directory. Replace:
+
+- `zone.py` with whatever spatial logic your task needs (line crossings? heatmaps? bounding-region intersection?)
+- The detection-filter logic in `IntrusionDetector.step()` with your task-specific predicate
+- Watch-labels + alert title/description for your domain
+
+Everything else — KAI-C call, correlation_id, audit trail, alert dispatch, frame fetching, config loading, SIGINT handling — is the same template.
+
+That template is exactly what §12.4 of the design doc calls "first-party example as a first-class community contribution lane." Submit a PR adding your example under `examples/{your-slug}/` and you join the catalogue.
+
+## Roadmap (A2.5b)
+
+- RTSP input via ffmpeg subprocess
+- OpenNVR backend snapshot URL (`opennvr://cameras/{id}/snapshot`)
+- Native OpenNVR alerts-API integration (replace webhook for OpenNVR deployments)
+- WebSocket streaming through KAI-C once that proxy lands
+- Per-detection deduplication (so a stationary person doesn't fire continuously)

--- a/examples/intrusion-detection/alerts.py
+++ b/examples/intrusion-detection/alerts.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Alert emission for the intrusion-detection example.
+
+Two delivery channels in v1:
+
+* **stdout** — always fires. Operator-visible log line, machine-grep-able.
+* **webhook** — optional HTTP POST. Slack, Discord, Teams, PagerDuty —
+  any service that accepts an incoming-webhook JSON payload works.
+
+Future channels (NATS subjects, OpenNVR alerts-API native endpoint,
+SMS/email via OpenNVR's notification settings) land alongside the
+NATS event bus (B1) and the operator-UI alerts inbox (A2.5b).
+
+The Alert shape on the wire matches §11.5 of the contract design so
+downstream consumers (UI inbox, audit log, SIEM) parse it identically
+to KAI-C-emitted alerts. The contract calls this the "app-emitted
+alert" shape.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Protocol
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ── Alert payload (matches §11.5 wire shape) ───────────────────────
+
+
+@dataclass
+class AlertSource:
+    """The ``source`` block of the §11.5 alert envelope."""
+
+    kind: str = "app"  # one of: kai-c / adapter / app
+    name: str = "intrusion-detection"
+    version: str = "1.0.0"
+
+
+@dataclass
+class Alert:
+    """A single fired alert.
+
+    Maps 1:1 to the §11.5 alert wire shape: ``alert_id``, ``fired_at``,
+    ``title``, ``description``, ``severity``, ``source``, ``camera_id``,
+    ``correlation_id``, ``evidence``, ``tags``.
+
+    Severity levels are operator-visible — ``low`` / ``medium`` /
+    ``high`` / ``critical`` per the design doc.
+    """
+
+    title: str
+    description: str
+    camera_id: str
+    severity: str = "high"  # low / medium / high / critical
+    source: AlertSource = field(default_factory=AlertSource)
+    correlation_id: str | None = None
+    evidence: dict[str, Any] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    alert_id: str = field(default_factory=lambda: f"alrt_{uuid.uuid4().hex[:12]}")
+    fired_at: str = field(default_factory=lambda: _utcnow_iso())
+
+    def to_wire(self) -> dict[str, Any]:
+        """Serialize to the §11.5 JSON shape."""
+        return {
+            "alert_id": self.alert_id,
+            "fired_at": self.fired_at,
+            "title": self.title,
+            "description": self.description,
+            "severity": self.severity,
+            "source": asdict(self.source),
+            "camera_id": self.camera_id,
+            "correlation_id": self.correlation_id,
+            "evidence": dict(self.evidence),
+            "tags": list(self.tags),
+        }
+
+
+def _utcnow_iso() -> str:
+    """ISO-8601 UTC timestamp without microseconds."""
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+# ── Channels ───────────────────────────────────────────────────────
+
+
+class AlertChannel(Protocol):
+    """Anything that can ``send(alert)`` is a channel. Stdout + webhook
+    are the v1 implementations; future channels (NATS, OpenNVR alerts
+    API) plug in here without touching the detector loop."""
+
+    def send(self, alert: Alert) -> bool:
+        ...  # pragma: no cover — Protocol
+
+
+class StdoutChannel:
+    """Always-on channel: human-readable line to stdout."""
+
+    name = "stdout"
+
+    def send(self, alert: Alert) -> bool:
+        # Single line, machine-grep-friendly. Severity in CAPS so a
+        # tail -f operator spots high/critical quickly.
+        line = (
+            f"ALERT [{alert.severity.upper()}] "
+            f"{alert.fired_at} "
+            f"camera={alert.camera_id} "
+            f"title={alert.title!r} "
+            f"correlation_id={alert.correlation_id or '-'} "
+            f"alert_id={alert.alert_id}"
+        )
+        print(line, flush=True)
+        return True
+
+
+class WebhookChannel:
+    """POST the alert's JSON wire shape to an operator-configured URL.
+
+    Failures are LOGGED but never raise — a dead webhook should not
+    prevent stdout alerts from firing or crash the detector loop. This
+    matches the §11.2 "audit forwarding failures are themselves
+    audited" pattern (though we don't yet have an audit sink here —
+    that lands when the example talks to KAI-C's audit log directly).
+    """
+
+    name = "webhook"
+
+    def __init__(self, url: str, *, timeout_seconds: float = 5.0) -> None:
+        self._url = url
+        self._timeout = timeout_seconds
+
+    def send(self, alert: Alert) -> bool:
+        body = alert.to_wire()
+        try:
+            response = httpx.post(
+                self._url,
+                json=body,
+                timeout=self._timeout,
+                # trust_env=False so an operator-side HTTP_PROXY env
+                # doesn't redirect alert delivery through a proxy that
+                # might not honor the schema.
+                trust_env=False,
+            )
+            if response.status_code >= 400:
+                logger.warning(
+                    "webhook %s returned %d: %s",
+                    self._url,
+                    response.status_code,
+                    response.text[:200],
+                )
+                return False
+            return True
+        except Exception as exc:
+            logger.warning("webhook %s failed: %s", self._url, exc)
+            return False
+
+
+# ── Dispatcher ─────────────────────────────────────────────────────
+
+
+class AlertDispatcher:
+    """Holds an ordered list of channels and fires an alert through
+    all of them, isolating each channel's failures.
+
+    ``fire()`` returns a per-channel report so the caller can audit
+    delivery outcomes; the detector loop ignores this in v1 but the
+    OpenNVR alerts-API integration (A2.5b) will record it.
+    """
+
+    def __init__(self, channels: list[AlertChannel]) -> None:
+        if not channels:
+            raise ValueError("AlertDispatcher requires at least one channel.")
+        self._channels = channels
+
+    def fire(self, alert: Alert) -> dict[str, bool]:
+        results: dict[str, bool] = {}
+        for channel in self._channels:
+            channel_name = getattr(channel, "name", channel.__class__.__name__)
+            try:
+                ok = channel.send(alert)
+            except Exception as exc:
+                logger.exception("channel %s raised: %s", channel_name, exc)
+                ok = False
+            results[channel_name] = ok
+        return results
+
+
+def build_dispatcher(*, webhook_url: str | None) -> AlertDispatcher:
+    """Convenience factory used by ``intrusion_detection.py`` config
+    loading. stdout is always included; webhook is opt-in via config."""
+    channels: list[AlertChannel] = [StdoutChannel()]
+    if webhook_url:
+        channels.append(WebhookChannel(webhook_url))
+    return AlertDispatcher(channels)

--- a/examples/intrusion-detection/config.example.yml
+++ b/examples/intrusion-detection/config.example.yml
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Intrusion-detection example app — config template.
+#
+# Copy this file to ``config.yml``, fill in the values for your
+# deployment, and run:
+#
+#   python intrusion_detection.py --config config.yml
+
+# ── KAI-C endpoint ──────────────────────────────────────────────────
+#
+# KAI-C's HTTP service. The example calls
+# ``POST {kaic_url}/api/v1/infer/{kaic_adapter_name}`` for every
+# polled frame. Default for a single-host deployment:
+kaic_url: "http://127.0.0.1:8100"
+
+# Name of the registered adapter to use for object detection. Must
+# match a name in KAI-C's adapter registry (POST /api/v1/adapters/register).
+kaic_adapter_name: "yolov8"
+
+# Shared secret between OpenNVR backend and KAI-C (the same
+# INTERNAL_API_KEY env var KAI-C uses). Leave null in dev / single-
+# host loopback deployments where KAI-C is running with the dev-mode
+# auth bypass.
+kaic_api_key: null
+
+# ── Polling cadence ─────────────────────────────────────────────────
+#
+# How often to pull a frame from each camera. 1 fps (1.0) is a sane
+# default for security-camera monitoring; tune up for fast-moving
+# scenes, down to save GPU.
+poll_interval_seconds: 1.0
+
+# How long to wait for KAI-C inference before giving up on a frame.
+# A slow adapter shouldn't block the whole loop indefinitely.
+request_timeout_seconds: 30.0
+
+# ── Detection filter ────────────────────────────────────────────────
+#
+# Only COCO labels in this list trigger zone evaluation. Lower-case;
+# the example case-folds when matching. Common starting points:
+#   "person"   — basic intrusion detection
+#   "car", "truck", "motorcycle" — vehicle intrusion
+#   "person", "dog"   — porch monitoring with pet allowance
+watch_labels:
+  - "person"
+  - "car"
+  - "truck"
+
+# ── Restricted hours ────────────────────────────────────────────────
+#
+# Times in HH:MM (24h, **host-local timezone**). Cross-midnight ranges
+# are supported (start > end). Example: 22:00 - 06:00 means
+# "every day between 10 PM and 6 AM the next morning."
+#
+# Note: DST transitions cause one duplicated or skipped hour per year
+# in TZs that observe daylight saving. If precision matters, pin the
+# container to UTC and translate your restricted-hours window
+# accordingly. See README "Operational notes".
+restricted_hours:
+  start: "22:00"
+  end: "06:00"
+
+# ── Webhook (optional) ──────────────────────────────────────────────
+#
+# Alerts are always logged to stdout. If you set ``webhook_url``,
+# they're also POSTed as JSON to that URL. Works with any service
+# that accepts an incoming-webhook payload (Slack, Discord, Teams,
+# PagerDuty, n8n, a custom listener).
+#
+# webhook_url: "https://hooks.slack.com/services/T000/B000/XXXXXX"
+webhook_url: null
+
+# ── Cameras ─────────────────────────────────────────────────────────
+#
+# One entry per camera you want to watch. Each entry needs:
+#   camera_id     — operator-chosen string; flows through to the
+#                    alert payload and KAI-C's audit log.
+#   frame_url     — where to fetch a JPEG/PNG snapshot:
+#                    file:///abs/path/test.jpg    (testing / demo)
+#                    http://192.168.1.50/jpg/image.jpg  (cheap IP cams)
+#                    https://camera.example.com/snapshot.jpg  (TLS-fronted)
+#                    rtsp://…    — deferred to A2.5b
+#   frame_width / frame_height  — pixel dimensions of the camera's
+#                    output (needed to convert §5.1 normalized [0, 1]
+#                    bboxes back to pixel coords for the zone polygon).
+#   zone_name     — human label that appears in alerts.
+#   zone          — polygon vertices in pixel coords (x, y from
+#                    top-left). Minimum 3 vertices. Convex or concave.
+cameras:
+  - camera_id: "cam-front-gate"
+    frame_url: "https://camera-front-gate.lan/snapshot.jpg"
+    frame_width: 1920
+    frame_height: 1080
+    zone_name: "front-yard-restricted"
+    zone:
+      # A trapezoid covering the driveway from 200 px in on the
+      # left to 200 px in on the right, between 400 - 900 px down.
+      - [200, 400]
+      - [1720, 400]
+      - [1820, 900]
+      - [100, 900]
+
+  - camera_id: "cam-back-shed"
+    frame_url: "file:///opt/intrusion-detection/sample-back-shed.jpg"
+    frame_width: 1920
+    frame_height: 1080
+    zone_name: "shed-perimeter"
+    zone:
+      - [600, 300]
+      - [1400, 300]
+      - [1400, 800]
+      - [600, 800]

--- a/examples/intrusion-detection/frame_sources.py
+++ b/examples/intrusion-detection/frame_sources.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Frame source abstractions.
+
+A frame source is anything that produces raw image bytes on demand.
+For v1 we support:
+
+* ``file://`` URLs   — read a JPEG/PNG from disk. Useful for tests and
+                       demos without a real camera.
+* ``http://`` /      — GET an HTTP snapshot URL. Real cameras (Hikvision,
+  ``https://`` URLs    Axis, Reolink, …) all expose a snapshot endpoint;
+                       OpenNVR cameras expose one too via the backend.
+
+Deferred to A2.5b:
+
+* ``rtsp://`` URLs   — needs ffmpeg subprocess + decode loop. Significant
+                       extra code; the snapshot path covers the common
+                       polling use case for v1.
+* ``opennvr://``     — Once OpenNVR backend exposes a typed snapshot
+  scheme              endpoint, we'll add ``opennvr://cameras/{id}/snapshot``
+                       resolving to the right HTTPS URL.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+from abc import ABC, abstractmethod
+from typing import Protocol
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class FrameSourceError(Exception):
+    """Raised when a frame source cannot produce a frame this cycle.
+    Caller (the detector loop) decides whether to skip or abort —
+    transient failures are normal (network blips, camera offline)."""
+
+
+class FrameSource(Protocol):
+    """Anything with ``fetch() -> bytes`` and a stable ``camera_id``
+    is a frame source."""
+
+    camera_id: str
+
+    def fetch(self) -> bytes:
+        ...  # pragma: no cover — Protocol
+
+
+# ── Concrete sources ───────────────────────────────────────────────
+
+
+class FileFrameSource:
+    """Read a JPEG/PNG from disk. ``camera_id`` is operator-supplied.
+
+    Path-traversal protected: we resolve the configured path once at
+    init time and reject any subsequent change. (Operators shouldn't
+    be passing user-controlled paths anyway, but the example sets the
+    pattern for future sources.)
+    """
+
+    def __init__(self, *, camera_id: str, path: str) -> None:
+        resolved = pathlib.Path(path).expanduser().resolve()
+        if not resolved.is_file():
+            raise FrameSourceError(
+                f"file frame source: {path!r} does not exist or is not a file"
+            )
+        self.camera_id = camera_id
+        self._path = resolved
+
+    def fetch(self) -> bytes:
+        return self._path.read_bytes()
+
+
+class HttpSnapshotSource:
+    """GET an HTTP snapshot URL. Supports basic-auth via the URL
+    (``http://user:pass@host/snapshot.jpg``) — standard pattern for
+    consumer-grade cameras.
+
+    Timeout is intentionally low (default 5s): a slow snapshot in the
+    polling loop blocks every camera. If the camera is consistently
+    slow, the operator should lower the poll interval or move to RTSP.
+    """
+
+    def __init__(
+        self,
+        *,
+        camera_id: str,
+        url: str,
+        timeout_seconds: float = 5.0,
+        verify_tls: bool = True,
+    ) -> None:
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise FrameSourceError(
+                f"http snapshot source: expected http(s) URL, got {parsed.scheme!r}"
+            )
+        self.camera_id = camera_id
+        self._url = url
+        self._timeout = timeout_seconds
+        self._verify_tls = verify_tls
+
+    def fetch(self) -> bytes:
+        try:
+            response = httpx.get(
+                self._url,
+                timeout=self._timeout,
+                verify=self._verify_tls,
+                trust_env=False,
+            )
+        except Exception as exc:
+            raise FrameSourceError(
+                f"http snapshot {self._url}: {type(exc).__name__}: {exc}"
+            ) from exc
+        if response.status_code != 200:
+            raise FrameSourceError(
+                f"http snapshot {self._url}: HTTP {response.status_code}"
+            )
+        content_type = response.headers.get("content-type", "").split(";", 1)[0].strip()
+        if content_type and not content_type.startswith("image/"):
+            logger.warning(
+                "http snapshot %s returned non-image Content-Type %r; passing through anyway",
+                self._url,
+                content_type,
+            )
+        return response.content
+
+
+# ── Factory ────────────────────────────────────────────────────────
+
+
+def build_frame_source(*, camera_id: str, url: str) -> FrameSource:
+    """Pick the right source class based on the URL scheme. Anything
+    unrecognised raises ``FrameSourceError`` — fail fast at config-load
+    time rather than mid-loop."""
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme == "file":
+        # urlparse("file:///path") → path is in parsed.path
+        return FileFrameSource(camera_id=camera_id, path=parsed.path)
+    if scheme in ("http", "https"):
+        return HttpSnapshotSource(camera_id=camera_id, url=url)
+    if scheme == "opennvr":
+        raise FrameSourceError(
+            "opennvr:// scheme is reserved for a future OpenNVR-backend snapshot "
+            "endpoint and is not yet implemented. Use http(s):// against the "
+            "camera's snapshot URL directly for now."
+        )
+    if scheme == "rtsp":
+        raise FrameSourceError(
+            "rtsp:// scheme requires the ffmpeg-based RTSP pipeline that lands in "
+            "A2.5b. For now use the camera's HTTP snapshot endpoint instead."
+        )
+    raise FrameSourceError(
+        f"unsupported frame source scheme {scheme!r}; expected file/http/https."
+    )

--- a/examples/intrusion-detection/intrusion_detection.py
+++ b/examples/intrusion-detection/intrusion_detection.py
@@ -1,0 +1,458 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Intrusion-detection example app.
+
+Watches one or more cameras for persons/vehicles entering operator-
+defined restricted zones during operator-defined restricted hours. On
+detection, fires an alert via stdout (always) and an optional
+webhook. Uses KAI-C's contract proxy (``POST /api/v1/infer/{adapter}``)
+for inference — so every alert is correlation-id-traceable through
+the audit log.
+
+This is the first first-party example app per §12 of the AI Adapter
+Contract design. Operators run it as a sidecar to OpenNVR; community
+contributors copy it as a template for their own monitoring apps.
+
+Run:
+    python intrusion_detection.py --config config.yml          # daemon
+    python intrusion_detection.py --config config.yml --once    # one cycle (testing)
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as _dt
+import logging
+import signal
+import sys
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+
+from alerts import Alert, AlertDispatcher, build_dispatcher
+from frame_sources import FrameSource, FrameSourceError, build_frame_source
+from zone import Point, Zone, bbox_center
+
+logger = logging.getLogger("intrusion-detection")
+
+
+# ── Config ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class CameraWatch:
+    """One camera + its zone + its frame source. Multiple cameras
+    can share the same KAI-C/adapter target — each gets its own
+    detector loop iteration."""
+
+    camera_id: str
+    frame_url: str  # file://, http://, https://
+    zone: Zone
+    # Camera frame dimensions in pixels. The contract emits
+    # normalized [0, 1] bboxes; we translate back to pixels to
+    # compare against the zone polygon, which is operator-defined
+    # in pixels.
+    frame_width: int
+    frame_height: int
+
+
+@dataclass
+class RestrictedHours:
+    """A daily time window during which alerts fire. Supports
+    cross-midnight ranges (e.g. ``start=22:00, end=06:00``).
+
+    All comparisons use the LOCAL timezone of the host (or the
+    operator-supplied ``timezone`` if pytz/zoneinfo is configured).
+    For v1 we use ``datetime.now()`` which picks up the host TZ.
+    """
+
+    start: _dt.time
+    end: _dt.time
+
+    def contains(self, when: _dt.datetime) -> bool:
+        """True if ``when.time()`` is within [start, end). Handles
+        cross-midnight ranges by inverting the comparison."""
+        t = when.time()
+        if self.start <= self.end:
+            # Normal range, e.g. 09:00 - 17:00.
+            return self.start <= t < self.end
+        # Cross-midnight range, e.g. 22:00 - 06:00.
+        return t >= self.start or t < self.end
+
+
+@dataclass
+class AppConfig:
+    """Top-level config loaded from YAML."""
+
+    kaic_url: str
+    kaic_adapter_name: str
+    kaic_api_key: str | None
+    poll_interval_seconds: float
+    watch_labels: list[str]
+    restricted_hours: RestrictedHours
+    cameras: list[CameraWatch]
+    webhook_url: str | None
+    request_timeout_seconds: float = 30.0
+
+
+def load_config(path: str) -> AppConfig:
+    """Parse a YAML config file into a typed AppConfig.
+
+    Raises ``ValueError`` on malformed config — caller's job to
+    surface a useful operator message and exit non-zero."""
+    raw = yaml.safe_load(Path(path).read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(f"config {path!r}: root must be a mapping")
+
+    try:
+        kaic_url = str(raw["kaic_url"]).rstrip("/")
+    except KeyError as exc:
+        raise ValueError("config: 'kaic_url' is required") from exc
+
+    poll_interval = float(raw.get("poll_interval_seconds", 5.0))
+    if poll_interval <= 0:
+        raise ValueError("config: 'poll_interval_seconds' must be > 0")
+
+    rh_raw = raw.get("restricted_hours", {})
+    try:
+        rh = RestrictedHours(
+            start=_dt.time.fromisoformat(str(rh_raw.get("start", "00:00"))),
+            end=_dt.time.fromisoformat(str(rh_raw.get("end", "23:59"))),
+        )
+    except ValueError as exc:
+        raise ValueError(f"config: bad restricted_hours value: {exc}") from exc
+
+    cameras_raw = raw.get("cameras") or []
+    if not cameras_raw:
+        raise ValueError("config: at least one camera entry is required")
+    cameras: list[CameraWatch] = []
+    for idx, c in enumerate(cameras_raw):
+        try:
+            zone = Zone.from_config(
+                name=str(c.get("zone_name", f"zone-{idx}")),
+                vertices=c["zone"],
+            )
+            cameras.append(
+                CameraWatch(
+                    camera_id=str(c["camera_id"]),
+                    frame_url=str(c["frame_url"]),
+                    zone=zone,
+                    frame_width=int(c.get("frame_width", 1920)),
+                    frame_height=int(c.get("frame_height", 1080)),
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"config: camera entry {idx} malformed: {exc}"
+            ) from exc
+
+    return AppConfig(
+        kaic_url=kaic_url,
+        kaic_adapter_name=str(raw.get("kaic_adapter_name", "yolov8")),
+        kaic_api_key=str(raw["kaic_api_key"]) if raw.get("kaic_api_key") else None,
+        poll_interval_seconds=poll_interval,
+        watch_labels=[str(s).lower() for s in raw.get("watch_labels", ["person"])],
+        restricted_hours=rh,
+        cameras=cameras,
+        webhook_url=str(raw["webhook_url"]) if raw.get("webhook_url") else None,
+        request_timeout_seconds=float(raw.get("request_timeout_seconds", 30.0)),
+    )
+
+
+# ── KAI-C client ───────────────────────────────────────────────────
+
+
+class KaicClient:
+    """Tiny client for KAI-C's ``POST /api/v1/infer/{adapter}``.
+
+    We send the frame as base64 JSON (the convenience path) because
+    multipart adds boilerplate without benefit at 1-fps polling.
+    Threads ``X-Correlation-Id`` so every alert traces back through
+    KAI-C's audit log and the adapter's logs alike.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        adapter_name: str,
+        *,
+        api_key: str | None,
+        timeout_seconds: float,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._base_url = base_url
+        self._adapter_name = adapter_name
+        self._api_key = api_key
+        self._timeout = timeout_seconds
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.Client(timeout=timeout_seconds, trust_env=False)
+
+    def close(self) -> None:
+        if self._owns_client and hasattr(self._client, "close"):
+            self._client.close()
+
+    def infer_frame(
+        self,
+        *,
+        camera_id: str,
+        frame_bytes: bytes,
+        correlation_id: str,
+    ) -> dict[str, Any]:
+        """Send a frame to KAI-C; return the raw InferResponse body.
+
+        Raises ``KaicError`` on transport failure or non-200; the
+        detector loop catches and decides whether to alert / skip /
+        abort."""
+        url = f"{self._base_url}/api/v1/infer/{self._adapter_name}"
+        headers = {"X-Correlation-Id": correlation_id}
+        if self._api_key:
+            headers["X-Internal-Api-Key"] = self._api_key
+        body = {
+            "camera_id": camera_id,
+            "frame_b64": base64.b64encode(frame_bytes).decode("ascii"),
+        }
+        try:
+            response = self._client.post(url, json=body, headers=headers)
+        except Exception as exc:
+            raise KaicError(f"KAI-C unreachable at {url}: {exc}") from exc
+        if response.status_code != 200:
+            raise KaicError(
+                f"KAI-C returned HTTP {response.status_code}: {response.text[:200]}"
+            )
+        return response.json()
+
+
+class KaicError(Exception):
+    """Raised when KAI-C is unreachable or returns a non-200. The
+    detector loop treats this as a transient skip — alerts don't fire
+    on a comms failure (the failure itself is visible in KAI-C's
+    audit log via the correlation_id we sent)."""
+
+
+# ── Detector loop ──────────────────────────────────────────────────
+
+
+class IntrusionDetector:
+    """The main detector. Holds config + KAI-C client + dispatcher.
+
+    ``step(camera)`` runs one cycle for one camera; ``run()`` schedules
+    every camera every ``poll_interval_seconds`` until SIGINT/SIGTERM
+    or a stop_flag is set.
+    """
+
+    def __init__(
+        self,
+        config: AppConfig,
+        kaic_client: KaicClient,
+        dispatcher: AlertDispatcher,
+        *,
+        now: Callable[[], _dt.datetime] = _dt.datetime.now,
+    ) -> None:
+        self._config = config
+        self._kaic = kaic_client
+        self._dispatcher = dispatcher
+        self._now = now
+        self._stop_flag = False
+        # Cache frame sources at init time so config errors surface
+        # immediately, not on the first cycle.
+        self._frame_sources: dict[str, FrameSource] = {}
+        for camera in config.cameras:
+            self._frame_sources[camera.camera_id] = build_frame_source(
+                camera_id=camera.camera_id,
+                url=camera.frame_url,
+            )
+
+    def stop(self) -> None:
+        self._stop_flag = True
+
+    def step(self, camera: CameraWatch) -> list[Alert]:
+        """Run one detection cycle for one camera. Returns the list
+        of alerts that were fired (mostly for testing — the dispatcher
+        already sent them through every channel)."""
+        # Outside restricted hours → no inference, no alert.
+        now = self._now()
+        if not self._config.restricted_hours.contains(now):
+            return []
+
+        try:
+            frame_bytes = self._frame_sources[camera.camera_id].fetch()
+        except FrameSourceError as exc:
+            logger.warning("frame fetch failed for %s: %s", camera.camera_id, exc)
+            return []
+
+        correlation_id = uuid.uuid4().hex
+        try:
+            infer_response = self._kaic.infer_frame(
+                camera_id=camera.camera_id,
+                frame_bytes=frame_bytes,
+                correlation_id=correlation_id,
+            )
+        except KaicError as exc:
+            logger.warning("kaic inference failed for %s: %s", camera.camera_id, exc)
+            return []
+
+        # Detection list lives at ``response.result.detections`` per
+        # §5.1. Defensive parsing — adapters might return error
+        # envelopes too, or (in pathological cases) non-dict bodies.
+        if not isinstance(infer_response, dict):
+            logger.warning(
+                "kaic returned non-dict body for %s: %r", camera.camera_id, type(infer_response).__name__,
+            )
+            return []
+        result = infer_response.get("result") or {}
+        if not isinstance(result, dict) or result.get("status") == "error":
+            logger.warning(
+                "kaic returned error envelope for %s: %s",
+                camera.camera_id,
+                result.get("error", {}) if isinstance(result, dict) else result,
+            )
+            return []
+        detections = result.get("detections") or []
+
+        fired: list[Alert] = []
+        for det in detections:
+            label = str(det.get("label", "")).lower()
+            if label not in self._config.watch_labels:
+                continue
+            bbox = det.get("bbox")
+            if not isinstance(bbox, dict):
+                continue
+            center = bbox_center(bbox, camera.frame_width, camera.frame_height)
+            if not camera.zone.contains(center):
+                continue
+            alert = self._build_alert(camera, det, center, correlation_id)
+            self._dispatcher.fire(alert)
+            fired.append(alert)
+        return fired
+
+    def _build_alert(
+        self,
+        camera: CameraWatch,
+        detection: dict[str, Any],
+        center: Point,
+        correlation_id: str,
+    ) -> Alert:
+        label = str(detection.get("label", "object"))
+        confidence = float(detection.get("confidence", 0.0))
+        return Alert(
+            title=f"{label.capitalize()} in restricted zone {camera.zone.name!r}",
+            description=(
+                f"Detected {label} (confidence={confidence:.2f}) inside zone "
+                f"{camera.zone.name!r} on camera {camera.camera_id} at "
+                f"({center.x:.0f}, {center.y:.0f})."
+            ),
+            camera_id=camera.camera_id,
+            severity="high",
+            correlation_id=correlation_id,
+            evidence={
+                "detection": detection,
+                "bbox_center_px": {"x": center.x, "y": center.y},
+                "zone_name": camera.zone.name,
+                "kaic_adapter": self._config.kaic_adapter_name,
+            },
+            tags=["intrusion", "restricted-zone", label],
+        )
+
+    def run(self) -> None:
+        """Daemon loop. Polls every camera every
+        ``poll_interval_seconds``. Returns when ``stop()`` is called
+        (e.g. via SIGINT handler) or when the process is killed."""
+        logger.info(
+            "intrusion-detection started: %d cameras, poll=%.1fs, watch=%s, hours=%s-%s",
+            len(self._config.cameras),
+            self._config.poll_interval_seconds,
+            self._config.watch_labels,
+            self._config.restricted_hours.start.isoformat(),
+            self._config.restricted_hours.end.isoformat(),
+        )
+        while not self._stop_flag:
+            cycle_started = time.monotonic()
+            for camera in self._config.cameras:
+                if self._stop_flag:
+                    break
+                try:
+                    self.step(camera)
+                except Exception:
+                    # No single camera failure should kill the loop.
+                    logger.exception("step() raised for camera=%s", camera.camera_id)
+            elapsed = time.monotonic() - cycle_started
+            sleep_for = max(0.0, self._config.poll_interval_seconds - elapsed)
+            # Sleep in short slices so SIGINT is responsive.
+            slept = 0.0
+            while slept < sleep_for and not self._stop_flag:
+                chunk = min(0.25, sleep_for - slept)
+                time.sleep(chunk)
+                slept += chunk
+        logger.info("intrusion-detection stopped")
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="intrusion-detection",
+        description="Watch cameras for intrusions; alert via KAI-C audit + webhook.",
+    )
+    parser.add_argument("--config", required=True, help="Path to config.yml")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run one cycle per configured camera and exit (testing).",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        config = load_config(args.config)
+    except (ValueError, OSError) as exc:
+        print(f"config error: {exc}", file=sys.stderr)
+        return 2
+
+    dispatcher = build_dispatcher(webhook_url=config.webhook_url)
+    kaic_client = KaicClient(
+        config.kaic_url,
+        config.kaic_adapter_name,
+        api_key=config.kaic_api_key,
+        timeout_seconds=config.request_timeout_seconds,
+    )
+    detector = IntrusionDetector(config, kaic_client, dispatcher)
+
+    # Wire SIGINT / SIGTERM to graceful shutdown.
+    def _handle_signal(_signum, _frame):
+        logger.info("signal received, stopping…")
+        detector.stop()
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    try:
+        if args.once:
+            for camera in config.cameras:
+                detector.step(camera)
+        else:
+            detector.run()
+    finally:
+        kaic_client.close()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/examples/intrusion-detection/pyproject.toml
+++ b/examples/intrusion-detection/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "opennvr-example-intrusion-detection"
+version = "1.0.0"
+description = "OpenNVR intrusion-detection example app (A2.5)"
+requires-python = ">=3.11"
+license = { text = "AGPL-3.0" }
+
+# Deps are deliberately minimal — the example is meant to be a clean
+# template for community contributors. httpx for HTTP, PyYAML for the
+# config, and that's it. Image bytes go to KAI-C as base64 so we don't
+# need cv2/PIL locally.
+dependencies = [
+    "httpx>=0.27,<1.0",
+    "PyYAML>=6.0,<7.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23",
+]
+
+[project.scripts]
+intrusion-detection = "intrusion_detection:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/examples/intrusion-detection/tests/test_alerts.py
+++ b/examples/intrusion-detection/tests/test_alerts.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Alert dispatch tests — stdout + webhook + failure isolation."""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from alerts import (
+    Alert,
+    AlertChannel,
+    AlertDispatcher,
+    AlertSource,
+    StdoutChannel,
+    WebhookChannel,
+    build_dispatcher,
+)
+
+
+def _alert() -> Alert:
+    return Alert(
+        title="Person in restricted zone 'front-yard'",
+        description="Detected person.",
+        camera_id="cam-front",
+        correlation_id="corr-123",
+        tags=["intrusion", "person"],
+    )
+
+
+# ── Alert wire shape ───────────────────────────────────────────────
+
+
+def test_alert_to_wire_includes_all_required_fields():
+    alert = _alert()
+    wire = alert.to_wire()
+    for key in (
+        "alert_id", "fired_at", "title", "description", "severity",
+        "source", "camera_id", "correlation_id", "evidence", "tags",
+    ):
+        assert key in wire, f"missing {key}"
+
+
+def test_alert_id_is_unique_prefix():
+    a1, a2 = _alert(), _alert()
+    assert a1.alert_id != a2.alert_id
+    assert a1.alert_id.startswith("alrt_")
+
+
+def test_alert_source_defaults_to_app_kind():
+    alert = _alert()
+    assert alert.source.kind == "app"
+    assert alert.source.name == "intrusion-detection"
+
+
+# ── Stdout channel ─────────────────────────────────────────────────
+
+
+def test_stdout_channel_prints_one_line(capsys):
+    channel = StdoutChannel()
+    assert channel.send(_alert())
+    out = capsys.readouterr().out
+    assert "ALERT" in out
+    assert "HIGH" in out
+    assert "corr-123" in out
+    # Single line
+    assert out.count("\n") == 1
+
+
+# ── Webhook channel ────────────────────────────────────────────────
+
+
+class _CapturingTransport(httpx.BaseTransport):
+    """Captures every request for assertions; returns a fixed status."""
+
+    def __init__(self, status_code: int = 200) -> None:
+        self.calls: list[dict] = []
+        self._status_code = status_code
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        body = bytes(request.read())
+        self.calls.append({
+            "url": str(request.url),
+            "method": request.method,
+            "body": body,
+        })
+        return httpx.Response(self._status_code, json={"ok": True})
+
+
+def test_webhook_channel_posts_alert_json(monkeypatch):
+    transport = _CapturingTransport(200)
+
+    def _patched(url, **kwargs):
+        # ``trust_env=`` lives on the Client constructor, not on
+        # per-request .post() — strip when proxying through a stub.
+        kwargs.pop("trust_env", None)
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr("alerts.httpx.post", _patched)
+    channel = WebhookChannel("https://example.invalid/hook")
+    assert channel.send(_alert())
+    assert len(transport.calls) == 1
+    parsed = json.loads(transport.calls[0]["body"])
+    assert parsed["title"].startswith("Person in restricted zone")
+    assert parsed["camera_id"] == "cam-front"
+
+
+def test_webhook_channel_returns_false_on_http_error(monkeypatch):
+    transport = _CapturingTransport(500)
+
+    def _patched(url, **kwargs):
+        kwargs.pop("trust_env", None)
+        return httpx.Client(transport=transport).post(url, **kwargs)
+
+    monkeypatch.setattr("alerts.httpx.post", _patched)
+    channel = WebhookChannel("https://example.invalid/hook")
+    assert not channel.send(_alert())  # but no raise
+
+
+def test_webhook_channel_swallows_transport_exception(monkeypatch):
+    def _raises(*args, **kwargs):
+        raise RuntimeError("DNS lookup failed")
+    monkeypatch.setattr("alerts.httpx.post", _raises)
+    channel = WebhookChannel("https://example.invalid/hook")
+    assert not channel.send(_alert())  # MUST NOT raise
+
+
+# ── Dispatcher ─────────────────────────────────────────────────────
+
+
+def test_dispatcher_requires_at_least_one_channel():
+    with pytest.raises(ValueError):
+        AlertDispatcher([])
+
+
+def test_dispatcher_fires_all_channels(capsys):
+    fired_through: dict[str, list[Alert]] = {}
+
+    class RecordingChannel:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            fired_through[name] = []
+
+        def send(self, alert: Alert) -> bool:
+            fired_through[self.name].append(alert)
+            return True
+
+    dispatcher = AlertDispatcher([RecordingChannel("a"), RecordingChannel("b")])
+    alert = _alert()
+    report = dispatcher.fire(alert)
+    assert report == {"a": True, "b": True}
+    assert fired_through["a"] == [alert]
+    assert fired_through["b"] == [alert]
+
+
+def test_dispatcher_isolates_channel_exceptions():
+    class BrokenChannel:
+        name = "broken"
+
+        def send(self, alert: Alert) -> bool:
+            raise RuntimeError("kaboom")
+
+    class WorkingChannel:
+        name = "working"
+        delivered = False
+
+        def send(self, alert: Alert) -> bool:
+            WorkingChannel.delivered = True
+            return True
+
+    dispatcher = AlertDispatcher([BrokenChannel(), WorkingChannel()])
+    report = dispatcher.fire(_alert())
+    assert report["broken"] is False  # caught
+    assert report["working"] is True  # downstream channel still fired
+    assert WorkingChannel.delivered
+
+
+# ── build_dispatcher factory ───────────────────────────────────────
+
+
+def test_build_dispatcher_without_webhook_has_only_stdout():
+    dispatcher = build_dispatcher(webhook_url=None)
+    report = dispatcher.fire(_alert())
+    assert list(report.keys()) == ["stdout"]
+
+
+def test_build_dispatcher_with_webhook_has_both():
+    dispatcher = build_dispatcher(webhook_url="https://example.invalid/hook")
+    # We don't actually send the webhook here (no monkeypatching);
+    # we just verify both channels are present.
+    assert {"stdout", "webhook"} <= set(
+        getattr(ch, "name", ch.__class__.__name__) for ch in dispatcher._channels
+    )

--- a/examples/intrusion-detection/tests/test_frame_sources.py
+++ b/examples/intrusion-detection/tests/test_frame_sources.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Frame-source tests — file:// + http(s):// + error paths."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from frame_sources import (
+    FileFrameSource,
+    FrameSourceError,
+    HttpSnapshotSource,
+    build_frame_source,
+)
+
+
+# ── File source ────────────────────────────────────────────────────
+
+
+def test_file_frame_source_reads_bytes(tmp_path: Path):
+    p = tmp_path / "frame.jpg"
+    p.write_bytes(b"FAKE_JPEG_BYTES")
+    src = FileFrameSource(camera_id="cam-1", path=str(p))
+    assert src.fetch() == b"FAKE_JPEG_BYTES"
+    assert src.camera_id == "cam-1"
+
+
+def test_file_frame_source_rejects_missing_path():
+    with pytest.raises(FrameSourceError, match="does not exist"):
+        FileFrameSource(camera_id="cam-x", path="/definitely/does/not/exist.jpg")
+
+
+def test_file_frame_source_rejects_directory(tmp_path: Path):
+    with pytest.raises(FrameSourceError, match="not a file"):
+        FileFrameSource(camera_id="cam-x", path=str(tmp_path))
+
+
+# ── HTTP source ────────────────────────────────────────────────────
+
+
+def _stub_http_transport(*, status: int = 200, body: bytes = b"OK_IMAGE",
+                          content_type: str = "image/jpeg") -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, content=body, headers={"content-type": content_type})
+    return httpx.MockTransport(handler)
+
+
+def test_http_snapshot_returns_bytes(monkeypatch):
+    transport = _stub_http_transport()
+    def _patched_get(url, **kw):
+        # httpx.get() accepts verify= and trust_env= as kwargs, but
+        # Client.get() does not — they belong on the Client constructor.
+        # Strip those here so the stub Client doesn't choke.
+        verify = kw.pop("verify", True)
+        kw.pop("trust_env", None)
+        return httpx.Client(transport=transport, verify=verify).get(url, **kw)
+    monkeypatch.setattr("frame_sources.httpx.get", _patched_get)
+    src = HttpSnapshotSource(camera_id="cam-2", url="https://camera.lan/snap.jpg")
+    assert src.fetch() == b"OK_IMAGE"
+
+
+def test_http_snapshot_raises_on_non_200(monkeypatch):
+    transport = _stub_http_transport(status=503)
+    def _patched_get(url, **kw):
+        # httpx.get() accepts verify= and trust_env= as kwargs, but
+        # Client.get() does not — they belong on the Client constructor.
+        # Strip those here so the stub Client doesn't choke.
+        verify = kw.pop("verify", True)
+        kw.pop("trust_env", None)
+        return httpx.Client(transport=transport, verify=verify).get(url, **kw)
+    monkeypatch.setattr("frame_sources.httpx.get", _patched_get)
+    src = HttpSnapshotSource(camera_id="cam-x", url="https://camera.lan/snap.jpg")
+    with pytest.raises(FrameSourceError, match="HTTP 503"):
+        src.fetch()
+
+
+def test_http_snapshot_raises_on_transport_error(monkeypatch):
+    def _raises(*args, **kwargs):
+        raise httpx.ConnectError("Network is unreachable")
+    monkeypatch.setattr("frame_sources.httpx.get", _raises)
+    src = HttpSnapshotSource(camera_id="cam-x", url="https://camera.lan/snap.jpg")
+    with pytest.raises(FrameSourceError, match="ConnectError"):
+        src.fetch()
+
+
+def test_http_snapshot_rejects_non_http_scheme():
+    with pytest.raises(FrameSourceError, match="http"):
+        HttpSnapshotSource(camera_id="cam-x", url="ftp://camera.lan/snap.jpg")
+
+
+def test_http_snapshot_warns_but_returns_non_image_content_type(monkeypatch, caplog):
+    transport = _stub_http_transport(content_type="text/plain")
+    def _patched_get(url, **kw):
+        # httpx.get() accepts verify= and trust_env= as kwargs, but
+        # Client.get() does not — they belong on the Client constructor.
+        # Strip those here so the stub Client doesn't choke.
+        verify = kw.pop("verify", True)
+        kw.pop("trust_env", None)
+        return httpx.Client(transport=transport, verify=verify).get(url, **kw)
+    monkeypatch.setattr("frame_sources.httpx.get", _patched_get)
+    src = HttpSnapshotSource(camera_id="cam-x", url="https://camera.lan/snap")
+    body = src.fetch()
+    assert body == b"OK_IMAGE"
+    # Warning logged but not fatal.
+
+
+# ── Factory ────────────────────────────────────────────────────────
+
+
+def test_build_frame_source_file_scheme(tmp_path):
+    p = tmp_path / "f.jpg"
+    p.write_bytes(b"x")
+    src = build_frame_source(camera_id="c", url=f"file://{p}")
+    assert isinstance(src, FileFrameSource)
+
+
+def test_build_frame_source_http_scheme():
+    src = build_frame_source(camera_id="c", url="http://192.168.1.1/snap.jpg")
+    assert isinstance(src, HttpSnapshotSource)
+
+
+def test_build_frame_source_https_scheme():
+    src = build_frame_source(camera_id="c", url="https://cam.example/snap.jpg")
+    assert isinstance(src, HttpSnapshotSource)
+
+
+def test_build_frame_source_rtsp_not_yet_supported():
+    with pytest.raises(FrameSourceError, match="rtsp"):
+        build_frame_source(camera_id="c", url="rtsp://cam.example/stream")
+
+
+def test_build_frame_source_opennvr_scheme_deferred():
+    with pytest.raises(FrameSourceError, match="opennvr"):
+        build_frame_source(camera_id="c", url="opennvr://cameras/cam-1/snapshot")
+
+
+def test_build_frame_source_unknown_scheme():
+    with pytest.raises(FrameSourceError, match="unsupported"):
+        build_frame_source(camera_id="c", url="weird://something")

--- a/examples/intrusion-detection/tests/test_intrusion_detection.py
+++ b/examples/intrusion-detection/tests/test_intrusion_detection.py
@@ -1,0 +1,412 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Integration tests — full IntrusionDetector loop with stubbed KAI-C.
+
+Wires up: a tmp config + a tmp JPEG frame source + a fake KAI-C HTTP
+endpoint that returns canned detection responses. Exercises every
+branch of ``IntrusionDetector.step``:
+
+* Detection in zone + restricted hours → alert fires
+* Detection in zone + safe hours → no alert
+* Detection outside zone → no alert
+* Empty detection list → no alert
+* KAI-C unreachable → no alert (but no crash)
+* KAI-C returns FailureEnvelope → no alert (logged + skip)
+* Non-watched label inside zone → no alert
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import httpx
+import pytest
+
+from alerts import AlertDispatcher
+from intrusion_detection import (
+    AppConfig,
+    CameraWatch,
+    IntrusionDetector,
+    KaicClient,
+    RestrictedHours,
+    load_config,
+)
+from zone import Zone
+
+
+# ── Fake KAI-C ─────────────────────────────────────────────────────
+
+
+class _FakeKaicTransport:
+    """Backs httpx.MockTransport with operator-controlled responses."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        self.next_response: tuple[int, dict] = (200, {
+            "status": "ok",
+            "model_name": "yolov8n",
+            "model_version": "v1",
+            "inference_ms": 12,
+            "result": {"detections": [], "frame_dimensions": {"w": 1920, "h": 1080}},
+        })
+
+    def respond(self, request: httpx.Request) -> httpx.Response:
+        body = bytes(request.read())
+        self.requests.append({
+            "url": str(request.url),
+            "method": request.method,
+            "headers": dict(request.headers),
+            "body": json.loads(body) if body else None,
+        })
+        status, payload = self.next_response
+        return httpx.Response(status, json=payload)
+
+    def set_detections(self, detections: list[dict]) -> None:
+        self.next_response = (200, {
+            "status": "ok",
+            "model_name": "yolov8n",
+            "model_version": "v1",
+            "inference_ms": 12,
+            "result": {
+                "detections": detections,
+                "frame_dimensions": {"w": 1920, "h": 1080},
+            },
+        })
+
+    def set_error_envelope(self) -> None:
+        self.next_response = (200, {
+            "status": "ok",
+            "model_name": "yolov8n",
+            "model_version": "v1",
+            "inference_ms": 0,
+            "result": {
+                "status": "error",
+                "error": {
+                    "category": "model_error",
+                    "code": "out_of_memory",
+                    "message": "GPU OOM",
+                    "transient": False,
+                    "details": {},
+                },
+            },
+        })
+
+    def set_unreachable(self) -> None:
+        self.next_response = (502, {"detail": "unreachable"})
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _detection(label: str, *, x: float, y: float, w: float = 0.1, h: float = 0.1,
+               confidence: float = 0.92) -> dict:
+    """§5.1 DetectionItem shape — normalized bbox in [0, 1]."""
+    return {
+        "label": label,
+        "confidence": confidence,
+        "bbox": {"x": x, "y": y, "w": w, "h": h},
+        "track_id": None,
+        "attributes": {},
+    }
+
+
+def _build_detector(
+    tmp_path: Path,
+    *,
+    transport: _FakeKaicTransport,
+    restricted_hours: RestrictedHours,
+    now: _dt.datetime,
+    watch_labels: list[str] | None = None,
+) -> tuple[IntrusionDetector, CameraWatch]:
+    """Build a fully-wired detector with one camera in tmp_path."""
+    # Camera frame
+    frame_path = tmp_path / "frame.jpg"
+    frame_path.write_bytes(b"FAKE_JPEG")
+    # Zone covers the center half of a 1920x1080 frame
+    zone = Zone.from_config("center", [[480, 270], [1440, 270], [1440, 810], [480, 810]])
+    camera = CameraWatch(
+        camera_id="cam-test",
+        frame_url=f"file://{frame_path}",
+        zone=zone,
+        frame_width=1920,
+        frame_height=1080,
+    )
+    config = AppConfig(
+        kaic_url="http://kaic.test",
+        kaic_adapter_name="yolov8",
+        kaic_api_key="test-key",
+        poll_interval_seconds=1.0,
+        watch_labels=watch_labels or ["person", "car"],
+        restricted_hours=restricted_hours,
+        cameras=[camera],
+        webhook_url=None,
+    )
+    client = httpx.Client(transport=httpx.MockTransport(transport.respond))
+    kaic = KaicClient(
+        config.kaic_url, config.kaic_adapter_name,
+        api_key=config.kaic_api_key,
+        timeout_seconds=30.0,
+        http_client=client,
+    )
+
+    # Peer-review PR-12/PR-13: use the normal AlertDispatcher
+    # constructor with a recorder channel; let tests inspect
+    # ``recorder.alerts`` directly rather than monkey-patching
+    # ``detector._test_fired``.
+    class _RecorderChannel:
+        name = "recorder"
+
+        def __init__(self) -> None:
+            self.alerts: list[Alert] = []
+
+        def send(self, alert):
+            self.alerts.append(alert)
+            return True
+
+    recorder = _RecorderChannel()
+    dispatcher = AlertDispatcher([recorder])
+    detector = IntrusionDetector(config, kaic, dispatcher, now=lambda: now)
+    # Expose the recorder so individual tests can assert on dispatch
+    # without poking at private state.
+    detector.recorder = recorder  # type: ignore[attr-defined]
+    return detector, camera
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+def test_person_in_zone_during_restricted_hours_fires_alert(tmp_path):
+    transport = _FakeKaicTransport()
+    # Person at center of frame (0.5, 0.5) → bbox center at (960, 540)
+    # which is inside the center zone (480-1440 x 270-810).
+    transport.set_detections([_detection("person", x=0.45, y=0.45)])
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),  # in window
+    )
+    fired = detector.step(detector._config.cameras[0])
+    assert len(fired) == 1
+    assert fired[0].camera_id == "cam-test"
+    assert "person" in fired[0].title.lower()
+    # Dispatcher received the same alerts step() returned.
+    assert detector.recorder.alerts == fired
+
+
+def test_person_in_zone_outside_restricted_hours_no_alert(tmp_path):
+    transport = _FakeKaicTransport()
+    transport.set_detections([_detection("person", x=0.45, y=0.45)])
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        # Restricted = night only
+        restricted_hours=RestrictedHours(start=_dt.time(22, 0), end=_dt.time(6, 0)),
+        now=_dt.datetime(2026, 5, 19, 14, 0),  # afternoon — safe
+    )
+    fired = detector.step(detector._config.cameras[0])
+    assert fired == []
+    # KAI-C should NOT have been called — safe hours skip the network entirely
+    assert len(transport.requests) == 0
+
+
+def test_person_outside_zone_no_alert(tmp_path):
+    transport = _FakeKaicTransport()
+    # Detection in the top-left corner — bbox center at (96, 54) — outside center zone
+    transport.set_detections([_detection("person", x=0.0, y=0.0)])
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),
+    )
+    fired = detector.step(detector._config.cameras[0])
+    assert fired == []
+
+
+def test_empty_detections_no_alert(tmp_path):
+    transport = _FakeKaicTransport()  # default response = []
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),
+    )
+    fired = detector.step(detector._config.cameras[0])
+    assert fired == []
+
+
+def test_non_watched_label_in_zone_no_alert(tmp_path):
+    transport = _FakeKaicTransport()
+    transport.set_detections([_detection("dog", x=0.45, y=0.45)])
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),
+        watch_labels=["person", "car"],  # "dog" not watched
+    )
+    fired = detector.step(detector._config.cameras[0])
+    assert fired == []
+
+
+def test_kaic_unreachable_no_alert_no_crash(tmp_path):
+    transport = _FakeKaicTransport()
+    transport.set_unreachable()
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),
+    )
+    fired = detector.step(detector._config.cameras[0])  # must not raise
+    assert fired == []
+
+
+def test_kaic_returns_non_dict_body_no_alert_no_crash(tmp_path):
+    """Regression for self-review SR-12: a pathological non-dict body
+    (which shouldn't happen but defensive) returns no alerts instead
+    of crashing the loop."""
+    transport = _FakeKaicTransport()
+    transport.next_response = (200, ["not", "a", "dict"])  # type: ignore[assignment]
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),
+    )
+    fired = detector.step(detector._config.cameras[0])
+    assert fired == []
+
+
+def test_kaic_error_envelope_no_alert(tmp_path):
+    transport = _FakeKaicTransport()
+    transport.set_error_envelope()
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),
+    )
+    fired = detector.step(detector._config.cameras[0])
+    assert fired == []
+
+
+def test_kaic_request_threads_correlation_id_and_api_key(tmp_path):
+    transport = _FakeKaicTransport()
+    transport.set_detections([_detection("person", x=0.45, y=0.45)])
+    detector, _ = _build_detector(
+        tmp_path,
+        transport=transport,
+        restricted_hours=RestrictedHours(start=_dt.time(0, 0), end=_dt.time(23, 59)),
+        now=_dt.datetime(2026, 5, 19, 10, 0),
+    )
+    detector.step(detector._config.cameras[0])
+    assert len(transport.requests) == 1
+    headers = transport.requests[0]["headers"]
+    assert headers.get("x-correlation-id")
+    assert len(headers["x-correlation-id"]) >= 16
+    assert headers.get("x-internal-api-key") == "test-key"
+    # Body carries camera_id and base64 frame
+    body = transport.requests[0]["body"]
+    assert body["camera_id"] == "cam-test"
+    assert body["frame_b64"]
+
+
+# ── Restricted-hours edge cases ────────────────────────────────────
+
+
+def test_restricted_hours_cross_midnight_late_night():
+    """22:00 - 06:00 window. 23:30 IS in window."""
+    rh = RestrictedHours(start=_dt.time(22, 0), end=_dt.time(6, 0))
+    assert rh.contains(_dt.datetime(2026, 5, 19, 23, 30))
+
+
+def test_restricted_hours_cross_midnight_early_morning():
+    """22:00 - 06:00 window. 03:00 IS in window."""
+    rh = RestrictedHours(start=_dt.time(22, 0), end=_dt.time(6, 0))
+    assert rh.contains(_dt.datetime(2026, 5, 19, 3, 0))
+
+
+def test_restricted_hours_cross_midnight_safe_afternoon():
+    """22:00 - 06:00 window. 14:00 is NOT in window."""
+    rh = RestrictedHours(start=_dt.time(22, 0), end=_dt.time(6, 0))
+    assert not rh.contains(_dt.datetime(2026, 5, 19, 14, 0))
+
+
+def test_restricted_hours_normal_window_inclusive_start():
+    rh = RestrictedHours(start=_dt.time(9, 0), end=_dt.time(17, 0))
+    assert rh.contains(_dt.datetime(2026, 5, 19, 9, 0))
+    assert rh.contains(_dt.datetime(2026, 5, 19, 16, 59))
+    assert not rh.contains(_dt.datetime(2026, 5, 19, 17, 0))  # exclusive end
+
+
+# ── Config loader ──────────────────────────────────────────────────
+
+
+def test_load_config_minimal(tmp_path: Path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(dedent("""
+        kaic_url: "http://kaic:8100"
+        kaic_adapter_name: "yolov8"
+        restricted_hours:
+            start: "00:00"
+            end: "23:59"
+        cameras:
+          - camera_id: "cam-1"
+            frame_url: "file:///tmp/x.jpg"
+            zone:
+              - [0, 0]
+              - [100, 0]
+              - [100, 100]
+              - [0, 100]
+    """))
+    config = load_config(str(cfg))
+    assert config.kaic_url == "http://kaic:8100"
+    assert config.kaic_adapter_name == "yolov8"
+    assert config.watch_labels == ["person"]
+    assert len(config.cameras) == 1
+
+
+def test_load_config_rejects_no_cameras(tmp_path: Path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("kaic_url: x\nrestricted_hours:\n    start: '00:00'\n    end: '01:00'\n")
+    with pytest.raises(ValueError, match="at least one camera"):
+        load_config(str(cfg))
+
+
+def test_load_config_rejects_bad_hours(tmp_path: Path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(dedent("""
+        kaic_url: "x"
+        restricted_hours:
+            start: "not a time"
+            end: "01:00"
+        cameras:
+          - camera_id: "c"
+            frame_url: "file:///x"
+            zone: [[0,0],[1,0],[1,1]]
+    """))
+    with pytest.raises(ValueError, match="restricted_hours"):
+        load_config(str(cfg))
+
+
+def test_load_config_rejects_zero_poll_interval(tmp_path: Path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(dedent("""
+        kaic_url: "x"
+        poll_interval_seconds: 0
+        restricted_hours:
+            start: "00:00"
+            end: "01:00"
+        cameras:
+          - camera_id: "c"
+            frame_url: "file:///x"
+            zone: [[0,0],[1,0],[1,1]]
+    """))
+    with pytest.raises(ValueError, match="poll_interval_seconds"):
+        load_config(str(cfg))

--- a/examples/intrusion-detection/tests/test_zone.py
+++ b/examples/intrusion-detection/tests/test_zone.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Point-in-polygon + bbox-center tests."""
+from __future__ import annotations
+
+import pytest
+
+from zone import Point, Zone, bbox_center
+
+
+def _square() -> Zone:
+    """A unit-square zone for quick inside/outside checks."""
+    return Zone(
+        name="unit-square",
+        polygon=[Point(0, 0), Point(10, 0), Point(10, 10), Point(0, 10)],
+    )
+
+
+def _concave_arrow() -> Zone:
+    """A concave (arrow-shape) zone — exercises the odd-crossings rule."""
+    return Zone(
+        name="arrow",
+        polygon=[
+            Point(0, 0),
+            Point(10, 5),   # tip
+            Point(0, 10),
+            Point(3, 5),    # inner concave point
+        ],
+    )
+
+
+# ── Construction ───────────────────────────────────────────────────
+
+
+def test_zone_requires_three_vertices():
+    with pytest.raises(ValueError, match="3 vertices"):
+        Zone(name="bad", polygon=[Point(0, 0), Point(1, 1)])
+
+
+def test_zone_from_config_parses_list_of_pairs():
+    z = Zone.from_config("z1", [[0, 0], [10, 0], [10, 10]])
+    assert z.name == "z1"
+    assert len(z.polygon) == 3
+    assert z.polygon[0] == Point(0, 0)
+
+
+# ── Inside / outside (convex) ──────────────────────────────────────
+
+
+def test_point_clearly_inside():
+    assert _square().contains(Point(5, 5))
+
+
+def test_point_clearly_outside():
+    z = _square()
+    assert not z.contains(Point(15, 5))
+    assert not z.contains(Point(5, 15))
+    assert not z.contains(Point(-1, 5))
+
+
+def test_point_on_edge_treated_as_inside():
+    """We deliberately treat edge points as inside (intrusion bias)."""
+    z = _square()
+    assert z.contains(Point(5, 0))   # bottom edge
+    assert z.contains(Point(10, 5))  # right edge
+    assert z.contains(Point(0, 0))   # corner
+
+
+# ── Inside / outside (concave) ─────────────────────────────────────
+
+
+def test_concave_arrow_inside_legitimate():
+    z = _concave_arrow()
+    # Inside the body of the arrow (not the notch)
+    assert z.contains(Point(2, 2))
+
+
+def test_concave_arrow_outside_in_notch():
+    z = _concave_arrow()
+    # The notch cuts inward at (3, 5) → a point slightly to the
+    # right of the notch but still in the "indentation" should be
+    # OUTSIDE the polygon.
+    assert not z.contains(Point(2, 5))  # in the notch — outside arrow shape
+
+
+# ── bbox_center ────────────────────────────────────────────────────
+
+
+def test_bbox_center_normalizes_to_pixels():
+    # Normalized bbox covers (x=0.2, y=0.3, w=0.4, h=0.2) → center at
+    # (0.2 + 0.2, 0.3 + 0.1) = (0.4, 0.4) in normalized space.
+    # On 1920x1080 → (768, 432).
+    center = bbox_center({"x": 0.2, "y": 0.3, "w": 0.4, "h": 0.2}, 1920, 1080)
+    assert center.x == pytest.approx(768.0)
+    assert center.y == pytest.approx(432.0)
+
+
+def test_bbox_center_at_origin():
+    center = bbox_center({"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}, 1000, 1000)
+    assert center.x == pytest.approx(250.0)
+    assert center.y == pytest.approx(250.0)
+
+
+# ── Combined: detection-in-zone flow ───────────────────────────────
+
+
+def test_normalized_detection_inside_polygon():
+    # Detection bbox center (768, 432) on 1920x1080 frame; zone is the
+    # rectangle (500, 300) - (1000, 600) — center is inside.
+    zone = Zone.from_config("z", [[500, 300], [1000, 300], [1000, 600], [500, 600]])
+    center = bbox_center({"x": 0.3, "y": 0.35, "w": 0.1, "h": 0.1}, 1920, 1080)
+    assert zone.contains(center)
+
+
+def test_normalized_detection_outside_polygon():
+    zone = Zone.from_config("z", [[500, 300], [1000, 300], [1000, 600], [500, 600]])
+    # Center deep in the top-left corner of the frame.
+    center = bbox_center({"x": 0.0, "y": 0.0, "w": 0.05, "h": 0.05}, 1920, 1080)
+    assert not zone.contains(center)
+
+
+# ── Defensive bbox parsing (regression for self-review SR-4) ──────
+
+
+def test_bbox_center_treats_missing_keys_as_zero():
+    """If a detection has a partial bbox (programmer error or spec
+    drift), bbox_center returns Point(0, 0) instead of crashing."""
+    center = bbox_center({}, 1920, 1080)
+    assert center.x == 0.0
+    assert center.y == 0.0
+
+
+def test_bbox_center_handles_non_numeric_values():
+    """String or None values in the bbox dict default to 0 rather
+    than raising — the detector then filters the (0, 0) corner case
+    via the zone check."""
+    center = bbox_center({"x": "not-a-number", "y": None, "w": 0.1, "h": 0.1}, 1000, 1000)
+    # x defaults to 0, w=0.1 → center.x = 50; y defaults to 0, h=0.1 → center.y = 50
+    assert center.x == pytest.approx(50.0)
+    assert center.y == pytest.approx(50.0)

--- a/examples/intrusion-detection/zone.py
+++ b/examples/intrusion-detection/zone.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Point-in-polygon test for restricted-zone evaluation.
+
+A zone is a closed polygon in pixel coordinates of the camera frame.
+Detections whose bbox center falls inside the polygon (and during
+restricted hours) trigger alerts.
+
+Ray-casting algorithm: cast a horizontal ray from the test point to
+the right and count intersections with polygon edges. Odd = inside,
+even = outside. Standard textbook implementation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class Point:
+    """2D point in pixel coordinates (origin top-left, y-down)."""
+
+    x: float
+    y: float
+
+
+@dataclass
+class Zone:
+    """A named polygonal restricted zone in pixel coordinates.
+
+    Polygon vertices are pixel coords on the camera frame. The polygon
+    is implicitly closed (we connect the last vertex back to the
+    first). A degenerate zone with < 3 vertices is rejected.
+    """
+
+    name: str
+    polygon: list[Point]
+
+    def __post_init__(self) -> None:
+        if len(self.polygon) < 3:
+            raise ValueError(
+                f"Zone {self.name!r} requires at least 3 vertices; got {len(self.polygon)}"
+            )
+
+    def contains(self, point: Point) -> bool:
+        """True if the point lies inside the polygon (ray-casting)."""
+        return _point_in_polygon(point, self.polygon)
+
+    @classmethod
+    def from_config(cls, name: str, vertices: Sequence[Sequence[float]]) -> "Zone":
+        """Build a Zone from config-style vertex list ``[[x, y], [x, y], ...]``."""
+        return cls(
+            name=name,
+            polygon=[Point(float(v[0]), float(v[1])) for v in vertices],
+        )
+
+
+def _point_in_polygon(point: Point, polygon: Sequence[Point]) -> bool:
+    """Ray-casting point-in-polygon. Points exactly on an edge are
+    treated as INSIDE — the safer choice for an intrusion-detector
+    (we'd rather alert on a borderline case than miss it)."""
+    n = len(polygon)
+    inside = False
+    j = n - 1
+    for i in range(n):
+        pi, pj = polygon[i], polygon[j]
+        # Edge-on-the-ray special case: treat as inside.
+        if _point_on_segment(point, pi, pj):
+            return True
+        # Standard ray cast: does the horizontal ray from point.x→+∞
+        # at y=point.y cross the edge (pi, pj)?
+        if (pi.y > point.y) != (pj.y > point.y):
+            # Compute x-coordinate where the edge crosses y=point.y.
+            slope_x = (pj.x - pi.x) * (point.y - pi.y) / (pj.y - pi.y) + pi.x
+            if point.x < slope_x:
+                inside = not inside
+        j = i
+    return inside
+
+
+def _point_on_segment(point: Point, a: Point, b: Point, *, eps: float = 1e-9) -> bool:
+    """True if ``point`` lies on the segment ``a-b`` (within ``eps``)."""
+    # Cross product collinearity check
+    cross = (b.x - a.x) * (point.y - a.y) - (b.y - a.y) * (point.x - a.x)
+    if abs(cross) > eps:
+        return False
+    # Dot product to confirm the point is BETWEEN a and b, not on the
+    # extended line.
+    dot = (point.x - a.x) * (b.x - a.x) + (point.y - a.y) * (b.y - a.y)
+    if dot < -eps:
+        return False
+    sq_len = (b.x - a.x) ** 2 + (b.y - a.y) ** 2
+    return dot - sq_len <= eps
+
+
+def bbox_center(bbox_normalized: dict, frame_width: int, frame_height: int) -> Point:
+    """Convert a §5.1 ``NormalizedBBox`` (x/y/w/h in [0, 1]) into a
+    pixel-space center point given the camera's actual frame size.
+
+    The contract emits normalized bboxes so consumers don't need to
+    know each adapter's input resolution. We translate back to pixels
+    so the zone polygon (operator-defined in pixels) can be compared.
+
+    Defensive against partial bboxes: missing keys default to 0 so a
+    malformed detection doesn't crash the loop. The caller (the
+    detector) is responsible for refusing to alert on bogus geometry.
+    """
+    def _coerce(key: str) -> float:
+        value = bbox_normalized.get(key, 0.0)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    x = _coerce("x")
+    y = _coerce("y")
+    w = _coerce("w")
+    h = _coerce("h")
+    return Point(
+        x=(x + w / 2.0) * frame_width,
+        y=(y + h / 2.0) * frame_height,
+    )

--- a/kai-c/README.md
+++ b/kai-c/README.md
@@ -1,6 +1,56 @@
 # KAI-C (Kavach AI Connector)
 
-KAI-C is the middleware layer between the OpenNVR NVR backend and the AI Adapters engine. The backend never talks to AIAdapters directly -- KAI-C handles routing, URL management, authentication, and response standardization.
+KAI-C is the middleware layer between the OpenNVR NVR backend and the AI Adapters engine. The backend never talks to AIAdapters directly — KAI-C handles routing, URL management, authentication, response standardization, **audit logging, sovereignty enforcement, and fingerprint-drift detection**.
+
+## v2.0 (A2.4) — registry, audit, and the trust contract
+
+As of A2.4 KAI-C is the registry and audit layer per §11 of the [AI Adapter Contract v1](../docs/AI_ADAPTER_CONTRACT.md). It still works as a thin proxy for the legacy endpoints; the new behaviour is layered on top.
+
+**What's new:**
+
+- **Adapter registry** (`kai_c/registry.py`) — polls each adapter's `/capabilities` on registration + every 60s. Caches capabilities, fingerprint, health. Detects drift between polls.
+- **Audit log** (`kai_c/audit.py`) — append-only JSONL store. Every registration, every inference, every sovereignty refusal, every fingerprint mismatch is recorded. Queryable from `/api/v1/audit`.
+- **Sovereignty v2** (`kai_c/sovereignty.py`) — V-022 tightening: under `local_only`, refuses adapters whose declared `permissions.network_egress` is non-empty (cloud-proxy adapters). Under `federated`, refuses wildcard egress entries. Re-checks on every poll so a runtime drift de-registers the adapter.
+- **Correlation IDs** (`kai_c/correlation.py`) — every inbound request gets a `X-Correlation-Id` (minted if absent), threaded through to the adapter, echoed in the response, and stamped on every audit event for the request. One id joins logs across KAI-C, the adapter, and downstream consumers.
+
+**New v1 endpoints** (legacy endpoints unchanged for back-compat):
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/v1/adapters/register` | Register an adapter URL → polls /capabilities → runs sovereignty check → stores |
+| `DELETE /api/v1/adapters/{name}` | Deregister |
+| `GET  /api/v1/adapters` | Lightweight adapter summaries for the UI |
+| `GET  /api/v1/ai/capabilities` | Aggregated capabilities (§11 — single call for the UI to render every adapter) |
+| `POST /api/v1/adapters/refresh` | Force-refresh /capabilities + /health |
+| `GET  /api/v1/audit` | Query the audit log (filters: adapter, event_type, camera_id, since, limit) |
+| `POST /api/v1/infer/{adapter}` | Contract-compliant proxy with correlation_id threading + audit emission |
+
+**Drift handling matches §11.3:**
+
+| Field that changed | Action |
+|---|---|
+| `model.fingerprint` | `adapter.fingerprint_mismatch` audit, keep serving (operator decides) |
+| `model.version` | `adapter.capability_drift` audit, keep serving |
+| `permissions.*` adds a new permission | **BLOCKING** — de-register adapter, await re-approval |
+| `permissions.network_egress` violates `local_only` | De-register + `inference.refused_sovereignty` audit |
+| `endpoints.*` | Audit, no action |
+| `scheduling.*` | Apply silently |
+
+**Audit event vocabulary (subset for v1)**: `adapter.registered`, `adapter.deregistered`, `adapter.fingerprint_mismatch`, `adapter.capability_drift`, `adapter.unavailable`, `inference.completed`, `inference.failed`, `inference.refused_sovereignty`. JSONL format on disk at `$KAI_C_AUDIT_LOG` (defaults to `/var/log/opennvr/kai-c-audit.jsonl`).
+
+**Deferred to follow-up** (documented in the design doc §11): NATS / SIEM forwarding, operator-UI approval flow, hash-chained audit integrity (v1.5), fair-queuing per-camera token bucket implementation, full WS streaming proxy.
+
+### Known limitation — legacy `/infer` is unaudited
+
+The legacy endpoints `/infer`, `/infer/local`, and `/infer/cloud` (kept for OpenNVR backend back-compat) **bypass the new audit + registry pipeline**. They read the static `ADAPTER_REGISTRY` env-derived dict, not the live registry; they don't thread `X-Correlation-Id`; they don't emit `inference.completed` / `inference.failed` events.
+
+**Consequence**: an adapter de-registered by the new registry (e.g., for permission drift in §11.3) is still reachable via the legacy `/infer` path because that endpoint only sees the static config. The startup-time loopback check (V-022 M1a) still applies, so the legacy path is safe for the URL-loopback story — it just doesn't get the audit story.
+
+**Fix path**: migrate OpenNVR backend onto `POST /api/v1/infer/{adapter_name}`, which has full audit + sovereignty + correlation_id. Once nothing uses legacy `/infer`, those endpoints retire. Tracked as A2.5.
+
+
+
+
 
 ## Why KAI-C Exists
 

--- a/kai-c/kai_c/audit.py
+++ b/kai-c/kai_c/audit.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+KAI-C audit event store.
+
+§11.2 of the contract design defines the audit-trail contract: every
+registration, every inference, every refusal, every drift event is
+recorded with a stable correlation_id so an operator can pull the
+causal chain for any incident.
+
+This module is the v1 implementation: an append-only JSON-Lines file.
+Each line is a single audit event. The file is queryable via tail-read
+plus simple in-process filtering — fine up to ~1M events, after which
+we'll want a real datastore. The shape is forward-compatible with the
+"SIEM forwarding" hook in §11.2 (syslog / webhook / Splunk HEC) —
+those land in a follow-up commit; this module just exposes the events.
+
+What we do NOT implement here:
+* Hash-chained integrity (§11.2 v1.5 roadmap).
+* SIEM export sinks (the design doc names syslog/webhook/file/splunk_hec/
+  datadog — file is implicit here; the rest follow-up).
+* Retention enforcement (operators rotate the file manually in v1).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+class AuditEventType(str, Enum):
+    """§11.2 event vocabulary. Adapter-related + inference-related.
+
+    String mixin so events serialize as plain strings in JSON.
+    """
+
+    # Adapter lifecycle
+    ADAPTER_REGISTERED = "adapter.registered"
+    ADAPTER_DEREGISTERED = "adapter.deregistered"
+    ADAPTER_PERMISSION_GRANTED = "adapter.permission_granted"
+    ADAPTER_PERMISSION_REVOKED = "adapter.permission_revoked"
+    ADAPTER_CAPABILITY_DRIFT = "adapter.capability_drift"
+    ADAPTER_FINGERPRINT_MISMATCH = "adapter.fingerprint_mismatch"
+    ADAPTER_UNAVAILABLE = "adapter.unavailable"
+
+    # Inference
+    INFERENCE_COMPLETED = "inference.completed"
+    INFERENCE_FAILED = "inference.failed"
+    INFERENCE_REFUSED_SOVEREIGNTY = "inference.refused_sovereignty"
+    INFERENCE_REFUSED_PERMISSION = "inference.refused_permission"
+    INFERENCE_REFUSED_BUDGET = "inference.refused_budget"
+
+    # Stream lifecycle (logged via /infer/stream; KAI-C currently
+    # proxies HTTP /infer only, so these are placeholders for A2.5)
+    STREAM_OPENED = "stream.opened"
+    STREAM_CLOSED = "stream.closed"
+
+
+class AuditEvent(dict):
+    """A single audit record. Inherits from dict so it serializes
+    cleanly via json.dumps and so callers can stash extra fields
+    without subclassing."""
+
+
+def new_correlation_id() -> str:
+    """KAI-C mints a fresh correlation_id when a client doesn't supply
+    one. Format matches the §3.8 wire spec: a hex UUID."""
+    return uuid.uuid4().hex
+
+
+class AuditStore:
+    """Append-only JSONL audit log.
+
+    Thread-safe for concurrent emit() calls — every event flushes
+    immediately so a crash mid-write loses at most the latest record.
+    The file is opened in line-buffered mode; on POSIX the kernel
+    flushes after every newline.
+    """
+
+    def __init__(self, path: str | None = None) -> None:
+        """
+        ``path`` defaults to ``$KAI_C_AUDIT_LOG`` or
+        ``/var/log/opennvr/kai-c-audit.jsonl``. The parent directory is
+        created on first write so a missing dir doesn't crash startup
+        — the file is opened lazily on the first emit.
+        """
+        self._path: str = (
+            path
+            or os.environ.get("KAI_C_AUDIT_LOG")
+            or "/var/log/opennvr/kai-c-audit.jsonl"
+        )
+        self._lock = threading.Lock()
+        self._opened: bool = False
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    def emit(
+        self,
+        event_type: AuditEventType | str,
+        *,
+        correlation_id: str | None = None,
+        adapter: str | None = None,
+        camera_id: str | None = None,
+        **fields: Any,
+    ) -> AuditEvent:
+        """Write one audit record. Returns the event so callers can
+        attach the ``correlation_id`` to whatever they emit next."""
+        event = AuditEvent({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "type": str(event_type.value if isinstance(event_type, AuditEventType) else event_type),
+            "correlation_id": correlation_id or new_correlation_id(),
+        })
+        if adapter is not None:
+            event["adapter"] = adapter
+        if camera_id is not None:
+            event["camera_id"] = camera_id
+        event.update(fields)
+
+        line = json.dumps(event, default=_json_safe_default) + "\n"
+        with self._lock:
+            try:
+                if not self._opened:
+                    os.makedirs(os.path.dirname(self._path), exist_ok=True)
+                    self._opened = True
+                with open(self._path, "a", buffering=1) as fh:
+                    fh.write(line)
+            except OSError as exc:
+                # Audit-log failure is itself an event (§11.2 says
+                # forwarding failures are audited and don't block the
+                # local write — here the LOCAL write failed, which is
+                # serious; we surface it via stderr/logger but do NOT
+                # raise: the caller's main path should not be broken
+                # by audit-disk issues.
+                logger.error("audit-log write failed: %s line=%r", exc, line.rstrip())
+        return event
+
+    def read_all(self) -> list[AuditEvent]:
+        """Read the entire audit log into memory. Used by the
+        ``/api/v1/audit`` endpoint with subsequent in-process filter.
+        Fine up to ~1M events; future work lands a real store."""
+        events: list[AuditEvent] = []
+        try:
+            with open(self._path, "r") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        events.append(AuditEvent(json.loads(line)))
+                    except json.JSONDecodeError:
+                        # Skip corrupt lines but don't crash — operators
+                        # may have hand-edited the file.
+                        continue
+        except FileNotFoundError:
+            return []
+        return events
+
+    def filter(
+        self,
+        *,
+        adapter: str | None = None,
+        event_type: AuditEventType | str | None = None,
+        camera_id: str | None = None,
+        since: str | None = None,  # ISO-8601 string
+        limit: int = 100,
+    ) -> list[AuditEvent]:
+        """Read + filter. Limit is applied AFTER filtering, so callers
+        get up to ``limit`` matching events from the END of the log
+        (most recent first)."""
+        events = self.read_all()
+        et_value = (
+            event_type.value
+            if isinstance(event_type, AuditEventType)
+            else event_type
+        )
+        filtered: list[AuditEvent] = []
+        for ev in events:
+            if adapter is not None and ev.get("adapter") != adapter:
+                continue
+            if et_value is not None and ev.get("type") != et_value:
+                continue
+            if camera_id is not None and ev.get("camera_id") != camera_id:
+                continue
+            if since is not None and ev.get("ts", "") < since:
+                continue
+            filtered.append(ev)
+        return filtered[-limit:]
+
+
+def _json_safe_default(value: Any) -> Any:
+    """Fallback for json.dumps on objects it can't serialize natively."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, set):
+        return sorted(value)
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    return repr(value)

--- a/kai-c/kai_c/contract_types.py
+++ b/kai-c/kai_c/contract_types.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Vendored Pydantic copies of the AI Adapter Contract v1 wire shapes.
+
+KAI-C lives in the ``open-nvr`` repo; the source-of-truth Pydantic
+models live in ``ai-adapter/app/interfaces/contract.py``. Because the
+two are separate repos that may deploy on different release cadences,
+KAI-C carries its own vendored copies of the shapes it consumes. On a
+contract version bump the two sides MUST be updated in lockstep —
+``CapabilitiesResponse.adapter.supported_contract_versions`` is the
+canonical version-handshake field.
+
+Only the shapes KAI-C actually parses are vendored — we do not need
+the WebSocket-specific message types (HandshakeMessage / FrameMessage
+/ etc.) because KAI-C does not currently proxy WebSocket streams.
+
+Forward-compat note: every model uses ``extra="ignore"`` deliberately.
+The adapter side uses ``extra="forbid"`` to keep its own wire shape
+honest. KAI-C is the *consumer* — if an adapter's contract evolves
+to add a new optional field on a future spec bump, KAI-C must keep
+parsing the old fields without crashing on the new ones. Strict-on-
+the-server, lenient-on-the-client is the classic Postel split.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+CONTRACT_VERSION: str = "1"
+
+
+class HealthStatus(str, Enum):
+    OK = "ok"
+    DEGRADED = "degraded"
+    LOADING = "loading"
+    ERROR = "error"
+
+
+class HardwareVerdict(str, Enum):
+    OK = "ok"
+    WARN = "warn"
+    BLOCKED = "blocked"
+
+
+class ErrorCategory(str, Enum):
+    MODEL_ERROR = "model_error"
+    PROVIDER_ERROR = "provider_error"
+    TRANSPORT_ERROR = "transport_error"
+    PERMISSION_DENIED = "permission_denied"
+    NOT_SUPPORTED = "not_supported"
+    OVERLOADED = "overloaded"
+
+
+class FairQueuing(str, Enum):
+    NONE = "none"
+    PER_CAMERA = "per_camera"
+
+
+# ── /health ────────────────────────────────────────────────────────
+
+
+class HealthResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    status: HealthStatus
+    adapter_name: str = Field(min_length=1)
+    adapter_version: str = Field(min_length=1)
+    model_name: str = Field(min_length=1)
+    model_version: str = Field(min_length=1)
+    started_at: str  # ISO-8601; not parsed as datetime here — we just relay
+    uptime_seconds: int = Field(ge=0)
+
+
+# ── /capabilities ──────────────────────────────────────────────────
+
+
+class AdapterInfo(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    vendor: str = Field(min_length=1)
+    license: str = Field(min_length=1)
+    model_card_url: str | None = None
+    supported_contract_versions: list[str] = Field(min_length=1)
+
+
+class ModelInfo(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    framework: str = Field(min_length=1)
+    size_mb: float | None = Field(default=None, ge=0.0)
+    modalities_in: list[str] = Field(default_factory=list)
+    modalities_out: list[str] = Field(default_factory=list)
+    fingerprint: str | None = Field(default=None, min_length=1)
+
+
+class InferEndpointInfo(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    supported: bool
+    input_content_types: list[str] = Field(default_factory=list)
+    input_schema_ref: str | None = None
+    output_schema_ref: str | None = None
+
+
+class StreamEndpointInfo(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    supported: bool
+    max_concurrent_streams: int = Field(default=0, ge=0)
+    supports_shared_memory: bool = False
+    shared_memory_protocol_version: int | None = Field(default=None, ge=1)
+
+
+class ExtraEndpoint(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    path: str = Field(min_length=1)
+    method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
+    purpose: str = Field(min_length=1)
+
+
+class EndpointsInfo(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    infer: InferEndpointInfo
+    infer_stream: StreamEndpointInfo
+    extra: list[ExtraEndpoint] = Field(default_factory=list)
+
+
+class Permissions(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    gpu: bool = False
+    network_egress: list[str] = Field(default_factory=list)
+    host_filesystem: list[str] = Field(default_factory=list)
+    shared_memory_paths: list[str] = Field(default_factory=list)
+    host_metadata: bool = False
+
+
+class Scheduling(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    max_inflight: int = Field(default=1, ge=1)
+    preferred_batch_size: int = Field(default=1, ge=1)
+    fair_queuing: FairQueuing = FairQueuing.NONE
+
+
+class Cost(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    estimated_per_call: float = Field(default=0.0, ge=0.0)
+    estimated_per_hour: float = Field(default=0.0, ge=0.0)
+    rate_limit_per_minute: int | None = Field(default=None, ge=0)
+    is_metered: bool = False
+
+
+class CapabilitiesResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    adapter: AdapterInfo
+    model: ModelInfo
+    endpoints: EndpointsInfo
+    tasks_advertised: list[str] = Field(default_factory=list)
+    permissions: Permissions = Field(default_factory=Permissions)
+    scheduling: Scheduling
+    cost: Cost = Field(default_factory=Cost)
+
+
+# ── Failure envelope ───────────────────────────────────────────────
+
+
+class ErrorDetail(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    category: ErrorCategory
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    transient: bool
+    retry_after_ms: int | None = Field(default=None, ge=0)
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class FailureEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    status: Literal["error"] = "error"
+    error: ErrorDetail

--- a/kai-c/kai_c/correlation.py
+++ b/kai-c/kai_c/correlation.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Correlation-ID middleware for KAI-C.
+
+§3.8 of the contract specifies that every request from KAI-C carries
+an ``X-Correlation-Id: <uuid>`` header. This middleware:
+
+* Reads ``X-Correlation-Id`` from inbound requests, OR mints one if
+  absent. KAI-C is the canonical mint point — OpenNVR backend or any
+  client SHOULD send a value, but if they don't we want a stable id
+  for the audit log.
+* Stashes it on ``request.state.correlation_id`` so handlers can
+  attach it to every audit event they emit.
+* Echoes it on the response.
+
+Forwarding to the adapter is the handler's job (it adds the header
+when calling httpx).
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from kai_c.audit import new_correlation_id
+
+CORRELATION_ID_HEADER: str = "X-Correlation-Id"
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        correlation_id = request.headers.get(CORRELATION_ID_HEADER) or new_correlation_id()
+        request.state.correlation_id = correlation_id
+        response: Response = await call_next(request)
+        response.headers[CORRELATION_ID_HEADER] = correlation_id
+        return response

--- a/kai-c/kai_c/registry.py
+++ b/kai-c/kai_c/registry.py
@@ -1,0 +1,489 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+KAI-C adapter registry.
+
+Per §11 of the contract design, KAI-C polls each registered adapter's
+``/capabilities`` and ``/health`` on:
+
+* adapter registration
+* every 60s thereafter (configurable)
+* on demand via ``POST /api/v1/adapters/refresh``
+
+It maintains an in-memory cache of capabilities + health + the operator's
+permission grants, and emits the §11.2 audit events on every drift:
+
+* ``adapter.registered``           — initial registration
+* ``adapter.fingerprint_mismatch`` — ``model.fingerprint`` changed between polls
+* ``adapter.capability_drift``     — any other capability field changed
+* ``adapter.unavailable``          — ≥3 consecutive /health failures
+* ``adapter.deregistered``         — operator removed, or permissions drift
+                                     added a new permission (§11.3 blocking change)
+
+Drift behaviour matches §11.3:
+
+| Field changed                        | Action                                  |
+|--------------------------------------|-----------------------------------------|
+| ``adapter.{name,version}``           | de-register (treat as new adapter)      |
+| ``model.fingerprint``                | audit, alert, keep serving              |
+| ``model.version``                    | audit, keep serving                     |
+| ``permissions.*`` add new permission | BLOCKING — de-register, await re-approve|
+| ``permissions.*`` remove permission  | allow, audit                            |
+| ``endpoints.*``                      | audit, no action                        |
+| ``scheduling.*``                     | apply silently                          |
+| ``cost.*``                           | apply, recompute budget                 |
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from kai_c.audit import AuditEventType, AuditStore
+from kai_c.contract_types import (
+    CapabilitiesResponse,
+    HealthResponse,
+    Permissions,
+)
+from kai_c.sovereignty import (
+    SovereigntyViolation,
+    adapter_summary_for_audit,
+    check_adapter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_POLL_INTERVAL_SECONDS: int = 60
+DEFAULT_HEALTH_TIMEOUT_SECONDS: float = 2.0
+DEFAULT_CAPABILITIES_TIMEOUT_SECONDS: float = 5.0
+UNAVAILABLE_THRESHOLD: int = 3  # consecutive health failures → unavailable
+
+# Permissions that are "default-safe" — no operator approval required.
+# Anything outside this set requires explicit grant (§8). For v1 we
+# record the requirement in the audit log but DO NOT block registration;
+# A2.4b will land the operator-UI approval flow. The audit event has
+# ``requires_operator_approval=true`` so a downstream dashboard can
+# surface pending approvals.
+SAFE_PERMISSIONS: frozenset[str] = frozenset()  # nothing is default-safe; §8 is strict
+
+
+# ── Drift comparison helpers ───────────────────────────────────────
+
+
+def _permissions_added(old: Permissions, new: Permissions) -> list[str]:
+    """Return permission deltas that ADD new scope (the §11.3
+    "blocking change" set)."""
+    additions: list[str] = []
+    if new.gpu and not old.gpu:
+        additions.append("gpu")
+    new_egress = set(new.network_egress) - set(old.network_egress)
+    if new_egress:
+        additions.append(f"network_egress+={sorted(new_egress)}")
+    new_fs = set(new.host_filesystem) - set(old.host_filesystem)
+    if new_fs:
+        additions.append(f"host_filesystem+={sorted(new_fs)}")
+    new_shm = set(new.shared_memory_paths) - set(old.shared_memory_paths)
+    if new_shm:
+        additions.append(f"shared_memory_paths+={sorted(new_shm)}")
+    if new.host_metadata and not old.host_metadata:
+        additions.append("host_metadata")
+    return additions
+
+
+def _capabilities_diff(
+    old: CapabilitiesResponse, new: CapabilitiesResponse
+) -> dict[str, Any]:
+    """Compute a high-level diff between two capability snapshots —
+    used for the audit ``adapter.capability_drift`` event."""
+    diff: dict[str, Any] = {}
+    if old.adapter.name != new.adapter.name:
+        diff["adapter.name"] = [old.adapter.name, new.adapter.name]
+    if old.adapter.version != new.adapter.version:
+        diff["adapter.version"] = [old.adapter.version, new.adapter.version]
+    if old.model.version != new.model.version:
+        diff["model.version"] = [old.model.version, new.model.version]
+    if old.tasks_advertised != new.tasks_advertised:
+        diff["tasks_advertised"] = [
+            list(old.tasks_advertised),
+            list(new.tasks_advertised),
+        ]
+    if old.endpoints.model_dump() != new.endpoints.model_dump():
+        diff["endpoints"] = "changed"
+    return diff
+
+
+# ── Registry state ─────────────────────────────────────────────────
+
+
+@dataclass
+class RegisteredAdapter:
+    """Per-adapter cache. Capabilities + health + permission grants
+    + consecutive-failure counter for the unavailable threshold."""
+
+    name: str
+    url: str
+    capabilities: CapabilitiesResponse
+    fingerprint: str | None
+    health: HealthResponse | None = None
+    last_polled: float = 0.0
+    consecutive_health_failures: int = 0
+    granted_permissions: set[str] = field(default_factory=set)
+
+
+# ── Async HTTP helpers ─────────────────────────────────────────────
+
+
+async def fetch_capabilities(client: httpx.AsyncClient, url: str) -> CapabilitiesResponse:
+    """Fetch + validate /capabilities. Raises on any failure."""
+    response = await client.get(f"{url.rstrip('/')}/capabilities", timeout=DEFAULT_CAPABILITIES_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return CapabilitiesResponse.model_validate(response.json())
+
+
+async def fetch_health(client: httpx.AsyncClient, url: str) -> HealthResponse:
+    """Fetch + validate /health. Raises on any failure."""
+    response = await client.get(f"{url.rstrip('/')}/health", timeout=DEFAULT_HEALTH_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return HealthResponse.model_validate(response.json())
+
+
+# ── Registry ───────────────────────────────────────────────────────
+
+
+class AdapterRegistry:
+    """In-memory adapter registry with background polling.
+
+    Lifecycle:
+      1. ``await registry.register(name, url)`` polls /capabilities,
+         runs sovereignty + permission checks, stores. Emits
+         ``adapter.registered``.
+      2. ``await registry.refresh(name)`` re-polls /capabilities +
+         /health for a single adapter; emits drift events as needed.
+      3. ``await registry.start_polling()`` kicks off a background
+         task that calls ``refresh`` for every adapter every
+         ``poll_interval_seconds``.
+      4. ``await registry.deregister(name)`` removes, emits
+         ``adapter.deregistered``.
+
+    All operations are async because httpx + asyncio is the natural
+    fit for KAI-C's FastAPI host. The internal state dict is guarded
+    by a threading.Lock so synchronous lookups (e.g., from the /infer
+    handler) are safe to call without the async loop.
+    """
+
+    def __init__(
+        self,
+        *,
+        sovereignty_mode: str,
+        audit: AuditStore,
+        poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._sovereignty_mode = sovereignty_mode.lower()
+        self._audit = audit
+        self._poll_interval = poll_interval_seconds
+        self._adapters: dict[str, RegisteredAdapter] = {}
+        self._lock = threading.Lock()
+        # ``trust_env=False`` so HTTP_PROXY etc. don't redirect our
+        # adapter probes through some operator-side proxy (same logic
+        # as the conformance kit).
+        self._owns_client = http_client is None
+        self._client: httpx.AsyncClient = http_client or httpx.AsyncClient(trust_env=False)
+        self._poll_task: asyncio.Task | None = None
+        self._stop_flag = asyncio.Event()
+
+    @property
+    def sovereignty_mode(self) -> str:
+        return self._sovereignty_mode
+
+    async def aclose(self) -> None:
+        await self.stop_polling()
+        if self._owns_client:
+            await self._client.aclose()
+
+    # ── Public API ─────────────────────────────────────────────────
+
+    async def register(self, name: str, url: str) -> RegisteredAdapter:
+        """Register an adapter. Polls /capabilities, runs sovereignty,
+        stores. Raises ``SovereigntyViolation`` on policy failure,
+        ``httpx.HTTPError`` on adapter unreachability."""
+        url = url.rstrip("/")
+
+        # URL-only sovereignty check (no capabilities yet for the
+        # network_egress check — but we want to fail fast on bad URLs).
+        check_adapter(
+            sovereignty_mode=self._sovereignty_mode,
+            adapter_url=url,
+            capabilities=None,
+        )
+
+        caps = await fetch_capabilities(self._client, url)
+
+        # Now the full check including egress.
+        check_adapter(
+            sovereignty_mode=self._sovereignty_mode,
+            adapter_url=url,
+            capabilities=caps,
+        )
+
+        adapter = RegisteredAdapter(
+            name=name,
+            url=url,
+            capabilities=caps,
+            fingerprint=caps.model.fingerprint,
+        )
+        with self._lock:
+            self._adapters[name] = adapter
+
+        # §11.2 audit — adapter.registered
+        self._audit.emit(
+            AuditEventType.ADAPTER_REGISTERED,
+            adapter=name,
+            registration_url=url,
+            adapter_version=caps.adapter.version,
+            model_name=caps.model.name,
+            model_version=caps.model.version,
+            model_fingerprint=caps.model.fingerprint,
+            declared_permissions=caps.permissions.model_dump(mode="json"),
+            contract_version=caps.adapter.supported_contract_versions,
+            requires_operator_approval=self._requires_approval(caps.permissions),
+        )
+        logger.info("adapter registered: %s @ %s", name, url)
+        return adapter
+
+    async def deregister(self, name: str, *, reason: str = "operator_action") -> None:
+        with self._lock:
+            adapter = self._adapters.pop(name, None)
+        if adapter is None:
+            return
+        self._audit.emit(
+            AuditEventType.ADAPTER_DEREGISTERED,
+            adapter=name,
+            reason=reason,
+        )
+        logger.info("adapter deregistered: %s reason=%s", name, reason)
+
+    async def refresh(self, name: str) -> None:
+        """Re-poll /capabilities + /health for one adapter; emit drift
+        events as appropriate."""
+        with self._lock:
+            adapter = self._adapters.get(name)
+        if adapter is None:
+            return
+
+        # Health probe — failures bump the unavailable counter; we do
+        # NOT de-register on health flakiness alone.
+        try:
+            health = await fetch_health(self._client, adapter.url)
+            adapter.health = health
+            adapter.consecutive_health_failures = 0
+        except Exception as exc:
+            adapter.consecutive_health_failures += 1
+            if adapter.consecutive_health_failures == UNAVAILABLE_THRESHOLD:
+                self._audit.emit(
+                    AuditEventType.ADAPTER_UNAVAILABLE,
+                    adapter=name,
+                    reason=str(exc),
+                    consecutive_failures=adapter.consecutive_health_failures,
+                )
+
+        # Capabilities probe — drift detection vs. cached snapshot.
+        try:
+            new_caps = await fetch_capabilities(self._client, adapter.url)
+        except Exception as exc:
+            logger.warning("capabilities poll failed for %s: %s", name, exc)
+            adapter.last_polled = time.time()
+            return
+
+        old_caps = adapter.capabilities
+
+        # Sovereignty check on the FRESH capabilities. An adapter that
+        # adds network_egress at runtime in local_only mode gets
+        # de-registered.
+        try:
+            check_adapter(
+                sovereignty_mode=self._sovereignty_mode,
+                adapter_url=adapter.url,
+                capabilities=new_caps,
+            )
+        except SovereigntyViolation as exc:
+            self._audit.emit(
+                AuditEventType.INFERENCE_REFUSED_SOVEREIGNTY,
+                adapter=name,
+                reason=str(exc),
+                sovereignty_mode=self._sovereignty_mode,
+                **adapter_summary_for_audit(new_caps),
+            )
+            await self.deregister(name, reason="sovereignty_violation_on_refresh")
+            return
+
+        # Fingerprint mismatch (§11.3 — audit + keep serving).
+        if (
+            new_caps.model.fingerprint
+            and adapter.fingerprint
+            and new_caps.model.fingerprint != adapter.fingerprint
+        ):
+            self._audit.emit(
+                AuditEventType.ADAPTER_FINGERPRINT_MISMATCH,
+                adapter=name,
+                previous_fingerprint=adapter.fingerprint,
+                current_fingerprint=new_caps.model.fingerprint,
+            )
+            adapter.fingerprint = new_caps.model.fingerprint
+
+        # Permissions ADDED — §11.3 blocking change → de-register.
+        added = _permissions_added(old_caps.permissions, new_caps.permissions)
+        if added:
+            self._audit.emit(
+                AuditEventType.ADAPTER_CAPABILITY_DRIFT,
+                adapter=name,
+                field_path="permissions",
+                action_taken="de-registered (blocking change)",
+                added_permissions=added,
+            )
+            await self.deregister(name, reason="permissions_added_requires_reapproval")
+            return
+
+        # Other drift — audit, keep serving.
+        diff = _capabilities_diff(old_caps, new_caps)
+        if diff:
+            self._audit.emit(
+                AuditEventType.ADAPTER_CAPABILITY_DRIFT,
+                adapter=name,
+                diff=diff,
+                action_taken="audited",
+            )
+
+        # Apply the new snapshot.
+        adapter.capabilities = new_caps
+        adapter.last_polled = time.time()
+
+    # ── Synchronous lookups (safe to call from the /infer handler) ──
+
+    def get(self, name: str) -> RegisteredAdapter | None:
+        with self._lock:
+            return self._adapters.get(name)
+
+    def list_names(self) -> list[str]:
+        with self._lock:
+            return sorted(self._adapters.keys())
+
+    def list_summaries(self) -> list[dict[str, Any]]:
+        """Lightweight summary for the /api/v1/adapters listing."""
+        with self._lock:
+            return [
+                {
+                    "name": a.name,
+                    "url": a.url,
+                    "adapter_name": a.capabilities.adapter.name,
+                    "adapter_version": a.capabilities.adapter.version,
+                    "model_name": a.capabilities.model.name,
+                    "model_version": a.capabilities.model.version,
+                    "tasks_advertised": list(a.capabilities.tasks_advertised),
+                    "fingerprint": a.fingerprint,
+                    "health_status": (
+                        a.health.status.value if a.health else "unknown"
+                    ),
+                    "consecutive_health_failures": a.consecutive_health_failures,
+                }
+                for a in self._adapters.values()
+            ]
+
+    def aggregated_capabilities(self) -> dict[str, Any]:
+        """The §11 aggregated capabilities view for OpenNVR UI."""
+        with self._lock:
+            return {
+                "contract_version": "1",
+                "sovereignty_mode": self._sovereignty_mode,
+                "adapters": {
+                    a.name: a.capabilities.model_dump(mode="json")
+                    for a in self._adapters.values()
+                },
+            }
+
+    # ── Inference proxy ────────────────────────────────────────────
+
+    async def proxy_infer(
+        self,
+        adapter_name: str,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        """Forward a JSON inference request to a registered adapter,
+        threading the correlation_id header. Returns ``(status_code, body)``.
+
+        Audit emission is the caller's responsibility — the registry
+        doesn't know about camera_id or latency budgeting, so the
+        FastAPI route emits the right events.
+        """
+        adapter = self.get(adapter_name)
+        if adapter is None:
+            raise KeyError(adapter_name)
+        response = await self._client.post(
+            f"{adapter.url}/infer",
+            json=payload,
+            headers={"X-Correlation-Id": correlation_id},
+            timeout=30.0,
+        )
+        try:
+            body = response.json()
+        except ValueError:
+            body = {"status": "error", "raw": response.text[:200]}
+        return response.status_code, body
+
+    # ── Background polling ─────────────────────────────────────────
+
+    async def start_polling(self) -> None:
+        if self._poll_task is not None:
+            return
+        self._stop_flag.clear()
+        self._poll_task = asyncio.create_task(self._poll_loop())
+
+    async def stop_polling(self) -> None:
+        if self._poll_task is None:
+            return
+        self._stop_flag.set()
+        try:
+            await self._poll_task
+        except asyncio.CancelledError:
+            pass
+        self._poll_task = None
+
+    async def _poll_loop(self) -> None:
+        while not self._stop_flag.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._stop_flag.wait(), timeout=self._poll_interval
+                )
+                break  # stop flag set
+            except asyncio.TimeoutError:
+                pass
+            names = self.list_names()
+            for name in names:
+                if self._stop_flag.is_set():
+                    break
+                try:
+                    await self.refresh(name)
+                except Exception as exc:
+                    logger.exception("refresh failed for %s: %s", name, exc)
+
+    # ── Helpers ────────────────────────────────────────────────────
+
+    def _requires_approval(self, permissions: Permissions) -> bool:
+        """True if any non-default permission is declared. §8 says these
+        require operator approval — the audit event flags this for the
+        downstream approval-UI."""
+        return (
+            permissions.gpu
+            or bool(permissions.network_egress)
+            or bool(permissions.host_filesystem)
+            or bool(permissions.shared_memory_paths)
+            or permissions.host_metadata
+        )

--- a/kai-c/kai_c/sovereignty.py
+++ b/kai-c/kai_c/sovereignty.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+V-022 sovereignty enforcement (v2).
+
+The original M1a implementation in main.py only checked that adapter
+URLs were loopback. Per §11.1 of the contract design, the V-022
+tightening also inspects the adapter's declared
+``permissions.network_egress``:
+
+* ``local_only``    — adapter URL MUST be loopback AND
+                       ``permissions.network_egress`` MUST be empty.
+                       Any non-empty egress list means the adapter is
+                       a cloud-proxy and is refused.
+* ``federated``     — adapter MAY have a non-empty
+                       ``permissions.network_egress`` list but it MUST
+                       enumerate every host explicitly. Wildcards
+                       (``*``, ``*.example.com``) are refused.
+* ``cloud_allowed`` — no checks; suitable for hosted deployments.
+
+These checks run at registration time (so an adapter that violates
+policy never enters the registry) and on every ``/capabilities`` poll
+(so an adapter that ADDS egress at runtime gets de-registered).
+"""
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from urllib.parse import urlparse
+
+from kai_c.contract_types import CapabilitiesResponse, Permissions
+
+logger = logging.getLogger(__name__)
+
+
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+VALID_SOVEREIGNTY_MODES = frozenset({"local_only", "federated", "cloud_allowed"})
+
+
+class SovereigntyViolation(Exception):
+    """Raised when an adapter (or its declared egress) violates the
+    active sovereignty policy. The string form is operator-facing."""
+
+
+def host_is_loopback(host: str | None) -> bool:
+    """Same logic as the legacy main.py helper, kept here so callers
+    don't need to reach into main.py to use it."""
+    if not host:
+        return False
+    h = host.strip("[]").lower()
+    if h in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(h).is_loopback
+    except ValueError:
+        pass
+    saved = socket.getdefaulttimeout()
+    try:
+        socket.setdefaulttimeout(2.0)
+        try:
+            infos = socket.getaddrinfo(h, None)
+        except (socket.gaierror, socket.timeout, OSError):
+            return False
+    finally:
+        socket.setdefaulttimeout(saved)
+    return bool(infos) and all(
+        ipaddress.ip_address(info[4][0]).is_loopback for info in infos
+    )
+
+
+def _url_host(url: str) -> str | None:
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if host == "0.0.0.0":
+        # The wildcard bind isn't a routable destination; treat as
+        # non-loopback so we refuse it explicitly.
+        return host
+    return host
+
+
+def _has_wildcard(egress: list[str]) -> bool:
+    return any("*" in entry for entry in egress)
+
+
+def check_adapter(
+    *,
+    sovereignty_mode: str,
+    adapter_url: str,
+    capabilities: CapabilitiesResponse | None,
+) -> None:
+    """Raise :class:`SovereigntyViolation` if the adapter doesn't fit
+    the active sovereignty mode.
+
+    ``capabilities`` may be None for early-stage checks (URL-only,
+    before we've polled the adapter). When provided, we also inspect
+    ``capabilities.permissions.network_egress``.
+    """
+    mode = sovereignty_mode.lower()
+    if mode not in VALID_SOVEREIGNTY_MODES:
+        raise SovereigntyViolation(
+            f"AI_SOVEREIGNTY={sovereignty_mode!r} is invalid; expected one of "
+            f"{sorted(VALID_SOVEREIGNTY_MODES)}."
+        )
+
+    if mode == "cloud_allowed":
+        return
+
+    host = _url_host(adapter_url)
+
+    if mode == "local_only":
+        if host == "0.0.0.0":
+            raise SovereigntyViolation(
+                f"adapter URL {adapter_url!r}: host 0.0.0.0 is the wildcard "
+                f"bind, not a loopback address."
+            )
+        if not host_is_loopback(host):
+            raise SovereigntyViolation(
+                f"AI_SOVEREIGNTY=local_only refuses non-loopback adapter URL "
+                f"{adapter_url!r} (host={host})."
+            )
+        if capabilities is not None:
+            egress = capabilities.permissions.network_egress
+            if egress:
+                raise SovereigntyViolation(
+                    f"AI_SOVEREIGNTY=local_only refuses adapter "
+                    f"{capabilities.adapter.name!r}: declared "
+                    f"permissions.network_egress={egress!r} is non-empty "
+                    f"(cloud-proxy adapter)."
+                )
+        return
+
+    # mode == "federated"
+    if capabilities is not None:
+        egress = capabilities.permissions.network_egress
+        if _has_wildcard(egress):
+            raise SovereigntyViolation(
+                f"AI_SOVEREIGNTY=federated refuses adapter "
+                f"{capabilities.adapter.name!r}: "
+                f"permissions.network_egress contains wildcard entries "
+                f"({egress!r}); enumerate every host explicitly."
+            )
+
+
+def adapter_summary_for_audit(capabilities: CapabilitiesResponse | None) -> dict:
+    """Subset of the capabilities dict that lands in the audit log on
+    sovereignty refusals. Keeps the log compact while preserving
+    enough context for an incident reviewer."""
+    if capabilities is None:
+        return {}
+    return {
+        "adapter_name": capabilities.adapter.name,
+        "adapter_version": capabilities.adapter.version,
+        "permissions": capabilities.permissions.model_dump(mode="json"),
+    }

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -23,20 +23,29 @@ This service runs as a standalone HTTP server that:
 3. Returns standardized responses
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import AnyHttpUrl, BaseModel, Field
 from typing import Dict, Any, Optional
+import httpx
 import ipaddress
+import logging
 import socket
+import time
 import uvicorn
 import requests
 import os
 from urllib.parse import urlparse
 from fastapi import Header
 
+from kai_c.audit import AuditEventType, AuditStore, new_correlation_id
 from kai_c.connector import KaiConnector
+from kai_c.correlation import CORRELATION_ID_HEADER, CorrelationIdMiddleware
+from kai_c.registry import AdapterRegistry
 from kai_c.schemas import KAIRequest
+from kai_c.sovereignty import SovereigntyViolation
+
+logger = logging.getLogger("kai-c")
 
 
 # ============================================================
@@ -130,7 +139,7 @@ def _validate_adapters_match_sovereignty() -> None:
 app = FastAPI(
     title="KAI-C (Kavach AI Connector)",
     description="Middleware connector between OpenNVR Kavach and AI Adapters",
-    version="1.0.0"
+    version="2.0.0"  # A2.4: bumped — added registry / audit / correlation_id
 )
 
 # Add CORS middleware
@@ -141,6 +150,66 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# A2.4: correlation_id middleware (§3.8). Runs on every request so the
+# audit log lines below can pull the id off request.state.
+app.add_middleware(CorrelationIdMiddleware)
+
+# A2.4: audit store + adapter registry singletons. The audit store is
+# eager; the registry is built at startup so the poller can begin
+# polling once known adapters are registered.
+_audit = AuditStore()
+_registry: AdapterRegistry | None = None
+
+
+def get_registry() -> AdapterRegistry:
+    if _registry is None:  # pragma: no cover — guarded by startup
+        raise RuntimeError("registry not initialized; startup did not run")
+    return _registry
+
+
+def get_audit() -> AuditStore:
+    return _audit
+
+
+@app.on_event("startup")
+async def _kaic_startup() -> None:
+    """Build the registry + register any adapters from the legacy
+    ``ADAPTER_REGISTRY`` env-derived dict. Adapters that fail
+    registration (sovereignty refusal, unreachable, etc.) are logged
+    but do NOT block startup — operators may register them later via
+    POST /api/v1/adapters/register."""
+    global _registry
+    _registry = AdapterRegistry(
+        sovereignty_mode=AI_SOVEREIGNTY,
+        audit=_audit,
+    )
+    for name, url in ADAPTER_REGISTRY.items():
+        try:
+            await _registry.register(name, url)
+        except SovereigntyViolation as exc:
+            logger.warning("sovereignty refused %s@%s: %s", name, url, exc)
+            _audit.emit(
+                AuditEventType.INFERENCE_REFUSED_SOVEREIGNTY,
+                adapter=name,
+                reason=str(exc),
+                sovereignty_mode=AI_SOVEREIGNTY,
+                registration_url=url,
+            )
+        except Exception as exc:
+            # Adapter unreachable / malformed /capabilities — log and
+            # continue. Operators can re-register via the v2 endpoint
+            # once the adapter is up.
+            logger.info("registration deferred for %s@%s: %s", name, url, exc)
+    await _registry.start_polling()
+
+
+@app.on_event("shutdown")
+async def _kaic_shutdown() -> None:
+    global _registry
+    if _registry is not None:
+        await _registry.aclose()
+        _registry = None
 
 # ============================================================
 # ADAPTER REGISTRY - KAI-C manages all AI Adapter URLs
@@ -528,6 +597,204 @@ async def get_schemas(task: Optional[str] = None):
         )
 
 
+# ============================================================
+# A2.4: v2 registry / audit / aggregated-capabilities endpoints
+# ============================================================
+# These live under /api/v1/* so future versioning (v2, v3) is cheap.
+# The legacy /infer, /infer/local, /infer/cloud, /health, /capabilities,
+# /adapters/health, /schema endpoints above are kept for back-compat
+# until OpenNVR backend migrates onto the v1 surface.
+
+
+def require_internal_api_key(x_internal_api_key: Optional[str] = Header(None)) -> None:
+    """Auth dependency for the v2 endpoints (peer-review SR-NEW-7).
+
+    Same dev-mode-bypass pattern as the legacy ``/infer/cloud`` endpoint:
+    if ``INTERNAL_API_KEY`` is empty (dev / single-host loopback
+    deployments) all calls pass. In production the operator sets the
+    env var and OpenNVR backend MUST send the matching
+    ``X-Internal-Api-Key`` header.
+
+    All v2 endpoints depend on this so register/deregister/infer cannot
+    be reached anonymously by an attacker who finds KAI-C's port open
+    on a non-loopback interface.
+    """
+    if INTERNAL_API_KEY and x_internal_api_key != INTERNAL_API_KEY:
+        raise HTTPException(
+            status_code=401,
+            detail="Unauthorized: missing or invalid X-Internal-Api-Key",
+        )
+
+
+class RegisterAdapterRequest(BaseModel):
+    """Payload for POST /api/v1/adapters/register.
+
+    ``url`` is validated as a real HTTP/HTTPS URL — malformed strings
+    return 422 (Unprocessable Entity) before they hit the sovereignty
+    layer, where they'd otherwise look like a sovereignty refusal.
+    """
+    name: str = Field(min_length=1)
+    url: AnyHttpUrl
+
+
+@app.post("/api/v1/adapters/register", dependencies=[Depends(require_internal_api_key)])
+async def v1_register_adapter(payload: RegisterAdapterRequest):
+    """Register an adapter at runtime. Polls /capabilities, runs the
+    sovereignty + permission checks, stores in the registry."""
+    try:
+        adapter = await get_registry().register(payload.name, str(payload.url))
+    except SovereigntyViolation as exc:
+        get_audit().emit(
+            AuditEventType.INFERENCE_REFUSED_SOVEREIGNTY,
+            adapter=payload.name,
+            reason=str(exc),
+            sovereignty_mode=AI_SOVEREIGNTY,
+            registration_url=payload.url,
+        )
+        raise HTTPException(status_code=403, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"adapter unreachable: {exc}")
+    return {
+        "status": "ok",
+        "adapter": {
+            "name": adapter.name,
+            "url": adapter.url,
+            "adapter_version": adapter.capabilities.adapter.version,
+            "fingerprint": adapter.fingerprint,
+        },
+    }
+
+
+@app.delete("/api/v1/adapters/{name}", dependencies=[Depends(require_internal_api_key)])
+async def v1_deregister_adapter(name: str):
+    """Remove an adapter from the registry. Emits adapter.deregistered."""
+    registry = get_registry()
+    if registry.get(name) is None:
+        raise HTTPException(status_code=404, detail=f"unknown adapter: {name}")
+    await registry.deregister(name, reason="operator_action")
+    return {"status": "ok"}
+
+
+@app.get("/api/v1/adapters", dependencies=[Depends(require_internal_api_key)])
+async def v1_list_adapters():
+    """Lightweight adapter summaries — what the OpenNVR UI lists."""
+    return {"adapters": get_registry().list_summaries()}
+
+
+@app.get("/api/v1/ai/capabilities", dependencies=[Depends(require_internal_api_key)])
+async def v1_aggregated_capabilities():
+    """The §11 aggregated capabilities view — a single call so the UI
+    doesn't fan out across N adapter URLs."""
+    return get_registry().aggregated_capabilities()
+
+
+@app.post("/api/v1/adapters/refresh", dependencies=[Depends(require_internal_api_key)])
+async def v1_refresh_adapters(name: Optional[str] = None):
+    """Force a /capabilities + /health re-poll. Without ``name`` refreshes
+    every registered adapter; with it, just the one. §11."""
+    registry = get_registry()
+    if name is not None:
+        if registry.get(name) is None:
+            raise HTTPException(status_code=404, detail=f"unknown adapter: {name}")
+        await registry.refresh(name)
+        return {"status": "ok", "refreshed": [name]}
+    names = registry.list_names()
+    for n in names:
+        await registry.refresh(n)
+    return {"status": "ok", "refreshed": names}
+
+
+@app.post("/api/v1/infer/{adapter_name}", dependencies=[Depends(require_internal_api_key)])
+async def v1_infer(
+    adapter_name: str,
+    payload: Dict[str, Any],
+    request: Request,
+):
+    """Contract-compliant proxy: forwards JSON payload to the named
+    adapter's /infer, threading the request's X-Correlation-Id, and
+    emitting inference.completed / inference.failed audit events.
+
+    For v1 we only proxy ``application/json`` requests — multipart
+    proxying lands when KAI-C starts brokering binary frame payloads
+    itself (A2.4b alongside the WS streaming bridge)."""
+    registry = get_registry()
+    audit = get_audit()
+    adapter = registry.get(adapter_name)
+    if adapter is None:
+        raise HTTPException(status_code=404, detail=f"unknown adapter: {adapter_name}")
+
+    correlation_id = getattr(request.state, "correlation_id", None)
+    if correlation_id is None:  # belt-and-braces
+        correlation_id = new_correlation_id()
+
+    camera_id = payload.get("camera_id") if isinstance(payload, dict) else None
+    started = time.monotonic()
+
+    try:
+        status_code, body = await registry.proxy_infer(adapter_name, payload, correlation_id)
+    except Exception as exc:
+        latency_ms = int((time.monotonic() - started) * 1000)
+        audit.emit(
+            AuditEventType.INFERENCE_FAILED,
+            correlation_id=correlation_id,
+            adapter=adapter_name,
+            camera_id=camera_id,
+            latency_ms=latency_ms,
+            error_category="transport_error",
+            error_code="adapter_unreachable",
+            error_message=str(exc),
+        )
+        raise HTTPException(status_code=502, detail=f"adapter unreachable: {exc}")
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+
+    if status_code == 200:
+        audit.emit(
+            AuditEventType.INFERENCE_COMPLETED,
+            correlation_id=correlation_id,
+            adapter=adapter_name,
+            camera_id=camera_id,
+            latency_ms=latency_ms,
+            model_version=adapter.capabilities.model.version,
+        )
+        return body
+
+    error_info = body.get("error", {}) if isinstance(body, dict) else {}
+    audit.emit(
+        AuditEventType.INFERENCE_FAILED,
+        correlation_id=correlation_id,
+        adapter=adapter_name,
+        camera_id=camera_id,
+        latency_ms=latency_ms,
+        error_category=error_info.get("category", "unknown"),
+        error_code=error_info.get("code", "unknown"),
+        transient=error_info.get("transient", False),
+    )
+    raise HTTPException(status_code=status_code, detail=body)
+
+
+@app.get("/api/v1/audit", dependencies=[Depends(require_internal_api_key)])
+async def v1_audit_query(
+    adapter: Optional[str] = None,
+    event_type: Optional[str] = None,
+    camera_id: Optional[str] = None,
+    since: Optional[str] = None,
+    limit: int = 100,
+):
+    """Query recent audit events. Filters: adapter, event_type,
+    camera_id, since (ISO-8601). Returns up to ``limit`` newest matches."""
+    if limit < 1 or limit > 10_000:
+        raise HTTPException(status_code=400, detail="limit must be between 1 and 10000")
+    events = get_audit().filter(
+        adapter=adapter,
+        event_type=event_type,
+        camera_id=camera_id,
+        since=since,
+        limit=limit,
+    )
+    return {"count": len(events), "events": events}
+
+
 if __name__ == "__main__":
     print("=" * 60)
     print("Starting KAI-C (Kavach AI Connector) Service")
@@ -535,7 +802,7 @@ if __name__ == "__main__":
     print("Running on: http://localhost:8100")
     print("API Docs: http://localhost:8100/docs")
     print("=" * 60)
-    
+
     uvicorn.run(
         app,
         host="0.0.0.0",

--- a/kai-c/test/test_audit.py
+++ b/kai-c/test/test_audit.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Audit store unit tests — emit / read / filter / corruption tolerance."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kai_c.audit import AuditEventType, AuditStore, new_correlation_id
+
+
+@pytest.fixture
+def audit(tmp_path: Path) -> AuditStore:
+    return AuditStore(path=str(tmp_path / "audit.jsonl"))
+
+
+def test_emit_writes_jsonl_line(audit):
+    event = audit.emit(
+        AuditEventType.ADAPTER_REGISTERED,
+        adapter="yolov8",
+        adapter_version="1.0.0",
+    )
+    assert event["type"] == "adapter.registered"
+    assert event["adapter"] == "yolov8"
+    assert event["correlation_id"]
+    contents = Path(audit.path).read_text().strip().splitlines()
+    assert len(contents) == 1
+    parsed = json.loads(contents[0])
+    assert parsed["adapter"] == "yolov8"
+    assert parsed["adapter_version"] == "1.0.0"
+    assert "ts" in parsed
+
+
+def test_emit_mints_correlation_id_when_absent(audit):
+    event = audit.emit(AuditEventType.INFERENCE_COMPLETED, adapter="x", camera_id="cam-1")
+    assert len(event["correlation_id"]) == 32  # hex uuid
+
+
+def test_emit_preserves_supplied_correlation_id(audit):
+    cid = new_correlation_id()
+    event = audit.emit(AuditEventType.INFERENCE_COMPLETED, correlation_id=cid, adapter="x")
+    assert event["correlation_id"] == cid
+
+
+def test_filter_by_adapter(audit):
+    audit.emit(AuditEventType.ADAPTER_REGISTERED, adapter="a")
+    audit.emit(AuditEventType.ADAPTER_REGISTERED, adapter="b")
+    audit.emit(AuditEventType.INFERENCE_COMPLETED, adapter="a", camera_id="cam-1")
+    rows = audit.filter(adapter="a")
+    assert len(rows) == 2
+    assert all(r["adapter"] == "a" for r in rows)
+
+
+def test_filter_by_event_type(audit):
+    audit.emit(AuditEventType.ADAPTER_REGISTERED, adapter="a")
+    audit.emit(AuditEventType.INFERENCE_COMPLETED, adapter="a")
+    audit.emit(AuditEventType.INFERENCE_FAILED, adapter="a")
+    rows = audit.filter(event_type=AuditEventType.INFERENCE_COMPLETED)
+    assert len(rows) == 1
+    assert rows[0]["type"] == "inference.completed"
+
+
+def test_filter_by_camera_id_and_since(audit):
+    audit.emit(AuditEventType.INFERENCE_COMPLETED, adapter="a", camera_id="cam-1", ts="2020-01-01T00:00:00Z")
+    audit.emit(AuditEventType.INFERENCE_COMPLETED, adapter="a", camera_id="cam-2", ts="2026-01-01T00:00:00Z")
+    rows = audit.filter(camera_id="cam-2")
+    assert len(rows) == 1
+
+
+def test_filter_limit(audit):
+    for i in range(10):
+        audit.emit(AuditEventType.INFERENCE_COMPLETED, adapter="a", camera_id=f"cam-{i}")
+    rows = audit.filter(limit=3)
+    assert len(rows) == 3
+    # Newest first → last three cams
+    assert [r["camera_id"] for r in rows] == ["cam-7", "cam-8", "cam-9"]
+
+
+def test_corrupt_lines_are_skipped(audit):
+    audit.emit(AuditEventType.ADAPTER_REGISTERED, adapter="a")
+    Path(audit.path).write_text(
+        Path(audit.path).read_text() + "not-json-at-all\n" + json.dumps({"type": "x"}) + "\n"
+    )
+    rows = audit.read_all()
+    # Original + the new valid one; corrupt line skipped.
+    assert len(rows) == 2
+
+
+def test_read_all_missing_file_returns_empty(tmp_path):
+    audit = AuditStore(path=str(tmp_path / "missing.jsonl"))
+    assert audit.read_all() == []

--- a/kai-c/test/test_main_v2.py
+++ b/kai-c/test/test_main_v2.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Integration tests for the A2.4 v2 endpoints + correlation_id wiring.
+
+Stubs out a contract-compliant adapter via httpx.MockTransport so the
+tests don't need a real adapter container running. Verifies the
+registry + audit + sovereignty + correlation_id paths end-to-end.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+def _base_caps(*, fingerprint: str = "sha256:zzz", egress: list[str] | None = None) -> dict:
+    return {
+        "adapter": {
+            "name": "stub", "version": "1.0.0", "vendor": "open-nvr",
+            "license": "AGPL-3.0", "supported_contract_versions": ["1"],
+        },
+        "model": {"name": "stub-model", "version": "v1", "framework": "f", "fingerprint": fingerprint},
+        "endpoints": {
+            "infer": {"supported": True, "input_content_types": ["application/json"]},
+            "infer_stream": {"supported": False},
+        },
+        "tasks_advertised": ["echo"],
+        "permissions": {
+            "gpu": False, "network_egress": egress or [],
+            "host_filesystem": [], "shared_memory_paths": [], "host_metadata": False,
+        },
+        "scheduling": {"max_inflight": 1, "preferred_batch_size": 1, "fair_queuing": "none"},
+        "cost": {"currency": "USD", "estimated_per_call": 0.0, "estimated_per_hour": 0.0,
+                 "rate_limit_per_minute": None, "is_metered": False},
+    }
+
+
+class _StubAdapter:
+    """Pretends to be a contract-compliant adapter. Captures the
+    correlation_id header on /infer so tests can assert it gets
+    threaded through."""
+
+    def __init__(self) -> None:
+        self.last_correlation_id: str | None = None
+        self.last_payload: dict | None = None
+        self.infer_response: dict = {
+            "status": "ok",
+            "model_name": "stub-model",
+            "model_version": "v1",
+            "inference_ms": 5,
+            "result": {"echoed": True},
+        }
+        self.infer_status_code: int = 200
+
+    async def respond(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/capabilities":
+            return httpx.Response(200, json=_base_caps())
+        if path == "/health":
+            return httpx.Response(200, json={
+                "status": "ok",
+                "adapter_name": "stub", "adapter_version": "1.0.0",
+                "model_name": "stub-model", "model_version": "v1",
+                "started_at": "2026-05-19T00:00:00Z", "uptime_seconds": 1,
+            })
+        if path == "/infer":
+            self.last_correlation_id = request.headers.get("x-correlation-id")
+            body = bytes(request.read())
+            import json as _json
+            try:
+                self.last_payload = _json.loads(body) if body else None
+            except _json.JSONDecodeError:
+                self.last_payload = None
+            return httpx.Response(self.infer_status_code, json=self.infer_response)
+        return httpx.Response(404)
+
+
+@pytest.fixture
+def kaic_test_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AI_SOVEREIGNTY", "local_only")
+    monkeypatch.setenv("ADAPTER_URL", "http://127.0.0.1:9100")
+    monkeypatch.setenv("KAI_C_AUDIT_LOG", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("INTERNAL_API_KEY", "")
+    return {"audit_path": tmp_path / "audit.jsonl"}
+
+
+@pytest.fixture
+def kaic_app(kaic_test_env, monkeypatch: pytest.MonkeyPatch):
+    """Build the FastAPI app with the stub adapter wired in.
+
+    The startup hook tries to register adapters from the env-derived
+    ADAPTER_REGISTRY dict — we let that fail silently (the stub
+    adapter URL won't resolve on real network), then register the
+    stub explicitly via the v2 endpoint inside each test.
+    """
+    if "main" in sys.modules:
+        importlib.reload(sys.modules["main"])
+    import main as kaic_main
+
+    stub = _StubAdapter()
+    transport = httpx.MockTransport(stub.respond)
+
+    from fastapi.testclient import TestClient
+
+    # Patch AdapterRegistry to use the mock transport.
+    original_init = kaic_main.AdapterRegistry.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["http_client"] = httpx.AsyncClient(transport=transport)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(kaic_main.AdapterRegistry, "__init__", patched_init)
+
+    with TestClient(kaic_main.app) as client:
+        yield client, stub
+
+
+# ── Registry endpoints ─────────────────────────────────────────────
+
+
+def test_register_adapter_returns_ok(kaic_app):
+    client, stub = kaic_app
+    # Default startup registers "default" → http://127.0.0.1:9100;
+    # because we mocked it, registration should succeed.
+    response = client.post(
+        "/api/v1/adapters/register",
+        json={"name": "stub-x", "url": "http://127.0.0.1:9100"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["adapter"]["name"] == "stub-x"
+    assert body["adapter"]["fingerprint"] == "sha256:zzz"
+
+
+def test_register_refuses_non_loopback_under_local_only(kaic_app):
+    client, _ = kaic_app
+    response = client.post(
+        "/api/v1/adapters/register",
+        json={"name": "bad", "url": "http://192.168.1.50:9100"},
+    )
+    assert response.status_code == 403
+    assert "non-loopback" in response.json()["detail"].lower()
+
+
+def test_list_adapters_after_register(kaic_app):
+    client, _ = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+    response = client.get("/api/v1/adapters")
+    body = response.json()
+    names = [a["name"] for a in body["adapters"]]
+    assert "stub-x" in names
+
+
+def test_aggregated_capabilities(kaic_app):
+    client, _ = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+    response = client.get("/api/v1/ai/capabilities")
+    body = response.json()
+    assert body["sovereignty_mode"] == "local_only"
+    assert body["contract_version"] == "1"
+    assert "stub-x" in body["adapters"]
+
+
+def test_deregister(kaic_app):
+    client, _ = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+    response = client.delete("/api/v1/adapters/stub-x")
+    assert response.status_code == 200
+    # Now /adapters should not include stub-x
+    listing = client.get("/api/v1/adapters").json()
+    assert not any(a["name"] == "stub-x" for a in listing["adapters"])
+
+
+def test_refresh_unknown_adapter_returns_404(kaic_app):
+    client, _ = kaic_app
+    response = client.post("/api/v1/adapters/refresh?name=missing")
+    assert response.status_code == 404
+
+
+# ── Inference proxy + correlation_id ──────────────────────────────
+
+
+def test_v1_infer_threads_correlation_id_to_adapter(kaic_app):
+    client, stub = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+
+    response = client.post(
+        "/api/v1/infer/stub-x",
+        json={"camera_id": "cam-1", "text": "hello"},
+        headers={"X-Correlation-Id": "corr-abc-123"},
+    )
+    assert response.status_code == 200, response.text
+    # Adapter saw the threaded correlation_id
+    assert stub.last_correlation_id == "corr-abc-123"
+    # Response echoed the id back
+    assert response.headers.get("X-Correlation-Id") == "corr-abc-123"
+
+
+def test_v1_infer_mints_correlation_id_when_absent(kaic_app):
+    client, stub = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+    response = client.post("/api/v1/infer/stub-x", json={"camera_id": "cam-1"})
+    assert response.status_code == 200
+    # Adapter still got A correlation_id (minted server-side)
+    assert stub.last_correlation_id
+    assert len(stub.last_correlation_id) >= 16
+
+
+def test_v1_infer_unknown_adapter_returns_404(kaic_app):
+    client, _ = kaic_app
+    response = client.post("/api/v1/infer/nonexistent", json={})
+    assert response.status_code == 404
+
+
+# ── Audit emission via inference ───────────────────────────────────
+
+
+def test_inference_completed_audit_event_after_success(kaic_app, kaic_test_env):
+    client, _ = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+    client.post(
+        "/api/v1/infer/stub-x",
+        json={"camera_id": "cam-audit-test"},
+        headers={"X-Correlation-Id": "corr-audit-test"},
+    )
+    # Query the audit log
+    response = client.get("/api/v1/audit?adapter=stub-x&event_type=inference.completed")
+    body = response.json()
+    matching = [
+        e for e in body["events"]
+        if e.get("camera_id") == "cam-audit-test"
+    ]
+    assert matching, "expected inference.completed audit event"
+    assert matching[-1]["correlation_id"] == "corr-audit-test"
+
+
+def test_inference_failed_audit_event_on_adapter_error(kaic_app):
+    client, stub = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+    # Make the stub return a failure envelope
+    stub.infer_status_code = 400
+    stub.infer_response = {
+        "status": "error",
+        "error": {
+            "category": "transport_error", "code": "malformed_input",
+            "message": "bad", "transient": False, "details": {},
+        },
+    }
+    response = client.post("/api/v1/infer/stub-x", json={}, headers={"X-Correlation-Id": "corr-fail"})
+    assert response.status_code == 400
+    # Audit event recorded with error category
+    audit_response = client.get("/api/v1/audit?event_type=inference.failed")
+    matching = [e for e in audit_response.json()["events"] if e.get("correlation_id") == "corr-fail"]
+    assert matching
+    assert matching[-1]["error_category"] == "transport_error"
+    assert matching[-1]["error_code"] == "malformed_input"
+
+
+# ── Audit query filters ────────────────────────────────────────────
+
+
+def test_audit_query_limit_validation(kaic_app):
+    client, _ = kaic_app
+    response = client.get("/api/v1/audit?limit=0")
+    assert response.status_code == 400
+    response = client.get("/api/v1/audit?limit=99999")
+    assert response.status_code == 400
+
+
+def test_audit_query_filters_by_camera(kaic_app):
+    client, _ = kaic_app
+    client.post("/api/v1/adapters/register", json={"name": "stub-x", "url": "http://127.0.0.1:9100"})
+    client.post("/api/v1/infer/stub-x", json={"camera_id": "cam-a"})
+    client.post("/api/v1/infer/stub-x", json={"camera_id": "cam-b"})
+    response = client.get("/api/v1/audit?camera_id=cam-a")
+    body = response.json()
+    assert all(e.get("camera_id") == "cam-a" for e in body["events"] if "camera_id" in e)
+
+
+# ── Auth on v2 endpoints (regression for self-review SR-NEW-7) ────
+
+
+def test_v2_endpoints_require_internal_api_key_when_set(kaic_test_env, monkeypatch, tmp_path):
+    """Regression for self-review SR-NEW-7: when INTERNAL_API_KEY is set,
+    every v2 endpoint must reject anonymous calls."""
+    monkeypatch.setenv("INTERNAL_API_KEY", "production-secret-token")
+    if "main" in sys.modules:
+        importlib.reload(sys.modules["main"])
+    import main as kaic_main
+
+    stub = _StubAdapter()
+    transport = httpx.MockTransport(stub.respond)
+    original_init = kaic_main.AdapterRegistry.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["http_client"] = httpx.AsyncClient(transport=transport)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(kaic_main.AdapterRegistry, "__init__", patched_init)
+
+    from fastapi.testclient import TestClient
+    with TestClient(kaic_main.app) as client:
+        # Without the header → 401 on every v2 endpoint
+        for method, path, body in [
+            ("POST",   "/api/v1/adapters/register", {"name": "x", "url": "http://127.0.0.1:9100"}),
+            ("DELETE", "/api/v1/adapters/x",        None),
+            ("GET",    "/api/v1/adapters",          None),
+            ("GET",    "/api/v1/ai/capabilities",   None),
+            ("POST",   "/api/v1/adapters/refresh",  None),
+            ("POST",   "/api/v1/infer/x",           {}),
+            ("GET",    "/api/v1/audit",             None),
+        ]:
+            request_kwargs = {"json": body} if body is not None else {}
+            response = client.request(method, path, **request_kwargs)
+            assert response.status_code == 401, f"{method} {path} returned {response.status_code} (should be 401 without auth)"
+
+        # With the correct header → registration succeeds
+        response = client.post(
+            "/api/v1/adapters/register",
+            json={"name": "auth-test", "url": "http://127.0.0.1:9100"},
+            headers={"X-Internal-Api-Key": "production-secret-token"},
+        )
+        assert response.status_code == 200, response.text
+
+
+def test_register_rejects_malformed_url(kaic_app):
+    """Regression for self-review SR-NEW-8: malformed URLs produce a
+    422 validation error (Pydantic) before they reach the sovereignty
+    layer — operator sees 'bad URL', not a confusing 'sovereignty refused'."""
+    client, _ = kaic_app
+    response = client.post(
+        "/api/v1/adapters/register",
+        json={"name": "bad", "url": "this is not a url at all"},
+    )
+    assert response.status_code == 422, response.text

--- a/kai-c/test/test_registry.py
+++ b/kai-c/test/test_registry.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Registry tests — registration, polling, drift detection, deregistration."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+
+from kai_c.audit import AuditEventType, AuditStore
+from kai_c.contract_types import CapabilitiesResponse
+from kai_c.registry import AdapterRegistry
+from kai_c.sovereignty import SovereigntyViolation
+
+
+def _base_caps(*, fingerprint: str = "sha256:aaa", egress: list[str] | None = None, gpu: bool = False) -> dict:
+    return {
+        "adapter": {
+            "name": "test-adapter", "version": "1.0.0", "vendor": "open-nvr",
+            "license": "AGPL-3.0", "supported_contract_versions": ["1"],
+        },
+        "model": {
+            "name": "m1", "version": "v1", "framework": "f", "fingerprint": fingerprint,
+        },
+        "endpoints": {
+            "infer": {"supported": True, "input_content_types": ["application/json"]},
+            "infer_stream": {"supported": False},
+        },
+        "tasks_advertised": ["echo"],
+        "permissions": {
+            "gpu": gpu, "network_egress": egress or [],
+            "host_filesystem": [], "shared_memory_paths": [], "host_metadata": False,
+        },
+        "scheduling": {"max_inflight": 1, "preferred_batch_size": 1, "fair_queuing": "none"},
+        "cost": {"currency": "USD", "estimated_per_call": 0.0, "estimated_per_hour": 0.0,
+                 "rate_limit_per_minute": None, "is_metered": False},
+    }
+
+
+class _StubAdapter:
+    """Fake httpx response source backing a single adapter URL."""
+
+    def __init__(self, url: str, capabilities: dict, health_ok: bool = True) -> None:
+        self.url = url
+        self._caps = capabilities
+        self._health_ok = health_ok
+        self.call_count = 0
+
+    def update_capabilities(self, capabilities: dict) -> None:
+        self._caps = capabilities
+
+    def set_health(self, ok: bool) -> None:
+        self._health_ok = ok
+
+    async def respond(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        path = request.url.path
+        if path == "/capabilities":
+            return httpx.Response(200, json=self._caps)
+        if path == "/health":
+            if not self._health_ok:
+                return httpx.Response(503)
+            return httpx.Response(200, json={
+                "status": "ok",
+                "adapter_name": "test-adapter",
+                "adapter_version": "1.0.0",
+                "model_name": "m1",
+                "model_version": "v1",
+                "started_at": "2026-05-19T00:00:00Z",
+                "uptime_seconds": 1,
+            })
+        return httpx.Response(404)
+
+
+@pytest.fixture
+def audit(tmp_path: Path) -> AuditStore:
+    return AuditStore(path=str(tmp_path / "audit.jsonl"))
+
+
+@pytest.fixture
+def adapter_stub() -> _StubAdapter:
+    return _StubAdapter(url="http://127.0.0.1:9100", capabilities=_base_caps())
+
+
+@pytest.fixture
+async def registry(audit, adapter_stub):
+    """Build a registry whose http client is wired through the stub."""
+    transport = httpx.MockTransport(adapter_stub.respond)
+    client = httpx.AsyncClient(transport=transport)
+    reg = AdapterRegistry(
+        sovereignty_mode="local_only", audit=audit, http_client=client,
+        poll_interval_seconds=999,  # disable auto-poll
+    )
+    yield reg
+    await reg.aclose()
+
+
+# ── Registration ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_stores_adapter_and_emits_audit_event(registry, adapter_stub, audit):
+    adapter = await registry.register("yolov8", adapter_stub.url)
+    assert adapter.name == "yolov8"
+    assert adapter.fingerprint == "sha256:aaa"
+    assert registry.get("yolov8") is not None
+
+    rows = audit.read_all()
+    assert any(r["type"] == "adapter.registered" and r["adapter"] == "yolov8" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_register_refuses_under_local_only_with_egress(audit):
+    caps_with_egress = _base_caps(egress=["api.openai.com"])
+    stub = _StubAdapter("http://127.0.0.1:9100", caps_with_egress)
+    transport = httpx.MockTransport(stub.respond)
+    client = httpx.AsyncClient(transport=transport)
+    reg = AdapterRegistry(sovereignty_mode="local_only", audit=audit, http_client=client)
+    try:
+        with pytest.raises(SovereigntyViolation, match="network_egress"):
+            await reg.register("bad", stub.url)
+        assert reg.get("bad") is None
+    finally:
+        await reg.aclose()
+
+
+# ── Refresh / drift ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_fingerprint_drift_emits_event(registry, adapter_stub, audit):
+    await registry.register("yolov8", adapter_stub.url)
+    # Rotate the weights — fingerprint changes
+    adapter_stub.update_capabilities(_base_caps(fingerprint="sha256:bbb"))
+    await registry.refresh("yolov8")
+    rows = audit.read_all()
+    drift = [r for r in rows if r["type"] == "adapter.fingerprint_mismatch"]
+    assert len(drift) == 1
+    assert drift[0]["previous_fingerprint"] == "sha256:aaa"
+    assert drift[0]["current_fingerprint"] == "sha256:bbb"
+
+
+@pytest.mark.asyncio
+async def test_refresh_adds_permission_deregisters(registry, adapter_stub, audit):
+    """§11.3 blocking change: adding a permission de-registers the adapter."""
+    await registry.register("yolov8", adapter_stub.url)
+    # Adapter now claims it needs GPU permission — under §11.3 this is a
+    # blocking drift event.
+    adapter_stub.update_capabilities(_base_caps(gpu=True))
+    await registry.refresh("yolov8")
+    assert registry.get("yolov8") is None  # de-registered
+    rows = audit.read_all()
+    drift = [r for r in rows if r["type"] == "adapter.capability_drift"]
+    assert any("gpu" in r.get("added_permissions", []) for r in drift)
+
+
+@pytest.mark.asyncio
+async def test_refresh_adds_egress_under_local_only_deregisters(registry, adapter_stub, audit):
+    """Adapter that ADDS network_egress at runtime under local_only
+    gets refused on the next poll."""
+    await registry.register("yolov8", adapter_stub.url)
+    adapter_stub.update_capabilities(_base_caps(egress=["api.openai.com"]))
+    await registry.refresh("yolov8")
+    assert registry.get("yolov8") is None
+    rows = audit.read_all()
+    assert any(r["type"] == "inference.refused_sovereignty" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_refresh_health_failures_emit_unavailable(registry, adapter_stub, audit):
+    """Three consecutive /health failures → adapter.unavailable audit."""
+    await registry.register("yolov8", adapter_stub.url)
+    adapter_stub.set_health(False)
+    for _ in range(3):
+        await registry.refresh("yolov8")
+    rows = audit.read_all()
+    assert any(r["type"] == "adapter.unavailable" for r in rows)
+
+
+# ── Deregister ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deregister_removes_and_emits(registry, adapter_stub, audit):
+    await registry.register("yolov8", adapter_stub.url)
+    await registry.deregister("yolov8")
+    assert registry.get("yolov8") is None
+    rows = audit.read_all()
+    assert any(r["type"] == "adapter.deregistered" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_deregister_unknown_is_noop(registry):
+    # Should not raise
+    await registry.deregister("does-not-exist")
+
+
+# ── Listing / aggregation ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_summaries_includes_registered_adapters(registry, adapter_stub):
+    await registry.register("yolov8", adapter_stub.url)
+    summaries = registry.list_summaries()
+    assert len(summaries) == 1
+    assert summaries[0]["name"] == "yolov8"
+    assert summaries[0]["fingerprint"] == "sha256:aaa"
+    assert "echo" in summaries[0]["tasks_advertised"]
+
+
+@pytest.mark.asyncio
+async def test_aggregated_capabilities_includes_sovereignty_mode(registry, adapter_stub):
+    await registry.register("yolov8", adapter_stub.url)
+    agg = registry.aggregated_capabilities()
+    assert agg["sovereignty_mode"] == "local_only"
+    assert agg["contract_version"] == "1"
+    assert "yolov8" in agg["adapters"]
+
+
+# ── Forward compatibility (peer-review PR-5) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_tolerates_unknown_capability_fields(audit):
+    """Regression for peer-review PR-5: if an adapter's /capabilities
+    response includes a future contract field KAI-C doesn't recognize,
+    KAI-C must still parse and register the adapter (extra='ignore'
+    on vendored types). Strict-server, lenient-client per Postel."""
+    caps_with_future_field = _base_caps()
+    caps_with_future_field["future_extension"] = {"some_new_thing": True}
+    caps_with_future_field["adapter"]["future_capability_signal"] = "x"
+    caps_with_future_field["model"]["future_metric"] = 42.0
+
+    stub = _StubAdapter("http://127.0.0.1:9100", caps_with_future_field)
+    transport = httpx.MockTransport(stub.respond)
+    client = httpx.AsyncClient(transport=transport)
+    reg = AdapterRegistry(sovereignty_mode="local_only", audit=audit, http_client=client)
+    try:
+        adapter = await reg.register("future-adapter", stub.url)
+        assert adapter is not None
+        assert adapter.fingerprint == "sha256:aaa"
+    finally:
+        await reg.aclose()

--- a/kai-c/test/test_sovereignty.py
+++ b/kai-c/test/test_sovereignty.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Sovereignty enforcement v2 tests — including the network_egress
+tightening that A2.4 adds vs. the M1a loopback-only check."""
+from __future__ import annotations
+
+import pytest
+
+from kai_c.contract_types import (
+    AdapterInfo,
+    CapabilitiesResponse,
+    EndpointsInfo,
+    InferEndpointInfo,
+    ModelInfo,
+    Permissions,
+    Scheduling,
+    StreamEndpointInfo,
+)
+from kai_c.sovereignty import (
+    SovereigntyViolation,
+    check_adapter,
+    host_is_loopback,
+)
+
+
+def _caps(*, egress: list[str] | None = None) -> CapabilitiesResponse:
+    return CapabilitiesResponse(
+        adapter=AdapterInfo(
+            name="test-adapter", version="1.0.0", vendor="x", license="MIT",
+            supported_contract_versions=["1"],
+        ),
+        model=ModelInfo(name="m", version="1", framework="f"),
+        endpoints=EndpointsInfo(
+            infer=InferEndpointInfo(supported=True),
+            infer_stream=StreamEndpointInfo(supported=False),
+        ),
+        permissions=Permissions(network_egress=egress or []),
+        scheduling=Scheduling(),
+    )
+
+
+# ── host_is_loopback ───────────────────────────────────────────────
+
+
+def test_host_is_loopback_recognises_common_forms():
+    assert host_is_loopback("localhost")
+    assert host_is_loopback("127.0.0.1")
+    assert host_is_loopback("::1")
+    assert host_is_loopback("[::1]")  # bracketed IPv6
+
+
+def test_host_is_loopback_rejects_routable():
+    assert not host_is_loopback("8.8.8.8")
+    assert not host_is_loopback("example.com")
+    assert not host_is_loopback("0.0.0.0")  # wildcard bind, not loopback
+    assert not host_is_loopback(None)
+    assert not host_is_loopback("")
+
+
+# ── local_only mode ────────────────────────────────────────────────
+
+
+def test_local_only_accepts_loopback_url_no_egress():
+    check_adapter(
+        sovereignty_mode="local_only",
+        adapter_url="http://127.0.0.1:9100",
+        capabilities=_caps(egress=[]),
+    )
+
+
+def test_local_only_refuses_non_loopback_url():
+    with pytest.raises(SovereigntyViolation, match="non-loopback"):
+        check_adapter(
+            sovereignty_mode="local_only",
+            adapter_url="http://192.168.1.10:9100",
+            capabilities=None,
+        )
+
+
+def test_local_only_refuses_wildcard_bind():
+    with pytest.raises(SovereigntyViolation, match="0.0.0.0"):
+        check_adapter(
+            sovereignty_mode="local_only",
+            adapter_url="http://0.0.0.0:9100",
+            capabilities=None,
+        )
+
+
+def test_local_only_refuses_loopback_url_with_egress_declared():
+    """A2.4 tightening: under local_only, even loopback adapters get
+    refused if they advertise non-empty permissions.network_egress
+    (because that means they're a cloud-proxy)."""
+    with pytest.raises(SovereigntyViolation, match="network_egress"):
+        check_adapter(
+            sovereignty_mode="local_only",
+            adapter_url="http://127.0.0.1:9100",
+            capabilities=_caps(egress=["api.openai.com"]),
+        )
+
+
+# ── federated mode ─────────────────────────────────────────────────
+
+
+def test_federated_accepts_explicit_egress_list():
+    check_adapter(
+        sovereignty_mode="federated",
+        adapter_url="http://192.168.1.10:9100",
+        capabilities=_caps(egress=["api-inference.huggingface.co", "models.example.com"]),
+    )
+
+
+def test_federated_refuses_wildcard_egress():
+    with pytest.raises(SovereigntyViolation, match="wildcard"):
+        check_adapter(
+            sovereignty_mode="federated",
+            adapter_url="http://192.168.1.10:9100",
+            capabilities=_caps(egress=["*.example.com"]),
+        )
+
+
+# ── cloud_allowed mode ─────────────────────────────────────────────
+
+
+def test_cloud_allowed_skips_all_checks():
+    # Even wildcards under non-loopback URL — cloud_allowed lets it through.
+    check_adapter(
+        sovereignty_mode="cloud_allowed",
+        adapter_url="https://external.example.com",
+        capabilities=_caps(egress=["*"]),
+    )
+
+
+# ── Invalid mode ───────────────────────────────────────────────────
+
+
+def test_invalid_mode_raises():
+    with pytest.raises(SovereigntyViolation, match="invalid"):
+        check_adapter(
+            sovereignty_mode="banana",
+            adapter_url="http://127.0.0.1:9100",
+            capabilities=None,
+        )


### PR DESCRIPTION
Adds the load-bearing artefact for the AI architecture refactor: a versioned HTTP/WebSocket contract every adapter implements, plus the trust + popularity story the platform needs.

  docs/AI_ADAPTER_CONTRACT.md  +1257

The doc covers: TL;DR for four reader frames, six mandatory endpoints with a 30-line minimum-viable example and bearer-token auth + correlation_id wire spec, full /capabilities shape with optional model.fingerprint for tamper detection, four inference output conventions, WebSocket streaming protocol with optional shared-memory fast path, six-category failure envelope plus 13 canonical error codes, permission declaration with mandatory operator-approval gate, per-camera fair queuing, KAI-C aggregator with sovereignty enforcement / audit-trail + SIEM export / capability-drift handling / conformance kit + two SDKs / built-in and app-emitted alerts with seven channels, camera identifiers with ONVIF vendor support, 12-row use-case catalogue, three-lane community publishing flow with conformance badge, and an 8-adapter migration matrix in dependency-safe order.

The Pydantic skeleton codifying every wire shape from this doc lives in ai-adapter/app/interfaces/contract.py (separate commit in that repo). Verified against every JSON example here: 19/19 round-trip tests pass.

Nothing wired up yet — A2 migrates BaseAdapter and the first reference adapter (YOLOv8) onto the contract types and ships the conformance kit + SDKs.