### PR TITLE
platform: apps compose overlay + service registration auth; finish SD…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,10 @@ server/test_*.py
 # Example-app pytest suites (A2.5+): each example/{slug}/tests/ is part
 # of the shipped artifact and must be tracked.
 !examples/**/tests/test_*.py
+# App SDK pytest suite: same negation pattern as server/tests/. Without
+# this the blanket ``test_*.py`` above silently untracked the whole
+# sdk/opennvr-app-sdk/tests/ suite.
+!sdk/opennvr-app-sdk/tests/test_*.py
 server/scripts/check_*.py
 server/scripts/get_*.py
 server/scripts/delete_*.py

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -1,0 +1,155 @@
+# ==========================================
+# OpenNVR — SDK detector apps overlay
+# ==========================================
+#
+# Runs the migrated opennvr-app-sdk detector apps against a deployed
+# stack. Each app subscribes to KAI-C's NATS inference broadcast
+# (zero extra GPU cost — it rides the stream the stack is already
+# producing), serves the §03 contract endpoints (/health /manifest
+# /state) on its contract port, and self-registers with the OpenNVR
+# app registry on boot — so it appears in the App Catalog
+# (Settings → App Catalog, backed by GET /api/v1/apps) with a live
+# status dot and an auto-generated config form.
+#
+# Run (from the repo root, on top of the standard stack):
+#
+#     docker compose -f docker-compose.yml -f docker-compose.apps.yml --profile apps up -d
+#
+# Stop just the apps:
+#
+#     docker compose -f docker-compose.yml -f docker-compose.apps.yml --profile apps down
+#
+# Registration auth: the apps authenticate to POST /api/v1/apps/register
+# with the deployment's INTERNAL_API_KEY (X-Internal-Api-Key header) —
+# the same secret NATS and the adapters use. No user JWT is involved.
+#
+# Config: each app's config.yml is generated at ``up`` time from
+# examples/<app>/config.docker.yml by a one-shot init container
+# (busybox sed substitution — same pattern as the camera-agent
+# overlay), so secrets come from .env, not the repo. Edit the
+# template's cameras/zones for your scene, then re-run ``up``.
+# ==========================================
+
+services:
+  # ──────────────────────────────────────────────────────────────
+  # Loitering detection — dwell-time alerts for watched labels in
+  # operator-defined zones. Contract surface on :9200.
+  # ──────────────────────────────────────────────────────────────
+  loitering-detection-config-init:
+    profiles: [apps]
+    image: alpine:3.20
+    container_name: opennvr_loitering_config_init
+    restart: "no"
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        # busybox sed substitutes only INTERNAL_API_KEY, leaving other
+        # ``$`` sigils untouched (no envsubst / apk fetch, which some
+        # operator ISPs filter). Same pattern as the camera-agent overlay.
+        sed_esc() { printf '%s' "$$1" | sed -e 's/\\/\\\\/g; s/&/\\&/g; s/\//\\\//g'; }
+        ikey=$$(sed_esc "$${INTERNAL_API_KEY}")
+        sed -e "s/[$$][{]INTERNAL_API_KEY[}]/$$ikey/g" \
+            < /template/config.docker.yml > /generated/config.yml
+        echo "Wrote /generated/config.yml (loitering-detection) from template."
+    environment:
+      - INTERNAL_API_KEY=${INTERNAL_API_KEY}
+    volumes:
+      - ./examples/loitering-detection:/template:ro
+      - opennvr_loitering_config:/generated
+
+  loitering-detection:
+    profiles: [apps]
+    build:
+      context: .
+      dockerfile: examples/loitering-detection/Dockerfile
+    image: opennvr/loitering-detection:local-build
+    container_name: opennvr_loitering_detection
+    restart: unless-stopped
+    depends_on:
+      loitering-detection-config-init:
+        condition: service_completed_successfully
+      nats:
+        condition: service_healthy
+      opennvr-core:
+        condition: service_healthy
+    environment:
+      # The SDK's registration call reads the token from this env var
+      # (cfg opennvr_token wins when set; the template leaves it unset).
+      - OPENNVR_INTERNAL_API_KEY=${INTERNAL_API_KEY}
+      # Informational — the effective values live in the generated
+      # config.yml (see the config-init container above).
+      - NATS_URL=nats://nats:4222
+      - OPENNVR_URL=http://opennvr-core:8000
+    # Contract surface (/health /manifest /state) — internal-only; the
+    # registry polls it over the compose network. Add a
+    # ``127.0.0.1:9200:9200`` port mapping to poke it from the host.
+    expose:
+      - "9200"
+    volumes:
+      - opennvr_loitering_config:/app/config:ro
+    command:
+      - --config
+      - /app/config/config.yml
+    networks:
+      - opennvr_internal
+
+  # ──────────────────────────────────────────────────────────────
+  # Occupancy counting — over/under-occupancy alerts per camera ×
+  # zone. Contract surface on :9201.
+  # ──────────────────────────────────────────────────────────────
+  occupancy-counting-config-init:
+    profiles: [apps]
+    image: alpine:3.20
+    container_name: opennvr_occupancy_config_init
+    restart: "no"
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        sed_esc() { printf '%s' "$$1" | sed -e 's/\\/\\\\/g; s/&/\\&/g; s/\//\\\//g'; }
+        ikey=$$(sed_esc "$${INTERNAL_API_KEY}")
+        sed -e "s/[$$][{]INTERNAL_API_KEY[}]/$$ikey/g" \
+            < /template/config.docker.yml > /generated/config.yml
+        echo "Wrote /generated/config.yml (occupancy-counting) from template."
+    environment:
+      - INTERNAL_API_KEY=${INTERNAL_API_KEY}
+    volumes:
+      - ./examples/occupancy-counting:/template:ro
+      - opennvr_occupancy_config:/generated
+
+  occupancy-counting:
+    profiles: [apps]
+    build:
+      context: .
+      dockerfile: examples/occupancy-counting/Dockerfile
+    image: opennvr/occupancy-counting:local-build
+    container_name: opennvr_occupancy_counting
+    restart: unless-stopped
+    depends_on:
+      occupancy-counting-config-init:
+        condition: service_completed_successfully
+      nats:
+        condition: service_healthy
+      opennvr-core:
+        condition: service_healthy
+    environment:
+      - OPENNVR_INTERNAL_API_KEY=${INTERNAL_API_KEY}
+      - NATS_URL=nats://nats:4222
+      - OPENNVR_URL=http://opennvr-core:8000
+    expose:
+      - "9201"
+    volumes:
+      - opennvr_occupancy_config:/app/config:ro
+    command:
+      - --config
+      - /app/config/config.yml
+    networks:
+      - opennvr_internal
+
+volumes:
+  # Generated config.yml files (mounted read-only by each app).
+  opennvr_loitering_config:
+  opennvr_occupancy_config:

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,30 @@ The thirteen shipped examples cover two orthogonal axes of the OpenNVR pipeline:
 
 ---
 
+## 🐳 Run the detector apps against the stack
+
+The migrated SDK detector apps ship a compose overlay
+([`docker-compose.apps.yml`](../docker-compose.apps.yml) at the repo
+root). On boot each app subscribes to the stack's NATS inference
+stream, serves the SDK contract endpoints (`/health` `/manifest`
+`/state`), **self-registers with the app registry** using the
+deployment's `INTERNAL_API_KEY`, and appears in the **App Catalog**
+(Settings → App Catalog) with a live status dot and an auto-generated
+config form:
+
+```bash
+# From the repo root, on top of the standard stack:
+docker compose -f docker-compose.yml -f docker-compose.apps.yml --profile apps up -d
+```
+
+Currently in the overlay: `loitering-detection` (contract port 9200)
+and `occupancy-counting` (9201). Each app's runtime config is
+generated at `up` time from its `config.docker.yml` template (secrets
+come from `.env`) — edit the template's cameras/zones for your scene
+and re-run `up`.
+
+---
+
 ## ✅ Shipped — runnable today
 
 ### [`intrusion-detection/`](intrusion-detection)

--- a/examples/footage-search/footage_search.py
+++ b/examples/footage-search/footage_search.py
@@ -3,7 +3,7 @@
 
 """
 Footage-search example app — natural-language search over recorded
-inference history.
+inference history, now on the ``opennvr-app-sdk``.
 
     $ python footage_search.py search "red truck at the dock yesterday"
 
@@ -29,6 +29,29 @@ Two subcommands:
   match carries the ``correlation_id`` that ties it to the exact
   recorded segment in OpenNVR.
 
+What lives where after the migration
+------------------------------------
+
+The :class:`Indexer` is a :class:`~opennvr_app_sdk.Detector` (App SDK
+spec §02): the SDK base owns the NATS connect / subscribe / drain
+loop, per-message JSON decoding + exception isolation, and the §03
+contract endpoints. Because the indexer also stores caption-only
+events (no ``result.detections``), it hooks ``handle_event`` — the
+whole-event stage above the base's detections walk — rather than
+``on_detections``.
+
+Deliberately app-side (the "don't force it" clause):
+
+* ``store.py`` — the SQLite keyframe schema + FTS-ish search query,
+  and ``keyframe_from_event`` (which result shapes are indexable is
+  this app's business);
+* ``query.py`` — the natural-language → structured-filter parsers
+  (heuristic + optional Ollama);
+* the two-subcommand CLI (``index`` / ``search``): the SDK's
+  ``app(...)`` runner models single-loop daemons, so ``main`` keeps
+  its own argparse and drives ``Indexer.run()`` itself for the
+  ``index`` path.
+
 Why this works without a special model: object *classes* come from the
 detector's labels; *attributes* like "red" come from the captioner's
 scene text. Searching across both is what lets "red truck" resolve. For
@@ -46,20 +69,44 @@ from __future__ import annotations
 import argparse
 import asyncio
 import datetime as _dt
-import json
 import logging
 import signal
 import sys
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass
 from typing import Any
 
-import yaml
+from opennvr_app_sdk import Alert, AppManifest, Detector, Param
+from opennvr_app_sdk.config import load_yaml
 
 from query import DEFAULT_LABELS, parse_heuristic, parse_with_ollama
 from store import FootageStore, SearchResult, keyframe_from_event
 
 logger = logging.getLogger("footage-search")
+
+
+MANIFEST = AppManifest(
+    id="footage-search",
+    name="Footage Search",
+    version="1.0.0",
+    category="forensics",
+    summary=(
+        "Indexes inference events (labels + captions) into SQLite and "
+        "answers natural-language footage queries like 'red truck at "
+        "the dock yesterday'."
+    ),
+    requires_tasks=[],  # indexes whatever detector/captioner streams exist
+    subscribes="opennvr.inference.>",
+    params=[
+        Param("db_path", str, default="footage_index.sqlite3"),
+        Param("subject_pattern", str, default="opennvr.inference.>"),
+        Param("extra_labels", list, default=[],
+              description="Extra label vocabulary for the query parser."),
+        Param("camera_aliases", dict, default={},
+              description="word -> camera_id aliases ('dock' -> 'cam-dock')."),
+        Param("result_limit", int, default=25),
+    ],
+    emits=[],  # writes an index; fires no alerts
+)
 
 
 # ── Config ─────────────────────────────────────────────────────────
@@ -85,9 +132,7 @@ class AppConfig:
 
 
 def load_config(path: str) -> AppConfig:
-    raw = yaml.safe_load(Path(path).read_text())
-    if not isinstance(raw, dict):
-        raise ValueError(f"config {path!r}: root must be a mapping")
+    raw = load_yaml(path)
 
     db_path = str(raw.get("db_path") or "footage_index.sqlite3").strip()
     if not db_path:
@@ -134,19 +179,29 @@ def load_config(path: str) -> AppConfig:
 # ── Indexer ────────────────────────────────────────────────────────
 
 
-class Indexer:
-    """Subscribes to NATS inference events and writes searchable
-    keyframes into the store."""
+class Indexer(Detector):
+    """Subscribes to NATS inference events (via the SDK's Detector
+    loop) and writes searchable keyframes into the store.
 
-    def __init__(self, config: AppConfig, store: FootageStore) -> None:
-        self._config = config
+    Hooks :meth:`handle_event` instead of ``on_detections`` because
+    caption-only events (a BLIP result has ``result.caption`` and no
+    detections list) are exactly as indexable as detection events —
+    the base's detections walk would drop them.
+    """
+
+    manifest = MANIFEST
+
+    def __init__(
+        self,
+        config: AppConfig,
+        store: FootageStore,
+        dispatcher: Any = None,
+    ) -> None:
+        # ``dispatcher`` is unused (this app fires no alerts); the
+        # historical constructor is ``Indexer(config, store)``.
         self._store = store
-        self._stop_event = asyncio.Event()
-        self._nc: Any = None
+        super().__init__(config, dispatcher)
         self._indexed = 0
-
-    def stop(self) -> None:
-        self._stop_event.set()
 
     def ingest(self, event: dict[str, Any]) -> bool:
         """Index one event. Returns True if a keyframe was stored."""
@@ -157,47 +212,31 @@ class Indexer:
         self._indexed += 1
         return True
 
-    async def run(self, *, once: bool = False) -> None:
-        import nats
+    def handle_event(self, event: Any) -> list[Alert]:
+        """Whole-event hook (decode + isolation live in the SDK's
+        ``_handle_raw`` above this)."""
+        self._contract_note_event()
+        if isinstance(event, dict):
+            self.ingest(event)
+            if self._indexed and self._indexed % 100 == 0:
+                logger.info("indexed %d keyframes", self._indexed)
+        return []
 
-        connect_kwargs: dict[str, Any] = {
-            "servers": [self._config.nats_url],
-            "connect_timeout": 5.0,
-            "reconnect_time_wait": 1.0,
-            "max_reconnect_attempts": -1,
+    def state_snapshot(self) -> dict[str, Any]:
+        """``GET /state`` — session + total index counters."""
+        return {
+            "indexed_this_session": self._indexed,
+            "rows_total": self._store.count(),
         }
-        if self._config.nats_token:
-            connect_kwargs["token"] = self._config.nats_token
-        self._nc = await nats.connect(**connect_kwargs)
+
+    async def run(self, *, once: bool = False) -> None:
         logger.info(
             "footage-search indexer started: db=%s, subject=%r (%d rows already indexed)",
-            self._config.db_path, self._config.subject_pattern, self._store.count(),
+            self.cfg.db_path, self.cfg.subject_pattern, self._store.count(),
         )
         try:
-            sub = await self._nc.subscribe(self._config.subject_pattern)
-            async for msg in sub.messages:
-                try:
-                    payload = json.loads(msg.data)
-                except json.JSONDecodeError:
-                    continue
-                try:
-                    self.ingest(payload)
-                except Exception:
-                    logger.exception("ingest failed for subject=%s", msg.subject)
-                if self._indexed and self._indexed % 100 == 0:
-                    logger.info("indexed %d keyframes", self._indexed)
-                if once:
-                    self.stop()
-                if self._stop_event.is_set():
-                    break
+            await super().run(once=once)
         finally:
-            try:
-                await self._nc.drain()
-            except Exception:
-                try:
-                    await self._nc.close()
-                except Exception:
-                    pass
             logger.info("indexer stopped; %d keyframes this session", self._indexed)
 
 
@@ -249,6 +288,8 @@ def format_results(results: list[SearchResult]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Two-subcommand CLI — kept app-side (the SDK's ``app(...)``
+    # runner models single-loop daemons; ``search`` is a one-shot).
     parser = argparse.ArgumentParser(
         prog="footage-search",
         description="Index inference events and search recorded footage in natural language.",

--- a/examples/footage-search/pyproject.toml
+++ b/examples/footage-search/pyproject.toml
@@ -5,16 +5,26 @@ description = "OpenNVR footage-search example app (natural-language search over 
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0" }
 
-# nats-py for the indexer subscribe loop, httpx for the optional Ollama
-# query parser, PyYAML for config. SQLite is in the stdlib. No kai-c
-# imports — the event schema is documented JSON.
+# The SDK owns the runtime stack (nats-py subscribe loop, PyYAML
+# config, httpx — which the optional Ollama query parser also rides).
+# SQLite is in the stdlib. No kai-c imports — the event schema is
+# documented JSON.
 dependencies = [
-    "nats-py>=2.6",
-    "httpx>=0.27,<1.0",
-    "PyYAML>=6.0,<7.0",
+    "opennvr-app-sdk",
 ]
 
+[tool.uv.sources]
+opennvr-app-sdk = { path = "../../sdk/opennvr-app-sdk", editable = true }
+
 [project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23",
+]
+
+# Mirrors the optional-dependencies group so a plain ``uv sync`` gets a
+# test-ready environment (uv installs the ``dev`` group by default).
+[dependency-groups]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23",

--- a/examples/footage-search/uv.lock
+++ b/examples/footage-search/uv.lock
@@ -1,0 +1,275 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f0/fc5e93f2b0dd14a202590ad9d30eda1955ea872039b5204357348d0f4b1e/nats_py-2.15.0.tar.gz", hash = "sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93", size = 75995, upload-time = "2026-06-05T07:34:03.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl", hash = "sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd", size = 90334, upload-time = "2026-06-05T07:34:02.81Z" },
+]
+
+[[package]]
+name = "opennvr-app-sdk"
+version = "0.1.0"
+source = { editable = "../../sdk/opennvr-app-sdk" }
+dependencies = [
+    { name = "httpx" },
+    { name = "nats-py" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27,<1.0" },
+    { name = "nats-py", specifier = ">=2.6" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "opennvr-example-footage-search"
+version = "1.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "opennvr-app-sdk" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "opennvr-app-sdk", editable = "../../sdk/opennvr-app-sdk" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/examples/home-assistant-relay/Dockerfile
+++ b/examples/home-assistant-relay/Dockerfile
@@ -19,10 +19,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# The app SDK owns the runtime stack (nats-py, PyYAML, httpx); only
+# paho-mqtt (the MQTT-discovery backend) stays app-side. Build from
+# the repo root so the SDK folder is in the build context.
+COPY sdk/opennvr-app-sdk /opt/opennvr-app-sdk
 RUN pip install --no-cache-dir \
-        "httpx>=0.27,<1.0" \
-        "PyYAML>=6.0,<7.0" \
-        "nats-py>=2.6,<3.0" \
+        /opt/opennvr-app-sdk \
         "paho-mqtt>=2.0,<3.0"
 
 COPY examples/home-assistant-relay/__init__.py            ./__init__.py

--- a/examples/home-assistant-relay/home_assistant_relay.py
+++ b/examples/home-assistant-relay/home_assistant_relay.py
@@ -2,13 +2,38 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 """
-home-assistant-relay — bridge OpenNVR alerts into Home Assistant.
+home-assistant-relay — bridge OpenNVR alerts into Home Assistant,
+now on the ``opennvr-app-sdk``.
 
 Subscribes to ``opennvr.alerts.>`` on NATS, runs each alert through
 the HA mapper (alert envelope → HA entity definition + state),
 publishes via either MQTT discovery or HA's REST API, and schedules
 an auto-off flip for binary_sensors after a configurable window so
 the dashboard reads like an event log, not a sticky alarm.
