### PR TITLE
app: theme-aware badge colors — fix light-mode contrast

### DIFF
--- a/app/src/components/ui/index.tsx
+++ b/app/src/components/ui/index.tsx
@@ -46,12 +46,15 @@ export function CardContent({ children, className = '' }: { children: ReactNode;
 
 export type BadgeVariant = 'success' | 'warning' | 'destructive' | 'neutral' | 'info'
 
+// Theme-token driven (see the --badge-* variables in index.css): the dark
+// theme keeps the translucent deep tints, the light theme swaps to pale
+// tints with dark text — raw palette classes here would wash out on light.
 const BADGE_STYLES: Record<BadgeVariant, string> = {
-  success: 'bg-green-900/50 text-green-400',
-  warning: 'bg-yellow-900/50 text-yellow-400',
-  destructive: 'bg-red-900/50 text-red-400',
-  neutral: 'bg-gray-900/50 text-gray-400',
-  info: 'bg-blue-900/50 text-blue-400',
+  success: 'bg-[var(--badge-success-bg)] text-[var(--badge-success-text)]',
+  warning: 'bg-[var(--badge-warning-bg)] text-[var(--badge-warning-text)]',
+  destructive: 'bg-[var(--badge-destructive-bg)] text-[var(--badge-destructive-text)]',
+  neutral: 'bg-[var(--badge-neutral-bg)] text-[var(--badge-neutral-text)]',
+  info: 'bg-[var(--badge-info-bg)] text-[var(--badge-info-text)]',
 }
 
 export function Badge({ children, variant = 'neutral', className = '' }: { children: ReactNode; variant?: BadgeVariant; className?: string }) {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -14,6 +14,17 @@
   --radius-card: 0px;
   --radius-input: 0px;
   --radius-button: 0px;
+  /* Badge tokens — dark theme: translucent deep tints, light text */
+  --badge-success-bg: rgba(20, 83, 45, 0.5);    /* green-900/50 */
+  --badge-success-text: #4ade80;                /* green-400 */
+  --badge-warning-bg: rgba(113, 63, 18, 0.5);   /* yellow-900/50 */
+  --badge-warning-text: #facc15;                /* yellow-400 */
+  --badge-destructive-bg: rgba(127, 29, 29, 0.5); /* red-900/50 */
+  --badge-destructive-text: #f87171;            /* red-400 */
+  --badge-neutral-bg: rgba(17, 24, 39, 0.5);    /* gray-900/50 */
+  --badge-neutral-text: #9ca3af;                /* gray-400 */
+  --badge-info-bg: rgba(30, 58, 138, 0.5);      /* blue-900/50 */
+  --badge-info-text: #60a5fa;                   /* blue-400 */
 }
 
 /* Light theme overrides */
@@ -30,6 +41,17 @@
   --radius-card: 0px;
   --radius-input: 0px;
   --radius-button: 0px;
+  /* Badge tokens — light theme: pale tints, dark text */
+  --badge-success-bg: #dcfce7;                  /* green-100 */
+  --badge-success-text: #15803d;                /* green-700 */
+  --badge-warning-bg: #fef9c3;                  /* yellow-100 */
+  --badge-warning-text: #a16207;                /* yellow-700 */
+  --badge-destructive-bg: #fee2e2;              /* red-100 */
+  --badge-destructive-text: #b91c1c;            /* red-700 */
+  --badge-neutral-bg: #f3f4f6;                  /* gray-100 */
+  --badge-neutral-text: #374151;                /* gray-700 */
+  --badge-info-bg: #dbeafe;                     /* blue-100 */
+  --badge-info-text: #1d4ed8;                   /* blue-700 */
 }
 
 html, body, #root { height: 100%; }


### PR DESCRIPTION
The shared Badge variants used raw Tailwind palette classes (bg-green-900/50 text-green-400 etc.) tuned for the dark theme; on the light theme they rendered as dark translucent smudges with pale text — nearly unreadable on the App Catalog dependency chips and the AI Adapters task/status chips. Same class of bug as the border-neutral-700 fix in the design-system extraction: the badge bypassed the CSS-variable token system the themes flip.

Badge colors are now semantic tokens (--badge-{variant}-{bg,text}) in index.css with per-theme values: dark keeps the exact previous look (verified: computed colors byte-identical), light gets pale tints with dark text (green-100/green-700 etc.).

Verified: tsc + build clean; browser check in both themes — light-mode success badge now computes rgb(220,252,231)/rgb(21,128,61).