### PR TITLE
fix(security): stop passing the login JWT in URLs — header-only REST …

### DIFF
--- a/app/src/services/aiService.ts
+++ b/app/src/services/aiService.ts
@@ -55,4 +55,9 @@ export const aiService = {
     api.delete(`/api/v1/ai-detection-results/${id}`),
   deleteOldDetectionResults: (days: number) =>
     api.delete(`/api/v1/ai-detection-results/bulk/older-than/${days}`),
+
+  // Live events WebSocket: mint a short-lived, single-use ticket so the
+  // long-lived JWT never has to ride in the ws URL (which leaks into logs).
+  createEventsWsTicket: () =>
+    api.post('/api/v1/events/ws-ticket'),
 }

--- a/app/src/services/recordingService.ts
+++ b/app/src/services/recordingService.ts
@@ -20,10 +20,12 @@ import { api } from '../lib/api'
 
 export const recordingService = {
   // Playback
-  getRecordingsByDate: (cameraId?: number, token?: string) => {
+  // Note: these go through the shared api client, which already sends the
+  // bearer token in the Authorization header. We deliberately do NOT pass the
+  // JWT as a ?token= query param (it would leak into access logs/history).
+  getRecordingsByDate: (cameraId?: number) => {
     const params: Record<string, any> = {}
     if (cameraId) params.camera_id = cameraId
-    if (token) params.token = token
     return api.get('/api/v1/recordings/list', { params })
   },
   getRecordings: (opts?: { limit?: number; offset?: number; camera_id?: number }) => {
@@ -32,21 +34,13 @@ export const recordingService = {
   getRecordingSessionsForAI: (params?: { camera_id?: number }) => {
     return api.get('/api/v1/recordings/sessions-for-ai', { params })
   },
-  getRecordingStats: (token?: string) => {
-    const params: Record<string, any> = {}
-    if (token) params.token = token
-    return api.get('/api/v1/recordings/stats', { params })
-  },
+  getRecordingStats: () => api.get('/api/v1/recordings/stats'),
   getPlaybackConfig: () => api.get('/api/v1/recordings/config'),
-  getPlaybackList: (path: string, token?: string) => {
-    const params: Record<string, any> = { path }
-    if (token) params.token = token
-    return api.get('/api/v1/recordings/playback/list', { params })
+  getPlaybackList: (path: string) => {
+    return api.get('/api/v1/recordings/playback/list', { params: { path } })
   },
-  getPlaybackUrl: (path: string, start: string, duration: number, token?: string) => {
-    const params: Record<string, any> = { path, start, duration }
-    if (token) params.token = token
-    return api.get('/api/v1/recordings/playback/url', { params })
+  getPlaybackUrl: (path: string, start: string, duration: number) => {
+    return api.get('/api/v1/recordings/playback/url', { params: { path, start, duration } })
   },
   getTodaySegments: (cameraId: number) => api.get(`/api/v1/recordings/today/${cameraId}`),
 

--- a/app/src/views/AIDetectionResults.tsx
+++ b/app/src/views/AIDetectionResults.tsx
@@ -157,9 +157,30 @@ export function AIDetectionResults() {
     const reconnectDelayMs = () =>
       Math.min(60000, 1000 * Math.pow(2, reconnectAttempt))
 
-    const connect = () => {
+    const scheduleReconnect = () => {
+      if (closedByUnmount) return
+      const delay = reconnectDelayMs()
+      reconnectAttempt += 1
+      reconnectTimer = setTimeout(connect, delay)
+    }
+
+    const connect = async () => {
+      // Browsers can't set an Authorization header on a WebSocket handshake,
+      // so mint a short-lived, single-use ticket over the authenticated REST
+      // API and pass that instead of the long-lived JWT (which would leak into
+      // access logs). A fresh ticket is fetched on every (re)connect.
+      let ticket: string
+      try {
+        const res = await apiService.createEventsWsTicket()
+        ticket = res.data.ticket
+      } catch {
+        scheduleReconnect()
+        return
+      }
+      if (closedByUnmount) return
+
       const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-      const url = `${proto}://${window.location.host}/api/v1/events/ws?token=${encodeURIComponent(token)}`
+      const url = `${proto}://${window.location.host}/api/v1/events/ws?ticket=${encodeURIComponent(ticket)}`
       ws = new WebSocket(url)
 
       ws.onopen = () => {
@@ -241,10 +262,7 @@ export function AIDetectionResults() {
       }
 
       ws.onclose = () => {
-        if (closedByUnmount) return
-        const delay = reconnectDelayMs()
-        reconnectAttempt += 1
-        reconnectTimer = setTimeout(connect, delay)
+        scheduleReconnect()
       }
     }
 

--- a/app/src/views/PlaybackView.tsx
+++ b/app/src/views/PlaybackView.tsx
@@ -122,8 +122,8 @@ export function PlaybackView() {
     setError(null)
     try {
       if (token) api.setToken(token)
-      
-      const recordingsRes = await apiService.getRecordingsByDate(undefined, token || undefined)
+
+      const recordingsRes = await apiService.getRecordingsByDate()
       
       setCameras(recordingsRes.data?.cameras || [])
       setTotalRecordings(recordingsRes.data?.total_recordings || 0)

--- a/server/routers/events.py
+++ b/server/routers/events.py
@@ -26,10 +26,12 @@ Used by:
 Auth
 ----
 FastAPI's HTTPBearer dependency doesn't work on the WS handshake — browsers
-can't set custom headers when opening a WebSocket. So we accept the JWT as
-a ``?token=<jwt>`` query param and validate it with the same ``verify_token``
-used for the REST API. Server-to-server clients can send the token either
-way (query param wins if both present).
+can't set custom headers when opening a WebSocket. So the client first calls
+the authenticated ``POST /events/ws-ticket`` endpoint to mint a short-lived,
+single-use ticket, then opens ``/events/ws?ticket=<ticket>``. This keeps the
+long-lived JWT out of URLs (and therefore out of access logs). Server-to-server
+clients authenticate the same way: call ``POST /events/ws-ticket`` with their
+bearer token, then open the socket with the returned ticket.
 
 Filters
 -------
@@ -43,12 +45,14 @@ Both can be combined. Missing filters mean "everything".
 from __future__ import annotations
 
 import json
+import secrets
+import time
 from typing import Any
 
-from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect, status
+from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect, status
 from sqlalchemy.orm import Session
 
-from core.auth import verify_token
+from core.auth import get_current_active_user
 from core.database import get_db
 from core.logging_config import main_logger
 from models import User
@@ -57,20 +61,68 @@ from services.event_bus_service import get_event_bus
 router = APIRouter()
 
 
-def _authenticate_ws_token(token: str | None, db: Session) -> User | None:
-    """
-    Validate a JWT supplied via query param, return the matching active user
-    or None. We deliberately do NOT raise here — the caller closes the socket
-    with a proper code so the client sees a clean rejection.
-    """
-    if not token:
-        return None
+# ---------------------------------------------------------------------------
+# Single-use WebSocket tickets
+#
+# Browsers cannot attach an Authorization header to a WebSocket handshake, so
+# historically the long-lived JWT was passed as ``?token=<jwt>`` — which lands
+# in nginx/proxy access logs and browser history. Instead, an authenticated
+# REST call mints a short-lived, single-use ticket and the client opens
+# ``/events/ws?ticket=<ticket>``. An in-memory store is safe because the API
+# runs as a single uvicorn worker (see supervisord.conf); if that ever becomes
+# multiple workers, move this to a shared store (e.g. Redis).
+# ---------------------------------------------------------------------------
+_WS_TICKET_TTL_SECONDS = 30
+_ws_tickets: dict[str, tuple[str, float]] = {}  # ticket -> (username, expires_at)
 
-    token_data = verify_token(token)
-    if token_data is None:
-        return None
 
-    user = db.query(User).filter(User.username == token_data.username).first()
+def _prune_ws_tickets(now: float) -> None:
+    for tok in [t for t, (_, exp) in _ws_tickets.items() if exp <= now]:
+        _ws_tickets.pop(tok, None)
+
+
+def _mint_ws_ticket(username: str) -> tuple[str, int]:
+    now = time.time()
+    _prune_ws_tickets(now)
+    ticket = secrets.token_urlsafe(32)
+    _ws_tickets[ticket] = (username, now + _WS_TICKET_TTL_SECONDS)
+    return ticket, _WS_TICKET_TTL_SECONDS
+
+
+def _consume_ws_ticket(ticket: str) -> str | None:
+    """Validate and *consume* a ticket (single use); return its username or None."""
+    entry = _ws_tickets.pop(ticket, None)  # pop() => cannot be replayed
+    if entry is None:
+        return None
+    username, expires_at = entry
+    if expires_at <= time.time():
+        return None
+    return username
+
+
+@router.post("/events/ws-ticket")
+async def create_ws_ticket(current_user: User = Depends(get_current_active_user)):
+    """Mint a short-lived, single-use ticket for opening the events WebSocket.
+
+    The client (which cannot set an Authorization header on a WebSocket) calls
+    this authenticated endpoint, then opens ``/events/ws?ticket=<ticket>``.
+    """
+    ticket, ttl = _mint_ws_ticket(current_user.username)
+    return {"ticket": ticket, "expires_in": ttl}
+
+
+def _authenticate_ws(ticket: str | None, db: Session) -> User | None:
+    """Authenticate a WS handshake using a single-use ticket.
+
+    We deliberately do NOT raise here — the caller closes the socket with a
+    proper code so the client sees a clean rejection.
+    """
+    if not ticket:
+        return None
+    username = _consume_ws_ticket(ticket)
+    if not username:
+        return None
+    user = db.query(User).filter(User.username == username).first()
     if user is None or not user.is_active:
         return None
     return user
@@ -79,7 +131,7 @@ def _authenticate_ws_token(token: str | None, db: Session) -> User | None:
 @router.websocket("/events/ws")
 async def events_stream(
     websocket: WebSocket,
-    token: str | None = Query(default=None, description="JWT access token"),
+    ticket: str | None = Query(default=None, description="Single-use WS ticket"),
     camera_id: int | None = Query(default=None, description="Filter to one camera"),
     task: list[str] | None = Query(default=None, description="Filter to these task names"),
 ):
@@ -106,7 +158,7 @@ async def events_stream(
     db_gen = get_db()
     db: Session = next(db_gen)
     try:
-        user = _authenticate_ws_token(token, db)
+        user = _authenticate_ws(ticket, db)
     finally:
         # Mirror FastAPI's get_db teardown without relying on Depends here
         # (WebSocket routes can't use Depends() for request-scoped DB sessions

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -282,10 +282,12 @@ def _get_or_init(db: Session, key: str, default_obj) -> SecuritySetting:
     return row
 
 
-async def _authenticate_request(
-    request: Request, token: str | None, db: Session
-) -> User | None:
-    """Authenticate request from either Authorization header or token query param."""
+async def _authenticate_request(request: Request, db: Session) -> User | None:
+    """Authenticate a request from the Authorization: Bearer header.
+
+    The JWT is taken ONLY from the header — never from a ?token= query param,
+    which would leak the long-lived token into access logs / browser history.
+    """
     user_obj = None
 
     if request:
@@ -295,11 +297,6 @@ async def _authenticate_request(
             td = verify_token(tok)
             if td:
                 user_obj = db.query(User).filter(User.username == td.username).first()
-
-    if not user_obj and token:
-        td = verify_token(token)
-        if td:
-            user_obj = db.query(User).filter(User.username == td.username).first()
 
     if user_obj and user_obj.is_active:
         return user_obj
@@ -526,7 +523,6 @@ async def recording_status(
 @router.get("/playback/list")
 async def list_recordings(
     path: str = Query(..., description="Camera path (e.g., cam-57)"),
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -534,7 +530,7 @@ async def list_recordings(
     List available recordings from MediaMTX playback server.
     Returns segments with direct playback URLs.
     """
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -581,7 +577,6 @@ async def list_recordings(
 
 @router.get("/playback/cameras")
 async def list_recording_cameras(
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -589,7 +584,7 @@ async def list_recording_cameras(
     List all cameras that have recordings.
     Queries MediaMTX for each active camera.
     """
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -637,7 +632,6 @@ async def get_playback_url(
     path: str = Query(..., description="Camera path (e.g., cam-57)"),
     start: str = Query(..., description="Start time in RFC3339 format"),
     duration: float = Query(..., description="Duration in seconds"),
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -645,7 +639,7 @@ async def get_playback_url(
     Get a direct MediaMTX playback URL for a recording.
     The URL can be used directly in a video player.
     """
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -677,7 +671,6 @@ async def create_hls_session(
     camera_id: int = Query(..., description="Camera ID"),
     start: str = Query(..., description="Start time in RFC3339 format"),
     end: str = Query(..., description="End time in RFC3339 format"),
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -696,7 +689,7 @@ async def create_hls_session(
 
     from services.hls_playback_service import HlsPlaybackService
 
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -856,7 +849,6 @@ async def get_hls_segment(
 @router.delete("/playback/hls/{session_id}")
 async def delete_hls_session(
     session_id: str,
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -867,7 +859,7 @@ async def delete_hls_session(
     """
     from services.hls_playback_service import HlsPlaybackService
 
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -917,7 +909,6 @@ async def get_playback_config(
 @router.get("/today/{camera_id}")
 async def get_today_segments(
     camera_id: int,
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -929,7 +920,7 @@ async def get_today_segments(
     from datetime import datetime
     from urllib.parse import quote
 
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -1160,7 +1151,6 @@ def _group_filesystem_recordings_by_date(
 @router.get("/list")
 async def list_recordings_by_date(
     camera_id: int | None = Query(default=None, description="Filter by camera ID"),
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -1169,7 +1159,7 @@ async def list_recordings_by_date(
     Returns user-friendly recording counts (1 recording = 1 day per camera).
     Falls back to filesystem listing if MediaMTX is unavailable.
     """
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -1268,7 +1258,6 @@ async def list_recordings_by_date(
 
 @router.get("/stats")
 async def get_recording_stats(
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -1277,7 +1266,7 @@ async def get_recording_stats(
     Returns counts and durations in user-friendly format.
     Falls back to filesystem listing if MediaMTX is unavailable.
     """
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -1560,7 +1549,6 @@ def _group_filesystem_items_into_sessions(
 @router.get("/sessions-for-ai")
 async def get_recording_sessions_for_ai(
     camera_id: int | None = Query(default=None, description="Filter by camera ID"),
-    token: str | None = Query(default=None),
     request: Request = None,
     db: Session = Depends(get_db),
 ):
@@ -1569,7 +1557,7 @@ async def get_recording_sessions_for_ai(
     Sessions are continuous recording periods (with small gaps allowed).
     Falls back to filesystem listing if MediaMTX is unavailable.
     """
-    user_obj = await _authenticate_request(request, token, db)
+    user_obj = await _authenticate_request(request, db)
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 


### PR DESCRIPTION
…auth + single-use Ws tickets

Stops putting the login token in URLs: recordings now authenticate via the header only, and the events WebSocket uses a short-lived one-time ticket instead of ?token=.