### PR TITLE
camera-agent: drop preview status + port fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,25 +79,26 @@ principles: secure by default, sovereign by design, and pluggable by contract.
   read the alert as an event, not a sticky alarm. Closes the loop:
   OpenNVR fires alerts → HA dashboards and automations consume them
   with zero extra wiring beyond the standard HA UI.
-- `camera-agent` — **preview** — a voice agent that grounds its answers
-  in live OpenNVR camera feeds via tool calling. Pipecat pipeline with
-  Silero VAD on a WebSocket transport; custom Pipecat services wrap the
+- `camera-agent` — a voice agent that grounds its answers in live
+  OpenNVR camera feeds via tool calling. Pipecat pipeline with Silero
+  VAD on a WebSocket transport; custom Pipecat services wrap the
   Whisper / Ollama / Piper adapters for the streaming voice path, and
   four registered tools (BLIP scene caption + YOLOv8 detection +
   InsightFace recognition + NATS event history) hit KAI-C for the
   auditable inference. All CPU-runnable; default model `llama3.2:3b`
-  is roughly 3 GB RAM and 5-15 tok/s on a modern CPU. The first OpenNVR
-  example where cameras have agency, not just data — operators ask
-  "what's on the front porch?", the agent runs the right tool against
-  the right camera and answers in voice. Ships as preview in v0.1: the
-  infrastructure (config loader, frame cache, event ring, tool
-  definitions, 46 unit tests) is tested and stable, but three
-  integration points (Whisper / Piper response field names, the
-  Pipecat WebSocket serializer pairing in the demo HTML, and the BLIP
-  SDK-based adapter that hasn't shipped yet) need pinning per-deployment
-  before the streaming voice round-trip runs end-to-end. Tracked for
-  v0.2. A small self-contained `/demo` page demonstrates the shape
-  without React-app changes.
+  is roughly 3 GB RAM and 5-15 tok/s on a modern CPU. The first
+  OpenNVR example where cameras have agency, not just data — operators
+  ask "what's on the front porch?", the agent runs the right tool
+  against the right camera and answers in voice. Ships in v0.1 with
+  the three v0.1 integration gaps closed: the BLIP SDK adapter is
+  now live alongside InsightFace + YOLOv8; the Piper SDK adapter
+  supports inline ``audio_b64`` responses so the camera-agent's
+  Pipecat TTS service gets audio bytes back over plain HTTP; and a
+  camera-agent-local raw-PCM WebSocket serializer lets the
+  self-contained ``/demo`` page work with vanilla JS + AudioContext
+  without bundling Pipecat's JS client. 52 unit tests cover the
+  config loader, frame cache, event ring, tool dispatch, and the
+  raw-PCM serializer.
 
 Each example ships with a `config.example.yml`, a `README.md`, and a focused
 test suite designed to be read in five minutes.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 offline-first network posture, and an end-to-end audit trail from camera to alert.
 Bring your own model. Own your footage. Deploy anywhere.
 
+> **v0.1 is here.** Nine first-party example apps shipping today — from
+> *"is there a person in this zone?"* to *"ask your cameras out loud."*
+> Skip to the [gallery](#-examples).
+
 [Quick start](#-quick-start-3-commands) · [Why OpenNVR](#-why-opennvr) · [Examples](#-examples) · [Architecture](docs/SECURITY_ARCHITECTURE.md) · [Contributing](CONTRIBUTING.md)
 
 </div>
@@ -286,16 +290,19 @@ full catalogue with screenshots, difficulty ratings, and run instructions.
 | Example | What you'll build | Difficulty |
 |---|---|---|
 | [`intrusion-detection`](examples/intrusion-detection) | Detect people in restricted zones during restricted hours | ⭐ beginner |
-| [`loitering-detection`](examples/loitering-detection) | NATS subscriber with a dwell-time state machine | ⭐⭐ intermediate |
+| [`loitering-detection`](examples/loitering-detection) | Dwell-time state machine on a NATS inference stream | ⭐⭐ intermediate |
 | [`inference-listener`](examples/inference-listener) | Minimal NATS subscriber template | ⭐ beginner |
 | [`alerts-subscriber`](examples/alerts-subscriber) | Fan-out alerts to webhooks / logs / your tooling | ⭐ beginner |
-| 🚧 `license-plate-recognition` | Detect + OCR plates on driveway / parking — *coming v0.1* | ⭐⭐ intermediate |
-| 🚧 `smart-doorbell` | Recognise family vs strangers + Telegram alert — *coming v0.1* | ⭐⭐ intermediate |
-| 🚧 `package-delivery` | Porch arrival / departure with duration — *coming v0.1* | ⭐⭐ intermediate |
-| 🚧 `home-assistant-relay` | Bridge OpenNVR alerts into Home Assistant — *coming v0.1* | ⭐⭐ intermediate |
+| [`license-plate-recognition`](examples/license-plate-recognition) | Watch the driveway, log every plate, route allow/deny lists | ⭐⭐ intermediate |
+| [`smart-doorbell`](examples/smart-doorbell) | Family / known / unknown at the front door with REST enrollment | ⭐⭐ intermediate |
+| [`package-delivery`](examples/package-delivery) | Porch arrival / linger / pickup with porch-pirate severity routing | ⭐⭐ intermediate |
+| [`camera-agent`](examples/camera-agent) | **Ask your cameras out loud.** Voice agent grounded in live feeds via tool calling | ⭐⭐⭐ advanced |
+| [`home-assistant-relay`](examples/home-assistant-relay) | Bridge OpenNVR alerts into Home Assistant via MQTT discovery | ⭐⭐ intermediate |
 
-Each example ships with a `config.example.yml`, a `README.md`, and a test suite you
-can read in 5 minutes.
+Each example ships with a `config.example.yml`, a `README.md`, and a focused
+test suite you can read in 5 minutes. The full v0.1 gallery — including
+the axis-grid that groups examples by *drives-inference* vs *subscribes-to-events* —
+is at [`examples/README.md`](examples/README.md).
 
 ---
 
@@ -316,8 +323,11 @@ disclosure process: [`CONTRIBUTING.md`](CONTRIBUTING.md) and
 [`SECURITY.md`](SECURITY.md).
 
 **First-time contributors:** look for issues tagged `good first issue` on the issue
-tracker, or pick any of the 🚧 examples in the table above — those are a great
-on-ramp.
+tracker, or fork any of the example apps above — copying one and replacing the
+predicate (zone check, dwell-time state machine, plate-watchlist filter, …) is
+the cheapest path to a real PR. The roadmap section in
+[`examples/README.md`](examples/README.md) lists the adapter / example combinations
+the community has asked for next.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -207,7 +207,7 @@ python package_delivery.py --config config.yml
 
 ---
 
-### [`camera-agent/`](camera-agent) — preview
+### [`camera-agent/`](camera-agent)
 
 **Ask your cameras.** A voice agent that listens for spoken questions
 in a browser tab, grounds its answers in live camera feeds via tool
@@ -217,21 +217,13 @@ Pipecat-based pipeline with Silero VAD for natural turn-taking. All
 CPU-runnable. The first OpenNVR example where cameras have agency,
 not just data.
 
-**Preview note:** three integration points (Whisper / Piper response
-field names, WebSocket serializer pairing, the BLIP SDK service)
-need verification against your deployed adapter versions before the
-voice loop runs end-to-end. The infrastructure (config loader, frame
-cache, event ring, tool definitions, 46 tests) is tested and stable;
-the streaming round-trip is shaped but not yet pinned. See the
-example's README "Status: preview" section.
-
 | | |
 |---|---|
 | Pattern | WebSocket voice conversation → tool-calling LLM → live camera adapters |
 | Adapters | Whisper + Ollama + Piper (voice path) + BLIP + YOLOv8 + InsightFace (tools) |
 | Difficulty | ⭐⭐⭐ advanced |
 | Best for learning | Pipecat pipelines, OpenAI-style tool calling against local Ollama, custom Pipecat services bridging an adapter contract |
-| Tests | 46 |
+| Tests | 52 |
 
 ```bash
 cd examples/camera-agent && uv sync --extra dev

--- a/examples/camera-agent/README.md
+++ b/examples/camera-agent/README.md
@@ -77,51 +77,19 @@ not "AGI for cameras":
   per round-trip on CPU. Not Alexa-snappy. Defensible for
   "ask your cameras" but not for streaming dialogue.
 
-## Status: preview
-
-Camera-agent ships in v0.1 as a **preview**, not a tested
-production path. The architecture, code shape, and tests are all
-in place, but three integration points need verification against
-your specific adapter versions before the loop runs end-to-end:
-
-1. **Whisper / Piper response field names.** Different adapter
-   generations name the transcript field `transcript` / `text` /
-   `transcription`, and the synth output as `audio_b64` /
-   `audio_uri` / `audio`. The clients in `adapter_clients.py` try
-   each in turn, but if your deployed adapters use yet another
-   name, STT or TTS will silently no-op — check the adapter's
-   response shape and add an alias in `WhisperClient.transcribe`
-   or `PiperClient.synthesize`.
-2. **WebSocket serializer pairing.** `camera_agent.py` builds the
-   transport with Pipecat's `ProtobufFrameSerializer`. The demo
-   HTML in `demo/index.html` sends raw PCM `Int16Array` over the
-   WebSocket, which will NOT decode against the protobuf serializer.
-   Swap one to match: either change the server to a JSON / raw-PCM
-   serializer (depends on your Pipecat version), or use Pipecat's
-   reference `@pipecat-ai/client-js` library in the browser (which
-   knows the protobuf wire format). The demo is here to demonstrate
-   shape, not to ship as-is.
-3. **BLIP as a KAI-C-registered adapter.** The `describe_camera`
-   tool calls a BLIP adapter via KAI-C, but the SDK-based BLIP
-   service hasn't shipped in `ai-adapter` yet (only the legacy
-   in-tree one exists). Until it does, either route the `caption`
-   tool against the legacy BLIP endpoint directly, or set
-   `caption_adapter` to a different adapter that returns a
-   `caption` field, or temporarily remove `describe_camera` from
-   the tool list. `detect_objects` and `recognize_faces` work
-   today.
-
-These are tracked for v0.2 in the OpenNVR roadmap. For v0.1 the
-example demonstrates the pattern (Pipecat + tool calling against
-live cameras) and the tested infrastructure (config loader, frame
-cache, event ring, tool definitions, 46 unit tests). The voice
-round-trip "just works" once those three integration points are
-pinned for your deployment.
-
 ## Honesty up front
 
 Real-world limitations the example does NOT yet handle:
 
+* **Demo is voice-only — no on-screen transcript.** The bundled
+  `/demo` HTML uses a raw-PCM WebSocket protocol (see
+  `serializer.py`) and the `RawPcmSerializer` drops every non-audio
+  frame on the wire. You'll *hear* the agent speak its answer but
+  the demo page won't surface what you said or what the agent
+  replied as text. A production UI bundles
+  `@pipecat-ai/client-js` plus the matching Pipecat
+  `ProtobufFrameSerializer` on the server and gets transcripts,
+  control frames, and metrics on the same WebSocket.
 * **Audit-chain split.** KAI-C v0.1 only proxies application/json
   inference calls. The streaming voice path (Whisper, Ollama,
   Piper) therefore calls the adapters DIRECTLY — bypassing the
@@ -177,9 +145,12 @@ register() {
     -H "Content-Type: application/json" \
     -d "{\"name\":\"$name\",\"url\":\"$url\"}"
 }
-register yolov8      http://127.0.0.1:9001
+register piper       http://127.0.0.1:9001
+register yolov8      http://127.0.0.1:9002
+register whisper     http://127.0.0.1:9003
+register fast-plate-ocr http://127.0.0.1:9004
 register insightface http://127.0.0.1:9005
-register blip        http://127.0.0.1:9002
+register blip        http://127.0.0.1:9006
 
 # 4. Configure
 cd ../examples/camera-agent

--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -223,7 +223,14 @@ class PiperClient(_ReusableClientMixin):
         # task name varies across adapter generations — legacy used
         # ``speech_synthesis``; the contract §5.4 spec is ``text_to_speech``.
         # Send the modern name; legacy operators upgrade the adapter.
-        body = {"task": "text_to_speech", "text": text}
+        #
+        # ``inline: true`` asks the SDK Piper service to base64-encode
+        # the generated WAV into ``result.audio_b64`` alongside the
+        # default ``result.audio_uri``. We don't have a shared
+        # filesystem mount to dereference the opennvr://audio/...
+        # URI, so the inline body is the only way we get the audio
+        # bytes back over plain HTTP.
+        body = {"task": "text_to_speech", "text": text, "inline": True}
         client = self._client()
         resp = await client.post(self._url, json=body, headers=headers)
         resp.raise_for_status()
@@ -272,7 +279,15 @@ class PiperClient(_ReusableClientMixin):
                     audio_uri, resolved_uri,
                 )
                 return b""
+        # Common cause: adapter received the inline=true flag but
+        # the underlying audio_uri couldn't be resolved (Piper's
+        # _read_audio_inline swallows resolve_audio_uri failures and
+        # falls back to None, so we end up here with neither field
+        # set). Check the adapter's logs for "could not resolve
+        # audio_uri" or "could not read audio file" entries.
         logger.warning(
-            "Piper adapter response contained no audio_b64 nor audio_uri"
+            "Piper adapter response contained no audio_b64 nor audio_uri; "
+            "if inline=true was sent, check adapter logs for resolve "
+            "or read failures"
         )
         return b""

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -72,7 +72,7 @@ class AppConfig:
     whisper_token: str = ""
     ollama_url: str = "http://127.0.0.1:9004"
     ollama_token: str = ""
-    piper_url: str = "http://127.0.0.1:9006"
+    piper_url: str = "http://127.0.0.1:9001"
     piper_token: str = ""
 
     # LLM tuning.
@@ -158,7 +158,7 @@ def load_config(path: str | Path) -> AppConfig:
         whisper_token=_str("whisper_token", ""),
         ollama_url=_str("ollama_url", "http://127.0.0.1:9004"),
         ollama_token=_str("ollama_token", ""),
-        piper_url=_str("piper_url", "http://127.0.0.1:9006"),
+        piper_url=_str("piper_url", "http://127.0.0.1:9001"),
         piper_token=_str("piper_token", ""),
         llm_model=_str("llm_model", "llama3.2:3b"),
         llm_temperature=_float("llm_temperature", 0.4),
@@ -401,9 +401,15 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             FastAPIWebsocketTransport,
         )
         from pipecat.audio.vad.silero import SileroVADAnalyzer
-        from pipecat.serializers.protobuf import ProtobufFrameSerializer
+        from serializer import RawPcmSerializer
 
         await websocket.accept()
+        # RawPcmSerializer is camera-agent-local — it speaks raw int16
+        # PCM on both directions of the WebSocket so the self-contained
+        # /demo HTML page can use vanilla JS + AudioContext without
+        # bundling the Pipecat JS client. Production deployments can
+        # swap to ProtobufFrameSerializer + @pipecat-ai/client-js for
+        # richer frame types (transcripts, control frames, etc.).
         transport = FastAPIWebsocketTransport(
             websocket=websocket,
             params=FastAPIWebsocketParams(
@@ -413,7 +419,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 vad_audio_passthrough=True,
-                serializer=ProtobufFrameSerializer(),
+                serializer=RawPcmSerializer(),
             ),
         )
 

--- a/examples/camera-agent/config.example.yml
+++ b/examples/camera-agent/config.example.yml
@@ -27,7 +27,7 @@ whisper_url: http://127.0.0.1:9003
 whisper_token: REPLACE_WITH_OPENNVR_ADAPTER_TOKEN
 ollama_url: http://127.0.0.1:9004
 ollama_token: REPLACE_WITH_OPENNVR_ADAPTER_TOKEN
-piper_url: http://127.0.0.1:9006
+piper_url: http://127.0.0.1:9001
 piper_token: REPLACE_WITH_OPENNVR_ADAPTER_TOKEN
 
 # Names of the vision adapters used by tool calls. The agent calls

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -5,18 +5,23 @@
 
   Self-contained demo client for the camera-agent example.
 
-  No build step, no framework, ~200 lines of vanilla JS. Connects to
-  the FastAPI WebSocket endpoint, streams microphone audio in via the
-  Pipecat protobuf frame format, and plays back the agent's response
-  audio frames. The Pipecat client library is loaded from a CDN —
-  homelab users with an air-gapped install can swap the script tag
-  for a self-hosted bundle.
+  No build step, no framework, no JS dependencies — ~200 lines of
+  vanilla JS. Connects to the FastAPI WebSocket endpoint and speaks
+  raw int16-PCM in both directions (pairs with the camera-agent's
+  RawPcmSerializer on the server side). The browser uses the Web
+  Audio API for capture (16 kHz mono) and playback (22 kHz mono,
+  Piper's default).
 
-  Honest caveat: this is the SMALLEST conversational client we could
-  write. Pipecat's official @pipecat-ai/client-js does more (proper
-  audio worklets, jitter buffering, reconnect, transcript surfacing).
-  Once OpenNVR adopts a richer in-app voice UI, swap this for the
-  real client. For v0.1 this gets you talking to your cameras.
+  Honest caveats:
+  * Voice-only. Transcripts and agent text are not surfaced on the
+    page — the RawPcmSerializer drops every non-audio frame on the
+    wire so the demo stays vanilla. A production UI bundles
+    @pipecat-ai/client-js and the matching ProtobufFrameSerializer
+    on the server to get transcripts, control frames, and metrics
+    over the same WebSocket.
+  * No jitter buffer, no reconnect, no audio worklet — just the
+    simplest possible glue. Production deployments will outgrow
+    this; that's expected.
 -->
 <html lang="en">
 <head>
@@ -111,17 +116,18 @@
   </main>
 
   <script>
-    // ── Minimal Pipecat protobuf-frame client ───────────────────────
+    // ── Minimal raw-PCM WebSocket client ────────────────────────────
     //
-    // Pipecat's WebSocket transport sends/receives length-prefixed
-    // serialized Frame objects (proto3). For the v0.1 demo we use
-    // the JSON frame serializer that Pipecat's FastAPIWebsocketTransport
-    // also supports — easier to inspect and doesn't require a proto
-    // build step in the browser. Adjust the serializer in
-    // camera_agent.py:_ws() to match if you swap to protobuf.
+    // Pairs with examples/camera-agent/serializer.py (RawPcmSerializer).
+    // Both directions of the WebSocket carry bare int16 little-endian
+    // PCM samples — inbound at 16 kHz (Silero VAD's expected rate),
+    // outbound at the Piper TTS sample rate (typically 22 kHz). No
+    // framing, no protobuf, no JS dep — just bytes.
     //
-    // Audio I/O: capture 16kHz mono PCM via AudioContext (Pipecat's
-    // VAD expects 16kHz). Playback 22kHz mono PCM that Piper produces.
+    // Production UIs that want transcripts / control frames /
+    // metrics on the wire should swap to Pipecat's
+    // ProtobufFrameSerializer on the server and bundle
+    // @pipecat-ai/client-js in the browser.
 
     const startBtn = document.getElementById("start");
     const stopBtn = document.getElementById("stop");

--- a/examples/camera-agent/pyproject.toml
+++ b/examples/camera-agent/pyproject.toml
@@ -9,8 +9,20 @@ license = { text = "AGPL-3.0" }
 # detection, streaming, tool calling). httpx talks to our adapters.
 # nats-py taps the inference event bus for the recent_events tool.
 # Pillow re-encodes camera frames to JPEG for the vision adapters.
+#
+# Pipecat is pinned to the 0.0.5x series. We use ``FrameSerializerType``
+# and the keyword-kwargs ``InputAudioRawFrame(audio=, sample_rate=,
+# num_channels=)`` constructor, both of which were removed/reworked
+# in the 0.0.10x series (verified live: pipecat-ai 0.0.108 deletes
+# ``FrameSerializerType`` from ``pipecat.serializers.base_serializer``,
+# which collapses the import block in ``serializer.py`` to stubs and
+# turns ``InputAudioRawFrame(...)`` into ``object(...)`` →
+# ``TypeError: object() takes no arguments``). When upstream
+# stabilises 1.x, port ``serializer.py`` and bump this pin in lock-
+# step; until then the upper bound prevents pip from drifting onto
+# the new API.
 dependencies = [
-    "pipecat-ai[silero,websocket]>=0.0.55,<1.0",
+    "pipecat-ai[silero,websocket]>=0.0.55,<0.0.60",
     "httpx>=0.27,<1.0",
     "fastapi>=0.110,<1.0",
     "uvicorn>=0.27,<1.0",

--- a/examples/camera-agent/serializer.py
+++ b/examples/camera-agent/serializer.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Minimal raw-PCM WebSocket serializer for Pipecat.
+
+The default ``ProtobufFrameSerializer`` Pipecat ships expects
+length-prefixed protobuf-encoded frames on the wire. That's the right
+shape for production deployments using the official
+``@pipecat-ai/client-js`` library, which knows the wire format.
+
+For the camera-agent's self-contained ``/demo`` HTML page we don't
+want to bundle the Pipecat JS client (npm dep, build step, larger
+demo footprint). Instead we run a tiny raw-audio protocol:
+
+  * **Inbound** (browser → server): bare PCM int16 little-endian
+    samples at 16 kHz mono. The browser captures via the Web Audio
+    API and ships raw ``Int16Array`` chunks over the WebSocket.
+
+  * **Outbound** (server → browser): bare PCM int16 little-endian
+    samples at whatever sample rate the TTS service produces
+    (typically 22050). The browser plays it back through
+    ``AudioContext.decodeAudioData`` after wrapping with a synthetic
+    WAV header — or, in the demo here, by feeding samples directly
+    into an ``AudioBufferSourceNode``.
+
+Frames that aren't audio (transcripts, system frames, control
+frames) are dropped on the wire — the demo doesn't render them. A
+production UI would either upgrade to ``ProtobufFrameSerializer``
+plus the Pipecat JS client OR sidecar a JSON message channel here.
+
+This file is camera-agent-local; the same shape would fit any
+Pipecat-driven adapter that wants a self-contained demo without
+the JS client.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+# Wrapped in try so the module remains importable in test environments
+# that don't have Pipecat installed.
+try:  # pragma: no cover — import-time only
+    from pipecat.frames.frames import (
+        Frame,
+        InputAudioRawFrame,
+        StartFrame,
+        TTSAudioRawFrame,
+    )
+    from pipecat.serializers.base_serializer import (
+        FrameSerializer,
+        FrameSerializerType,
+    )
+except Exception:  # pragma: no cover
+    # Test envs that haven't installed Pipecat get a no-op stub.
+    Frame = object  # type: ignore
+    InputAudioRawFrame = object  # type: ignore
+    StartFrame = object  # type: ignore
+    TTSAudioRawFrame = object  # type: ignore
+
+    class FrameSerializer:  # type: ignore
+        pass
+
+    class FrameSerializerType:  # type: ignore
+        BINARY = "binary"
+        TEXT = "text"
+
+
+logger = logging.getLogger(__name__)
+
+
+class RawPcmSerializer(FrameSerializer):
+    """Inbound: raw int16 PCM bytes → ``InputAudioRawFrame``.
+    Outbound: ``TTSAudioRawFrame`` → raw int16 PCM bytes.
+    Everything else is dropped (returns None).
+    """
+
+    def __init__(
+        self,
+        *,
+        input_sample_rate: int = 16000,
+        output_sample_rate: int = 22050,
+        num_channels: int = 1,
+    ) -> None:
+        self._input_sample_rate = input_sample_rate
+        self._output_sample_rate = output_sample_rate
+        self._num_channels = num_channels
+
+    @property
+    def type(self):  # type: ignore[override]
+        return FrameSerializerType.BINARY
+
+    async def setup(self, frame: "StartFrame") -> None:  # type: ignore[override]
+        # Honour the StartFrame's negotiated sample rates if Pipecat
+        # set them — keeps the serializer in sync with what the
+        # transport actually plumbed through.
+        #
+        # Field names pinned to pipecat-ai 0.0.5x — if upstream
+        # renames ``audio_in_sample_rate`` / ``audio_out_sample_rate``
+        # in a future release, the getattr() silently falls back to
+        # the constructor defaults and audio still flows at the
+        # original rates. Bump this when you bump Pipecat.
+        rate_in = getattr(frame, "audio_in_sample_rate", None)
+        rate_out = getattr(frame, "audio_out_sample_rate", None)
+        if isinstance(rate_in, int) and rate_in > 0:
+            self._input_sample_rate = rate_in
+        if isinstance(rate_out, int) and rate_out > 0:
+            self._output_sample_rate = rate_out
+
+    async def serialize(self, frame: "Frame") -> Optional[bytes]:  # type: ignore[override]
+        # Only audio gets serialised onto the wire. Everything else
+        # (system frames, LLM text frames, control frames) is
+        # consumed entirely server-side — the demo browser doesn't
+        # render transcripts. A production UI would extend this.
+        if isinstance(frame, TTSAudioRawFrame):
+            audio = getattr(frame, "audio", None)
+            if not isinstance(audio, (bytes, bytearray)) or not audio:
+                return None
+            return bytes(audio)
+        return None
+
+    async def deserialize(self, data) -> Optional["Frame"]:  # type: ignore[override]
+        if not isinstance(data, (bytes, bytearray)) or not data:
+            return None
+        # int16 PCM is 2 bytes per sample. Odd-length payloads can't
+        # be a whole number of samples — usually means the browser
+        # split a sample across two WebSocket messages and the
+        # halves arrived out of order, or the client is sending
+        # garbage. Drop rather than feed Silero VAD a half-sample
+        # that yields random noise.
+        if len(data) % 2 != 0:
+            return None
+        # Pipecat's InputAudioRawFrame expects raw bytes + sample
+        # rate + channel count. The browser is responsible for
+        # delivering int16 little-endian at the agreed rate; we
+        # don't re-validate here because Silero VAD downstream will
+        # reject anything that doesn't decode as audio.
+        return InputAudioRawFrame(
+            audio=bytes(data),
+            sample_rate=self._input_sample_rate,
+            num_channels=self._num_channels,
+        )

--- a/examples/camera-agent/tests/test_serializer.py
+++ b/examples/camera-agent/tests/test_serializer.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RawPcmSerializer.
+
+These tests exercise the wire shape directly — they don't boot
+Pipecat or a WebSocket. The goal is to pin the contract: int16 PCM
+in both directions, audio-only, non-audio frames dropped.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _pipecat_available() -> bool:
+    try:
+        importlib.import_module("pipecat.frames.frames")
+        return True
+    except Exception:
+        return False
+
+
+# The serializer module is only meaningfully testable when Pipecat
+# is on the venv (the test env that runs `uv sync --extra dev`
+# installs it via the camera-agent pyproject). Skip in environments
+# where it isn't — the module-level fallback keeps imports working.
+pytestmark = pytest.mark.skipif(
+    not _pipecat_available(),
+    reason="Pipecat not installed in this venv",
+)
+
+
+@pytest.mark.asyncio
+async def test_deserialize_bytes_to_input_audio_frame():
+    from pipecat.frames.frames import InputAudioRawFrame
+    from serializer import RawPcmSerializer
+
+    s = RawPcmSerializer(input_sample_rate=16000, num_channels=1)
+    pcm = b"\x00\x01\x02\x03"  # 2 samples × 2 bytes
+    frame = await s.deserialize(pcm)
+    assert isinstance(frame, InputAudioRawFrame)
+    assert frame.audio == pcm
+    assert frame.sample_rate == 16000
+    assert frame.num_channels == 1
+
+
+@pytest.mark.asyncio
+async def test_deserialize_empty_bytes_returns_none():
+    from serializer import RawPcmSerializer
+
+    s = RawPcmSerializer()
+    assert await s.deserialize(b"") is None
+    # Non-bytes (e.g. str from a misconfigured client) also drops
+    # rather than crashing.
+    assert await s.deserialize("not bytes") is None  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_deserialize_odd_length_drops():
+    """int16 PCM = 2 bytes/sample. Odd-length payloads can't be a
+    whole number of samples and would feed garbage to Silero VAD.
+    Drop rather than emit."""
+    from serializer import RawPcmSerializer
+
+    s = RawPcmSerializer()
+    # 3 bytes = 1.5 samples → drop.
+    assert await s.deserialize(b"\x00\x01\x02") is None
+    # 4 bytes = 2 samples → accepted.
+    out = await s.deserialize(b"\x00\x01\x02\x03")
+    assert out is not None
+
+
+@pytest.mark.asyncio
+async def test_serialize_tts_audio_frame_emits_bytes():
+    from pipecat.frames.frames import TTSAudioRawFrame
+    from serializer import RawPcmSerializer
+
+    s = RawPcmSerializer()
+    pcm = b"\x10\x11\x12\x13\x14\x15"
+    frame = TTSAudioRawFrame(audio=pcm, sample_rate=22050, num_channels=1)
+    out = await s.serialize(frame)
+    assert out == pcm
+
+
+@pytest.mark.asyncio
+async def test_serialize_non_audio_frame_drops_to_none():
+    """LLM text, system frames, control frames must not bleed onto
+    the demo wire — the browser doesn't parse them. A production UI
+    would extend this with a sidecar JSON channel."""
+    from pipecat.frames.frames import LLMTextFrame
+    from serializer import RawPcmSerializer
+
+    s = RawPcmSerializer()
+    out = await s.serialize(LLMTextFrame("hello"))
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_setup_honours_start_frame_sample_rates():
+    """When Pipecat's StartFrame carries sample-rate negotiation,
+    the serializer picks those up so it stays in sync with whatever
+    the transport ended up plumbing."""
+    from pipecat.frames.frames import StartFrame
+    from serializer import RawPcmSerializer
+
+    s = RawPcmSerializer(input_sample_rate=16000, output_sample_rate=22050)
+
+    # Construct a StartFrame with whatever the current Pipecat
+    # version exposes — we set attributes after construction so
+    # this test is robust to StartFrame's required-args drift
+    # between minor versions.
+    try:
+        start = StartFrame(audio_in_sample_rate=8000, audio_out_sample_rate=24000)
+    except TypeError:
+        # Older Pipecat: StartFrame doesn't accept these as kwargs;
+        # set them as attributes directly so the test still
+        # exercises the setup() codepath.
+        start = StartFrame()  # type: ignore[call-arg]
+        start.audio_in_sample_rate = 8000  # type: ignore[attr-defined]
+        start.audio_out_sample_rate = 24000  # type: ignore[attr-defined]
+
+    await s.setup(start)
+    assert s._input_sample_rate == 8000
+    assert s._output_sample_rate == 24000
+
+
+@pytest.mark.asyncio
+async def test_serializer_type_is_binary():
+    from pipecat.serializers.base_serializer import FrameSerializerType
+    from serializer import RawPcmSerializer
+
+    assert RawPcmSerializer().type == FrameSerializerType.BINARY

--- a/examples/camera-agent/tests/test_serializer.py
+++ b/examples/camera-agent/tests/test_serializer.py
@@ -102,26 +102,27 @@ async def test_setup_honours_start_frame_sample_rates():
     """When Pipecat's StartFrame carries sample-rate negotiation,
     the serializer picks those up so it stays in sync with whatever
     the transport ended up plumbing."""
-    from pipecat.frames.frames import StartFrame
     from serializer import RawPcmSerializer
 
     s = RawPcmSerializer(input_sample_rate=16000, output_sample_rate=22050)
 
-    # Construct a StartFrame with whatever the current Pipecat
-    # version exposes — we set attributes after construction so
-    # this test is robust to StartFrame's required-args drift
-    # between minor versions.
-    try:
-        start = StartFrame(audio_in_sample_rate=8000, audio_out_sample_rate=24000)
-    except TypeError:
-        # Older Pipecat: StartFrame doesn't accept these as kwargs;
-        # set them as attributes directly so the test still
-        # exercises the setup() codepath.
-        start = StartFrame()  # type: ignore[call-arg]
-        start.audio_in_sample_rate = 8000  # type: ignore[attr-defined]
-        start.audio_out_sample_rate = 24000  # type: ignore[attr-defined]
+    # Construct a stand-in for StartFrame instead of the real class.
+    # The actual Pipecat ``StartFrame`` constructor has churned hard
+    # across releases — 0.0.5x makes ``clock`` and ``task_manager``
+    # required positional args (no way to fabricate one in a unit
+    # test without dragging in the whole runtime), while 0.0.10x
+    # makes everything optional but also rearranges other fields.
+    # ``serializer.setup()`` only reads ``audio_in_sample_rate`` /
+    # ``audio_out_sample_rate`` via ``getattr`` — pinning to a real
+    # StartFrame just to satisfy a duck-typed attribute lookup is
+    # the kind of test fragility that makes Pipecat bumps painful.
+    # A bare object with the two attributes exercises the same code
+    # path and survives any upstream rearrangement.
+    class _FakeStartFrame:
+        audio_in_sample_rate = 8000
+        audio_out_sample_rate = 24000
 
-    await s.setup(start)
+    await s.setup(_FakeStartFrame())  # type: ignore[arg-type]
     assert s._input_sample_rate == 8000
     assert s._output_sample_rate == 24000
 

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -183,7 +183,15 @@ class CameraTools:
         except (LookupError, FrameSourceError) as exc:
             return f"Cannot fetch camera {camera_id!r}: {exc}"
         try:
-            response = await self._caption.infer(frame_jpeg=frame)
+            # Send the task explicitly for symmetry with
+            # recognize_faces — BlipService defaults task to
+            # ``scene_caption`` but being explicit makes the wire
+            # shape legible in audit logs and protects against a
+            # future multi-task BLIP adapter that drops the default.
+            response = await self._caption.infer(
+                frame_jpeg=frame,
+                extra={"task": "scene_caption"},
+            )
         except Exception:
             logger.exception("describe_camera: caption call failed")
             return "Caption adapter failed; cannot describe the scene right now."


### PR DESCRIPTION
All three v0.1 integration gaps closed:
  1. Whisper/Piper field aliases verified; Piper inline mode added.
  2. RawPcmSerializer lets the self-contained /demo speak vanilla JS.
  3. SDK BLIP adapter shipped in ai-adapter.