+
+What lives where after the migration
+------------------------------------
+
+This app is an :class:`~opennvr_app_sdk.AlertSubscriber` (App SDK spec
+§02, the "pass-through" shape — same archetype as the reference
+``alerts-subscriber``). The SDK base owns the NATS connect / subscribe
+/ drain loop, the §03 contract endpoints, and the CLI / signal
+lifecycle behind ``alert_app(HomeAssistantRelay).run()``.
+
+Deliberately app-side (the "don't force it" clause):
+
+* ``ha_mapper.py`` — the alert → HA-entity mapping rules and override
+  table. HA vocabulary (device_class, ``binary_sensor`` vs ``sensor``)
+  is this bridge's business, not the SDK's.
+* ``publishers.py`` — the MQTT-discovery and HA-REST clients. Both
+  are **async** (paho bridged via ``asyncio.to_thread``, httpx's
+  AsyncClient), which is also why this app overrides the base's
+  per-message hook: ``_handle_raw`` here is a coroutine (the shared
+  NATS loop awaits awaitable results), so the sink can ``await`` its
+  publisher instead of squeezing async I/O through the sync
+  ``on_alert`` hook.
+* the auto-off generation machinery — HA-entity semantics, not alert
+  semantics.
 
 Why MQTT discovery is the default
 ----------------------------------
@@ -28,17 +53,20 @@ Run:
 """
 from __future__ import annotations
 
-import argparse
 import asyncio
 import json
 import logging
-import signal
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
+from opennvr_app_sdk import (
+    AlertSubscriber,
+    AppManifest,
+    Param,
+    alert_app,
+)
+from opennvr_app_sdk.config import load_yaml
 
 from ha_mapper import HaEntity, HaMapper, MappingOverride, parse_overrides
 from publishers import (
@@ -50,6 +78,30 @@ from publishers import (
 )
 
 logger = logging.getLogger("home-assistant-relay")
+
+
+MANIFEST = AppManifest(
+    id="home-assistant-relay",
+    name="Home Assistant Relay",
+    version="1.0.0",
+    category="integration",
+    summary=(
+        "Bridges the opennvr.alerts.* fan-out into Home Assistant "
+        "entities via MQTT discovery or the HA REST API, with "
+        "auto-off windows so sensors read like an event log."
+    ),
+    requires_tasks=[],  # rides the alert bus; no adapter prerequisites
+    subscribes="opennvr.alerts.>",
+    params=[
+        Param("subject_pattern", str, default="opennvr.alerts.>"),
+        Param("backend", str, default="mqtt",
+              description="'mqtt' (discovery; preferred) or 'rest'."),
+        Param("default_auto_off_seconds", int, default=30,
+              description="Auto-off window for binary_sensors when a "
+                          "mapping override doesn't set one."),
+    ],
+    emits=[],  # pass-through: consumes alerts, emits none
+)
 
 
 # ── Config ─────────────────────────────────────────────────────────
@@ -80,9 +132,10 @@ class AppConfig:
 
 
 def load_config(path: str | Path) -> AppConfig:
-    raw = yaml.safe_load(Path(path).read_text())
-    if not isinstance(raw, dict):
-        raise SystemExit(f"config file {path} did not parse to a dict")
+    # Historical quirk kept on purpose: this app's validation raises
+    # ``SystemExit`` with an operator-facing message (the other
+    # examples raise ``ValueError``); its tests pin that contract.
+    raw = load_yaml(path)
 
     nats_url = str(raw.get("nats_url") or "").strip()
     if not nats_url:
@@ -189,13 +242,20 @@ def load_config(path: str | Path) -> AppConfig:
 # ── Relay daemon ───────────────────────────────────────────────────
 
 
-class HomeAssistantRelay:
+class HomeAssistantRelay(AlertSubscriber):
     """The daemon. One instance per process.
 
     Lifecycle:
-      ``await relay.run()`` — connects to NATS, subscribes, dispatches
-      every alert through the mapper into the publisher. Blocks until
-      ``stop()`` (or SIGINT / SIGTERM) fires.
+      ``await relay.run()`` — the SDK base connects to NATS,
+      subscribes, and drives every alert through the mapper into the
+      publisher. Blocks until ``stop()`` (or SIGINT / SIGTERM via the
+      runner) fires.
+
+    Async sink:
+      Both publishers are awaitable, so this app overrides the base's
+      ``_handle_raw`` as a *coroutine* (the SDK's NATS loop awaits
+      awaitable results) instead of implementing the sync ``on_alert``
+      hook. Decode + isolation semantics mirror the base method.
 
     Auto-off:
       For each binary_sensor we publish, schedule a task that flips
@@ -205,16 +265,25 @@ class HomeAssistantRelay:
       entity "ON" as long as alerts keep firing.
     """
 
+    manifest = MANIFEST
+
     def __init__(
         self,
         config: AppConfig,
-        mapper: HaMapper,
-        publisher: Publisher,
+        mapper: HaMapper | None = None,
+        publisher: Publisher | None = None,
     ) -> None:
-        self._config = config
-        self._mapper = mapper
-        self._publisher = publisher
-        self._stop_event = asyncio.Event()
+        # ``mapper`` / ``publisher`` are injectable for the tests (the
+        # historical 3-arg constructor); the SDK runner constructs the
+        # relay with config alone and the defaults are built from it.
+        self._mapper = mapper or HaMapper(
+            overrides=config.overrides,
+            default_auto_off_seconds=config.default_auto_off_seconds,
+        )
+        self._publisher = publisher or build_publisher(config)
+        super().__init__(config)
+
+    def setup(self) -> None:
         self._auto_off_tasks: dict[str, asyncio.Task] = {}
         # Per-entity monotonic generation counter. Each fresh alert
         # bumps the entity's generation; the auto-off task captures
@@ -232,58 +301,27 @@ class HomeAssistantRelay:
         self._failed_count = 0
         self._skipped_count = 0
 
-    def stop(self) -> None:
-        self._stop_event.set()
-
-    async def run(self) -> None:
-        # Lazy import — keeps the module importable in test envs
-        # that don't have nats-py.
-        import nats  # type: ignore
-
-        connect_kwargs: dict[str, Any] = {
-            "servers": [self._config.nats_url],
-            "connect_timeout": 5.0,
-            "reconnect_time_wait": 1.0,
-            "max_reconnect_attempts": -1,
-        }
-        if self._config.nats_token:
-            connect_kwargs["token"] = self._config.nats_token
-        nc = await nats.connect(**connect_kwargs)
+    async def run(self, *, once: bool = False) -> None:
+        # The historical ``--once`` contract stops after the first
+        # *published* alert, not the first message — unmappable or
+        # failed alerts keep the smoke test waiting. Map the runner's
+        # ``once`` onto that instead of the loop-level stop.
+        if once:
+            self._once_mode = True
         logger.info(
-            "connected to %s, subscribing to %r (backend=%s)",
-            self._config.nats_url,
-            self._config.subject_pattern,
-            self._config.backend,
+            "subscribing to %r on %s (backend=%s)",
+            self.cfg.subject_pattern,
+            self.cfg.nats_url,
+            self.cfg.backend,
         )
         try:
-            sub = await nc.subscribe(self._config.subject_pattern)
-            async for msg in sub.messages:
-                if self._stop_event.is_set():
-                    break
-                try:
-                    payload = json.loads(msg.data)
-                except json.JSONDecodeError as exc:
-                    logger.warning(
-                        "skipping non-JSON message on %r: %s",
-                        msg.subject, exc,
-                    )
-                    continue
-                await self._handle_alert(payload)
-                if self._stop_event.is_set():
-                    break
+            await super().run(once=False)
         finally:
             # Cancel any pending auto-off tasks so we don't block on
             # them — operator wants a fast exit.
             for task in self._auto_off_tasks.values():
                 task.cancel()
             self._auto_off_tasks.clear()
-            try:
-                await nc.drain()
-            except Exception:
-                try:
-                    await nc.close()
-                except Exception:
-                    logger.exception("nats close failed")
             try:
                 await self._publisher.aclose()
             except Exception:
@@ -294,6 +332,36 @@ class HomeAssistantRelay:
                 self._received_count, self._published_count,
                 self._failed_count, self._skipped_count,
             )
+
+    def state_snapshot(self) -> dict[str, Any]:
+        """``GET /state`` — running relay counters."""
+        return {
+            "received": self._received_count,
+            "published": self._published_count,
+            "failed": self._failed_count,
+            "skipped": self._skipped_count,
+            "pending_auto_off": len(self._auto_off_tasks),
+        }
+
+    # ── Per-message handling (async override of the SDK hook) ─────
+
+    async def _handle_raw(self, data: bytes, *, subject: str = "") -> bool:
+        """Async twin of :meth:`AlertSubscriber._handle_raw` — same
+        decode + isolation contract, but the sink is awaited so the
+        publishers' async I/O stays on the event loop."""
+        try:
+            payload = json.loads(data)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            logger.warning("skipping non-JSON message on %r: %s", subject, exc)
+            return False
+        self._contract_note_event()
+        try:
+            await self._handle_alert(payload)
+        except Exception:
+            # No single alert failure should kill the bridge.
+            logger.exception("alert handling failed for subject=%s", subject)
+            return False
+        return True
 
     async def step(self, alert: dict[str, Any]) -> None:
         """Process one alert. Public so tests can drive without NATS."""
