### PR TITLE
Issue 68

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@ MEDIAMTX_STREAM_PREFIX=cam-
 MEDIAMTX_PATH_MODE=id
 MEDIAMTX_AUTO_PROVISION=True
 
+# Recording segment length (seconds) the backend sends to MediaMTX per camera.
+# Keep in sync with mediamtx.docker.yml `recordSegmentDuration` (default 1h = 3600).
+# Shorter values = more, smaller files (e.g. 300 = 5-min segments).
+RECORDING_SEGMENT_SECONDS=3600
+
 # ============================================================
 # DOCKER SERVICE NETWORKING
 # ============================================================

--- a/app/src/services/mediaMtxService.ts
+++ b/app/src/services/mediaMtxService.ts
@@ -42,9 +42,10 @@ export const mediaMtxService = {
   mtxPathPatch: (cameraId: number, payload: any) => api.patch(`/api/v1/mediamtx/admin/paths/${cameraId}`, payload as any),
   mtxPushRtsp: (cameraId: number, rtspUrl: string, enableRecording: boolean) =>
     api.post(`/api/v1/mediamtx/admin/streams/push/${cameraId}`, '', { params: { rtsp_url: rtspUrl, enable_recording: enableRecording } }),
-  // duration omitted => backend applies the configured RECORDING_SEGMENT_SECONDS (single source of truth)
-  mtxEnableRecording: (cameraId: number, duration?: string, segmentDuration: string = '10s') =>
-    api.post(`/api/v1/mediamtx/admin/recordings/enable/${cameraId}`, '', { params: { duration, segment_duration: segmentDuration } }),
+  // duration = segment length (recordSegmentDuration); omitted => backend applies the configured RECORDING_SEGMENT_SECONDS (single source of truth).
+  // partDuration = fMP4 part length (recordPartDuration); '1s' matches mediamtx*.yml and favours low-latency playback.
+  mtxEnableRecording: (cameraId: number, duration?: string, partDuration: string = '1s') =>
+    api.post(`/api/v1/mediamtx/admin/recordings/enable/${cameraId}`, '', { params: { duration, part_duration: partDuration } }),
   mtxDisableRecording: (cameraId: number) =>
     api.post(`/api/v1/mediamtx/admin/recordings/disable/${cameraId}`, ''),
   

--- a/app/src/services/mediaMtxService.ts
+++ b/app/src/services/mediaMtxService.ts
@@ -42,7 +42,8 @@ export const mediaMtxService = {
   mtxPathPatch: (cameraId: number, payload: any) => api.patch(`/api/v1/mediamtx/admin/paths/${cameraId}`, payload as any),
   mtxPushRtsp: (cameraId: number, rtspUrl: string, enableRecording: boolean) =>
     api.post(`/api/v1/mediamtx/admin/streams/push/${cameraId}`, '', { params: { rtsp_url: rtspUrl, enable_recording: enableRecording } }),
-  mtxEnableRecording: (cameraId: number, duration: string = '60s', segmentDuration: string = '10s') =>
+  // duration omitted => backend applies the configured RECORDING_SEGMENT_SECONDS (single source of truth)
+  mtxEnableRecording: (cameraId: number, duration?: string, segmentDuration: string = '10s') =>
     api.post(`/api/v1/mediamtx/admin/recordings/enable/${cameraId}`, '', { params: { duration, segment_duration: segmentDuration } }),
   mtxDisableRecording: (cameraId: number) =>
     api.post(`/api/v1/mediamtx/admin/recordings/disable/${cameraId}`, ''),

--- a/app/src/views/settings/CameraConfigManager.tsx
+++ b/app/src/views/settings/CameraConfigManager.tsx
@@ -45,7 +45,7 @@ export function CameraConfigManager() {
   const navigate = useNavigate()
   const [cameras, setCameras] = useState<Camera[]>([])
   const [selectedCamId, setSelectedCamId] = useState<number | ''>('')
-  const [cfg, setCfg] = useState<Partial<CameraConfig>>({ stream_protocol: 'rtsp', recording_enabled: false, recording_segment_seconds: 60 })
+  const [cfg, setCfg] = useState<Partial<CameraConfig>>({ stream_protocol: 'rtsp', recording_enabled: false })
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
@@ -93,8 +93,7 @@ export function CameraConfigManager() {
         setCfg({ 
           camera_id: camId, 
           stream_protocol: 'rtsp', 
-          recording_enabled: false, 
-          recording_segment_seconds: 60,
+          recording_enabled: false,
           source_url: selectedCamera?.rtsp_url || null
         })
       } else {
@@ -123,7 +122,6 @@ export function CameraConfigManager() {
           source_url: cfg.source_url || null,
           recording_enabled: !!cfg.recording_enabled,
           recording_path: cfg.recording_path || null,
-          recording_segment_seconds: Number(cfg.recording_segment_seconds) || 60,
           webrtc_publisher: !!cfg.webrtc_publisher,
           rtmp_publisher: !!cfg.rtmp_publisher,
           rtsp_transport: cfg.rtsp_transport || null,
@@ -138,7 +136,6 @@ export function CameraConfigManager() {
           source_url: cfg.source_url || null,
           recording_enabled: !!cfg.recording_enabled,
           recording_path: cfg.recording_path || null,
-          recording_segment_seconds: Number(cfg.recording_segment_seconds) || 60,
           webrtc_publisher: !!cfg.webrtc_publisher,
           rtmp_publisher: !!cfg.rtmp_publisher,
           rtsp_transport: cfg.rtsp_transport || null,
@@ -273,21 +270,6 @@ export function CameraConfigManager() {
                   
                   {cfg.recording_enabled && (
                     <>
-                      <label className="flex flex-col gap-1">
-                        <span className="text-[var(--text-dim)]">Segment Duration</span>
-                        <select 
-                          className="bg-[var(--panel)] border border-neutral-700 px-2 py-1" 
-                          value={cfg.recording_segment_seconds || 60} 
-                          onChange={(e) => setCfg({ ...cfg, recording_segment_seconds: Number(e.target.value) })}
-                        >
-                          <option value="60">1 minute</option>
-                          <option value="300">5 minutes</option>
-                          <option value="600">10 minutes</option>
-                          <option value="1800">30 minutes</option>
-                          <option value="3600">1 hour</option>
-                        </select>
-                      </label>
-                      
                       <label className="flex flex-col gap-1 col-span-2">
                         <span className="text-[var(--text-dim)]">Recording Path (optional)</span>
                         <input 

--- a/app/src/views/settings/CamerasManager.tsx
+++ b/app/src/views/settings/CamerasManager.tsx
@@ -79,7 +79,6 @@ export function CamerasManager() {
   const [provisionConfig, setProvisionConfig] = useState({
     enable_recording: false,
     rtsp_transport: 'tcp',
-    recording_segment_seconds: 300,
     recording_path: ''
   })
   const [showBulkAssign, setShowBulkAssign] = useState(false)
@@ -314,7 +313,6 @@ export function CamerasManager() {
     setProvisionConfig({
       enable_recording: false,
       rtsp_transport: 'tcp',
-      recording_segment_seconds: 300,
       recording_path: ''
     })
     setShowProvisionDialog(true)
@@ -740,20 +738,6 @@ export function CamerasManager() {
 
               {provisionConfig.enable_recording && (
                 <>
-                  <Field label="Recording Segment Duration">
-                    <select
-                      className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2"
-                      value={provisionConfig.recording_segment_seconds}
-                      onChange={(e) => setProvisionConfig(prev => ({ ...prev, recording_segment_seconds: Number(e.target.value) }))}
-                    >
-                      <option value="60">1 minute</option>
-                      <option value="300">5 minutes (default)</option>
-                      <option value="600">10 minutes</option>
-                      <option value="1800">30 minutes</option>
-                      <option value="3600">1 hour</option>
-                    </select>
-                  </Field>
-
                   <Field label="Recording Path (Optional)">
                     <input
                       className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 w-full"

--- a/mediamtx.docker.yml
+++ b/mediamtx.docker.yml
@@ -387,9 +387,11 @@ pathDefaults:
   # No manual editing required - just set MEDIAMTX_SECRET in server/.env!
   ###############################################
 
-  # Startup hook - provisions cameras from backend database on MediaMTX start
-  runOnInit: 'curl -X GET -H "X-MTX-Secret: ${MEDIAMTX_SECRET}" "http://${BACKEND_HOST}:${BACKEND_PORT}/api/v1/mediamtx/startup/hook"'
-  runOnInitRestart: yes
+  # NOTE: runOnInit lives ONLY on the __startup__ path below, not here in
+  # pathDefaults. If it's in pathDefaults it is inherited by EVERY camera path,
+  # so every camera (re)provision re-fires the startup hook, which re-provisions
+  # cameras, which re-fires the hook → an infinite reload/provision loop that
+  # also fragments recordings. Keep it out of pathDefaults.
 
   runOnDemand:
   runOnDemandRestart: no
@@ -425,4 +427,10 @@ paths:
   __startup__:
     source: publisher
     record: no
+    # Startup hook - provisions cameras from backend DB once on MediaMTX start.
+    # runOnInitRestart MUST be 'no': the curl exits immediately, so 'yes' would
+    # re-run it forever (the loop bug). The backend also self-provisions on its
+    # own startup, so a single best-effort fire here is enough.
+    runOnInit: 'curl -X GET -H "X-MTX-Secret: ${MEDIAMTX_SECRET}" "http://${BACKEND_HOST}:${BACKEND_PORT}/api/v1/mediamtx/startup/hook?delay=5"'
+    runOnInitRestart: no
 

--- a/mediamtx.local.yml
+++ b/mediamtx.local.yml
@@ -374,9 +374,10 @@ pathDefaults:
   # NOTE: Uses curl.exe on Windows (not PowerShell's curl alias)
   ###############################################
 
-  # Startup hook - calls backend with secret
-  runOnInit: 'curl.exe -X GET -H "X-MTX-Secret: YOUR_SECRET_HERE" "http://127.0.0.1:8000/api/v1/mediamtx/startup/hook"'
-  runOnInitRestart: yes
+  # NOTE: runOnInit lives ONLY on the __startup__ path below, not here in
+  # pathDefaults. In pathDefaults it is inherited by EVERY camera path, so each
+  # camera (re)provision re-fires the startup hook → re-provision → re-fire,
+  # an infinite reload/provision loop that also fragments recordings.
 
   runOnDemand:
   runOnDemandRestart: no
@@ -410,4 +411,9 @@ paths:
   __startup__:
     source: publisher
     record: no
+    # Startup hook - provisions cameras from backend DB once on MediaMTX start.
+    # runOnInitRestart MUST be 'no': the curl exits immediately, so 'yes' would
+    # re-run it forever. The backend also self-provisions on its own startup.
+    runOnInit: 'curl.exe -X GET -H "X-MTX-Secret: YOUR_SECRET_HERE" "http://127.0.0.1:8000/api/v1/mediamtx/startup/hook"'
+    runOnInitRestart: no
 

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -381,9 +381,10 @@ pathDefaults:
   # No manual editing required - just set MEDIAMTX_SECRET in server/.env!
   ###############################################
 
-  # Startup hook - calls backend with secret from environment variable
-  runOnInit: 'curl -X GET -H "X-MTX-Secret: ${MEDIAMTX_SECRET}" "http://${BACKEND_HOST:-opennvr_core}:${BACKEND_PORT:-8000}/api/v1/mediamtx/startup/hook?delay=5"'
-  runOnInitRestart: no
+  # NOTE: runOnInit lives ONLY on the __startup__ path below, not here in
+  # pathDefaults. In pathDefaults it is inherited by EVERY camera path, so each
+  # camera (re)provision re-fires the startup hook → re-provision → re-fire,
+  # an infinite reload/provision loop that also fragments recordings.
 
   runOnDemand:
   runOnDemandRestart: no
@@ -417,4 +418,9 @@ paths:
   __startup__:
     source: publisher
     record: no
+    # Startup hook - provisions cameras from backend DB once on MediaMTX start.
+    # runOnInitRestart MUST be 'no': the curl exits immediately, so 'yes' would
+    # re-run it forever. The backend also self-provisions on its own startup.
+    runOnInit: 'curl -X GET -H "X-MTX-Secret: ${MEDIAMTX_SECRET}" "http://${BACKEND_HOST:-opennvr_core}:${BACKEND_PORT:-8000}/api/v1/mediamtx/startup/hook?delay=5"'
+    runOnInitRestart: no
 

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -225,6 +225,12 @@ class Settings(BaseSettings):
     mediamtx_admin_token: str | None = None
     mediamtx_auto_provision: bool = True  # Enable/disable auto-provisioning on startup
 
+    # Default recording segment length (seconds) the backend sends to MediaMTX
+    # when provisioning a camera that has no explicit value of its own. Env var:
+    # RECORDING_SEGMENT_SECONDS. Default 3600 (1h) to match the MediaMTX
+    # pathDefaults `recordSegmentDuration: 1h` — keep them in sync.
+    recording_segment_seconds: int = 3600
+
     # MediaMTX service URLs (internal - for backend to MediaMTX communication)
     mediamtx_hls_url: str | None = "http://localhost:8888"  # HLS streaming endpoint
     mediamtx_rtsp_url: str | None = "rtsp://localhost:8554"  # RTSP streaming endpoint

--- a/server/env.example
+++ b/server/env.example
@@ -70,6 +70,11 @@ MEDIAMTX_HLS_URL=http://127.0.0.1:8888
 MEDIAMTX_RTSP_URL=rtsp://127.0.0.1:8554
 MEDIAMTX_PLAYBACK_URL=http://127.0.0.1:9996
 
+# Recording segment length (seconds) the backend sends to MediaMTX per camera.
+# Keep in sync with mediamtx.*.yml `recordSegmentDuration` (default 1h = 3600).
+# Shorter values = more, smaller files (e.g. 300 = 5-min segments).
+RECORDING_SEGMENT_SECONDS=3600
+
 # V-019 (M1b): the MediaMTX YAML templates ship with rtspEncryption="yes"
 # so the operator-facing RTSP server refuses plaintext clients. Some dev
 # setups use mediamtx.local.yml which keeps rtspEncryption="no" because

--- a/server/models.py
+++ b/server/models.py
@@ -39,6 +39,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
+from core.config import settings
 from core.database import Base
 
 
@@ -251,7 +252,12 @@ class CameraConfig(Base):
     source_url = Column(String(500), nullable=True)
     recording_enabled = Column(Boolean, default=False)
     recording_path = Column(String(500), nullable=True)
-    recording_segment_seconds = Column(Integer, default=60)
+    # Fallback default for rows created without an explicit value. Reads the
+    # configured RECORDING_SEGMENT_SECONDS (default 1h) at insert time, so
+    # there is one source of truth — not a separate hardcoded number here.
+    recording_segment_seconds = Column(
+        Integer, default=lambda: settings.recording_segment_seconds
+    )
     webrtc_publisher = Column(Boolean, default=False)
     rtmp_publisher = Column(Boolean, default=False)
     rtsp_transport = Column(String(16), nullable=True)

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -791,7 +791,7 @@ async def provision_camera_mediamtx(
     camera_id: int,
     enable_recording: bool = False,
     rtsp_transport: str = "tcp",
-    recording_segment_seconds: int = 300,
+    recording_segment_seconds: int = settings.recording_segment_seconds,
     recording_path: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
@@ -945,7 +945,7 @@ def _update_camera_recording_config(db: Session, camera_id: int, enable: bool):
                 source_url=cam.rtsp_url,
                 recording_enabled=enable,
                 rtsp_transport="tcp",
-                recording_segment_seconds=300,
+                recording_segment_seconds=settings.recording_segment_seconds,
                 last_provisioned_at=func.now(),
             )
             db.add(config)

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -985,7 +985,9 @@ async def toggle_camera_recording(
     try:
         if enable:
             result = await MediaMtxAdminService.enable_recording(
-                camera_id, duration="300s", segment_duration="10s"
+                camera_id,
+                duration=f"{settings.recording_segment_seconds}s",
+                segment_duration="10s",
             )
         else:
             result = await MediaMtxAdminService.disable_recording(camera_id)

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -987,7 +987,7 @@ async def toggle_camera_recording(
             result = await MediaMtxAdminService.enable_recording(
                 camera_id,
                 duration=f"{settings.recording_segment_seconds}s",
-                segment_duration="10s",
+                part_duration="1s",
             )
         else:
             result = await MediaMtxAdminService.disable_recording(camera_id)

--- a/server/routers/mediamtx_admin.py
+++ b/server/routers/mediamtx_admin.py
@@ -262,11 +262,20 @@ async def mtx_recording_delete(
 async def enable_recording(
     camera_id: int,
     duration: str | None = None,
-    segment_duration: str | None = "10s",
+    part_duration: str | None = "1s",
     db: Session = Depends(get_db),
     current_user=Depends(get_current_superuser),
 ):
-    """Enable recording for a camera stream with configurable duration."""
+    """Enable recording for a camera stream with configurable duration.
+
+    `duration` is the segment length (`recordSegmentDuration`) — when a new
+    recording file is started. Defaults to the configured
+    RECORDING_SEGMENT_SECONDS (single source of truth).
+
+    `part_duration` is the fMP4 part length (`recordPartDuration`) — the
+    flush/seek granularity *inside* each file. Defaults to `1s` to match the
+    mediamtx*.yml configs and favour low-latency playback.
+    """
     cam = db.query(Camera).filter(Camera.id == camera_id).first()
     if not cam:
         raise HTTPException(status_code=404, detail="Camera not found")
@@ -284,7 +293,7 @@ async def enable_recording(
         "record": True,
         "recordPath": f"{base_path}/cam-{camera_id}/%Y/%m/%d/%H-%M-%S-%f",
         "recordFormat": "mp4",
-        "recordPartDuration": segment_duration,
+        "recordPartDuration": part_duration,
         "recordSegmentDuration": duration,
         "recordDeleteAfter": "168h",  # 7 days default
     }
@@ -334,8 +343,10 @@ async def get_recording_status(
             "recording_enabled": conf.get("record", False),
             "record_path": conf.get("recordPath"),
             "record_format": conf.get("recordFormat", "mp4"),
-            "segment_duration": conf.get("recordPartDuration", "10s"),
-            "total_duration": conf.get("recordSegmentDuration", "60s"),
+            "part_duration": conf.get("recordPartDuration", "1s"),
+            "segment_duration": conf.get(
+                "recordSegmentDuration", f"{settings.recording_segment_seconds}s"
+            ),
             "delete_after": conf.get("recordDeleteAfter", "168h"),
         }
 

--- a/server/routers/mediamtx_admin.py
+++ b/server/routers/mediamtx_admin.py
@@ -261,7 +261,7 @@ async def mtx_recording_delete(
 @router.post("/admin/recordings/enable/{camera_id}")
 async def enable_recording(
     camera_id: int,
-    duration: str | None = "60s",
+    duration: str | None = None,
     segment_duration: str | None = "10s",
     db: Session = Depends(get_db),
     current_user=Depends(get_current_superuser),
@@ -270,6 +270,11 @@ async def enable_recording(
     cam = db.query(Camera).filter(Camera.id == camera_id).first()
     if not cam:
         raise HTTPException(status_code=404, detail="Camera not found")
+
+    # Default the segment length to the configured RECORDING_SEGMENT_SECONDS
+    # instead of a hardcoded value — single source of truth.
+    if duration is None:
+        duration = f"{settings.recording_segment_seconds}s"
 
     # Use effective path from database (user setting) or settings fallback
     base_path = get_effective_recordings_base_path(db)

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -28,6 +28,8 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
+from core.config import settings
+
 
 # Base schemas
 class RoleBase(BaseModel):
@@ -236,7 +238,9 @@ class CameraConfigBase(BaseModel):
     source_url: str | None = None
     recording_enabled: bool = False
     recording_path: str | None = None
-    recording_segment_seconds: int = 60
+    recording_segment_seconds: int = Field(
+        default_factory=lambda: settings.recording_segment_seconds
+    )
     webrtc_publisher: bool = False
     rtmp_publisher: bool = False
     rtsp_transport: str | None = Field(None, pattern="^(udp|tcp|auto)?$")

--- a/server/services/camera_service.py
+++ b/server/services/camera_service.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
+from core.config import settings
 from core.logging_config import camera_logger
 from models import Camera, CameraPermission, User
 from schemas import CameraCreate, CameraUpdate
@@ -111,7 +112,7 @@ class CameraService:
                         rtsp_url=db_camera.rtsp_url,
                         enable_recording=False,
                         rtsp_transport="tcp",
-                        recording_segment_seconds=300,
+                        recording_segment_seconds=settings.recording_segment_seconds,
                     )
 
                     if provision_result.get("status") == "ok":
@@ -159,7 +160,7 @@ class CameraService:
                                 source_url=db_camera.rtsp_url,
                                 recording_enabled=False,
                                 rtsp_transport="tcp",
-                                recording_segment_seconds=300,
+                                recording_segment_seconds=settings.recording_segment_seconds,
                                 last_provisioned_at=func.now(),
                                 transport_security=transport_security,
                                 # M1c-selfrev H-2: probe-driven, not

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -942,8 +942,14 @@ class MediaMtxAdminService:
 
     @staticmethod
     async def enable_recording(
-        camera_id: int, duration: str = "60s", segment_duration: str = "10s"
+        camera_id: int,
+        duration: str | None = None,
+        segment_duration: str = "10s",
     ) -> dict[str, Any]:
+        # Default the segment length to the configured RECORDING_SEGMENT_SECONDS
+        # (resolved at call time) instead of a hardcoded value.
+        if duration is None:
+            duration = f"{settings.recording_segment_seconds}s"
         """Enable recording for a camera stream."""
         from core.database import SessionLocal
         from models import Camera

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -944,10 +944,13 @@ class MediaMtxAdminService:
     async def enable_recording(
         camera_id: int,
         duration: str | None = None,
-        segment_duration: str = "10s",
+        part_duration: str = "1s",
     ) -> dict[str, Any]:
-        # Default the segment length to the configured RECORDING_SEGMENT_SECONDS
-        # (resolved at call time) instead of a hardcoded value.
+        # `duration` is the segment length (recordSegmentDuration) — default to the
+        # configured RECORDING_SEGMENT_SECONDS (resolved at call time) instead of a
+        # hardcoded value. `part_duration` is the fMP4 part length
+        # (recordPartDuration) — flush/seek granularity inside each file; `1s`
+        # matches the mediamtx*.yml configs and favours low-latency playback.
         if duration is None:
             duration = f"{settings.recording_segment_seconds}s"
         """Enable recording for a camera stream."""
@@ -968,6 +971,7 @@ class MediaMtxAdminService:
                 "record": True,
                 "recordPath": f"{container_path}/%path/%Y/%m/%d/%H-%M-%S-%f",
                 "recordFormat": "fmp4",
+                "recordPartDuration": part_duration,
                 "recordSegmentDuration": duration,
                 "recordDeleteAfter": "168h",  # 7 days default
             }
@@ -1015,8 +1019,10 @@ class MediaMtxAdminService:
                 "recording_enabled": conf.get("record", False),
                 "record_path": conf.get("recordPath"),
                 "record_format": conf.get("recordFormat", "mp4"),
-                "segment_duration": conf.get("recordPartDuration", "10s"),
-                "total_duration": conf.get("recordSegmentDuration", "60s"),
+                "part_duration": conf.get("recordPartDuration", "1s"),
+                "segment_duration": conf.get(
+                    "recordSegmentDuration", f"{settings.recording_segment_seconds}s"
+                ),
                 "delete_after": conf.get("recordDeleteAfter", "168h"),
             }
 

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -664,7 +664,7 @@ class MediaMtxAdminService:
         rtsp_url: str,
         enable_recording: bool = False,
         rtsp_transport: str = "tcp",
-        recording_segment_seconds: int = 300,
+        recording_segment_seconds: int = settings.recording_segment_seconds,
         recording_path: str | None = None,
         transport_security: str | None = None,
     ) -> dict[str, Any]:

--- a/server/services/mediamtx_config_service.py
+++ b/server/services/mediamtx_config_service.py
@@ -84,7 +84,7 @@ class MediaMtxConfigService:
             "record": True,
             "recordPath": f"{base_path}/{stream_name}/%Y/%m/%d/%H/%M/%S",
             "recordFormat": "mp4",  # or "ts" for transport stream
-            "recordSegmentDuration": "5m",  # 5-minute segments
+            "recordSegmentDuration": f"{settings.recording_segment_seconds}s",
             "recordDeleteAfter": "720h",  # Keep recordings for 30 days
         }
 
@@ -104,7 +104,7 @@ class MediaMtxConfigService:
             # Recording settings
             "recordPath": base_path + "/%path/%Y/%m/%d/%H/%M/%S",
             "recordFormat": "mp4",
-            "recordSegmentDuration": "5m",
+            "recordSegmentDuration": f"{settings.recording_segment_seconds}s",
             "recordDeleteAfter": "720h",  # 30 days
             # Performance settings
             "readTimeout": "10s",
@@ -144,7 +144,7 @@ class MediaMtxConfigService:
             "record": False,
             "recordPath": base_path + "/%path/%Y/%m/%d/%H/%M/%S",
             "recordFormat": "mp4",
-            "recordSegmentDuration": "5m",
+            "recordSegmentDuration": f"{settings.recording_segment_seconds}s",
             "recordDeleteAfter": "720h",
             # Webhook settings
             **{k: v for k, v in webhook_config.items() if v is not None},
@@ -401,7 +401,7 @@ pathDefaults:
   record: no
   recordPath: {base_path}/%path/%Y/%m/%d/%H-%M-%S-%f
   recordFormat: fmp4
-  recordSegmentDuration: 5m
+  recordSegmentDuration: {settings.recording_segment_seconds}s
   recordDeleteAfter: 168h  # 7 days
   
   # Webhook integration for recording events

--- a/server/services/mediamtx_startup_service.py
+++ b/server/services/mediamtx_startup_service.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from core.config import settings
 from core.database import SessionLocal
 from core.logging_config import mediamtx_logger
 from models import Camera, CameraConfig
@@ -438,7 +439,8 @@ class MediaMtxStartupService:
                 provision_config["recording"] = {
                     "enabled": True,
                     "path": recording_path,
-                    "segment_seconds": config.recording_segment_seconds or 300,
+                    "segment_seconds": config.recording_segment_seconds
+                    or settings.recording_segment_seconds,
                 }
             elif config.recording_enabled is False:
                 # Explicitly disabled - set recording to False


### PR DESCRIPTION
Replaces the hardcoded 300s recording-segment value (and the stray 60s model/schema defaults) with a single configurable setting RECORDING_SEGMENT_SECONDS