### PR TITLE
fix: stop cloud status polling when unconfigured or during playback

### DIFF
--- a/app/src/views/PlaybackView.tsx
+++ b/app/src/views/PlaybackView.tsx
@@ -187,6 +187,40 @@ export function PlaybackView() {
     }
   }, [user?.is_superuser, cloudUploadConfigured, showPlayer])
 
+  // Self-healing recovery from the "we gave up polling" state.
+  //
+  // The polling effect above flips cloudUploadConfigured → false when the
+  // backend reports no cloud server is configured. Without this, the
+  // frontend would stay in that state until the operator hard-refreshed
+  // the page, even if they configured the cloud server in another route.
+  //
+  // Two cheap recovery triggers:
+  //   * Tab visibility change. When the operator navigates away to
+  //     configure the cloud server and comes back, the visibilitychange
+  //     event fires; we re-arm the flag and the polling effect re-runs
+  //     once. If the backend STILL says unconfigured the polling effect
+  //     will flip the flag back to false immediately — no harm done.
+  //   * A custom ``opennvr:cloud-config-changed`` event. Any future cloud-
+  //     config UI can dispatch ``window.dispatchEvent(new CustomEvent(
+  //     'opennvr:cloud-config-changed'))`` immediately after a successful
+  //     save and the polling resumes without waiting for the next visible.
+  useEffect(() => {
+    if (!user?.is_superuser) return
+    if (cloudUploadConfigured) return  // already polling — nothing to re-arm
+
+    const rearm = () => setCloudUploadConfigured(true)
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') rearm()
+    }
+
+    document.addEventListener('visibilitychange', onVisible)
+    window.addEventListener('opennvr:cloud-config-changed', rearm)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible)
+      window.removeEventListener('opennvr:cloud-config-changed', rearm)
+    }
+  }, [user?.is_superuser, cloudUploadConfigured])
+
   // Toggle camera expansion
   const toggleCamera = (cameraId: number) => {
     setExpandedCameras(prev => {

--- a/app/src/views/PlaybackView.tsx
+++ b/app/src/views/PlaybackView.tsx
@@ -73,6 +73,7 @@ interface HlsPlaybackSession {
 interface CloudUploadStatus {
   queue_size: number
   worker_running: boolean
+  configured?: boolean
   active_file?: string | null
   stats?: {
     queued_total?: number
@@ -110,6 +111,7 @@ export function PlaybackView() {
   const [playbackError, setPlaybackError] = useState<string | null>(null)
   const [playbackLoading, setPlaybackLoading] = useState(false)
   const [cloudUploadStatus, setCloudUploadStatus] = useState<CloudUploadStatus | null>(null)
+  const [cloudUploadConfigured, setCloudUploadConfigured] = useState(true)
   const [queueingDayKey, setQueueingDayKey] = useState<string | null>(null)
   const [queuedDayKey, setQueuedDayKey] = useState<string | null>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
@@ -148,20 +150,31 @@ export function PlaybackView() {
 
   useEffect(() => {
     if (!user?.is_superuser) return
+    // No cloud recording server configured → nothing to poll.
+    if (!cloudUploadConfigured) return
+    // Pause polling while a recording is open in the player so it can't
+    // disturb playback; resumes automatically when the player is closed.
+    if (showPlayer) return
 
     let stopped = false
     let timer: ReturnType<typeof setTimeout> | null = null
 
     const poll = async () => {
+      let keepGoing = true
       try {
         const { data } = await apiService.getCloudUploadStatus()
         if (!stopped) {
           setCloudUploadStatus(data)
+          if (data?.configured === false) {
+            // Server not set up — stop polling for the rest of the session.
+            setCloudUploadConfigured(false)
+            keepGoing = false
+          }
         }
       } catch {
         // Non-blocking UI: keep playback usable even if status polling fails.
       } finally {
-        if (!stopped) {
+        if (!stopped && keepGoing) {
           timer = setTimeout(poll, 3000)
         }
       }
@@ -172,7 +185,7 @@ export function PlaybackView() {
       stopped = true
       if (timer) clearTimeout(timer)
     }
-  }, [user?.is_superuser])
+  }, [user?.is_superuser, cloudUploadConfigured, showPlayer])
 
   // Toggle camera expansion
   const toggleCamera = (cameraId: number) => {

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -235,11 +235,14 @@ async def queue_cloud_upload_for_day(
 
 @router.get("/cloud-upload/status")
 async def get_cloud_upload_status(
+    db: Session = Depends(get_db),
     current_user=Depends(get_current_superuser),
 ):
     """Get current cloud upload worker and queue status."""
     service = CloudRecordingService.get_instance()
-    return service.get_queue_status()
+    status = service.get_queue_status()
+    status["configured"] = service.is_cloud_configured(db)
+    return status
 
 
 def _check_mediamtx_available() -> bool:

--- a/server/services/cloud_recording_service.py
+++ b/server/services/cloud_recording_service.py
@@ -528,7 +528,23 @@ class CloudRecordingService:
             self._upload_queue.task_done()
     
     def is_cloud_configured(self, db: Session) -> bool:
-        """Whether a cloud recording server target is configured."""
+        """Whether a cloud recording server target is configured.
+
+        A target is considered configured iff the
+        ``media_source.cloud_recording_server_ip`` setting holds a
+        truthy value. An empty string (``""``) is treated as
+        unconfigured — the operator may have cleared the field in
+        the UI, and we don't want to keep polling a target that was
+        explicitly removed. Likewise a missing ``media_source`` row
+        or unparseable JSON returns False via
+        :meth:`_get_media_source_settings`.
+
+        Used by the ``/cloud-upload/status`` endpoint to tell the
+        frontend whether it's worth continuing to poll — see the
+        ``configured`` field in the response. The 3-second poll
+        loop in ``app/src/views/PlaybackView.tsx`` shuts itself
+        down when this returns False.
+        """
         media_cfg = self._get_media_source_settings(db)
         return bool(media_cfg.get("cloud_recording_server_ip"))
 

--- a/server/services/cloud_recording_service.py
+++ b/server/services/cloud_recording_service.py
@@ -527,6 +527,11 @@ class CloudRecordingService:
             
             self._upload_queue.task_done()
     
+    def is_cloud_configured(self, db: Session) -> bool:
+        """Whether a cloud recording server target is configured."""
+        media_cfg = self._get_media_source_settings(db)
+        return bool(media_cfg.get("cloud_recording_server_ip"))
+
     def get_queue_status(self) -> dict[str, Any]:
         """Get current upload queue status."""
         return {

--- a/server/tests/test_cloud_status_configured.py
+++ b/server/tests/test_cloud_status_configured.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""
+PR #50 regression tests for the ``configured`` field on the cloud upload
+status response.
+
+Run with:
+
+    cd server && pytest tests/test_cloud_status_configured.py -v
+
+Coverage:
+
+* ``CloudRecordingService.is_cloud_configured`` returns True when the
+  ``media_source`` SecuritySetting has a non-empty
+  ``cloud_recording_server_ip``.
+* Returns False when the IP key is missing from the JSON.
+* Returns False when the IP key is the empty string (operator cleared
+  the field in the UI — documented in the docstring on the method).
+* Returns False when the ``media_source`` row doesn't exist at all.
+* Returns False when ``json_value`` is unparseable garbage.
+
+These together pin the contract the frontend depends on: a False return
+must mean "stop polling — there is genuinely nothing to talk to" and a
+True return must mean "a cloud target is present". A drift on either
+direction would either burn requests against an unconfigured backend or
+silently miss real upload status updates.
+
+Note on test isolation
+----------------------
+``CloudRecordingService`` is a class-level singleton (``cls._instance``).
+All tests in this file are READ-ONLY on that singleton — none of them
+mutate ``_upload_queue``, ``_stats``, ``_active_file``, or any other
+shared field. A future test that adds upload jobs or sets stats should
+either (a) reset the relevant fields in a fixture teardown, or (b) move
+to a separate test module so this file's contract tests stay
+deterministic across pytest collection order.
+"""
+
+from __future__ import annotations
+
+# Python 3.10 sandbox polyfill — pyproject requires 3.11+ where
+# datetime.UTC exists. No-op on 3.11+.
+import datetime as _dt  # noqa: I001
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc
+
+import json
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+# Settings need to be valid for the modules under test to import.
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault(
+    "CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode()
+)
+
+# Stub ``core.logging_config`` — same pattern as
+# test_m1c_transport_probe.py. The real module wants a writable
+# ``logs/`` directory; the service under test only needs no-op loggers.
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def info(self, *a, **kw):  # noqa: D401
+        pass
+
+    def warning(self, *a, **kw):
+        pass
+
+    def error(self, *a, **kw):
+        pass
+
+    def debug(self, *a, **kw):
+        pass
+
+    def critical(self, *a, **kw):
+        pass
+
+
+for _name in (
+    "main_logger",
+    "auth_logger",
+    "camera_logger",
+    "recording_logger",
+    "cloud_logger",
+    "ai_logger",
+):
+    setattr(_lm, _name, _L())
+sys.modules["core.logging_config"] = _lm
+
+
+# ─── Real model + in-memory SQLite session ──────────────────────────────
+# We want to exercise the real ``is_cloud_configured`` against the real
+# SecuritySetting model — not mock it — so a refactor that breaks the JSON
+# shape or column name would also break this test.
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from core.database import Base  # noqa: E402
+from models import SecuritySetting  # noqa: E402
+from services.cloud_recording_service import CloudRecordingService  # noqa: E402
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite DB with the SecuritySetting table created."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[SecuritySetting.__table__])
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _set_media_source(db, payload: dict | str | None) -> None:
+    """Write a ``media_source`` SecuritySetting with the given JSON body.
+
+    Pass a dict for the normal case, a raw string for the malformed-JSON
+    case, or None to delete any existing row (covers "no row at all").
+    """
+    db.query(SecuritySetting).filter(
+        SecuritySetting.key == "media_source"
+    ).delete()
+    if payload is None:
+        db.commit()
+        return
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    db.add(SecuritySetting(key="media_source", json_value=body))
+    db.commit()
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────
+
+
+def test_configured_when_ip_is_set(db):
+    """Happy path: IP set ⇒ True."""
+    _set_media_source(db, {"cloud_recording_server_ip": "192.168.1.50"})
+    svc = CloudRecordingService.get_instance()
+    assert svc.is_cloud_configured(db) is True
+
+
+def test_not_configured_when_ip_missing(db):
+    """Other media_source keys present but no IP ⇒ False.
+
+    Operator may have populated the media_source row with unrelated
+    settings (recording path, retention, ...) without ever filling in
+    the cloud target. Frontend should not poll.
+    """
+    _set_media_source(db, {"recording_path": "/var/recordings"})
+    svc = CloudRecordingService.get_instance()
+    assert svc.is_cloud_configured(db) is False
+
+
+def test_not_configured_when_ip_is_empty_string(db):
+    """Operator cleared the field ⇒ False.
+
+    Pinned because the docstring on is_cloud_configured explicitly
+    treats empty string as unconfigured. ``bool("")`` is False; this
+    test is the contract that proves the docstring is correct.
+    """
+    _set_media_source(db, {"cloud_recording_server_ip": ""})
+    svc = CloudRecordingService.get_instance()
+    assert svc.is_cloud_configured(db) is False
+
+
+def test_not_configured_when_no_media_source_row(db):
+    """Fresh install, no media_source row at all ⇒ False."""
+    _set_media_source(db, None)
+    svc = CloudRecordingService.get_instance()
+    assert svc.is_cloud_configured(db) is False
+
+
+def test_not_configured_when_json_unparseable(db):
+    """Corrupted json_value ⇒ False, no exception.
+
+    A corrupted row in the DB (write failure, manual edit gone wrong)
+    must not crash the polling endpoint. ``_get_media_source_settings``
+    swallows JSON errors and returns {}, which makes is_cloud_configured
+    return False — surface the operator's polling to "off" so they
+    notice (instead of leaking a 500 every 3 seconds).
+    """
+    _set_media_source(db, "not even close to json")
+    svc = CloudRecordingService.get_instance()
+    assert svc.is_cloud_configured(db) is False
+
+
+def test_configured_field_round_trips_through_get_queue_status(db):
+    """End-to-end: simulate what the /cloud-upload/status endpoint does.
+
+    The router (server/routers/recordings.py) calls
+    ``get_queue_status()`` and adds ``configured`` from
+    ``is_cloud_configured(db)``. This test mirrors that composition so
+    a future drift in the response shape — either side losing the
+    ``configured`` key or its boolean type — fails here before
+    reaching production.
+    """
+    _set_media_source(db, {"cloud_recording_server_ip": "10.0.0.5"})
+    svc = CloudRecordingService.get_instance()
+    response = svc.get_queue_status()
+    response["configured"] = svc.is_cloud_configured(db)
+
+    # Shape checks.
+    assert "queue_size" in response
+    assert "worker_running" in response
+    assert "configured" in response
+    assert isinstance(response["configured"], bool)
+    assert response["configured"] is True


### PR DESCRIPTION
Polling for cloud upload status used to run every 3s for superusers no matter what, which wasted requests and could disturb the video player during playback.
Now it skips polling entirely when no cloud server is configured, and pauses while a recording is open in the player (resuming once it's closed).
Backend /cloud-upload/status now returns a configured flag so the frontend knows when to stop.