@@ -381,63 +449,9 @@ def build_publisher(config: AppConfig) -> Publisher:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        prog="home-assistant-relay",
-        description=(
-            "Bridge OpenNVR NATS alerts into Home Assistant entities."
-        ),
-    )
-    parser.add_argument("--config", required=True, help="Path to config.yml")
-    parser.add_argument(
-        "--once", action="store_true",
-        help="Process one alert and exit (smoke testing).",
-    )
-    parser.add_argument(
-        "--log-level", default="INFO",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-    )
-    args = parser.parse_args(argv)
-
-    logging.basicConfig(
-        level=args.log_level,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-
-    try:
-        config = load_config(args.config)
-    except OSError as exc:
-        # File-not-found / permission-denied → friendly stderr line
-        # + exit 2 (same shape as the other gallery examples).
-        # ``load_config`` itself raises SystemExit on schema errors,
-        # which propagates naturally with its own message + code.
-        print(f"config error: {exc}", file=sys.stderr)
-        return 2
-
-    mapper = HaMapper(
-        overrides=config.overrides,
-        default_auto_off_seconds=config.default_auto_off_seconds,
-    )
-    publisher = build_publisher(config)
-    relay = HomeAssistantRelay(config, mapper, publisher)
-
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-    def _handle_signal(_signum, _frame):
-        logger.info("signal received, stopping…")
-        loop.call_soon_threadsafe(relay.stop)
-
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
-
-    if args.once:
-        relay._once_mode = True  # type: ignore[attr-defined]
-
-    try:
-        loop.run_until_complete(relay.run())
-    finally:
-        loop.close()
-    return 0
+    """Console-script entry point. The SDK runner owns argparse,
+    logging, signals, and the loop lifecycle."""
+    return alert_app(HomeAssistantRelay, load_config=load_config).run(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/examples/home-assistant-relay/pyproject.toml
+++ b/examples/home-assistant-relay/pyproject.toml
@@ -5,22 +5,35 @@ description = "OpenNVR home-assistant-relay example app — bridges OpenNVR aler
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0" }
 
-# nats-py for the alert subscription; paho-mqtt for the MQTT-
-# discovery backend; httpx for the REST-API backend. PyYAML for
-# config loading. Pillow is NOT used here — this example only
-# touches alert envelopes, never camera frames.
+# The SDK owns the runtime stack (nats-py subscribe loop, PyYAML
+# config, httpx for the REST backend) — see docs/design/app-sdk-spec.html.
+# paho-mqtt stays app-side: the MQTT-discovery backend is this
+# bridge's business, not the SDK's. Pillow is NOT used here — this
+# example only touches alert envelopes, never camera frames.
 dependencies = [
-    "httpx>=0.27,<1.0",
-    "PyYAML>=6.0,<7.0",
-    "nats-py>=2.6,<3.0",
+    "opennvr-app-sdk",
     "paho-mqtt>=2.0,<3.0",
 ]
+
+[tool.uv.sources]
+opennvr-app-sdk = { path = "../../sdk/opennvr-app-sdk", editable = true }
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23",
 ]
+
+# Mirrors the optional-dependencies group so a plain ``uv sync`` gets a
+# test-ready environment (uv installs the ``dev`` group by default).
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23",
+]
+
+[project.scripts]
+home-assistant-relay = "home_assistant_relay:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/examples/home-assistant-relay/uv.lock
+++ b/examples/home-assistant-relay/uv.lock
@@ -1,0 +1,286 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f0/fc5e93f2b0dd14a202590ad9d30eda1955ea872039b5204357348d0f4b1e/nats_py-2.15.0.tar.gz", hash = "sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93", size = 75995, upload-time = "2026-06-05T07:34:03.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl", hash = "sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd", size = 90334, upload-time = "2026-06-05T07:34:02.81Z" },
+]
+
+[[package]]
+name = "opennvr-app-sdk"
+version = "0.1.0"
+source = { editable = "../../sdk/opennvr-app-sdk" }
+dependencies = [
+    { name = "httpx" },
+    { name = "nats-py" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27,<1.0" },
+    { name = "nats-py", specifier = ">=2.6" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "opennvr-example-home-assistant-relay"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "opennvr-app-sdk" },
+    { name = "paho-mqtt" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "opennvr-app-sdk", editable = "../../sdk/opennvr-app-sdk" },
+    { name = "paho-mqtt", specifier = ">=2.0,<3.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "paho-mqtt"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/15/0a6214e76d4d32e7f663b109cf71fb22561c2be0f701d67f93950cd40542/paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834", size = 148848, upload-time = "2024-04-29T19:52:55.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/cb/00451c3cf31790287768bb12c6bec834f5d292eaf3022afc88e14b8afc94/paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee", size = 67219, upload-time = "2024-04-29T19:52:48.345Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/examples/inference-listener/inference_listener.py
+++ b/examples/inference-listener/inference_listener.py
@@ -2,21 +2,29 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 """
-Inference-listener example app.
+Inference-listener example app — the "hello world" of the
+``opennvr-app-sdk``.
 
-The canonical subscriber-side template for KAI-C's NATS event bus.
-Connects to NATS, subscribes to a configurable
-``opennvr.inference.*`` subject pattern, and prints each
-``InferenceCompletedEvent`` to stdout. Every alert in the published
-stream is correlation-id-traceable back through KAI-C's audit log.
+Connects to NATS, subscribes to a configurable ``opennvr.inference.*``
+subject pattern, and prints each ``InferenceCompletedEvent`` to stdout.
+Every event in the stream is correlation-id-traceable back through
+KAI-C's audit log.
 
-This is the simplest possible consumer — community contributors copy
-it as a template for monitoring apps that prefer "subscribe to
-inference results" over "drive inference via /infer". The key
-difference from intrusion-detection: this app does NOT need its own
-camera or its own KAI-C call. It receives results that some OTHER
-component (intrusion-detection, a dashboard, etc.) already drove.
-One adapter inference fans out to N subscribers.
+This is the simplest possible :class:`~opennvr_app_sdk.Detector`
+(App SDK spec §02): the SDK base owns the NATS connect / subscribe /
+drain loop, per-message JSON decoding + exception isolation, the §03
+contract endpoints, and the CLI / signal lifecycle behind
+``app(InferenceListener).run()``. What's left here is the sink —
+``handle_event`` — plus config parsing and the MANIFEST.
+
+One deliberate twist: a stock Detector filters events down to
+``on_detections(camera_id, detections, event)``, dropping anything
+without a camera or a detections list. This listener prints EVERY
+event on the bus — ASR transcripts, captions, whatever — so it plugs
+in one hook lower, overriding ``_handle_raw`` and keeping its
+historical ``handle_event(subject, payload)`` extension point.
+Copy-as-template rule of thumb: if your app reacts to detections,
+implement ``on_detections``; if it wants the raw firehose, do this.
 
 Run:
     python inference_listener.py --config config.yml          # daemon
@@ -24,19 +32,33 @@ Run:
 """
 from __future__ import annotations
 
-import argparse
-import asyncio
 import json
 import logging
-import signal
-import sys
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
-import yaml
+from opennvr_app_sdk import AppManifest, Detector, Param, app
+from opennvr_app_sdk.config import load_yaml
 
 logger = logging.getLogger("inference-listener")
+
+
+MANIFEST = AppManifest(
+    id="inference-listener",
+    name="Inference Listener",
+    version="1.0.0",
+    category="observability",
+    summary=(
+        "Prints every InferenceCompletedEvent on the opennvr.inference.* "
+        "bus — the copy-as-template subscriber example."
+    ),
+    requires_tasks=[],  # listens to whatever is already flowing
+    subscribes="opennvr.inference.>",
+    params=[
+        Param("subject_pattern", str, default="opennvr.inference.>"),
+    ],
+    emits=[],  # prints to stdout; fires no alerts
+)
 
 
 # ── Config ─────────────────────────────────────────────────────────
@@ -54,9 +76,7 @@ def load_config(path: str) -> AppConfig:
     """Parse a YAML config file into a typed AppConfig. Raises
     ``ValueError`` on malformed input — caller's job to surface a
     useful operator message and exit non-zero."""
-    raw = yaml.safe_load(Path(path).read_text())
-    if not isinstance(raw, dict):
-        raise ValueError(f"config {path!r}: root must be a mapping")
+    raw = load_yaml(path)
     nats_url = str(raw.get("nats_url") or "").strip()
     if not nats_url:
         raise ValueError("config: 'nats_url' is required")
@@ -78,77 +98,47 @@ def load_config(path: str) -> AppConfig:
 # ── Subscriber ─────────────────────────────────────────────────────
 
 
-class InferenceListener:
-    """Holds the NATS connection + the subject subscription. The
-    main loop runs in an asyncio event loop; ``stop()`` (or SIGINT /
-    SIGTERM) cleanly drains and exits.
+class InferenceListener(Detector):
+    """The SDK base owns the NATS loop; ``stop()`` (or SIGINT /
+    SIGTERM via the runner) cleanly drains and exits.
 
-    Override ``handle_event(event_dict)`` in a subclass to plug your
-    own logic in — that's the extension point for community apps
+    Override ``handle_event(subject, payload)`` in a subclass to plug
+    your own logic in — that's the extension point for community apps
     (route to Slack, count detections, update a dashboard, etc.).
     The default implementation prints the event to stdout in a
     one-line-per-event format suitable for ``tail -f``.
     """
 
-    def __init__(self, config: AppConfig) -> None:
-        self._config = config
-        self._stop_event = asyncio.Event()
-        self._nc: Any = None
+    manifest = MANIFEST
+
+    def __init__(self, config: AppConfig, dispatcher: Any = None) -> None:
+        # ``dispatcher`` is unused (this app fires no alerts) but the
+        # SDK runner passes one; tests construct with config alone.
+        super().__init__(config, dispatcher)
         self._received_count: int = 0
 
-    def stop(self) -> None:
-        self._stop_event.set()
-
-    async def run(self) -> None:
-        """Connect, subscribe, loop until stop_event. Always cleans
-        up the NATS connection."""
-        # Lazy import — operators on the disabled path don't pay it.
-        import nats
-
-        connect_kwargs: dict[str, Any] = {
-            "servers": [self._config.nats_url],
-            "connect_timeout": 5.0,
-            "reconnect_time_wait": 1.0,
-            "max_reconnect_attempts": -1,  # keep retrying forever
-        }
-        if self._config.nats_token:
-            connect_kwargs["token"] = self._config.nats_token
-        self._nc = await nats.connect(**connect_kwargs)
-        logger.info(
-            "connected to %s, subscribing to %r",
-            self._config.nats_url, self._config.subject_pattern,
-        )
+    def _handle_raw(self, data: bytes, *, subject: str = "") -> list:
+        """Raw-firehose hook (see module docstring): decode + isolate,
+        then print — no camera_id / detections filtering."""
         try:
-            sub = await self._nc.subscribe(self._config.subject_pattern)
-            async for msg in sub.messages:
-                try:
-                    payload = json.loads(msg.data)
-                except json.JSONDecodeError as exc:
-                    logger.warning(
-                        "skipping non-JSON message on %r: %s",
-                        msg.subject, exc,
-                    )
-                    continue
-                self._received_count += 1
-                try:
-                    self.handle_event(msg.subject, payload)
-                except Exception:
-                    # No single event handler failure should kill the
-                    # subscriber. Operators will see the traceback in
-                    # the log and the next event is still processed.
-                    logger.exception("handler failed for subject=%s", msg.subject)
-                if self._config.once:
-                    self.stop()
-                if self._stop_event.is_set():
-                    break
-        finally:
-            try:
-                await self._nc.drain()
-            except Exception:
-                try:
-                    await self._nc.close()
-                except Exception:
-                    pass
+            payload = json.loads(data)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            logger.warning("skipping non-JSON message on %r: %s", subject, exc)
+            return []
+        self._contract_note_event()
+        self._received_count += 1
+        try:
+            self.handle_event(subject, payload)
+        except Exception:
+            # No single event handler failure should kill the
+            # subscriber. Operators will see the traceback in
+            # the log and the next event is still processed.
+            logger.exception("handler failed for subject=%s", subject)
+        return []
+
+    def state_snapshot(self) -> dict[str, Any]:
+        """``GET /state`` — the running receive counter."""
+        return {"received": self._received_count}
 
     # ── Extension point ───────────────────────────────────────────
 
@@ -186,50 +176,9 @@ class InferenceListener:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        prog="inference-listener",
-        description="Subscribe to KAI-C's NATS inference broadcast surface.",
-    )
-    parser.add_argument("--config", required=True, help="Path to config.yml")
-    parser.add_argument(
-        "--once",
-        action="store_true",
-        help="Process one event and exit (smoke testing).",
-    )
-    parser.add_argument(
-        "--log-level",
-        default="INFO",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-    )
-    args = parser.parse_args(argv)
-
-    logging.basicConfig(
-        level=args.log_level,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-    try:
-        config = load_config(args.config)
-    except (ValueError, OSError) as exc:
-        print(f"config error: {exc}", file=sys.stderr)
-        return 2
-    config.once = args.once
-
-    listener = InferenceListener(config)
-
-    # SIGINT / SIGTERM → graceful drain.
-    loop = asyncio.new_event_loop()
-
-    def _handle_signal(_signum, _frame):
-        logger.info("signal received, stopping…")
-        loop.call_soon_threadsafe(listener.stop)
-
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
-    try:
-        loop.run_until_complete(listener.run())
-    finally:
-        loop.close()
-    return 0
+    """Console-script entry point (``[project.scripts]``). The SDK
+    runner owns argparse, logging, signals, and the loop lifecycle."""
+    return app(InferenceListener, load_config=load_config).run(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/examples/inference-listener/pyproject.toml
+++ b/examples/inference-listener/pyproject.toml
@@ -6,15 +6,25 @@ requires-python = ">=3.11"
 license = { text = "AGPL-3.0" }
 
 # Deliberately minimal — meant as a clean copy-as-template for
-# community contributors building subscriber apps. The whole story
-# is `await nats.connect → subscribe → handle_event`, so the dep
-# list is just the NATS client + PyYAML for config.
+# community contributors building subscriber apps. The SDK owns the
+# whole runtime stack (nats-py subscribe loop, PyYAML config); the
+# whole story is `handle_event` plus a MANIFEST.
 dependencies = [
-    "nats-py>=2.6",
-    "PyYAML>=6.0,<7.0",
+    "opennvr-app-sdk",
 ]
 
+[tool.uv.sources]
+opennvr-app-sdk = { path = "../../sdk/opennvr-app-sdk", editable = true }
+
 [project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23",
+]
+
+# Mirrors the optional-dependencies group so a plain ``uv sync`` gets a
+# test-ready environment (uv installs the ``dev`` group by default).
+[dependency-groups]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23",

--- a/examples/inference-listener/uv.lock
+++ b/examples/inference-listener/uv.lock
@@ -1,0 +1,275 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f0/fc5e93f2b0dd14a202590ad9d30eda1955ea872039b5204357348d0f4b1e/nats_py-2.15.0.tar.gz", hash = "sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93", size = 75995, upload-time = "2026-06-05T07:34:03.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl", hash = "sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd", size = 90334, upload-time = "2026-06-05T07:34:02.81Z" },
+]
+
+[[package]]
+name = "opennvr-app-sdk"
+version = "0.1.0"
+source = { editable = "../../sdk/opennvr-app-sdk" }
+dependencies = [
+    { name = "httpx" },
+    { name = "nats-py" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27,<1.0" },
+    { name = "nats-py", specifier = ">=2.6" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "opennvr-example-inference-listener"
+version = "1.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "opennvr-app-sdk" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "opennvr-app-sdk", editable = "../../sdk/opennvr-app-sdk" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/examples/loitering-detection/Dockerfile
+++ b/examples/loitering-detection/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+# loitering-detection example app
+#
+# Build (from the open-nvr repo root — the context must include
+# sdk/opennvr-app-sdk, which this app depends on):
+#   docker build -f examples/loitering-detection/Dockerfile -t opennvr/loitering-detection:1.0.0 .
+#
+# Run (subscribes to the NATS event bus on the compose network):
+#   docker run --rm \
+#     --network opennvr_internal \
+#     -v $(pwd)/config.yml:/app/config.yml:ro \
+#     opennvr/loitering-detection:1.0.0 \
+#     --config /app/config.yml
+#
+# Or use the repo-root docker-compose.apps.yml overlay, which builds
+# this image, generates the config from config.docker.yml, and wires
+# NATS + registry self-registration automatically.
+
+FROM python:3.11-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# The SDK owns the runtime stack (nats-py subscribe loop, httpx alert
+# webhooks, PyYAML config) — install it from the repo checkout so the
+# image always matches the in-tree contract surface.
+COPY sdk/opennvr-app-sdk /opt/opennvr-app-sdk
+RUN pip install --no-cache-dir /opt/opennvr-app-sdk
+
+COPY examples/loitering-detection/loitering_detection.py ./loitering_detection.py
+COPY examples/loitering-detection/alerts.py              ./alerts.py
+COPY examples/loitering-detection/zone.py                ./zone.py
+COPY examples/loitering-detection/config.example.yml     ./config.example.yml
+
+ENV PYTHONUNBUFFERED=1
+
+# No HEALTHCHECK — liveness is Docker's "process is alive"; readiness
+# is the SDK contract server (/health on contract_port when enabled).
+
+ENTRYPOINT ["python", "loitering_detection.py"]
+CMD ["--config", "config.yml"]

--- a/examples/loitering-detection/config.docker.yml
+++ b/examples/loitering-detection/config.docker.yml
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# loitering-detection config consumed by docker-compose.apps.yml.
+#
+# Variables of the form ${VAR} are substituted by the
+# loitering-detection-config-init container at compose-up time (busybox
+# sed, same pattern as the camera-agent overlay). Only the variables
+# listed in the init container are replaced — everything else is left
+# untouched.
+#
+# DO NOT edit the substituted values directly. To change the secret,
+# update .env and re-run ``docker compose up`` so the init container
+# re-templates the file.
+
+# ── NATS endpoint (KAI-C's event bus, compose service ``nats``) ────
+nats_url: "nats://nats:4222"
+# The standard stack runs NATS with ``--auth INTERNAL_API_KEY``.
+nats_token: "${INTERNAL_API_KEY}"
+
+subject_pattern: "opennvr.inference.>"
+
+# ── Detection filter / thresholds — EDIT for your scene ────────────
+watch_labels:
+  - "person"
+threshold_seconds: 60
+grace_period_seconds: 5
+
+# ── Alert delivery ─────────────────────────────────────────────────
+# Alerts always go to stdout (``docker compose logs loitering-detection``).
+webhook_url: null
+# Fan alerts back onto the bus so the operator-UI alerts inbox and any
+# other subscriber pick them up without per-app webhooks.
+nats_alerts_url: "nats://nats:4222"
+nats_alerts_token: "${INTERNAL_API_KEY}"
+
+# ── Cameras — EDIT: camera_id must match KAI-C's event subjects ────
+cameras:
+  - camera_id: "cam-1"
+    frame_width: 1920
+    frame_height: 1080
+    zone_name: "full-frame"
+    zone:
+      - [0, 0]
+      - [1920, 0]
+      - [1920, 1080]
+      - [0, 1080]
+
+# ── App contract (spec §03) — powers the App Catalog ───────────────
+# The SDK serves /health /manifest /state on contract_port and
+# self-registers with the OpenNVR app registry on boot. The
+# registration token comes from the OPENNVR_INTERNAL_API_KEY
+# environment variable set by the overlay, so it is not templated here.
+contract_port: 9200
+contract_bind_host: "0.0.0.0"
+contract_host: "loitering-detection"   # the compose service name
+opennvr_url: "http://opennvr-core:8000"

--- a/examples/loitering-detection/loitering_detection.py
+++ b/examples/loitering-detection/loitering_detection.py
@@ -139,6 +139,15 @@ class AppConfig:
     nats_alerts_token: str | None = None
     nats_alerts_subject_prefix: str = "opennvr.alerts"
 
+    # App contract (spec §03) — all optional; see the SDK's contract
+    # module. ``contract_port`` serves /health /manifest /state;
+    # ``opennvr_url`` triggers registry self-registration on boot.
+    contract_port: int | None = None
+    contract_bind_host: str | None = None
+    contract_host: str | None = None
+    opennvr_url: str | None = None
+    opennvr_token: str | None = None
+
 
 def load_config(path: str) -> AppConfig:
     """Parse a YAML config file into a typed AppConfig.
@@ -254,6 +263,13 @@ def load_config(path: str) -> AppConfig:
         nats_alerts_url=nats_alerts_url,
         nats_alerts_token=nats_alerts_token,
         nats_alerts_subject_prefix=nats_prefix,
+        contract_port=(
+            int(raw["contract_port"]) if raw.get("contract_port") is not None else None
+        ),
+        contract_bind_host=raw.get("contract_bind_host"),
+        contract_host=raw.get("contract_host"),
+        opennvr_url=raw.get("opennvr_url"),
+        opennvr_token=raw.get("opennvr_token"),
     )
 
 

--- a/examples/occupancy-counting/Dockerfile
+++ b/examples/occupancy-counting/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+# occupancy-counting example app
+#
+# Build (from the open-nvr repo root — the context must include
+# sdk/opennvr-app-sdk, which this app depends on):
+#   docker build -f examples/occupancy-counting/Dockerfile -t opennvr/occupancy-counting:1.0.0 .
+#
+# Run (subscribes to the NATS event bus on the compose network):
+#   docker run --rm \
+#     --network opennvr_internal \
+#     -v $(pwd)/config.yml:/app/config.yml:ro \
+#     opennvr/occupancy-counting:1.0.0 \
+#     --config /app/config.yml
+#
+# Or use the repo-root docker-compose.apps.yml overlay, which builds
+# this image, generates the config from config.docker.yml, and wires
+# NATS + registry self-registration automatically.
+
+FROM python:3.11-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# The SDK owns the runtime stack (nats-py subscribe loop, httpx alert
+# webhooks, PyYAML config) — install it from the repo checkout so the
+# image always matches the in-tree contract surface.
+COPY sdk/opennvr-app-sdk /opt/opennvr-app-sdk
+RUN pip install --no-cache-dir /opt/opennvr-app-sdk
+
+COPY examples/occupancy-counting/occupancy_counting.py ./occupancy_counting.py
+COPY examples/occupancy-counting/alerts.py             ./alerts.py
+COPY examples/occupancy-counting/zone.py               ./zone.py
+COPY examples/occupancy-counting/config.example.yml    ./config.example.yml
+
+ENV PYTHONUNBUFFERED=1
+
+# No HEALTHCHECK — liveness is Docker's "process is alive"; readiness
+# is the SDK contract server (/health on contract_port when enabled).
+
+ENTRYPOINT ["python", "occupancy_counting.py"]
+CMD ["--config", "config.yml"]

--- a/examples/occupancy-counting/config.docker.yml
+++ b/examples/occupancy-counting/config.docker.yml
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# occupancy-counting config consumed by docker-compose.apps.yml.
+#
+# Variables of the form ${VAR} are substituted by the
+# occupancy-counting-config-init container at compose-up time (busybox
+# sed, same pattern as the camera-agent overlay). Only the variables
+# listed in the init container are replaced — everything else is left
+# untouched.
+#
+# DO NOT edit the substituted values directly. To change the secret,
+# update .env and re-run ``docker compose up`` so the init container
+# re-templates the file.
+
+# ── NATS endpoint (KAI-C's event bus, compose service ``nats``) ────
+nats_url: "nats://nats:4222"
+# The standard stack runs NATS with ``--auth INTERNAL_API_KEY``.
+nats_token: "${INTERNAL_API_KEY}"
+
+subject_pattern: "opennvr.inference.>"
+
+# ── What to count / thresholds — EDIT for your scene ───────────────
+watch_labels:
+  - "person"
+max_occupancy: 10
+min_occupancy: null
+debounce_frames: 1
+clear_alerts: false
+
+# ── Alert delivery ─────────────────────────────────────────────────
+# Alerts always go to stdout (``docker compose logs occupancy-counting``).
+webhook_url: null
+# Fan alerts back onto the bus so the operator-UI alerts inbox and any
+# other subscriber pick them up without per-app webhooks.
+nats_alerts_url: "nats://nats:4222"
+nats_alerts_token: "${INTERNAL_API_KEY}"
+
+# ── Cameras — EDIT: camera_id must match KAI-C's event subjects ────
+cameras:
+  - camera_id: "cam-1"
+    frame_width: 1920
+    frame_height: 1080
+    zone_name: "full-frame"
+    max_occupancy: 10
+    zone:
+      - [0, 0]
+      - [1920, 0]
+      - [1920, 1080]
+      - [0, 1080]
+
+# ── App contract (spec §03) — powers the App Catalog ───────────────
+# The SDK serves /health /manifest /state on contract_port and
+# self-registers with the OpenNVR app registry on boot. The
+# registration token comes from the OPENNVR_INTERNAL_API_KEY
+# environment variable set by the overlay, so it is not templated here.
+contract_port: 9201
+contract_bind_host: "0.0.0.0"
+contract_host: "occupancy-counting"   # the compose service name
+opennvr_url: "http://opennvr-core:8000"

--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -148,6 +148,15 @@ class AppConfig:
     nats_alerts_token: str | None = None
     nats_alerts_subject_prefix: str = "opennvr.alerts"
 
+    # App contract (spec §03) — all optional; see the SDK's contract
+    # module. ``contract_port`` serves /health /manifest /state;
+    # ``opennvr_url`` triggers registry self-registration on boot.
+    contract_port: int | None = None
+    contract_bind_host: str | None = None
+    contract_host: str | None = None
+    opennvr_url: str | None = None
+    opennvr_token: str | None = None
+
 
 def load_config(path: str) -> AppConfig:
     """Parse a YAML config file into a typed AppConfig.
@@ -273,6 +282,13 @@ def load_config(path: str) -> AppConfig:
         nats_alerts_url=nats_alerts_url,
         nats_alerts_token=nats_alerts_token,
         nats_alerts_subject_prefix=nats_prefix,
+        contract_port=(
+            int(raw["contract_port"]) if raw.get("contract_port") is not None else None
+        ),
+        contract_bind_host=raw.get("contract_bind_host"),
+        contract_host=raw.get("contract_host"),
+        opennvr_url=raw.get("opennvr_url"),
+        opennvr_token=raw.get("opennvr_token"),
     )
 
 

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
@@ -43,13 +43,19 @@ Config keys read (all via ``getattr``, all optional):
     ``{opennvr_url}/api/v1/apps/register`` on boot — best-effort: a
     down/refusing registry logs a warning and the app keeps running.
 ``opennvr_token``
-    Optional bearer token for the registration call (the registry
-    routes are auth-gated).
+    Optional token for the registration call (the registry routes are
+    auth-gated). Sent BOTH as a bearer ``Authorization`` header (for
+    user-JWT tokens) and as ``X-Internal-Api-Key`` (the deployment's
+    ``INTERNAL_API_KEY``, which the register route accepts as a
+    service credential). Falls back to the
+    ``OPENNVR_INTERNAL_API_KEY`` environment variable when the config
+    key is absent — the natural fit for compose deployments.
 """
 from __future__ import annotations
 
 import json
 import logging
+import os
 import socket
 import threading
 import time
@@ -300,9 +306,16 @@ class ContractMixin:
             "manifest": self.manifest_snapshot(),
         }
         headers: dict[str, str] = {}
-        token = getattr(self.cfg, "opennvr_token", None)
+        token = getattr(self.cfg, "opennvr_token", None) or os.environ.get(
+            "OPENNVR_INTERNAL_API_KEY"
+        )
         if token:
+            # Both header shapes: the registry's register route accepts
+            # a user JWT (Authorization: Bearer) or the deployment's
+            # INTERNAL_API_KEY (X-Internal-Api-Key) — sending both lets
+            # one config key work against either credential kind.
             headers["Authorization"] = f"Bearer {token}"
+            headers["X-Internal-Api-Key"] = str(token)
         endpoint = f"{str(opennvr_url).rstrip('/')}/api/v1/apps/register"
         try:
             response = httpx.post(

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/nats_loop.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/nats_loop.py
@@ -25,6 +25,7 @@ Host requirements (duck-typed, set by the archetype ``__init__``):
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from typing import Any
 
@@ -70,7 +71,14 @@ class NatsSubscriberMixin:
         try:
             sub = await self._nc.subscribe(self.cfg.subject_pattern)
             async for msg in sub.messages:
-                self._handle_raw(msg.data, subject=msg.subject)
+                # ``_handle_raw`` is sync on the stock archetypes, but
+                # apps with async sinks (the home-assistant-relay's
+                # publishers are awaitable) may override it as a
+                # coroutine — await it so per-message ordering and
+                # backpressure are preserved either way.
+                result = self._handle_raw(msg.data, subject=msg.subject)
+                if inspect.isawaitable(result):
+                    await result
                 if once:
                     self.stop()
                 if self._stop_event.is_set():

--- a/sdk/opennvr-app-sdk/tests/test_alert_subscriber.py
+++ b/sdk/opennvr-app-sdk/tests/test_alert_subscriber.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""AlertSubscriber base tests — the decode + on_alert dispatch path,
+exercised through ``_handle_raw`` so no NATS broker is needed."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opennvr_app_sdk import (
+    AlertSubscriber,
+    AlertType,
+    AppManifest,
+    alert_app,
+)
+
+MANIFEST = AppManifest(
+    id="echo-bridge",
+    name="Echo Bridge",
+    version="0.9.9",
+    category="test",
+    subscribes="opennvr.alerts.>",
+    emits=[AlertType("never", severity="low")],
+)
+
+
+class EchoBridge(AlertSubscriber):
+    """Records every (alert, subject) pair — just enough sink to prove
+    the base's decode → on_alert path."""
+
+    manifest = MANIFEST
+
+    def setup(self) -> None:
+        self.setup_ran = True
+        self.seen: list[tuple[dict[str, Any], str]] = []
+
+    def on_alert(self, alert: dict[str, Any], subject: str) -> None:
+        self.seen.append((alert, subject))
+
+
+def _build() -> EchoBridge:
+    cfg = SimpleNamespace(
+        nats_url="nats://test:4222",
+        nats_token=None,
+        subject_pattern="opennvr.alerts.>",
+    )
+    return EchoBridge(cfg)
+
+
+def _envelope(**overrides: Any) -> dict[str, Any]:
+    envelope: dict[str, Any] = {
+        "alert_id": "alrt_abc123",
+        "fired_at": "2026-05-21T14:33:24+00:00",
+        "title": "Person loitering",
+        "description": "Detected loitering.",
+        "severity": "medium",
+        "source": {"kind": "app", "name": "loitering-detection", "version": "1.0.0"},
+        "camera_id": "cam-back-shed",
+        "correlation_id": "corr-xyz",
+        "evidence": {},
+        "tags": ["loitering"],
+    }
+    envelope.update(overrides)
+    return envelope
+
+
+# ── _handle_raw: decode + dispatch without a broker ────────────────
+
+
+def test_handle_raw_delivers_alert_dict_and_subject():
+    bridge = _build()
+    subject = "opennvr.alerts.app.loitering-detection.cam-back-shed"
+    ok = bridge._handle_raw(json.dumps(_envelope()).encode(), subject=subject)
+    assert ok is True
+    assert bridge.seen == [(_envelope(), subject)]
+
+
+def test_handle_raw_skips_non_json_without_raising():
+    bridge = _build()
+    assert bridge._handle_raw(b"\x00not json{{") is False
+    assert bridge.seen == []
+
+
+def test_handle_raw_isolates_on_alert_exceptions():
+    bridge = _build()
+
+    class Boom(EchoBridge):
+        def on_alert(self, alert, subject):
+            raise RuntimeError("sink kaboom")
+
+    boom = Boom(bridge.cfg)
+    # MUST NOT raise — one bad envelope can't kill a long-lived bridge.
+    assert boom._handle_raw(json.dumps(_envelope()).encode()) is False
+
+
+def test_handle_raw_accepts_non_dict_json():
+    """The sink receives whatever JSON arrived — a non-dict payload is
+    the sink's problem to reject, not the loop's problem to crash on."""
+    bridge = _build()
+    assert bridge._handle_raw(b"[1, 2, 3]", subject="s") is True
+    assert bridge.seen == [([1, 2, 3], "s")]
+
+
+def test_on_alert_is_abstract():
+    bridge = _build()
+    base = AlertSubscriber(bridge.cfg)
+    with pytest.raises(NotImplementedError):
+        base.on_alert(_envelope(), "subject")
+    # Through the loop path it is isolated like any handler failure.
+    assert base._handle_raw(json.dumps(_envelope()).encode()) is False
+
+
+# ── Contract wiring (spec §03) ─────────────────────────────────────
+
+
+def test_contract_counts_decoded_alerts_as_events():
+    bridge = _build()
+    assert bridge.health_snapshot()["events_seen"] == 0
+    bridge._handle_raw(json.dumps(_envelope()).encode(), subject="s")
+    bridge._handle_raw(b"not json")  # skipped — not counted
+    health = bridge.health_snapshot()
+    assert health["events_seen"] == 1
+    assert health["alerts_fired"] == 0  # subscribers consume, not emit
+    assert health["last_event_age_s"] is not None
+
+
+def test_manifest_snapshot_defaults_to_empty_dict():
+    cfg = SimpleNamespace(
+        nats_url="nats://test:4222",
+        nats_token=None,
+        subject_pattern="opennvr.alerts.>",
+    )
+
+    class Bare(AlertSubscriber):
+        def on_alert(self, alert, subject):
+            pass
+
+    assert Bare(cfg).manifest_snapshot() == {}
+    assert EchoBridge(cfg).manifest_snapshot()["id"] == "echo-bridge"
+
+
+# ── Lifecycle glue ─────────────────────────────────────────────────
+
+
+def test_setup_hook_runs_at_construction():
+    bridge = _build()
+    assert bridge.setup_ran is True
+
+
+def test_config_compat_alias():
+    bridge = _build()
+    assert bridge._config is bridge.cfg
+
+
+def test_stop_sets_stop_event():
+    bridge = _build()
+    assert not bridge._stop_event.is_set()
+    bridge.stop()
+    assert bridge._stop_event.is_set()
+
+
+# ── alert_app() runner wiring ──────────────────────────────────────
+
+
+def test_alert_app_requires_a_config_loader():
+    with pytest.raises(TypeError, match="load_config"):
+        alert_app(EchoBridge)
+
+
+def test_alert_app_returns_2_on_config_error(capsys):
+    def bad_loader(path: str):
+        raise ValueError("nope, bad config")
+
+    runner = alert_app(EchoBridge, load_config=bad_loader)
+    rc = runner.run(["--config", "whatever.yml"])
+    assert rc == 2
+    assert "config error: nope, bad config" in capsys.readouterr().err
+
+
+def test_alert_app_uses_class_load_config_when_present():
+    class WithLoader(EchoBridge):
+        @classmethod
+        def load_config(cls, path: str):
+            raise ValueError("loader was called")
+
+    runner = alert_app(WithLoader)
+    assert runner.run(["--config", "x.yml"]) == 2  # proves the loader ran

--- a/sdk/opennvr-app-sdk/tests/test_alerts.py
+++ b/sdk/opennvr-app-sdk/tests/test_alerts.py
@@ -1,0 +1,532 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Alert dispatch tests — stdout + webhook + NATS + failure isolation.
+
+Ported from ``examples/loitering-detection/tests/test_alerts.py`` with
+only import paths (and monkeypatch targets, which are import paths)
+adjusted — the content is otherwise identical, because that suite is
+the §11.5 behavior spec the SDK promotion must preserve. The default
+``source.name == "loitering-detection"`` assertions are satisfied by
+the autouse fixture in ``conftest.py``.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from opennvr_app_sdk.alerts import (
+    Alert,
+    AlertChannel,
+    AlertDispatcher,
+    AlertSource,
+    StdoutChannel,
+    WebhookChannel,
+    build_dispatcher,
+)
+
+
+def _alert() -> Alert:
+    return Alert(
+        title="Person in restricted zone 'front-yard'",
+        description="Detected person.",
+        camera_id="cam-front",
+        correlation_id="corr-123",
+        tags=["intrusion", "person"],
+    )
+
+
+# ── Alert wire shape ───────────────────────────────────────────────
+
+
+def test_alert_to_wire_includes_all_required_fields():
+    alert = _alert()
+    wire = alert.to_wire()
+    for key in (
+        "alert_id", "fired_at", "title", "description", "severity",
+        "source", "camera_id", "correlation_id", "evidence", "tags",
+    ):
+        assert key in wire, f"missing {key}"
+
+
+def test_alert_id_is_unique_prefix():
+    a1, a2 = _alert(), _alert()
+    assert a1.alert_id != a2.alert_id
+    assert a1.alert_id.startswith("alrt_")
+
+
+def test_alert_source_defaults_to_app_kind():
+    alert = _alert()
+    assert alert.source.kind == "app"
+    assert alert.source.name == "loitering-detection"
+
+
+# ── Stdout channel ─────────────────────────────────────────────────
+
+
+def test_stdout_channel_prints_one_line(capsys):
+    channel = StdoutChannel()
+    assert channel.send(_alert())
+    out = capsys.readouterr().out
+    assert "ALERT" in out
+    assert "HIGH" in out
+    assert "corr-123" in out
+    # Single line
+    assert out.count("\n") == 1
+
+
+# ── Webhook channel ────────────────────────────────────────────────
+
+
+class _CapturingTransport(httpx.BaseTransport):
+    """Captures every request for assertions; returns a fixed status."""
+
+    def __init__(self, status_code: int = 200) -> None:
+        self.calls: list[dict] = []
+        self._status_code = status_code
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        body = bytes(request.read())
+        self.calls.append({
+            "url": str(request.url),
+            "method": request.method,
+            "body": body,
+        })
+        return httpx.Response(self._status_code, json={"ok": True})
+
+
+def test_webhook_channel_posts_alert_json(monkeypatch):
+    transport = _CapturingTransport(200)
+
+    def _patched(url, **kwargs):
+        # ``trust_env=`` lives on the Client constructor, not on
+        # per-request .post() — strip when proxying through a stub.
+        kwargs.pop("trust_env", None)
+        with httpx.Client(transport=transport) as client:
+            return client.post(url, **kwargs)
+
+    monkeypatch.setattr("opennvr_app_sdk.alerts.httpx.post", _patched)
+    channel = WebhookChannel("https://example.invalid/hook")
+    assert channel.send(_alert())
+    assert len(transport.calls) == 1
+    parsed = json.loads(transport.calls[0]["body"])
+    assert parsed["title"].startswith("Person in restricted zone")
+    assert parsed["camera_id"] == "cam-front"
+
+
+def test_webhook_channel_returns_false_on_http_error(monkeypatch):
+    transport = _CapturingTransport(500)
+
+    def _patched(url, **kwargs):
+        kwargs.pop("trust_env", None)
+        return httpx.Client(transport=transport).post(url, **kwargs)
+
+    monkeypatch.setattr("opennvr_app_sdk.alerts.httpx.post", _patched)
+    channel = WebhookChannel("https://example.invalid/hook")
+    assert not channel.send(_alert())  # but no raise
+
+
+def test_webhook_channel_swallows_transport_exception(monkeypatch):
+    def _raises(*args, **kwargs):
+        raise RuntimeError("DNS lookup failed")
+    monkeypatch.setattr("opennvr_app_sdk.alerts.httpx.post", _raises)
+    channel = WebhookChannel("https://example.invalid/hook")
+    assert not channel.send(_alert())  # MUST NOT raise
+
+
+# ── Dispatcher ─────────────────────────────────────────────────────
+
+
+def test_dispatcher_requires_at_least_one_channel():
+    with pytest.raises(ValueError):
+        AlertDispatcher([])
+
+
+def test_dispatcher_fires_all_channels(capsys):
+    fired_through: dict[str, list[Alert]] = {}
+
+    class RecordingChannel:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            fired_through[name] = []
+
+        def send(self, alert: Alert) -> bool:
+            fired_through[self.name].append(alert)
+            return True
+
+    dispatcher = AlertDispatcher([RecordingChannel("a"), RecordingChannel("b")])
+    alert = _alert()
+    report = dispatcher.fire(alert)
+    assert report == {"a": True, "b": True}
+    assert fired_through["a"] == [alert]
+    assert fired_through["b"] == [alert]
+
+
+def test_dispatcher_isolates_channel_exceptions():
+    class BrokenChannel:
+        name = "broken"
+
+        def send(self, alert: Alert) -> bool:
+            raise RuntimeError("kaboom")
+
+    class WorkingChannel:
+        name = "working"
+        delivered = False
+
+        def send(self, alert: Alert) -> bool:
+            WorkingChannel.delivered = True
+            return True
+
+    dispatcher = AlertDispatcher([BrokenChannel(), WorkingChannel()])
+    report = dispatcher.fire(_alert())
+    assert report["broken"] is False  # caught
+    assert report["working"] is True  # downstream channel still fired
+    assert WorkingChannel.delivered
+
+
+# ── build_dispatcher factory ───────────────────────────────────────
+
+
+def test_build_dispatcher_without_webhook_has_only_stdout():
+    dispatcher = build_dispatcher(webhook_url=None)
+    report = dispatcher.fire(_alert())
+    assert list(report.keys()) == ["stdout"]
+
+
+def test_build_dispatcher_with_webhook_has_both():
+    dispatcher = build_dispatcher(webhook_url="https://example.invalid/hook")
+    # We don't actually send the webhook here (no monkeypatching);
+    # we just verify both channels are present.
+    assert {"stdout", "webhook"} <= set(
+        getattr(ch, "name", ch.__class__.__name__) for ch in dispatcher._channels
+    )
+
+
+# ── NATS alert channel ─────────────────────────────────────────────
+#
+# These tests mock the nats-py module so they run without a broker.
+# The interesting axes are subject derivation (with sanitization) and
+# the failure-isolation contract (publish errors return False, never
+# raise, drop the cached connection so the next call retries).
+
+from opennvr_app_sdk.alerts import (  # noqa: E402  — keep grouped with the channel tests
+    DEFAULT_ALERT_SUBJECT_PREFIX,
+    NatsAlertChannel,
+    alert_subject,
+)
+
+
+def test_alert_subject_default_prefix():
+    subject = alert_subject(_alert())
+    assert subject == "opennvr.alerts.app.loitering-detection.cam-front"
+
+
+def test_alert_subject_custom_prefix():
+    subject = alert_subject(_alert(), prefix="org.example.alerts")
+    assert subject == "org.example.alerts.app.loitering-detection.cam-front"
+
+
+def test_alert_subject_sanitizes_disallowed_chars():
+    # Spaces, dots, slashes, NATS reserved (*, >) all collapse to _.
+    a = Alert(
+        title="t",
+        description="d",
+        camera_id="cam back/shed 2.0",
+        source=AlertSource(kind="app", name="my app *star*", version="1"),
+    )
+    subject = alert_subject(a)
+    assert subject == "opennvr.alerts.app.my_app__star.cam_back_shed_2_0"
+    # No NATS reserved chars survived
+    assert "*" not in subject
+    assert ">" not in subject
+    assert " " not in subject
+
+
+def test_alert_subject_empty_segments_become_unknown():
+    a = Alert(
+        title="t",
+        description="d",
+        camera_id="",  # empty
+        source=AlertSource(kind="!!!", name="", version="1"),  # all-sanitized-away
+    )
+    subject = alert_subject(a)
+    assert subject == f"{DEFAULT_ALERT_SUBJECT_PREFIX}.unknown.unknown.unknown"
+
+
+class _FakeNatsClient:
+    """Records publishes; honors a publish_error knob for failure tests."""
+
+    def __init__(self, publish_error: BaseException | None = None) -> None:
+        self.published: list[tuple[str, bytes]] = []
+        self._publish_error = publish_error
+        self.drained = False
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        if self._publish_error is not None:
+            raise self._publish_error
+        self.published.append((subject, payload))
+
+    async def drain(self) -> None:
+        self.drained = True
+
+
+class _FakeNatsModule:
+    """Stand-in for the ``nats`` module the channel does ``import nats``
+    on. ``connect`` returns a configurable fake client and records the
+    connect kwargs so tests can assert auth wiring."""
+
+    def __init__(
+        self,
+        client: _FakeNatsClient | None = None,
+        connect_error: BaseException | None = None,
+    ) -> None:
+        self.client = client or _FakeNatsClient()
+        self._connect_error = connect_error
+        self.connect_calls: list[dict] = []
+
+    async def connect(self, **kwargs):
+        self.connect_calls.append(kwargs)
+        if self._connect_error is not None:
+            raise self._connect_error
+        return self.client
+
+
+def _install_fake_nats(monkeypatch, fake: _FakeNatsModule) -> None:
+    import sys
+    monkeypatch.setitem(sys.modules, "nats", fake)
+
+
+def test_nats_channel_publishes_to_derived_subject(monkeypatch):
+    fake = _FakeNatsModule()
+    _install_fake_nats(monkeypatch, fake)
+    channel = NatsAlertChannel("nats://localhost:4222")
+    try:
+        assert channel.send(_alert()) is True
+        assert len(fake.client.published) == 1
+        subject, payload = fake.client.published[0]
+        assert subject == "opennvr.alerts.app.loitering-detection.cam-front"
+        # Payload is the exact §11.5 wire JSON
+        parsed = json.loads(payload)
+        assert parsed["camera_id"] == "cam-front"
+        assert parsed["correlation_id"] == "corr-123"
+        assert parsed["source"]["name"] == "loitering-detection"
+    finally:
+        channel.close()
+
+
+def test_nats_channel_passes_token_through(monkeypatch):
+    fake = _FakeNatsModule()
+    _install_fake_nats(monkeypatch, fake)
+    channel = NatsAlertChannel(
+        "nats://localhost:4222", token="s3cret",
+    )
+    try:
+        channel.send(_alert())
+        assert fake.connect_calls[0]["token"] == "s3cret"
+    finally:
+        channel.close()
+
+
+def test_nats_channel_omits_token_when_unset(monkeypatch):
+    fake = _FakeNatsModule()
+    _install_fake_nats(monkeypatch, fake)
+    channel = NatsAlertChannel("nats://localhost:4222")  # no token
+    try:
+        channel.send(_alert())
+        assert "token" not in fake.connect_calls[0]
+    finally:
+        channel.close()
+
+
+def test_nats_channel_returns_false_on_connect_error(monkeypatch):
+    fake = _FakeNatsModule(connect_error=ConnectionRefusedError("nope"))
+    _install_fake_nats(monkeypatch, fake)
+    channel = NatsAlertChannel("nats://localhost:4222")
+    try:
+        # MUST NOT raise; returns False and the detector loop carries on.
+        assert channel.send(_alert()) is False
+    finally:
+        channel.close()
+
+
+def test_nats_channel_returns_false_on_publish_error(monkeypatch):
+    client = _FakeNatsClient(publish_error=RuntimeError("broker hung up"))
+    fake = _FakeNatsModule(client=client)
+    _install_fake_nats(monkeypatch, fake)
+    channel = NatsAlertChannel("nats://localhost:4222")
+    try:
+        assert channel.send(_alert()) is False
+        # Cached connection was dropped — second send retries the connect.
+        assert channel._nc is None
+    finally:
+        channel.close()
+
+
+def test_nats_channel_uses_custom_subject_prefix(monkeypatch):
+    fake = _FakeNatsModule()
+    _install_fake_nats(monkeypatch, fake)
+    channel = NatsAlertChannel(
+        "nats://localhost:4222",
+        subject_prefix="org.example.alerts",
+    )
+    try:
+        channel.send(_alert())
+        subject, _ = fake.client.published[0]
+        assert subject == "org.example.alerts.app.loitering-detection.cam-front"
+    finally:
+        channel.close()
+
+
+def test_build_dispatcher_includes_nats_when_url_set():
+    dispatcher = build_dispatcher(
+        webhook_url=None,
+        nats_alerts_url="nats://localhost:4222",
+    )
+    names = {
+        getattr(ch, "name", ch.__class__.__name__) for ch in dispatcher._channels
+    }
+    assert "stdout" in names
+    assert "nats" in names
+    assert "webhook" not in names  # not configured this call
+
+
+def test_build_dispatcher_skips_nats_when_url_blank():
+    dispatcher = build_dispatcher(
+        webhook_url=None,
+        nats_alerts_url=None,
+    )
+    names = {
+        getattr(ch, "name", ch.__class__.__name__) for ch in dispatcher._channels
+    }
+    assert names == {"stdout"}
+
+
+def test_build_dispatcher_orders_stdout_first_then_webhook_then_nats():
+    dispatcher = build_dispatcher(
+        webhook_url="https://example.invalid/hook",
+        nats_alerts_url="nats://localhost:4222",
+    )
+    names = [
+        getattr(ch, "name", ch.__class__.__name__) for ch in dispatcher._channels
+    ]
+    assert names == ["stdout", "webhook", "nats"]
+
+
+# ── Punch-list regression tests ────────────────────────────────────
+
+
+def test_nats_channel_rejects_empty_subject_prefix():
+    """Peer-review L6: an empty (or all-dots) prefix is operator
+    misconfiguration; fail at construction, not silently at publish."""
+    with pytest.raises(ValueError, match="subject_prefix"):
+        NatsAlertChannel("nats://localhost:4222", subject_prefix="")
+    with pytest.raises(ValueError, match="subject_prefix"):
+        NatsAlertChannel("nats://localhost:4222", subject_prefix="...")
+
+
+def test_nats_channel_rejects_subject_prefix_with_invalid_chars():
+    """Peer-review L6: spaces / wildcards / other NATS-invalid chars
+    in the prefix would cause every publish to ErrBadSubject. Fail
+    at construction so operators see it immediately."""
+    for bad in ("open nvr.alerts", "opennvr.alerts.*", "opennvr.alerts.>"):
+        with pytest.raises(ValueError, match="subject_prefix"):
+            NatsAlertChannel("nats://localhost:4222", subject_prefix=bad)
+
+
+def test_nats_channel_accepts_multi_token_prefix():
+    """Multi-token prefixes are legal — operators may want to nest
+    OpenNVR alerts under an org-specific top-level subject."""
+    # Should not raise.
+    ch = NatsAlertChannel(
+        "nats://localhost:4222", subject_prefix="org.example.opennvr.alerts",
+    )
+    assert ch._subject_prefix == "org.example.opennvr.alerts"
+
+
+def test_dispatcher_close_calls_channel_close(monkeypatch):
+    """Peer-review H2: AlertDispatcher.close must propagate to any
+    channel that has its own close (in practice: NatsAlertChannel)."""
+    closed = {"n": 0}
+
+    class _ClosableChannel:
+        name = "closable"
+
+        def send(self, alert):
+            return True
+
+        def close(self):
+            closed["n"] += 1
+
+    dispatcher = AlertDispatcher([StdoutChannel(), _ClosableChannel()])
+    dispatcher.close()
+    assert closed["n"] == 1
+
+
+def test_dispatcher_close_isolates_close_failures(capsys):
+    """One channel's close raising must not stop subsequent channels
+    from being closed."""
+    closed_b = {"flag": False}
+
+    class _BadClose:
+        name = "bad"
+
+        def send(self, alert):
+            return True
+
+        def close(self):
+            raise RuntimeError("close kaboom")
+
+    class _GoodClose:
+        name = "good"
+
+        def send(self, alert):
+            return True
+
+        def close(self):
+            closed_b["flag"] = True
+
+    dispatcher = AlertDispatcher([_BadClose(), _GoodClose()])
+    # Must not raise.
+    dispatcher.close()
+    assert closed_b["flag"] is True
+
+
+def test_nats_channel_close_is_reinit_safe(monkeypatch):
+    """Peer-review M1: after close(), the channel must reset state
+    so a subsequent send() spins a fresh loop + connection rather
+    than scheduling on a stopped loop and hanging to timeout."""
+    fake = _FakeNatsModule()
+    _install_fake_nats(monkeypatch, fake)
+    channel = NatsAlertChannel("nats://localhost:4222")
+    assert channel.send(_alert()) is True
+    assert channel._loop is not None
+    channel.close()
+    # Internal state must be reset.
+    assert channel._loop is None
+    assert channel._thread is None
+    assert channel._nc is None
+    # And a second send works — re-spawns the thread, re-connects.
+    assert channel.send(_alert()) is True
+    assert len(fake.client.published) == 2
+    channel.close()
+
+
+# ── SDK-only: configurable default source ──────────────────────────
+
+
+def test_set_default_source_changes_new_alerts_only():
+    """The process-wide default stamps NEW AlertSource instances;
+    explicitly-constructed sources are untouched."""
+    from opennvr_app_sdk.alerts import set_default_source
+
+    set_default_source(kind="app", name="my-cool-app", version="2.3.4")
+    fresh = Alert(title="t", description="d", camera_id="c")
+    assert fresh.source.name == "my-cool-app"
+    assert fresh.source.version == "2.3.4"
+    explicit = Alert(
+        title="t", description="d", camera_id="c",
+        source=AlertSource(kind="adapter", name="yolov8", version="9"),
+    )
+    assert explicit.source.name == "yolov8"

--- a/sdk/opennvr-app-sdk/tests/test_config.py
+++ b/sdk/opennvr-app-sdk/tests/test_config.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic YAML config helper tests."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opennvr_app_sdk.config import load_yaml, require
+
+
+def test_load_yaml_returns_mapping(tmp_path: Path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("nats_url: nats://nats:4222\nthreshold_seconds: 60\n")
+    raw = load_yaml(cfg)
+    assert raw == {"nats_url": "nats://nats:4222", "threshold_seconds": 60}
+
+
+def test_load_yaml_rejects_non_mapping_root(tmp_path: Path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("- just\n- a\n- list\n")
+    with pytest.raises(ValueError, match="root must be a mapping"):
+        load_yaml(cfg)
+
+
+def test_load_yaml_rejects_empty_file(tmp_path: Path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("")
+    with pytest.raises(ValueError, match="root must be a mapping"):
+        load_yaml(cfg)
+
+
+def test_load_yaml_missing_file_raises_oserror(tmp_path: Path):
+    with pytest.raises(OSError):
+        load_yaml(tmp_path / "nope.yml")
+
+
+def test_require_returns_value():
+    assert require({"k": "v"}, "k") == "v"
+    assert require({"n": 0.5}, "n") == 0.5
+
+
+def test_require_rejects_missing_and_empty():
+    with pytest.raises(ValueError, match="'k' is required"):
+        require({}, "k")
+    with pytest.raises(ValueError, match="'k' is required"):
+        require({"k": None}, "k")
+    with pytest.raises(ValueError, match="'k' is required"):
+        require({"k": "   "}, "k")
+
+
+def test_require_error_names_the_config_path():
+    with pytest.raises(ValueError, match=r"config\.yml: 'nats_url' is required"):
+        require({}, "nats_url", path="config.yml")

--- a/sdk/opennvr-app-sdk/tests/test_contract.py
+++ b/sdk/opennvr-app-sdk/tests/test_contract.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract surface tests (spec §03) — the /health /manifest /state
+server, the loop-fed counters, and best-effort self-registration
+against the OpenNVR app registry. Real HTTP against an ephemeral
+127.0.0.1 port; the registry side is a monkeypatched ``httpx.post``."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from opennvr_app_sdk import (
+    Alert,
+    AlertDispatcher,
+    AppManifest,
+    Detector,
+    FrameApp,
+)
+from opennvr_app_sdk import contract as contract_mod
+
+
+class _RecorderChannel:
+    name = "recorder"
+
+    def __init__(self) -> None:
+        self.alerts: list[Alert] = []
+
+    def send(self, alert: Alert) -> bool:
+        self.alerts.append(alert)
+        return True
+
+
+MANIFEST = AppManifest(
+    id="contract-echo",
+    name="Contract Echo",
+    version="1.2.3",
+    category="test",
+    summary="Fires one alert per detection batch.",
+)
+
+
+class _EchoDetector(Detector):
+    manifest = MANIFEST
+
+    def on_detections(self, camera_id, detections, event):
+        if detections:
+            yield Alert(title="hit", description="d", camera_id=camera_id)
+
+    def state_snapshot(self):
+        return {"note": "live state"}
+
+
+def _cfg(**overrides) -> SimpleNamespace:
+    base = {"contract_port": 0, "contract_bind_host": "127.0.0.1"}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _detector(cfg=None) -> _EchoDetector:
+    return _EchoDetector(cfg or _cfg(), AlertDispatcher([_RecorderChannel()]))
+
+
+def _event(n: int = 1) -> dict:
+    return {
+        "camera_id": "cam-1",
+        "result": {"detections": [{"label": "person"}] * n},
+    }
+
+
+def _get(port: int, path: str) -> httpx.Response:
+    return httpx.get(f"http://127.0.0.1:{port}{path}", timeout=2.0, trust_env=False)
+
+
+# ── The three endpoints ────────────────────────────────────────────
+
+
+def test_serves_health_manifest_and_state():
+    det = _detector()
+    server = det.start_contract_server()
+    assert server is not None
+    try:
+        health = _get(server.port, "/health").json()
+        assert health["ready"] is True
+        assert health["uptime_s"] >= 0
+        assert health["events_seen"] == 0
+        assert health["alerts_fired"] == 0
+        assert health["last_event_age_s"] is None
+
+        manifest = _get(server.port, "/manifest").json()
+        assert manifest == MANIFEST.to_dict()
+
+        state = _get(server.port, "/state").json()
+        assert state == {"note": "live state"}
+    finally:
+        det.stop_contract_server()
+
+
+def test_health_counters_follow_the_event_loop():
+    det = _detector()
+    server = det.start_contract_server()
+    try:
+        det.handle_event(_event(2))           # 1 event, 1 alert
+        det.handle_event({"camera_id": "cam-1", "result": {"detections": []}})
+        det.handle_event("not-a-dict")        # malformed still counts as seen
+
+        health = _get(server.port, "/health").json()
+        assert health["events_seen"] == 3
+        assert health["alerts_fired"] == 1
+        assert health["last_event_age_s"] is not None
+        assert health["last_event_age_s"] >= 0
+    finally:
+        det.stop_contract_server()
+
+
+def test_default_state_snapshot_is_empty_dict():
+    class _Bare(Detector):
+        manifest = MANIFEST
+
+        def on_detections(self, camera_id, detections, event):
+            return None
+
+    det = _Bare(_cfg(), AlertDispatcher([_RecorderChannel()]))
+    server = det.start_contract_server()
+    try:
+        assert _get(server.port, "/state").json() == {}
+    finally:
+        det.stop_contract_server()
+
+
+def test_unknown_path_is_json_404():
+    det = _detector()
+    server = det.start_contract_server()
+    try:
+        response = _get(server.port, "/nope")
+        assert response.status_code == 404
+        assert "unknown path" in response.json()["error"]
+    finally:
+        det.stop_contract_server()
+
+
+def test_server_off_without_contract_port():
+    det = _detector(SimpleNamespace())
+    assert det.start_contract_server() is None
+    det.stop_contract_server()  # must be a safe no-op
+
+
+def test_frame_app_counters_follow_handle_tick():
+    class _App(FrameApp):
+        manifest = MANIFEST
+
+        def on_frame(self, camera_id, frame_bytes):
+            yield Alert(title="t", description="d", camera_id=camera_id)
+
+    class _Source:
+        def get_frame(self, camera_id):
+            return b"jpeg" if camera_id == "cam-1" else None
+
+    app_obj = _App(
+        SimpleNamespace(poll_interval_seconds=0.01),
+        AlertDispatcher([_RecorderChannel()]),
+        frame_source=_Source(),
+        cameras=["cam-1", "cam-2"],
+    )
+    app_obj.handle_tick()
+    # cam-2 produced no frame → 1 event; cam-1's rule fired 1 alert.
+    assert app_obj._events_seen == 1
+    assert app_obj._alerts_fired == 1
+
+
+# ── Self-registration ──────────────────────────────────────────────
+
+
+class _FakePost:
+    def __init__(self, status_code: int = 200, raise_exc: Exception | None = None):
+        self.calls: list[dict] = []
+        self._status = status_code
+        self._raise = raise_exc
+
+    def __call__(self, url, *, json=None, headers=None, timeout=None, trust_env=None):
+        self.calls.append(
+            {"url": url, "json": json, "headers": headers or {}, "timeout": timeout}
+        )
+        if self._raise is not None:
+            raise self._raise
+        return SimpleNamespace(status_code=self._status, text="registered")
+
+
+def test_registration_posts_url_manifest_and_auth_headers(monkeypatch):
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    det = _detector(_cfg(
+        contract_port=9200,
+        contract_host="loitering",
+        opennvr_url="http://opennvr:8080/",
+        opennvr_token="sekrit",
+    ))
+    assert det.register_with_opennvr() is True
+
+    call = fake.calls[0]
+    assert call["url"] == "http://opennvr:8080/api/v1/apps/register"
+    assert call["json"] == {
+        "url": "http://loitering:9200",
+        "manifest": MANIFEST.to_dict(),
+    }
+    # One token, both header shapes: the registry's register route
+    # accepts a user JWT (bearer) or the deployment's INTERNAL_API_KEY
+    # (X-Internal-Api-Key) — the SDK can't know which kind it holds.
+    assert call["headers"]["Authorization"] == "Bearer sekrit"
+    assert call["headers"]["X-Internal-Api-Key"] == "sekrit"
+
+
+def test_registration_token_falls_back_to_env(monkeypatch):
+    """No ``opennvr_token`` in the config ⇒ the token comes from the
+    ``OPENNVR_INTERNAL_API_KEY`` environment variable (the compose
+    overlay's wiring)."""
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    monkeypatch.setenv("OPENNVR_INTERNAL_API_KEY", "env-sekrit")
+    det = _detector(_cfg(
+        contract_port=9200,
+        contract_host="loitering",
+        opennvr_url="http://opennvr:8080",
+    ))
+    assert det.register_with_opennvr() is True
+    headers = fake.calls[0]["headers"]
+    assert headers["Authorization"] == "Bearer env-sekrit"
+    assert headers["X-Internal-Api-Key"] == "env-sekrit"
+
+
+def test_registration_cfg_token_beats_env(monkeypatch):
+    """An explicit config token wins over the env fallback."""
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    monkeypatch.setenv("OPENNVR_INTERNAL_API_KEY", "env-sekrit")
+    det = _detector(_cfg(
+        contract_port=9200,
+        contract_host="loitering",
+        opennvr_url="http://opennvr:8080",
+        opennvr_token="cfg-sekrit",
+    ))
+    assert det.register_with_opennvr() is True
+    assert fake.calls[0]["headers"]["X-Internal-Api-Key"] == "cfg-sekrit"
+
+
+def test_registration_no_token_sends_no_auth_headers(monkeypatch):
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    monkeypatch.delenv("OPENNVR_INTERNAL_API_KEY", raising=False)
+    det = _detector(_cfg(
+        contract_port=9200,
+        contract_host="loitering",
+        opennvr_url="http://opennvr:8080",
+    ))
+    assert det.register_with_opennvr() is True
+    headers = fake.calls[0]["headers"]
+    assert "Authorization" not in headers
+    assert "X-Internal-Api-Key" not in headers
+
+
+def test_registration_advertises_actual_ephemeral_port(monkeypatch):
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    det = _detector(_cfg(
+        contract_host="myapp", opennvr_url="http://opennvr:8080",
+    ))
+    server = det.start_contract_server()
+    try:
+        assert det.register_with_opennvr() is True
+        assert server.port != 0
+        assert fake.calls[0]["json"]["url"] == f"http://myapp:{server.port}"
+    finally:
+        det.stop_contract_server()
+
+
+def test_registration_failure_is_nonfatal(monkeypatch, caplog):
+    fake = _FakePost(raise_exc=RuntimeError("registry down"))
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    det = _detector(_cfg(contract_port=9200, opennvr_url="http://opennvr:8080"))
+    with caplog.at_level("WARNING", logger="opennvr_app_sdk.contract"):
+        assert det.register_with_opennvr() is False
+    assert any("self-registration failed" in r.getMessage() for r in caplog.records)
+
+
+def test_registration_rejection_is_nonfatal(monkeypatch, caplog):
+    fake = _FakePost(status_code=400)
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    det = _detector(_cfg(contract_port=9200, opennvr_url="http://opennvr:8080"))
+    with caplog.at_level("WARNING", logger="opennvr_app_sdk.contract"):
+        assert det.register_with_opennvr() is False
+    assert any("rejected" in r.getMessage() for r in caplog.records)
+
+
+def test_registration_skipped_without_opennvr_url(monkeypatch):
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    assert _detector(_cfg(contract_port=9200)).register_with_opennvr() is False
+    assert fake.calls == []
+
+
+def test_registration_needs_a_contract_port(monkeypatch, caplog):
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    det = _detector(SimpleNamespace(opennvr_url="http://opennvr:8080"))
+    with caplog.at_level("WARNING", logger="opennvr_app_sdk.contract"):
+        assert det.register_with_opennvr() is False
+    assert fake.calls == []
+    assert any("contract_port" in r.getMessage() for r in caplog.records)
+
+
+# ── run() lifecycle ────────────────────────────────────────────────
+
+
+async def test_frame_app_run_starts_registers_and_stops_contract(monkeypatch):
+    fake = _FakePost()
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+
+    seen_ports: list[int] = []
+
+    class _App(FrameApp):
+        manifest = MANIFEST
+
+        def on_frame(self, camera_id, frame_bytes):
+            # Prove the contract server is live DURING the loop.
+            seen_ports.append(self._contract_server.port)
+            health = _get(self._contract_server.port, "/health").json()
+            assert health["ready"] is True
+            return None
+
+    class _Source:
+        def get_frame(self, camera_id):
+            return b"jpeg"
+
+    app_obj = _App(
+        SimpleNamespace(
+            poll_interval_seconds=0.01,
+            contract_port=0,
+            contract_bind_host="127.0.0.1",
+            contract_host="pkg",
+            opennvr_url="http://opennvr:8080",
+        ),
+        AlertDispatcher([_RecorderChannel()]),
+        frame_source=_Source(),
+        cameras=["cam-1"],
+    )
+    await app_obj.run(once=True)
+
+    # Registered once, advertising the ephemeral port that was bound.
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["json"]["url"] == f"http://pkg:{seen_ports[0]}"
+    # And the server is torn down after run() returns.
+    assert app_obj._contract_server is None
+    with pytest.raises(httpx.TransportError):
+        _get(seen_ports[0], "/health")

--- a/sdk/opennvr-app-sdk/tests/test_detector.py
+++ b/sdk/opennvr-app-sdk/tests/test_detector.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Detector base tests — the event-parsing + on_detections dispatch
+path, exercised through ``_handle_raw`` so no NATS broker is needed."""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opennvr_app_sdk import (
+    Alert,
+    AlertDispatcher,
+    AlertType,
+    AppManifest,
+    Detector,
+    app,
+)
+from opennvr_app_sdk.alerts import get_default_source
+
+
+class _RecorderChannel:
+    name = "recorder"
+
+    def __init__(self) -> None:
+        self.alerts: list[Alert] = []
+
+    def send(self, alert: Alert) -> bool:
+        self.alerts.append(alert)
+        return True
+
+
+MANIFEST = AppManifest(
+    id="echo-detector",
+    name="Echo Detector",
+    version="0.9.9",
+    category="test",
+    subscribes="opennvr.inference.>",
+    emits=[AlertType("echo", severity="low")],
+)
+
+
+class EchoDetector(Detector):
+    """Fires one alert per watched-label detection — just enough rule
+    to prove the base's parse → on_detections → dispatch path."""
+
+    manifest = MANIFEST
+
+    def setup(self) -> None:
+        self.setup_ran = True
+
+    def on_detections(
+        self, camera_id: str, detections: list[dict[str, Any]], event: dict[str, Any],
+    ):
+        for det in detections:
+            if not isinstance(det, dict):
+                continue
+            if det.get("label") == "person":
+                yield Alert(
+                    title="person seen",
+                    description="echo",
+                    camera_id=camera_id,
+                    correlation_id=str(event.get("correlation_id") or ""),
+                    evidence={"ts": self.parse_event_ts(event.get("completed_at"))},
+                )
+
+
+def _build() -> tuple[EchoDetector, _RecorderChannel]:
+    recorder = _RecorderChannel()
+    dispatcher = AlertDispatcher([recorder])
+    cfg = SimpleNamespace(
+        nats_url="nats://test:4222",
+        nats_token=None,
+        subject_pattern="opennvr.inference.>",
+    )
+    fixed_now = _dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc)
+    detector = EchoDetector(cfg, dispatcher, clock=lambda: fixed_now)
+    return detector, recorder
+
+
+def _event(**overrides: Any) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "correlation_id": "corr-42",
+        "camera_id": "cam-1",
+        "completed_at": "2026-01-02T03:04:05Z",
+        "result": {
+            "detections": [
+                {"label": "person", "confidence": 0.9,
+                 "bbox": {"x": 0.4, "y": 0.4, "w": 0.1, "h": 0.1}},
+                {"label": "bike", "confidence": 0.8,
+                 "bbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}},
+            ],
+        },
+    }
+    event.update(overrides)
+    return event
+
+
+# ── _handle_raw: decode + dispatch without a broker ────────────────
+
+
+def test_handle_raw_dispatches_alerts_to_channel():
+    detector, recorder = _build()
+    fired = detector._handle_raw(json.dumps(_event()).encode())
+    assert len(fired) == 1
+    assert recorder.alerts == fired
+    alert = fired[0]
+    assert alert.camera_id == "cam-1"
+    assert alert.correlation_id == "corr-42"
+
+
+def test_handle_raw_skips_non_json_without_raising():
+    detector, recorder = _build()
+    assert detector._handle_raw(b"\x00not json{{") == []
+    assert recorder.alerts == []
+
+
+def test_handle_raw_isolates_on_detections_exceptions():
+    detector, recorder = _build()
+
+    class Boom(EchoDetector):
+        def on_detections(self, camera_id, detections, event):
+            raise RuntimeError("rule kaboom")
+
+    boom = Boom(detector.cfg, AlertDispatcher([recorder]))
+    # MUST NOT raise — one bad event can't kill a long-lived subscriber.
+    assert boom._handle_raw(json.dumps(_event()).encode()) == []
+    assert recorder.alerts == []
+
+
+# ── handle_event: defensive payload parsing ────────────────────────
+
+
+def test_handle_event_rejects_malformed_shapes():
+    detector, recorder = _build()
+    assert detector.handle_event(None) == []
+    assert detector.handle_event("not a dict") == []
+    assert detector.handle_event({"result": {"detections": []}}) == []  # no camera_id
+    assert detector.handle_event({"camera_id": "cam-1"}) == []  # no result
+    assert detector.handle_event(
+        {"camera_id": "cam-1", "result": {"detections": "not a list"}}
+    ) == []
+    assert detector.handle_event(
+        {"camera_id": "cam-1", "result": "not a dict"}
+    ) == []
+    assert recorder.alerts == []
+
+
+def test_handle_event_accepts_list_return():
+    detector, recorder = _build()
+
+    class ListDetector(EchoDetector):
+        def on_detections(self, camera_id, detections, event):
+            return [Alert(title="t", description="d", camera_id=camera_id)]
+
+    d = ListDetector(detector.cfg, AlertDispatcher([recorder]))
+    assert len(d.handle_event(_event())) == 1
+    assert len(recorder.alerts) == 1
+
+
+def test_handle_event_accepts_none_return():
+    detector, recorder = _build()
+
+    class QuietDetector(EchoDetector):
+        def on_detections(self, camera_id, detections, event):
+            return None
+
+    d = QuietDetector(detector.cfg, AlertDispatcher([recorder]))
+    assert d.handle_event(_event()) == []
+    assert recorder.alerts == []
+
+
+def test_on_detections_is_abstract():
+    detector, _ = _build()
+    base = Detector(detector.cfg, AlertDispatcher([_RecorderChannel()]))
+    with pytest.raises(NotImplementedError):
+        base.handle_event(_event())
+
+
+# ── Timestamp parsing ──────────────────────────────────────────────
+
+
+def test_parse_event_ts_iso_with_z_suffix():
+    detector, _ = _build()
+    ts = detector.parse_event_ts("2026-01-02T03:04:05Z")
+    expected = _dt.datetime(
+        2026, 1, 2, 3, 4, 5, tzinfo=_dt.timezone.utc,
+    ).timestamp()
+    assert ts == expected
+
+
+def test_parse_event_ts_naive_assumed_utc():
+    detector, _ = _build()
+    ts = detector.parse_event_ts("2026-01-02T03:04:05")
+    expected = _dt.datetime(
+        2026, 1, 2, 3, 4, 5, tzinfo=_dt.timezone.utc,
+    ).timestamp()
+    assert ts == expected
+
+
+def test_parse_event_ts_falls_back_to_clock_on_garbage():
+    detector, _ = _build()
+    fixed = _dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc).timestamp()
+    assert detector.parse_event_ts("not-a-timestamp") == fixed
+    assert detector.parse_event_ts(None) == fixed
+    assert detector.parse_event_ts(12345) == fixed  # non-str falls back too
+
+
+# ── Lifecycle glue ─────────────────────────────────────────────────
+
+
+def test_alert_source_scoped_to_handler_not_process_global():
+    # Constructing a detector must NOT mutate the process default —
+    # several detectors can share one process (the camera agent's
+    # create_monitor case) without clobbering each other.
+    before = get_default_source()
+    detector, recorder = _build()
+    assert get_default_source() == before
+    # But alerts created inside the rule inherit the app identity.
+    detector.handle_event(_event())
+    assert recorder.alerts[0].source.name == "echo-detector"
+    assert recorder.alerts[0].source.version == "0.9.9"
+    # And the default is restored once the handler returns.
+    assert get_default_source() == before
+
+
+def test_setup_hook_runs_at_construction():
+    detector, _ = _build()
+    assert detector.setup_ran is True
+
+
+def test_keyed_state_convenience():
+    detector, _ = _build()
+    states = detector.keyed_state(ttl=3.0)
+    rec = states.touch("k", at=1.0)
+    assert rec.age == 0.0
+
+
+def test_stop_sets_stop_event():
+    detector, _ = _build()
+    assert not detector._stop_event.is_set()
+    detector.stop()
+    assert detector._stop_event.is_set()
+
+
+# ── app() runner wiring ────────────────────────────────────────────
+
+
+def test_app_requires_a_config_loader():
+    with pytest.raises(TypeError, match="load_config"):
+        app(EchoDetector)
+
+
+def test_app_returns_2_on_config_error(capsys):
+    def bad_loader(path: str):
+        raise ValueError("nope, bad config")
+
+    runner = app(EchoDetector, load_config=bad_loader)
+    rc = runner.run(["--config", "whatever.yml"])
+    assert rc == 2
+    assert "config error: nope, bad config" in capsys.readouterr().err
+
+
+def test_app_uses_class_load_config_when_present():
+    class WithLoader(EchoDetector):
+        @classmethod
+        def load_config(cls, path: str):
+            raise ValueError("loader was called")
+
+    runner = app(WithLoader)
+    assert runner.run(["--config", "x.yml"]) == 2  # proves the loader ran

--- a/sdk/opennvr-app-sdk/tests/test_frame_app.py
+++ b/sdk/opennvr-app-sdk/tests/test_frame_app.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""FrameApp + KaiCClient tests — the poll-tick path and the
+contract-v1 base64 infer call, both without a live KAI-C."""
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from opennvr_app_sdk import (
+    Alert,
+    AlertDispatcher,
+    FrameApp,
+    KaiCClient,
+    KaiCError,
+)
+
+
+class _RecorderChannel:
+    name = "recorder"
+
+    def __init__(self) -> None:
+        self.alerts: list[Alert] = []
+
+    def send(self, alert: Alert) -> bool:
+        self.alerts.append(alert)
+        return True
+
+
+class _FakeSource:
+    """FrameSource returning canned bytes per camera; None = no frame."""
+
+    def __init__(self, frames: dict[str, bytes | None]) -> None:
+        self.frames = frames
+        self.calls: list[str] = []
+
+    def get_frame(self, camera_id: str) -> bytes | None:
+        self.calls.append(camera_id)
+        value = self.frames.get(camera_id)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class SpottingApp(FrameApp):
+    def on_frame(self, camera_id: str, frame_bytes: bytes):
+        if b"person" in frame_bytes:
+            yield Alert(title="spotted", description="d", camera_id=camera_id)
+
+
+def _build(frames: dict, **kwargs) -> tuple[SpottingApp, _FakeSource, _RecorderChannel]:
+    recorder = _RecorderChannel()
+    source = _FakeSource(frames)
+    cfg = SimpleNamespace(poll_interval_seconds=0.01)
+    app_obj = SpottingApp(
+        cfg,
+        AlertDispatcher([recorder]),
+        frame_source=source,
+        cameras=list(frames.keys()),
+        **kwargs,
+    )
+    return app_obj, source, recorder
+
+
+# ── handle_tick ────────────────────────────────────────────────────
+
+
+def test_tick_fetches_every_camera_and_dispatches():
+    app_obj, source, recorder = _build({
+        "cam-1": b"a person here",
+        "cam-2": b"empty porch",
+    })
+    fired = app_obj.handle_tick()
+    assert source.calls == ["cam-1", "cam-2"]
+    assert [a.camera_id for a in fired] == ["cam-1"]
+    assert recorder.alerts == fired
+
+
+def test_tick_skips_cameras_without_frames():
+    app_obj, _, recorder = _build({"cam-1": None})
+    assert app_obj.handle_tick() == []
+    assert recorder.alerts == []
+
+
+def test_tick_isolates_fetch_and_rule_failures():
+    app_obj, source, recorder = _build({
+        "cam-bad": RuntimeError("rtsp down"),
+        "cam-2": b"a person here",
+    })
+    # cam-bad raises in get_frame; cam-2 must still be processed.
+    fired = app_obj.handle_tick()
+    assert [a.camera_id for a in fired] == ["cam-2"]
+
+    class BoomApp(SpottingApp):
+        def on_frame(self, camera_id, frame_bytes):
+            raise RuntimeError("rule kaboom")
+
+    boom = BoomApp(
+        SimpleNamespace(poll_interval_seconds=1.0),
+        AlertDispatcher([recorder]),
+        frame_source=source,
+        cameras=["cam-2"],
+    )
+    assert boom.handle_tick() == []  # MUST NOT raise
+
+
+def test_interval_must_be_positive():
+    with pytest.raises(ValueError, match="poll_interval_seconds"):
+        _build({"cam-1": b"x"}, poll_interval_seconds=0)
+
+
+async def test_run_once_does_one_tick():
+    app_obj, source, _ = _build({"cam-1": b"a person here"})
+    await app_obj.run(once=True)
+    assert source.calls == ["cam-1"]
+
+
+# ── KaiCClient ─────────────────────────────────────────────────────
+
+
+class _CapturingTransport(httpx.BaseTransport):
+    def __init__(self, status_code: int = 200, body: dict | None = None) -> None:
+        self.requests: list[httpx.Request] = []
+        self._status = status_code
+        self._body = body if body is not None else {"result": {"detections": []}}
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        request.read()
+        self.requests.append(request)
+        return httpx.Response(self._status, json=self._body)
+
+
+def test_kaic_client_posts_contract_v1_base64_payload():
+    transport = _CapturingTransport()
+    client = KaiCClient(
+        "http://kaic:8000/",  # trailing slash must not double up
+        "yolov8",
+        api_key="sekrit",
+        http_client=httpx.Client(transport=transport),
+    )
+    frame = b"\xff\xd8jpegbytes"
+    response = client.infer(frame, task="object_detection", camera_id="cam-1", correlation_id="corr-9")
+    assert response == {"result": {"detections": []}}
+
+    request = transport.requests[0]
+    assert str(request.url) == "http://kaic:8000/api/v1/infer/yolov8"
+    assert request.headers["x-correlation-id"] == "corr-9"
+    assert request.headers["x-internal-api-key"] == "sekrit"
+    body = json.loads(request.content)
+    assert body["task"] == "object_detection"
+    assert body["camera_id"] == "cam-1"
+    assert base64.b64decode(body["frame_b64"]) == frame
+
+
+def test_kaic_client_generates_correlation_id_when_omitted():
+    transport = _CapturingTransport()
+    client = KaiCClient(
+        "http://kaic:8000", "yolov8",
+        http_client=httpx.Client(transport=transport),
+    )
+    client.infer(b"frame", task="object_detection", camera_id="cam-1")
+    request = transport.requests[0]
+    assert request.headers["x-correlation-id"].startswith("app-")
+    assert "x-internal-api-key" not in request.headers  # no key configured
+
+
+def test_kaic_client_raises_kaic_error_on_non_200():
+    transport = _CapturingTransport(status_code=503, body={"detail": "overloaded"})
+    client = KaiCClient(
+        "http://kaic:8000", "yolov8",
+        http_client=httpx.Client(transport=transport),
+    )
+    with pytest.raises(KaiCError, match="HTTP 503"):
+        client.infer(b"frame", task="object_detection", camera_id="cam-1")
+
+
+def test_kaic_client_wraps_transport_errors():
+    class _ExplodingTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom")
+
+    client = KaiCClient(
+        "http://kaic:8000", "yolov8",
+        http_client=httpx.Client(transport=_ExplodingTransport()),
+    )
+    with pytest.raises(KaiCError, match="unreachable"):
+        client.infer(b"frame", task="object_detection", camera_id="cam-1")

--- a/sdk/opennvr-app-sdk/tests/test_frame_sources.py
+++ b/sdk/opennvr-app-sdk/tests/test_frame_sources.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frame-source tests — the file / http snapshot sources, the scheme
+factory, and the dict bridge into the FrameApp poll loop. Promoted
+alongside the module from the package-delivery example."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from opennvr_app_sdk import frame_sources as fs
+from opennvr_app_sdk.frame_sources import (
+    DictFrameSource,
+    FileFrameSource,
+    FrameSourceError,
+    HttpSnapshotSource,
+    build_frame_source,
+)
+
+
+# ── FileFrameSource ────────────────────────────────────────────────
+
+
+def test_file_source_round_trips_bytes(tmp_path):
+    p = tmp_path / "frame.jpg"
+    p.write_bytes(b"\xff\xd8jpegbytes")
+    source = FileFrameSource(camera_id="cam-1", path=str(p))
+    assert source.camera_id == "cam-1"
+    assert source.fetch() == b"\xff\xd8jpegbytes"
+
+
+def test_file_source_rejects_missing_file(tmp_path):
+    with pytest.raises(FrameSourceError, match="does not exist"):
+        FileFrameSource(camera_id="cam-1", path=str(tmp_path / "nope.jpg"))
+
+
+# ── HttpSnapshotSource ─────────────────────────────────────────────
+
+
+class _FakeGet:
+    def __init__(self, status_code=200, content=b"img", content_type="image/jpeg",
+                 raise_exc: Exception | None = None):
+        self.calls: list[str] = []
+        self._response = SimpleNamespace(
+            status_code=status_code,
+            content=content,
+            headers={"content-type": content_type},
+        )
+        self._raise = raise_exc
+
+    def __call__(self, url, **kwargs):
+        self.calls.append(url)
+        if self._raise is not None:
+            raise self._raise
+        return self._response
+
+
+def test_http_source_returns_body_on_200(monkeypatch):
+    fake = _FakeGet(content=b"snapshot-bytes")
+    monkeypatch.setattr(fs.httpx, "get", fake)
+    source = HttpSnapshotSource(camera_id="cam-1", url="http://cam/snap.jpg")
+    assert source.fetch() == b"snapshot-bytes"
+    assert fake.calls == ["http://cam/snap.jpg"]
+
+
+def test_http_source_wraps_transport_errors(monkeypatch):
+    monkeypatch.setattr(fs.httpx, "get", _FakeGet(raise_exc=OSError("boom")))
+    source = HttpSnapshotSource(camera_id="cam-1", url="http://cam/snap.jpg")
+    with pytest.raises(FrameSourceError, match="OSError"):
+        source.fetch()
+
+
+def test_http_source_raises_on_non_200(monkeypatch):
+    monkeypatch.setattr(fs.httpx, "get", _FakeGet(status_code=503))
+    source = HttpSnapshotSource(camera_id="cam-1", url="http://cam/snap.jpg")
+    with pytest.raises(FrameSourceError, match="HTTP 503"):
+        source.fetch()
+
+
+def test_http_source_warns_on_non_image_content_type(monkeypatch, caplog):
+    fake = _FakeGet(content=b"<html>", content_type="text/html; charset=utf-8")
+    monkeypatch.setattr(fs.httpx, "get", fake)
+    source = HttpSnapshotSource(camera_id="cam-1", url="http://cam/snap.jpg")
+    with caplog.at_level("WARNING", logger="opennvr_app_sdk.frame_sources"):
+        assert source.fetch() == b"<html>"  # passed through anyway
+    assert any("non-image" in r.getMessage() for r in caplog.records)
+
+
+def test_http_source_rejects_non_http_url():
+    with pytest.raises(FrameSourceError, match="expected http"):
+        HttpSnapshotSource(camera_id="cam-1", url="ftp://cam/snap.jpg")
+
+
+# ── build_frame_source ─────────────────────────────────────────────
+
+
+def test_factory_routes_file_scheme(tmp_path):
+    p = tmp_path / "frame.jpg"
+    p.write_bytes(b"x")
+    source = build_frame_source(camera_id="cam-1", url=f"file://{p}")
+    assert isinstance(source, FileFrameSource)
+
+
+def test_factory_routes_http_schemes():
+    for url in ("http://cam/snap.jpg", "https://cam/snap.jpg"):
+        source = build_frame_source(camera_id="cam-1", url=url)
+        assert isinstance(source, HttpSnapshotSource)
+
+
+@pytest.mark.parametrize(
+    ("url", "match"),
+    [
+        ("rtsp://cam/stream", "rtsp"),
+        ("opennvr://cameras/1/snapshot", "opennvr"),
+        ("gopher://cam/snap", "unsupported frame source scheme"),
+    ],
+)
+def test_factory_rejects_unsupported_schemes(url, match):
+    with pytest.raises(FrameSourceError, match=match):
+        build_frame_source(camera_id="cam-1", url=url)
+
+
+# ── DictFrameSource bridge ─────────────────────────────────────────
+
+
+class _StubSource:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def fetch(self) -> bytes:
+        return self.payload
+
+
+def test_dict_source_routes_by_camera_id():
+    sources = {"cam-1": _StubSource(b"one"), "cam-2": _StubSource(b"two")}
+    bridge = DictFrameSource(sources)
+    assert bridge.get_frame("cam-1") == b"one"
+    assert bridge.get_frame("cam-2") == b"two"
+
+
+def test_dict_source_sees_live_mapping_swaps():
+    sources = {"cam-1": _StubSource(b"before")}
+    bridge = DictFrameSource(sources)
+    assert bridge.get_frame("cam-1") == b"before"
+    sources["cam-1"] = _StubSource(b"after")  # test-stub swap pattern
+    assert bridge.get_frame("cam-1") == b"after"
+
+
+def test_dict_source_unknown_camera_raises_key_error():
+    with pytest.raises(KeyError):
+        DictFrameSource({}).get_frame("cam-x")

--- a/sdk/opennvr-app-sdk/tests/test_geometry.py
+++ b/sdk/opennvr-app-sdk/tests/test_geometry.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Zone geometry tests — point-in-polygon + bbox_center scaling."""
+from __future__ import annotations
+
+import pytest
+
+from opennvr_app_sdk.geometry import Point, Zone, bbox_center
+
+
+def _square() -> Zone:
+    return Zone.from_config("sq", [[0, 0], [100, 0], [100, 100], [0, 100]])
+
+
+def test_zone_contains_interior_point():
+    assert _square().contains(Point(50, 50))
+
+
+def test_zone_excludes_exterior_point():
+    zone = _square()
+    assert not zone.contains(Point(150, 50))
+    assert not zone.contains(Point(-1, 50))
+    assert not zone.contains(Point(50, 101))
+
+
+def test_zone_edge_points_count_as_inside():
+    """Points exactly on an edge are INSIDE — the safer choice for a
+    monitoring app (track the borderline person, don't miss them)."""
+    zone = _square()
+    assert zone.contains(Point(0, 50))     # left edge
+    assert zone.contains(Point(100, 100))  # corner
+    assert zone.contains(Point(50, 0))     # top edge
+
+
+def test_concave_polygon():
+    # L-shape: the notch at top-right is outside.
+    zone = Zone.from_config(
+        "L", [[0, 0], [50, 0], [50, 50], [100, 50], [100, 100], [0, 100]],
+    )
+    assert zone.contains(Point(25, 25))    # in the vertical arm
+    assert zone.contains(Point(75, 75))    # in the horizontal arm
+    assert not zone.contains(Point(75, 25))  # in the notch
+
+
+def test_zone_rejects_degenerate_polygon():
+    with pytest.raises(ValueError, match="at least 3 vertices"):
+        Zone(name="line", polygon=[Point(0, 0), Point(1, 1)])
+    with pytest.raises(ValueError, match="at least 3 vertices"):
+        Zone.from_config("dot", [[5, 5]])
+
+
+def test_zone_from_config_coerces_floats():
+    zone = Zone.from_config("z", [["0", "0"], [10, 0], [10, 10]])
+    assert zone.polygon[0] == Point(0.0, 0.0)
+
+
+def test_bbox_center_scales_normalized_bbox_to_pixels():
+    # bbox (0.45, 0.45, 0.1, 0.1) on 1920x1080 → center (960, 540)...
+    center = bbox_center({"x": 0.45, "y": 0.45, "w": 0.1, "h": 0.1}, 1920, 1080)
+    assert center == Point(0.5 * 1920, 0.5 * 1080)
+
+
+def test_bbox_center_missing_keys_default_to_zero():
+    center = bbox_center({}, 1920, 1080)
+    assert center == Point(0.0, 0.0)
+    center = bbox_center({"x": 0.5, "y": 0.5}, 100, 100)  # no w/h
+    assert center == Point(50.0, 50.0)
+
+
+def test_bbox_center_non_numeric_values_default_to_zero():
+    center = bbox_center({"x": "junk", "y": None, "w": 0.2, "h": 0.2}, 100, 100)
+    assert center == Point(10.0, 10.0)

--- a/sdk/opennvr-app-sdk/tests/test_manifest.py
+++ b/sdk/opennvr-app-sdk/tests/test_manifest.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""AppManifest / Param / AlertType — the future GET /manifest payload."""
+from __future__ import annotations
+
+from opennvr_app_sdk.manifest import AlertType, AppManifest, Param
+
+
+def _manifest() -> AppManifest:
+    return AppManifest(
+        id="loitering-detection",
+        name="Loitering Detection",
+        version="1.0.0",
+        category="perimeter",
+        summary="Alerts when a watched object dwells in a zone.",
+        requires_tasks=["object_detection"],
+        subscribes="opennvr.inference.>",
+        params=[
+            Param("watch_labels", list, default=["person"]),
+            Param("threshold_seconds", float, default=30.0),
+            Param("zones", "geometry.polygon", per_camera=True,
+                  description="Drawn in the catalog UI."),
+        ],
+        emits=[AlertType("loitering", severity="high")],
+    )
+
+
+def test_to_dict_shape():
+    d = _manifest().to_dict()
+    assert d["id"] == "loitering-detection"
+    assert d["category"] == "perimeter"
+    assert d["requires_tasks"] == ["object_detection"]
+    assert d["subscribes"] == "opennvr.inference.>"
+    assert len(d["params"]) == 3
+    assert d["emits"] == [
+        {"name": "loitering", "severity": "high", "description": ""},
+    ]
+
+
+def test_param_python_types_render_by_name():
+    d = _manifest().to_dict()
+    by_name = {p["name"]: p for p in d["params"]}
+    assert by_name["watch_labels"]["type"] == "list"
+    assert by_name["threshold_seconds"]["type"] == "float"
+    assert by_name["watch_labels"]["default"] == ["person"]
+    assert by_name["watch_labels"]["per_camera"] is False
+
+
+def test_param_ui_schema_types_pass_through():
+    d = _manifest().to_dict()
+    zones = next(p for p in d["params"] if p["name"] == "zones")
+    assert zones["type"] == "geometry.polygon"
+    assert zones["per_camera"] is True
+
+
+def test_manifest_defaults():
+    m = AppManifest(id="x", name="X", version="0.1", category="test")
+    d = m.to_dict()
+    assert d["summary"] == ""
+    assert d["requires_tasks"] == []
+    assert d["subscribes"] is None
+    assert d["params"] == []
+    assert d["emits"] == []
+
+
+def test_to_dict_is_json_serializable():
+    import json
+    json.dumps(_manifest().to_dict())  # must not raise
+
+
+def test_alert_type_default_severity_is_medium():
+    assert AlertType("thing").severity == "medium"

--- a/sdk/opennvr-app-sdk/tests/test_state.py
+++ b/sdk/opennvr-app-sdk/tests/test_state.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""keyed_state tests — TTL expiry, the alerted latch, GC semantics,
+and the two archetypal consumers (loitering-style dwell and
+package-delivery-style per-track lifecycle)."""
+from __future__ import annotations
+
+import pytest
+
+from opennvr_app_sdk.state import KeyedState, StateRecord, keyed_state
+
+
+# ── Basics ─────────────────────────────────────────────────────────
+
+
+def test_keyed_state_factory_returns_keyed_state():
+    states = keyed_state(5.0)
+    assert isinstance(states, KeyedState)
+    assert states.ttl == 5.0
+    assert len(states) == 0
+
+
+def test_ttl_must_be_positive():
+    with pytest.raises(ValueError, match="ttl"):
+        keyed_state(0)
+    with pytest.raises(ValueError, match="ttl"):
+        keyed_state(-1.0)
+
+
+def test_first_touch_creates_record():
+    states = keyed_state(5.0)
+    rec = states.touch("k", at=100.0)
+    assert rec.first_seen == 100.0
+    assert rec.last_seen == 100.0
+    assert rec.age == 0.0
+    assert rec.alerted is False
+    assert "k" in states
+    assert states.get("k") is rec
+    assert states["k"] is rec
+
+
+def test_repeated_touch_refreshes_last_seen_and_grows_age():
+    states = keyed_state(5.0)
+    states.touch("k", at=100.0)
+    rec = states.touch("k", at=103.0)
+    assert rec.first_seen == 100.0
+    assert rec.last_seen == 103.0
+    assert rec.age == 3.0
+
+
+def test_touch_uses_wall_clock_when_at_omitted():
+    ticks = iter([100.0, 107.0])
+    states = keyed_state(5.0, clock=lambda: next(ticks))
+    rec = states.touch("k")
+    assert rec.first_seen == 100.0
+    rec = states.touch("k")
+    assert rec.last_seen == 107.0
+
+
+# ── Latch ──────────────────────────────────────────────────────────
+
+
+def test_alerted_latch_is_settable_and_persists_across_touches():
+    states = keyed_state(5.0)
+    rec = states.touch("k", at=0.0)
+    assert rec.alerted is False
+    rec.alerted = True
+    rec = states.touch("k", at=1.0)
+    assert rec.alerted is True  # same episode — the latch holds
+
+
+def test_latch_resets_when_key_expires_and_reappears():
+    states = keyed_state(5.0, auto_gc=False)
+    rec = states.touch("k", at=0.0)
+    rec.alerted = True
+    states.gc(100.0)  # long past TTL — episode over
+    rec2 = states.touch("k", at=100.0)
+    assert rec2.alerted is False  # fresh episode, fresh latch
+    assert rec2.first_seen == 100.0
+
+
+# ── GC ─────────────────────────────────────────────────────────────
+
+
+def test_gc_prunes_only_stale_keys_and_returns_them():
+    states = keyed_state(5.0, auto_gc=False)
+    states.touch("stale", at=0.0)
+    states.touch("fresh", at=8.0)
+    pruned = states.gc(10.0)  # cutoff = 5.0
+    assert [k for k, _ in pruned] == ["stale"]
+    assert isinstance(pruned[0][1], StateRecord)
+    assert states.get("stale") is None
+    assert "fresh" in states
+
+
+def test_gc_boundary_is_strict():
+    """A record exactly at the TTL boundary survives — matches the
+    ``last_seen < cutoff`` grace-period semantics the loitering
+    detector shipped with."""
+    states = keyed_state(5.0, auto_gc=False)
+    states.touch("edge", at=5.0)
+    assert states.gc(10.0) == []  # last_seen == cutoff → keep
+    assert "edge" in states
+    assert [k for k, _ in states.gc(10.001)] == ["edge"]
+
+
+def test_gc_respects_exclude():
+    states = keyed_state(5.0, auto_gc=False)
+    states.touch("a", at=0.0)
+    states.touch("b", at=0.0)
+    pruned = states.gc(100.0, exclude=("a",))
+    assert [k for k, _ in pruned] == ["b"]
+    assert "a" in states
+
+
+def test_touch_auto_gc_prunes_other_stale_keys():
+    states = keyed_state(5.0)  # auto_gc defaults on
+    states.touch("old", at=0.0)
+    states.touch("new", at=100.0)
+    assert states.get("old") is None
+    assert "new" in states
+
+
+def test_touch_never_prunes_its_own_key():
+    """A touch means "present now" — even after a gap far beyond the
+    TTL, the touched key is refreshed, not restarted. This is what
+    keeps a continuous-but-sparse presence stream (0.1 fps with a 5 s
+    TTL) accruing one dwell episode instead of many."""
+    states = keyed_state(5.0)
+    states.touch("k", at=0.0)
+    rec = states.touch("k", at=100.0)
+    assert rec.first_seen == 0.0  # episode NOT restarted
+    assert rec.age == 100.0
+
+
+def test_pop_and_items():
+    states = keyed_state(5.0)
+    states.touch(("cam-1", "person"), at=0.0)
+    states.touch(("cam-1", "car"), at=1.0)
+    keys = [k for k, _ in states.items()]
+    assert set(keys) == {("cam-1", "person"), ("cam-1", "car")}
+    # items() is a snapshot — popping while iterating is safe.
+    for key, rec in states.items():
+        if key[1] == "car":
+            assert states.pop(key) is rec
+    assert len(states) == 1
+    assert states.pop("missing") is None
+    assert states.pop("missing", "sentinel") == "sentinel"
+
+
+def test_record_factory_allows_typed_subclasses():
+    class DwellRecord(StateRecord):
+        @property
+        def present_since(self) -> float:
+            return self.first_seen
+
+    states = keyed_state(5.0, record_factory=DwellRecord)
+    rec = states.touch("k", at=42.0)
+    assert isinstance(rec, DwellRecord)
+    assert rec.present_since == 42.0
+
+
+def test_record_data_scratchpad():
+    states = keyed_state(5.0)
+    rec = states.touch("trk_1", at=0.0)
+    rec.data["phase"] = "arrived"
+    assert states.touch("trk_1", at=1.0).data["phase"] == "arrived"
+
+
+# ── Archetype scenario: package-delivery per-track lifecycle ───────
+
+
+def test_package_delivery_track_lifecycle():
+    """Per-track arrival → linger → disappear with a one-shot latch,
+    the shape ``examples/package-delivery`` needs from keyed_state:
+
+    * arrival: first touch of a track_id starts the clock
+    * linger: the alert fires exactly once when age crosses the
+      threshold (the ``alerted`` latch), no matter how many more
+      frames the package sits there
+    * disappear: no touches for > TTL → ``gc`` prunes the track and
+      hands the record back so the app can emit a "package gone"
+      event; a later same-id arrival is a fresh episode
+    """
+    linger_threshold = 2.0
+    gone_ttl = 3.0
+    states = keyed_state(gone_ttl, auto_gc=False)
+    linger_alerts: list[tuple[str, float]] = []
+    gone_events: list[str] = []
+
+    def tick(now: float, visible_tracks: list[str]) -> None:
+        # What a poll-loop tick does: touch what's visible, GC what's not.
+        for track_id in visible_tracks:
+            rec = states.touch(track_id, at=now)
+            if rec.age >= linger_threshold and not rec.alerted:
+                rec.alerted = True
+                linger_alerts.append((track_id, now))
+        for track_id, _rec in states.gc(now):
+            gone_events.append(track_id)
+
+    # Arrival at t=100; box sits on the porch through t=104.
+    for t in (100.0, 101.0, 102.0, 103.0, 104.0):
+        tick(t, ["trk_1"])
+    # Latch: fired exactly once, at the threshold crossing.
+    assert linger_alerts == [("trk_1", 102.0)]
+
+    # Box picked up — track vanishes. Within TTL: still tracked.
+    tick(106.0, [])
+    assert gone_events == []
+    # Beyond TTL: pruned, "gone" event emitted once.
+    tick(108.0, [])
+    assert gone_events == ["trk_1"]
+    assert states.get("trk_1") is None
+    tick(109.0, [])
+    assert gone_events == ["trk_1"]  # no re-fire after prune
+
+    # A new delivery reusing the id is a FRESH episode: alert re-arms.
+    for t in (200.0, 201.0, 202.0):
+        tick(t, ["trk_1"])
+    assert linger_alerts == [("trk_1", 102.0), ("trk_1", 202.0)]
+
+
+# ── Archetype scenario: loitering-style dwell with grace period ────
+
+
+def test_loitering_dwell_with_grace_reset():
+    """Absence beyond the grace period (= TTL) resets the dwell so a
+    fresh arrival doesn't inherit the earlier episode's clock."""
+    states = keyed_state(5.0, auto_gc=False)
+    key = ("cam-1", "person")
+
+    # Brief presence t=0..2.
+    for t in (0.0, 1.0, 2.0):
+        states.touch(key, at=t)
+    # Absent frames drive gc; state survives the grace window…
+    assert states.gc(6.0) == []          # 6 - 2 = 4 < 5
+    # …and resets once the gap exceeds it.
+    assert [k for k, _ in states.gc(8.0)] == [key]  # 8 - 2 = 6 > 5
+
+    # Fresh arrival at t=11 → age counts from 11, not 0.
+    rec = states.touch(key, at=11.0)
+    assert rec.first_seen == 11.0
+    rec = states.touch(key, at=20.0)
+    assert rec.age == 9.0

--- a/sdk/opennvr-app-sdk/tests/test_tripwire.py
+++ b/sdk/opennvr-app-sdk/tests/test_tripwire.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tripwire geometry tests — promoted alongside the implementation
+from ``examples/line-crossing`` (whose own suite keeps the app-level
+crossing state machine pinned)."""
+from __future__ import annotations
+
+import pytest
+
+from opennvr_app_sdk.geometry import Point, Tripwire
+
+
+def _vertical_mid(count_direction: str = "both") -> Tripwire:
+    # Vertical wire down the middle of a 1000-wide frame, A=top B=bottom.
+    return Tripwire.from_config(
+        "mid", a=[500, 0], b=[500, 1000], count_direction=count_direction,
+    )
+
+
+def test_detects_crossings_both_ways():
+    wire = _vertical_mid()
+    assert wire.crossing(Point(400, 500), Point(600, 500)) == "a_to_b"
+    assert wire.crossing(Point(600, 500), Point(400, 500)) == "b_to_a"
+
+
+def test_moving_along_one_side_is_not_a_crossing():
+    wire = _vertical_mid()
+    assert wire.crossing(Point(400, 100), Point(400, 900)) is None
+
+
+def test_respects_count_direction():
+    a_to_b_only = _vertical_mid("a_to_b")
+    assert a_to_b_only.crossing(Point(400, 500), Point(600, 500)) == "a_to_b"
+    assert a_to_b_only.crossing(Point(600, 500), Point(400, 500)) is None
+    b_to_a_only = _vertical_mid("b_to_a")
+    assert b_to_a_only.crossing(Point(400, 500), Point(600, 500)) is None
+    assert b_to_a_only.crossing(Point(600, 500), Point(400, 500)) == "b_to_a"
+
+
+def test_grazing_the_line_is_not_a_crossing():
+    wire = _vertical_mid()
+    # Ends exactly on the line → not a committed crossing.
+    assert wire.crossing(Point(400, 500), Point(500, 500)) is None
+    # Starts exactly on the line → same.
+    assert wire.crossing(Point(500, 500), Point(600, 500)) is None
+
+
+def test_side_flip_without_segment_intersection_is_not_a_crossing():
+    wire = _vertical_mid()
+    # Both points are beyond the wire's B end: the infinite line is
+    # crossed, the segment is not.
+    assert wire.crossing(Point(400, 1500), Point(600, 1500)) is None
+
+
+def test_side_sign_convention():
+    wire = _vertical_mid()
+    assert wire.side(Point(400, 500)) > 0   # left of A→B (y-down)
+    assert wire.side(Point(600, 500)) < 0   # right of A→B
+    assert wire.side(Point(500, 250)) == 0  # on the line
+
+
+def test_degenerate_wire_rejected():
+    with pytest.raises(ValueError, match="must differ"):
+        Tripwire.from_config("dot", a=[10, 10], b=[10, 10])
+
+
+def test_bad_count_direction_rejected():
+    with pytest.raises(ValueError, match="count_direction"):
+        Tripwire.from_config("mid", a=[0, 0], b=[1, 1], count_direction="sideways")

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -35,16 +35,18 @@ Routes (mounted under ``/api/v1``):
 """
 
 import ipaddress
+import secrets
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import APIRouter, Body, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from core.auth import get_current_active_user
+from core.auth import get_current_active_user, verify_token
 from core.database import get_db
 from models import InstalledApp, User
 from services.audit_service import write_audit_log
@@ -208,6 +210,83 @@ def validate_app_url(url: str) -> str | None:
     )
 
 
