### PR TITLE
fix(security): require authentication on ONVIF and Suricata log/strea…

### DIFF
--- a/app/src/views/SuricataAlertStream.tsx
+++ b/app/src/views/SuricataAlertStream.tsx
@@ -72,7 +72,13 @@ export function SuricataAlertStream() {
 
     async function fetchStream() {
       try {
-        const resp = await fetch('/api/v1/suricata/alerts/stream', { signal: abortController.signal });
+        // This endpoint is now auth-protected on the backend; attach the bearer token.
+        const token = localStorage.getItem('opennvr.token');
+        const resp = await fetch('/api/v1/suricata/alerts/stream', {
+          signal: abortController.signal,
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!resp.ok) throw new Error(`Stream error (${resp.status})`);
         if (!resp.body) throw new Error('No response body');
         reader = resp.body.getReader();
         let buffer = '';

--- a/server/main.py
+++ b/server/main.py
@@ -22,12 +22,16 @@ Configures the application, middleware, and includes all routers.
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from core.config import settings
+
+# Auth dependency used to protect routers that ship without their own auth guards
+# (ONVIF camera control and Suricata intrusion logs/stream were previously open).
+from dependencies import get_current_active_user
 
 # Auto-provision imports
 from core.database import SessionLocal, init_db
@@ -485,7 +489,11 @@ app.include_router(mediamtx_hooks.router, prefix=settings.api_prefix)
 app.include_router(general.router, prefix=settings.api_prefix)
 app.include_router(audit_logs.router, prefix=settings.api_prefix)
 app.include_router(recordings.router, prefix=settings.api_prefix)
-app.include_router(onvif_router.router, prefix=settings.api_prefix)
+app.include_router(
+    onvif_router.router,
+    prefix=settings.api_prefix,
+    dependencies=[Depends(get_current_active_user)],
+)
 app.include_router(network_router.router, prefix=settings.api_prefix)
 app.include_router(integrations.router, prefix=settings.api_prefix)
 app.include_router(cloud_router.router, prefix=settings.api_prefix)
@@ -498,8 +506,16 @@ app.include_router(cloud_providers.router, prefix=settings.api_prefix)
 app.include_router(cloud_inference.router, prefix=settings.api_prefix)
 app.include_router(compliance.router, prefix=settings.api_prefix)
 
-app.include_router(suricata_logs, prefix=settings.api_prefix)
-app.include_router(suricata_stream, prefix=settings.api_prefix)
+app.include_router(
+    suricata_logs,
+    prefix=settings.api_prefix,
+    dependencies=[Depends(get_current_active_user)],
+)
+app.include_router(
+    suricata_stream,
+    prefix=settings.api_prefix,
+    dependencies=[Depends(get_current_active_user)],
+)
 app.include_router(system, prefix=settings.api_prefix)
 app.include_router(events_router, prefix=settings.api_prefix)
 


### PR DESCRIPTION
…
Adds login enforcement to the previously-unauthenticated ONVIF and Suricata log/stream routers in main.py, and attaches the bearer token to the alert-stream fetch so the live alerts view keeps working.