+# ── Registration auth (user JWT or service key) ────────────────────
+
+# Registration is a service-to-service call: SDK apps boot with only
+# the deployment's INTERNAL_API_KEY (the same secret adapters use
+# against KAI-C), not a user JWT. ``POST /apps/register`` therefore
+# accepts EITHER a normal user bearer token OR an ``X-Internal-Api-Key``
+# header matching ``settings.internal_api_key``. Every other route
+# (enable/disable/config/status) is an operator action and stays
+# strictly user-authenticated via ``get_current_active_user``.
+
+# auto_error=False: a missing Authorization header must fall through to
+# the service-key check instead of short-circuiting with a 403.
+_optional_bearer = HTTPBearer(auto_error=False)
+
+
+def _internal_api_key() -> str:
+    """The shared secret SDK apps send in ``X-Internal-Api-Key``. Read
+    lazily from settings (same pattern as
+    ``services.kai_c_service.KaiCService._internal_api_key``) so tests
+    and dev setups that mutate the environment late still see it."""
+    try:
+        from core.config import settings
+
+        return settings.internal_api_key or ""
+    except Exception:
+        import os
+
+        return os.environ.get("INTERNAL_API_KEY", "")
+
+
+def get_register_principal(
+    x_internal_api_key: str | None = Header(default=None, alias="X-Internal-Api-Key"),
+    credentials: HTTPAuthorizationCredentials | None = Depends(_optional_bearer),
+    db: Session = Depends(get_db),
+) -> User | None:
+    """Authenticate a registration call.
+
+    Returns the ``User`` for the JWT path, or ``None`` for the
+    service-key path (audit-logged as the ``app-sdk`` service
+    identity). Raises 401 when neither credential is valid.
+    """
+    if x_internal_api_key is not None:
+        expected = _internal_api_key()
+        if expected and secrets.compare_digest(x_internal_api_key, expected):
+            return None  # service identity
+        # The SDK sends its one token as BOTH headers (it can't know
+        # which kind the operator provisioned) — a non-matching key
+        # only fails the request when there's no bearer to fall back to.
+        if credentials is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid internal API key",
+            )
+
+    if credentials is not None:
+        token_data = verify_token(credentials.credentials)
+        if token_data is not None:
+            user = (
+                db.query(User)
+                .filter(User.username == token_data.username)
+                .first()
+            )
+            if user is not None and user.is_active:
+                return user
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Provide a bearer token or X-Internal-Api-Key",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
 # ── Request schemas / serialization ────────────────────────────────
 
 
@@ -268,7 +347,7 @@ async def list_apps(
 @router.post("/register")
 async def register_app(
     request: AppRegisterRequest,
-    current_user: User = Depends(get_current_active_user),
+    principal: User | None = Depends(get_register_principal),
     db: Session = Depends(get_db),
 ):
     """
@@ -281,7 +360,9 @@ async def register_app(
     The app URL must pass :func:`validate_app_url` — /status later
     server-side fetches it, so off-box URLs are refused here (SSRF).
 
-    Requires authenticated user.
+    Requires an authenticated user OR the deployment's internal API
+    key (``X-Internal-Api-Key``) — registration is service-to-service;
+    see :func:`get_register_principal`.
     """
     manifest = request.manifest
     missing = [key for key in ("id", "name", "version") if not manifest.get(key)]
@@ -318,13 +399,20 @@ async def register_app(
     write_audit_log(
         db,
         action="app.register",
-        user_id=current_user.id,
+        # Service-key registrations have no user row; the actor is
+        # recorded in details instead so the audit trail stays whole.
+        user_id=principal.id if principal is not None else None,
         entity_type="app",
         entity_id=app_id,
         details={
             "created": created,
             "url": row.url,
             "version": row.version,
+            "registered_by": (
+                f"user:{principal.username}"
+                if principal is not None
+                else "service:internal-api-key"
+            ),
         },
     )
     return _serialize_app(row)

--- a/server/tests/test_apps_registry.py
+++ b/server/tests/test_apps_registry.py
@@ -81,6 +81,9 @@ class _L:
     def critical(self, *a, **kw):
         pass
 
+    def log_action(self, *a, **kw):
+        pass
+
 
 for _name in (
     "main_logger",
@@ -101,11 +104,11 @@ from sqlalchemy import create_engine  # noqa: E402
 from sqlalchemy.orm import sessionmaker  # noqa: E402
 from sqlalchemy.pool import StaticPool  # noqa: E402
 
-from core.auth import get_current_active_user  # noqa: E402
+from core.auth import create_access_token, get_current_active_user  # noqa: E402
 from core.database import Base, get_db  # noqa: E402
-from models import AuditLog, InstalledApp  # noqa: E402
+from models import AuditLog, InstalledApp, Role, User  # noqa: E402
 from routers import apps as apps_router  # noqa: E402
-from routers.apps import validate_app_config  # noqa: E402
+from routers.apps import get_register_principal, validate_app_config  # noqa: E402
 
 
 class _StubUser:
@@ -115,13 +118,12 @@ class _StubUser:
     username = "tester"
 
 
-@pytest.fixture
-def client():
-    """A TestClient over the real apps router and a shared in-memory DB.
+def _make_app():
+    """The real apps router over a shared in-memory DB.
 
     ``StaticPool`` pins every session to one connection so all requests
-    see the same ``:memory:`` database. Auth is overridden — RBAC is
-    exercised by the shared auth tests, not re-proven per router.
+    see the same ``:memory:`` database. Returns the FastAPI app plus
+    the session factory (for fixtures that need to seed rows).
     """
     engine = create_engine(
         "sqlite:///:memory:",
@@ -129,7 +131,13 @@ def client():
         poolclass=StaticPool,
     )
     Base.metadata.create_all(
-        engine, tables=[InstalledApp.__table__, AuditLog.__table__]
+        engine,
+        tables=[
+            InstalledApp.__table__,
+            AuditLog.__table__,
+            Role.__table__,
+            User.__table__,
+        ],
     )
     session_factory = sessionmaker(bind=engine)
 
@@ -144,7 +152,64 @@ def client():
             session.close()
 
     app.dependency_overrides[get_db] = _override_db
+    return app, session_factory, engine
+
+
+@pytest.fixture
+def client():
+    """A TestClient with auth overridden — RBAC is exercised by the
+    shared auth tests (and ``test_register_auth_*`` below), not
+    re-proven per route."""
+    app, _session_factory, engine = _make_app()
     app.dependency_overrides[get_current_active_user] = lambda: _StubUser()
+    app.dependency_overrides[get_register_principal] = lambda: _StubUser()
+
+    with TestClient(app) as test_client:
+        yield test_client
+    engine.dispose()
+
+
+class _AnyLogger:
+    """A no-op logger accepting ANY method — whichever test module's
+    logging stub won the ``sys.modules`` race, ``core.auth`` must not
+    blow up on the methods it calls (``log_action`` et al.)."""
+
+    def __getattr__(self, name):
+        return lambda *a, **kw: None
+
+
+@pytest.fixture
+def auth_client(monkeypatch):
+    """A TestClient with REAL registration auth (no
+    ``get_register_principal`` override) — exercises the user-JWT and
+    ``X-Internal-Api-Key`` service paths. A live user is seeded so the
+    JWT path can resolve ``sub`` to a row."""
+    # In full-suite runs another module's core.logging_config stub may
+    # have been imported first; core.auth's bound auth_logger then
+    # lacks log_action. The real logger isn't under test — replace it.
+    import core.auth as core_auth
+
+    monkeypatch.setattr(core_auth, "auth_logger", _AnyLogger())
+
+    app, session_factory, engine = _make_app()
+    # Operator routes stay overridden — only registration auth is real.
+    app.dependency_overrides[get_current_active_user] = lambda: _StubUser()
+
+    session = session_factory()
+    role = Role(name="admin")
+    session.add(role)
+    session.flush()
+    session.add(
+        User(
+            username="operator",
+            email="operator@example.com",
+            hashed_password="x",  # never verified — the JWT is the credential
+            is_active=True,
+            role_id=role.id,
+        )
+    )
+    session.commit()
+    session.close()
 
     with TestClient(app) as test_client:
         yield test_client
@@ -299,6 +364,110 @@ def test_register_accepts_local_urls(url, client):
     resp = _register(client, url=url)
     assert resp.status_code == 200
     assert resp.json()["url"] == url
+
+
+# ─── POST /apps/register auth (service key vs user JWT) ─────────────────
+#
+# Registration is service-to-service: SDK apps boot with only the
+# deployment's INTERNAL_API_KEY, so the route accepts EITHER a user JWT
+# OR a matching ``X-Internal-Api-Key`` header (get_register_principal).
+# These run against ``auth_client`` — the fixture WITHOUT the register
+# auth override — so the real dependency is exercised.
+
+
+def _effective_internal_key() -> str:
+    from core.config import settings
+
+    return settings.internal_api_key
+
+
+def test_register_with_internal_api_key_succeeds(auth_client):
+    """The SDK's boot-time register authenticates with the shared
+    internal key alone — no user JWT involved."""
+    resp = auth_client.post(
+        "/apps/register",
+        json={"url": "http://loitering:9200", "manifest": _manifest()},
+        headers={"X-Internal-Api-Key": _effective_internal_key()},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "loitering-detection"
+
+
+def test_register_with_wrong_internal_api_key_is_401(auth_client):
+    resp = auth_client.post(
+        "/apps/register",
+        json={"url": "http://loitering:9200", "manifest": _manifest()},
+        headers={"X-Internal-Api-Key": "not-the-key"},
+    )
+    assert resp.status_code == 401
+    # Nothing landed in the catalog.
+    assert auth_client.get("/apps").json() == []
+
+
+def test_register_without_any_credential_is_401(auth_client):
+    resp = auth_client.post(
+        "/apps/register",
+        json={"url": "http://loitering:9200", "manifest": _manifest()},
+    )
+    assert resp.status_code == 401
+    assert auth_client.get("/apps").json() == []
+
+
+def test_register_with_user_jwt_still_works(auth_client):
+    """The pre-existing operator path — a real bearer token minted for
+    a live user row — keeps working alongside the service key."""
+    token = create_access_token({"sub": "operator"})
+    resp = auth_client.post(
+        "/apps/register",
+        json={"url": "http://loitering:9200", "manifest": _manifest()},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "loitering-detection"
+
+
+def test_register_jwt_wins_when_key_header_does_not_match(auth_client):
+    """The SDK sends its one token as BOTH headers (Authorization +
+    X-Internal-Api-Key). When that token is a user JWT, the key check
+    misses but the bearer path must still authenticate the call."""
+    token = create_access_token({"sub": "operator"})
+    resp = auth_client.post(
+        "/apps/register",
+        json={"url": "http://loitering:9200", "manifest": _manifest()},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Internal-Api-Key": token,  # not the internal key
+        },
+    )
+    assert resp.status_code == 200
+
+
+def test_register_with_garbage_bearer_is_401(auth_client):
+    resp = auth_client.post(
+        "/apps/register",
+        json={"url": "http://loitering:9200", "manifest": _manifest()},
+        headers={"Authorization": "Bearer not-a-jwt"},
+    )
+    assert resp.status_code == 401
+
+
+def test_operator_routes_do_not_accept_internal_api_key(auth_client):
+    """enable/disable/config/status are operator actions — the service
+    key must NOT open them. (They 401/403 without a user JWT; here the
+    stubbed get_current_active_user is bypassed only for register.)"""
+    # Register via the service key, then try to enable with it: the
+    # enable route's auth is the overridden user dependency in this
+    # fixture, so instead assert the register-only dependency is not
+    # wired there by checking the real router's dependency graph.
+    from routers.apps import router as apps_router_obj
+
+    for route in apps_router_obj.routes:
+        if route.path.endswith("/register"):
+            continue
+        dependency_names = {
+            dep.call.__name__ for dep in route.dependant.dependencies
+        }
+        assert "get_register_principal" not in dependency_names, route.path
 
 
 # ─── enable / disable ───────────────────────────────────────────────────


### PR DESCRIPTION
…K sweep

Compose overlay (docker-compose.apps.yml, profile apps): loitering + occupancy detectors build from repo root, join opennvr_internal, ride NATS, and self-register against the core — the App Catalog populates with real cards on any deployed stack:
  docker compose -f docker-compose.yml -f docker-compose.apps.yml \
    --profile apps up -d

POST /api/v1/apps/register now accepts X-Internal-Api-Key (constant- time compare, same seam KAI-C uses) as service-to-service auth — apps carry INTERNAL_API_KEY, not user JWTs. Only registration; operator routes stay user-auth. SDK registration sends the key from cfg/env.

Final SDK sweep — all 12 examples now on the SDK: home-assistant-relay (AlertSubscriber, 55 tests), inference-listener (leanest Detector template, 7), footage-search indexer (Detector via handle_event so caption-only events index, 6). MQTT/HA clients, SQLite store, NL query parsing stay app-side per the don't-force-it clause. Shared NATS loop gains awaitable _handle_raw support (isawaitable-guarded, sync detectors unchanged).

Also fixes a repo-level trap: .gitignore's blanket test_*.py was silently keeping the entire SDK test suite out of git — negated for sdk/opennvr-app-sdk/tests/, and this commit lands those 11 test files for the first time.

Peer-reviewed: clean (auth compare, header emission, compose wiring, sed escaping, gitignore negation all verified). Tested: server 185, sdk 149, examples 55/7/6/50/7 — all suites green, tests byte-unchanged. Docker build/e2e deferred to CI/operator (no Docker on this machine).