### PR TITLE
platform: adapter permission-approval — operator grant/revoke gate (§…

### DIFF
--- a/app/src/services/aiService.ts
+++ b/app/src/services/aiService.ts
@@ -47,6 +47,16 @@ export const aiService = {
   runInference: (data: any) => api.post('/api/v1/ai-models/inference', data),
   getAdapterMetrics: (name: string) =>
     api.get(`/api/v1/ai-models/adapters/${encodeURIComponent(name)}/metrics`),
+
+  // Adapter permission approval (AI Adapter Contract v1 governance).
+  getAdapterPermissions: (name: string) =>
+    api.get(`/api/v1/ai-models/adapters/${encodeURIComponent(name)}/permissions`),
+  grantAdapterPermissions: (name: string, keys: string[]) =>
+    api.post(`/api/v1/ai-models/adapters/${encodeURIComponent(name)}/permissions/grant`, { keys }),
+  revokeAdapterPermissions: (name: string, keys: string[]) =>
+    api.post(`/api/v1/ai-models/adapters/${encodeURIComponent(name)}/permissions/revoke`, { keys }),
+  approveAllAdapterPermissions: (name: string) =>
+    api.post(`/api/v1/ai-models/adapters/${encodeURIComponent(name)}/permissions/approve-all`),
   runRecordingInference: (data: any) =>
     api.post('/api/v1/ai-models/inference/recording', data),
 

--- a/app/src/views/AIAdapters.tsx
+++ b/app/src/views/AIAdapters.tsx
@@ -22,10 +22,11 @@
 // /api/v1/adapters migration.
 
 import { useState, type ReactNode } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { Activity, Layers, RefreshCw, ShieldAlert, Server } from 'lucide-react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Activity, Cpu, Database, Globe, HardDrive, Info, Layers, Lock, RefreshCw, ShieldAlert, ShieldCheck, Share2, Server } from 'lucide-react'
 import { apiService } from '../lib/apiService'
 import { extractApiError } from '../lib/apiError'
+import { useSnackbar } from '../components/Snackbar'
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle, EmptyState, ErrorCard, PageHeader, Skeleton, type BadgeVariant } from '../components/ui'
 
 type AdapterInfo = Record<string, any>
@@ -238,6 +239,221 @@ function FingerprintChanges({ changes }: { changes: string[] }) {
   )
 }
 
+/* ----------------------- Permission approval ---------------------- */
+// The visible proof of the governance story (design spec §06): an adapter
+// declares the host resources it wants; nothing is granted until an operator
+// approves it, and the gateway fails closed until then.
+
+type PermissionKind = 'gpu' | 'network_egress' | 'host_filesystem' | 'shared_memory' | 'host_metadata'
+
+type DeclaredPermission = {
+  key: string
+  label: string
+  kind: PermissionKind
+  sovereignty_conflict: boolean
+}
+
+type AdapterPermissionsResp = {
+  adapter: string
+  approval_status: 'pending' | 'approved'
+  declared: DeclaredPermission[]
+  granted: string[]
+  pending: string[]
+}
+
+const PERMISSION_KIND_ICON: Record<PermissionKind, ReactNode> = {
+  gpu: <Cpu size={13} />,
+  network_egress: <Globe size={13} />,
+  host_filesystem: <HardDrive size={13} />,
+  shared_memory: <Share2 size={13} />,
+  host_metadata: <Database size={13} />,
+}
+
+function permissionKindIcon(kind: PermissionKind): ReactNode {
+  return PERMISSION_KIND_ICON[kind] ?? <Lock size={13} />
+}
+
+function useAdapterPermissions(name: string) {
+  // The approval badge is important enough to fetch on mount for every card —
+  // it's the governance status the operator needs to see immediately.
+  return useQuery({
+    queryKey: ['adapter-permissions', name],
+    queryFn: async () => {
+      const { data } = await apiService.getAdapterPermissions(name)
+      return data as AdapterPermissionsResp
+    },
+    retry: 0,
+  })
+}
+
+function AdapterApprovalBadge({ name }: { name: string }) {
+  const query = useAdapterPermissions(name)
+  if (query.isPending) return <Skeleton className="h-5 w-28" />
+  // Fail loud, not silent: if we can't read approval status, never imply the
+  // adapter is fine — surface an explicit unknown state so a pending adapter
+  // can't hide behind a failed request.
+  if (query.isError) {
+    return (
+      <Badge variant="neutral">
+        <ShieldAlert size={12} /> approval status unavailable
+      </Badge>
+    )
+  }
+  const status = query.data?.approval_status
+  if (status === 'approved') {
+    return (
+      <Badge variant="success">
+        <ShieldCheck size={12} /> approved
+      </Badge>
+    )
+  }
+  if (status === 'pending') {
+    return (
+      <Badge variant="warning">
+        <ShieldAlert size={12} /> approval required
+      </Badge>
+    )
+  }
+  return null
+}
+
+function AdapterPermissionsSection({ name }: { name: string }) {
+  const [open, setOpen] = useState(false)
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useSnackbar()
+  const query = useAdapterPermissions(name)
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['adapter-permissions', name] })
+    queryClient.invalidateQueries({ queryKey: ['kai-c-capabilities'] })
+  }
+
+  const grant = useMutation({
+    mutationFn: (keys: string[]) => apiService.grantAdapterPermissions(name, keys),
+    onSuccess: (_data, keys) => {
+      invalidate()
+      showSuccess(`Granted ${keys.length === 1 ? keys[0] : `${keys.length} permissions`} to ${name}.`)
+    },
+    onError: (err) => showError(extractApiError(err, 'Could not grant permission.')),
+  })
+
+  const revoke = useMutation({
+    mutationFn: (keys: string[]) => apiService.revokeAdapterPermissions(name, keys),
+    onSuccess: (_data, keys) => {
+      invalidate()
+      showSuccess(`Revoked ${keys.length === 1 ? keys[0] : `${keys.length} permissions`} from ${name}.`)
+    },
+    onError: (err) => showError(extractApiError(err, 'Could not revoke permission.')),
+  })
+
+  const approveAll = useMutation({
+    mutationFn: () => apiService.approveAllAdapterPermissions(name),
+    onSuccess: () => {
+      invalidate()
+      showSuccess(`Approved all permissions for ${name}.`)
+    },
+    onError: (err) => showError(extractApiError(err, 'Could not approve permissions.')),
+  })
+
+  const busy = grant.isPending || revoke.isPending || approveAll.isPending
+  const p = query.data
+  const granted = new Set(p?.granted ?? [])
+  const pending = new Set(p?.pending ?? [])
+  const anyPending = (p?.pending?.length ?? 0) > 0
+
+  return (
+    <div>
+      <Button variant="ghost" className="text-xs px-2 py-1" onClick={() => setOpen(!open)}>
+        <ShieldCheck size={12} /> {open ? 'Hide permissions' : 'Permissions'}
+      </Button>
+      {open && (
+        <div className="mt-2">
+          {query.isPending ? (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-10" />
+              ))}
+            </div>
+          ) : query.isError ? (
+            <div className="text-sm text-red-300/90 border border-red-700/40 rounded p-3">
+              {extractApiError(query.error, 'Could not load adapter permissions.')}
+            </div>
+          ) : p ? (
+            <div className="space-y-2">
+              {p.approval_status === 'pending' && (
+                <div className="flex items-start gap-2 text-xs text-amber-300 border border-amber-700/40 bg-amber-900/20 rounded p-3">
+                  <ShieldAlert size={14} className="flex-shrink-0 mt-0.5" />
+                  <span>This adapter cannot serve inference until its permissions are approved.</span>
+                </div>
+              )}
+
+              {p.declared.length === 0 ? (
+                <div className="text-xs text-[var(--text-dim)] border border-[var(--border)] rounded bg-[var(--bg-2)] p-3">
+                  This adapter declares no host permissions — nothing to approve.
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  {p.declared.map((perm) => {
+                    const isGranted = granted.has(perm.key)
+                    const isPending = pending.has(perm.key)
+                    return (
+                      <div
+                        key={perm.key}
+                        className="flex items-center gap-2 border border-[var(--border)] rounded bg-[var(--bg-2)] px-3 py-2"
+                      >
+                        <span className="text-[var(--text-dim)]">{permissionKindIcon(perm.kind)}</span>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm truncate" title={perm.label}>{perm.label}</div>
+                          {perm.sovereignty_conflict && (
+                            <div className="flex items-center gap-1 text-[11px] text-red-400 mt-0.5">
+                              <ShieldAlert size={11} /> conflicts with local_only
+                            </div>
+                          )}
+                        </div>
+                        <Badge variant={isGranted ? 'success' : 'warning'}>{isGranted ? 'granted' : 'pending'}</Badge>
+                        {isGranted ? (
+                          <Button
+                            variant="danger"
+                            className="text-xs px-2 py-1"
+                            disabled={busy}
+                            onClick={() => revoke.mutate([perm.key])}
+                          >
+                            Revoke
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="primary"
+                            className="text-xs px-2 py-1"
+                            disabled={busy || !isPending}
+                            onClick={() => grant.mutate([perm.key])}
+                          >
+                            Grant
+                          </Button>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+
+              {anyPending && (
+                <div className="flex items-center justify-between gap-2 pt-1">
+                  <div className="flex items-center gap-1 text-[11px] text-[var(--text-dim)]">
+                    <Info size={11} /> {p.pending.length} permission{p.pending.length === 1 ? '' : 's'} awaiting approval
+                  </div>
+                  <Button variant="primary" className="text-xs px-2 py-1" disabled={busy} onClick={() => approveAll.mutate()}>
+                    <ShieldCheck size={12} /> Approve all
+                  </Button>
+                </div>
+              )}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function AdapterMetricsSection({ name }: { name: string }) {
   const [open, setOpen] = useState(false)
   const query = useQuery({
@@ -400,6 +616,7 @@ export function AIAdapters() {
                 <Layers size={16} className="text-[var(--text-dim)]" />
                 <CardTitle>{a.name}</CardTitle>
                 <div className="ml-auto flex items-center gap-2">
+                  <AdapterApprovalBadge name={a.name} />
                   {a.status && <Badge variant={statusVariant(a.status)}>{a.status}</Badge>}
                 </div>
               </CardHeader>
@@ -444,6 +661,8 @@ export function AIAdapters() {
                     </div>
                   </div>
                 )}
+
+                <AdapterPermissionsSection name={a.name} />
 
                 <AdapterMetricsSection name={a.name} />
 

--- a/docs/AI_ADAPTER_CONTRACT.md
+++ b/docs/AI_ADAPTER_CONTRACT.md
@@ -694,9 +694,12 @@ before enabling the adapter — like an app-store permission prompt.
 | `host_metadata: false` | Block AWS/GCP/Azure IMDS endpoints + `/proc/host*` |
 
 **Operator approval is mandatory** for any permission outside the
-safe-by-default set. Specifically, KAI-C MUST refuse to register an
-adapter that declares any of the following until the operator
-explicitly approves it from the OpenNVR UI:
+safe-by-default set. Specifically, an adapter that declares any of the
+following registers into a **pending** state — stored, polled, and
+visible in the OpenNVR UI — but KAI-C MUST refuse to route inference
+to it (HTTP `/infer` proxying and WS streaming both fail closed with
+`inference.refused_permission` audited) until the operator explicitly
+approves every declared permission from the OpenNVR UI:
 
 - `gpu: true`
 - `network_egress` non-empty
@@ -706,10 +709,11 @@ explicitly approves it from the OpenNVR UI:
 
 The UI prompt looks like an app-store permission dialog: the operator
 sees the adapter name, version, fingerprint (§4), declared permission
-list, and a single approve/reject button per permission. Approvals
-are recorded to the audit log (§10.5) with a stable
-`adapter_grant_id` so a future incident review can answer "who
-approved this adapter to call out to api.openai.com on 2026-04-12."
+list, and a grant/revoke button per permission (plus an approve-all).
+Grants and revocations are recorded to the audit log (§11.2) with a
+stable `adapter_grant_id` and the acting operator so a future incident
+review can answer "who approved this adapter to call out to
+api.openai.com on 2026-04-12."
 
 This is the **biggest security upgrade** the contract delivers and the
 single best argument for why HTTP-adapter-per-container beats
@@ -816,8 +820,8 @@ time range, adapter, camera, outcome, and category — that's the
 | Event | When | Fields recorded |
 |---|---|---|
 | `adapter.registered` | Adapter passes registration checks | adapter_name, adapter_version, model_name, model_version, model_fingerprint, declared_permissions, registration_url, contract_version |
-| `adapter.permission_granted` | Operator approves a non-default permission (§8) | adapter_grant_id, adapter_name, permission_kind, permission_value, operator_user_id |
-| `adapter.permission_revoked` | Operator or system revokes a grant | adapter_grant_id, reason |
+| `adapter.permission_granted` | Operator grants non-default permission key(s) (§8) | adapter_grant_id, adapter, keys, actor, approval_status |
+| `adapter.permission_revoked` | Operator or system revokes granted key(s) | adapter_grant_id, adapter, keys, actor, approval_status |
 | `adapter.deregistered` | Adapter removed (operator action / drift / shutdown) | reason |
 | `adapter.capability_drift` | `/capabilities` poll shows changed values (§11.3) | field_path, previous_value, current_value, action_taken |
 | `adapter.fingerprint_mismatch` | `model.fingerprint` changed between polls | previous_fingerprint, current_fingerprint |
@@ -871,7 +875,7 @@ polls is treated as follows:
 | `adapter.version` or `adapter.name` | Treat as new adapter; require re-registration. Old registration de-registered. |
 | `model.fingerprint` | Audit `adapter.fingerprint_mismatch`. Alert operator. Keep serving (operator may decide it's a legitimate update); UI offers "re-approve" + "de-register" actions. |
 | `model.version` | Audit `adapter.capability_drift`. Inform operator. Keep serving. |
-| `permissions.*` adding a new permission | **Blocking.** De-register adapter. Operator must re-approve from registration flow. |
+| `permissions.*` adding a new permission | **Blocking.** Adapter stays registered but flips back to `pending` and stops serving. Operator must re-approve the new scope from the permission UI. |
 | `permissions.*` removing a permission | Allow; record audit event. |
 | `endpoints.*` | Audit; no action. |
 | `scheduling.*` | Apply new values on next request. No audit. |

--- a/docs/AI_ADAPTER_CONTRACT.md
+++ b/docs/AI_ADAPTER_CONTRACT.md
@@ -436,9 +436,16 @@ A few notes on the shape:
     }
   ]
   ```
-- `permissions` is the **sandboxing declaration** (§8). KAI-C reads
-  this and applies the declared scope as container constraints when
-  managing the adapter's lifecycle.
+- `permissions` is the **sandboxing declaration and the operator
+  approval gate** (§8). KAI-C reads this at registration, holds the
+  adapter in `pending` until an operator has granted every declared
+  scope, and applies the declared scope as container constraints when
+  managing the adapter's lifecycle. Mind the terminology: this whole
+  JSON document is the adapter's *capability card*;
+  `tasks_advertised` says what the adapter can do, `permissions` says
+  what it needs — the two never interact. §8.1 walks the full card
+  block-by-block; §8.4 is the authoring guide community contributors
+  are reviewed against.
 - `scheduling.fair_queuing: "per_camera"` opts the adapter in to
   KAI-C's per-camera fair-queuing (§9). Default `"none"` lets KAI-C
   forward requests as fast as they arrive; `"per_camera"` makes KAI-C
@@ -681,9 +688,169 @@ prefix-namespacing is encouraged for non-canonical codes).
 ## 8. Permission declaration + sandbox enforcement
 
 Adapters declare what they need in `/capabilities.permissions`. KAI-C
-reads this on adapter registration and applies the declared scope as
-container constraints. The operator sees the requested permissions
-before enabling the adapter — like an app-store permission prompt.
+reads this on adapter registration, shows the operator the requested
+scopes — like an app-store permission prompt — and holds the adapter
+in a **pending** state until every declared scope is granted. The
+gate is fail-closed: a pending adapter is stored, health-polled, and
+visible, but cannot serve a single inference until approved.
+
+This section is the full developer guide for the card and the gate:
+what the card looks like (§8.1), what a permission actually *means*
+(§8.2), the approval lifecycle end-to-end (§8.3), and the authoring
+rules community adapters are reviewed against (§8.4).
+
+This is the **biggest security upgrade** the contract delivers and the
+single best argument for why HTTP-adapter-per-container beats
+in-process plugins for community-contributed code. The enforcement
+half — and the model-tamper containment claim — is documented in
+[`SECURITY_ARCHITECTURE.md`](./SECURITY_ARCHITECTURE.md) (Jul 2026
+addendum).
+
+### 8.1 Anatomy of a capability card
+
+Terminology first, because "capabilities" is overloaded three ways:
+
+| Term | Meaning |
+|---|---|
+| **capability card** | The *whole* JSON document `GET /capabilities` returns — identity, model, endpoints, tasks, permissions, scheduling, cost. "Capabilities" unqualified means this card. |
+| `tasks_advertised` (+ optional `capabilities` descriptor list, §4) | **What the adapter can do.** Free-text task names that feed the derived task index, the capability catalog / skills surface, and agent discovery (`nvr.adapters.find(task=...)`). Purely descriptive — never gated, never approved. |
+| `permissions` | **What the adapter needs.** Host-scope authorization requests that gate whether the adapter may serve *at all*. Nothing to do with tasks or skills: granting a permission adds no task, and no task implies a permission. |
+
+Here is the real card served by the reference YOLOv8 adapter
+([`ai-adapter/adapters/yolov8/main.py`](https://github.com/open-nvr/ai-adapter/blob/main/adapters/yolov8/main.py)
+— the whole card is one `AdapterApp(...)` constructor call; the SDK
+renders it), annotated block by block:
+
+```json
+{
+  // ── IDENTITY. Who wrote this, under what license, which contract
+  //    versions it speaks. A change to name or version between polls
+  //    is treated as a NEW adapter — re-registration required (§11.3).
+  "adapter": {
+    "name": "yolov8-object-detection",
+    "version": "1.0.0",
+    "vendor": "open-nvr",
+    "license": "AGPL-3.0",
+    "model_card_url": "https://github.com/ultralytics/ultralytics",
+    "supported_contract_versions": ["1"]
+  },
+
+  // ── MODEL IDENTITY. `fingerprint` is the tamper signal: KAI-C
+  //    records it at registration and diffs it on every 60s poll.
+  //    A mismatch fires adapter.fingerprint_mismatch (critical
+  //    alert) but keeps serving — the operator decides whether it
+  //    was a legitimate weights update (§11.3).
+  "model": {
+    "name": "yolov8n",
+    "version": "8.0.196",
+    "framework": "onnx",
+    "size_mb": 12.2,
+    "modalities_in": ["image"],
+    "modalities_out": ["bbox_classes"],
+    "fingerprint": "sha256:c4f3a1...e7"
+  },
+
+  // ── MECHANICS. Which wire surface exists and how to feed it.
+  "endpoints": {
+    "infer": {
+      "supported": true,
+      "input_content_types": ["multipart/form-data", "application/json"]
+    },
+    "infer_stream": {
+      "supported": true,
+      "max_concurrent_streams": 16,
+      "supports_shared_memory": false
+    }
+  },
+
+  // ── WHAT IT CAN DO. Free-text; feeds the task index, the
+  //    capability catalog, and agent adapter discovery. Never gated.
+  "tasks_advertised": ["object_detection"],
+
+  // ── WHAT IT NEEDS. The approval gate (§8.2–§8.3). Each declared
+  //    scope expands into exactly one grantable key the operator
+  //    approves individually. This block is why this adapter
+  //    registers as `pending` on a fresh install: it asks for the
+  //    GPU device plus one host filesystem path.
+  "permissions": {
+    "gpu": true,                        // key: gpu
+    "network_egress": [],               // none — sovereignty-clean
+    "host_filesystem": ["/weights"],    // key: host_filesystem:/weights
+    "shared_memory_paths": [],
+    "host_metadata": false
+  },
+
+  // ── SCHEDULING. Hints for KAI-C's fair queuing (§9). max_inflight
+  //    is the honest concurrency of the underlying runtime, not an
+  //    aspiration.
+  "scheduling": {
+    "max_inflight": 1,
+    "preferred_batch_size": 1,
+    "fair_queuing": "per_camera"
+  },
+
+  // ── COST. All zeroes for a local adapter; metered cloud adapters
+  //    fill these in and get budget enforcement (§4).
+  "cost": {
+    "currency": "USD",
+    "estimated_per_call": 0.0,
+    "estimated_per_hour": 0.0,
+    "rate_limit_per_minute": null,
+    "is_metered": false
+  }
+}
+```
+
+The two blocks reviewers and operators read first are
+`tasks_advertised` (capability discovery) and `permissions` (the
+gate). Everything else is identity and mechanics.
+
+### 8.2 Permissions are authorization scopes, not hardware facts
+
+A permission answers **"may I?"**, never "is it there?". Declaring
+`gpu: true` means *"may I be handed the GPU device?"* — an
+authorization request the operator grants or refuses. Whether a GPU
+actually exists on the host is a different question with a different
+endpoint: `GET /hardware/evaluation` (§3.3).
+
+The reference YOLOv8 adapter makes the contrast concrete. It declares
+`gpu: true` (authorization), but its onnxruntime backend serves
+happily on CPU when no CUDA device is present — the hardware
+evaluation just says so:
+
+```json
+{
+  "verdict": "warn",
+  "reasoning": "Weights loaded but no CUDA device — running on CPU (expect 5-20x slower inference)",
+  "details": { "gpu_required": false, "gpu_in_use": false,
+               "onnxruntime_providers": ["CPUExecutionProvider"] }
+}
+```
+
+The adapter serves. Permission granted + hardware absent = slow but
+legal. Permission *not* granted + hardware present = refused. The two
+axes never substitute for each other.
+
+**Grantable keys.** Each declared scope expands into one stable
+string key — the unit the operator grants and revokes, and the unit
+audit events reference
+(`kai-c/kai_c/registry.py::permission_keys`):
+
+| Declared scope | Grantable key(s) |
+|---|---|
+| `gpu: true` | `gpu` |
+| `host_metadata: true` | `host_metadata` |
+| `network_egress: ["api.example.com"]` | `network_egress:api.example.com` — one key per host |
+| `host_filesystem: ["/weights"]` | `host_filesystem:/weights` — one key per path |
+| `shared_memory_paths: ["/dev/shm/opennvr/frames"]` | `shared_memory_paths:/dev/shm/opennvr/frames` — one key per path |
+
+Keys are compared by **string equality**, so declare canonical values
+— directory paths without a trailing slash, hostnames without a
+scheme. Key ordering is deterministic (`gpu`, `host_metadata`, then
+sorted per-host / per-path keys) so API responses and audit events
+are stable.
+
+**Enforcement.** The declared scope maps onto container constraints:
 
 | Permission | Enforcement |
 |---|---|
@@ -693,31 +860,177 @@ before enabling the adapter — like an app-store permission prompt.
 | `shared_memory_paths: ["/path"]` | tmpfs mount writable only at listed paths |
 | `host_metadata: false` | Block AWS/GCP/Azure IMDS endpoints + `/proc/host*` |
 
-**Operator approval is mandatory** for any permission outside the
-safe-by-default set. Specifically, an adapter that declares any of the
-following registers into a **pending** state — stored, polled, and
-visible in the OpenNVR UI — but KAI-C MUST refuse to route inference
-to it (HTTP `/infer` proxying and WS streaming both fail closed with
-`inference.refused_permission` audited) until the operator explicitly
-approves every declared permission from the OpenNVR UI:
+Per §15.3: sovereignty enforcement of `network_egress` (registration
+refusal under `local_only`) and the approval gate itself are live
+today; nftables / mount-level sandbox enforcement of the remaining
+scopes is on the v0.3 roadmap. The declaration + grant + audit chain
+is the trust contract that grounds both.
 
-- `gpu: true`
-- `network_egress` non-empty
-- `host_filesystem` non-empty
-- `shared_memory_paths` non-empty
-- `host_metadata: true`
+### 8.3 The approval lifecycle — fail-closed
 
-The UI prompt looks like an app-store permission dialog: the operator
-sees the adapter name, version, fingerprint (§4), declared permission
-list, and a grant/revoke button per permission (plus an approve-all).
-Grants and revocations are recorded to the audit log (§11.2) with a
-stable `adapter_grant_id` and the acting operator so a future incident
-review can answer "who approved this adapter to call out to
-api.openai.com on 2026-04-12."
+```
+declare (in /capabilities)
+   │  register
+   ▼
+pending ──── operator grants every declared key ────▶ approved (serving)
+   ▲                                                       │
+   ├──── operator revokes any granted key ─────────────────┤
+   └──── NEW key appears on a later 60s poll ──────────────┘
+```
 
-This is the **biggest security upgrade** the contract delivers and the
-single best argument for why HTTP-adapter-per-container beats
-in-process plugins for community-contributed code.
+1. **Declare.** The adapter states its scopes in
+   `/capabilities.permissions`. The declaration is the source of
+   truth; KAI-C will not infer scopes from behaviour.
+
+2. **Register as pending.** An adapter that declares *any* permission
+   registers into `pending` — stored, `/health`-polled, visible in
+   the registry and the OpenNVR UI — but KAI-C MUST refuse to route
+   inference to it on **every** serving path: the governed
+   `POST /api/v1/infer/{name}` proxy, the WebSocket stream (close
+   code `4001`), *and* the legacy `/infer` + `/infer/local`
+   passthroughs. Every refusal is audited as
+   `inference.refused_permission`. An adapter that declares nothing
+   is trivially approved (∅ ⊆ ∅) and serves immediately.
+
+3. **Operator grants, per scope.** The UI prompt looks like an
+   app-store permission dialog: adapter name, version, fingerprint
+   (§4), and one grant/revoke control per key (plus approve-all).
+   The API surface is
+   `GET/POST /api/v1/adapters/{name}/permissions[/grant|/revoke|/approve-all]`.
+   Every grant and revocation is recorded to the audit log (§11.2)
+   with a unique `adapter_grant_id`, the acting operator, and a
+   timestamp — so a future incident review can answer "who approved
+   this adapter to call out to api.openai.com on 2026-04-12" with a
+   receipt. Only *declared* keys can be granted; granting a key the
+   adapter never asked for is a no-op. `approval_status` is always
+   derived (`approved` iff every declared key is granted) — never
+   stored, so it can't drift out of sync.
+
+4. **Serving.** Once every declared key is granted, the adapter
+   serves on all paths.
+
+5. **Revoke → pending again.** Revoking any granted key immediately
+   flips the adapter back to `pending` and stops serving.
+
+**The 60-second re-poll.** KAI-C re-fetches `/capabilities` every 60s
+(§11) and diffs the card. The trust-relevant outcomes:
+
+| Drift between polls | Registry response | Why |
+|---|---|---|
+| `model.fingerprint` changed | `adapter.fingerprint_mismatch` audit + critical alert; **keep serving** | Weights updates are routine and the alert is loud; the operator decides re-approve vs de-register (§11.3) |
+| Permission **added** | **Blocking.** Flip to `pending`, stop serving immediately; audit + `adapter.permission_drift_blocking` alert | Model-tamper containment: a swapped or compromised model service that suddenly wants egress or a new path is stopped on the next poll — this complements the fingerprint signal |
+| Permission **removed** | Allowed; scope narrowed. The stale grant is **pruned** (actor `system:permission_no_longer_declared`) | A later re-add must earn fresh approval instead of silently inheriting the old grant |
+| `network_egress` declared under `local_only` | Refused at registration; on drift, de-registered with `inference.refused_sovereignty` audit | Sovereignty is absolute (§11.1) |
+
+The asymmetry is deliberate: fingerprint drift *alerts and serves*,
+permission drift *stops*. Widening host scope without consent is
+exactly what a compromised adapter does; a fail-open response there
+would defeat the gate.
+
+### 8.4 Authoring rules — how to declare permissions
+
+These are the rules community adapters are reviewed against. They all
+reduce to one sentence: **the card must describe the build you ship,
+and nothing more.**
+
+1. **Declare build-accurately.** The declaration describes what *this
+   image* touches at runtime — not what the model family could use.
+   The YOLOv8 lesson: the reference adapter ships one CPU+GPU-capable
+   image and declares `gpu: true`, so operators on CPU-only hosts are
+   still asked to grant a GPU that isn't there. If you ship separate
+   CPU and GPU builds, the CPU image MUST declare `gpu: false`; only
+   the GPU build declares `gpu: true`. Same logic for weights: files
+   **baked into the image at build time are NOT `host_filesystem`** —
+   they're inside the container already. The BLIP adapter bakes its
+   weights, declares nothing, and auto-approves; YOLOv8 bind-mounts
+   `/weights` from the host, so it declares
+   `host_filesystem:/weights`.
+
+2. **Declare minimally.** Every key you declare is one operator
+   decision at install time and one permanent line of audit surface
+   for the deployment's lifetime. If you can drop a scope by changing
+   your build (bake the weights, cache at build time, bind loopback),
+   drop it.
+
+3. **The empty set is the zero-friction default.** An adapter that
+   declares no permissions auto-approves and serves the moment it
+   registers — no operator action, no dialog. This is the target
+   state for most local adapters; the gate binds exactly where risk
+   enters (GPU, egress, host paths, host metadata).
+
+4. **Never declare egress you don't strictly need.** Under
+   `local_only` — the default posture for the deployments this
+   platform exists for — *any* declared `network_egress` entry means
+   your adapter is refused at registration, full stop (§11.1).
+   Wildcard entries are refused even under `federated`. If your
+   adapter is a cloud proxy by nature, declare every host explicitly
+   and accept that you only run under `federated` / `cloud_allowed`.
+
+**Worked example — a community cloud adapter.** Suppose you publish
+`ppe-cloud`, a PPE-compliance adapter that sends frames to a vendor
+API:
+
+```python
+from opennvr_adapter_sdk import AdapterApp, Permissions
+
+app = AdapterApp(
+    service_factory=PpeCloudService,
+    name="ppe-cloud", version="1.0.0", vendor="you", license="MIT",
+    tasks_advertised=["ppe_compliance"],
+    permissions=Permissions(
+        gpu=False,                              # inference is remote
+        network_egress=["api.ppevendor.com"],   # the ONE host you call
+        host_filesystem=[],
+        shared_memory_paths=[],
+        host_metadata=False,
+    ),
+).fastapi_app
+```
+
+What the operator experiences:
+
+- Under `local_only`: registration is **refused outright** — the
+  declared egress marks this as a cloud-proxy adapter (§11.1). No
+  dialog, no pending state.
+- Under `federated` / `cloud_allowed`: the adapter registers as
+  `pending`. The permission view
+  (`GET /api/v1/adapters/ppe-cloud/permissions`) shows:
+
+  ```json
+  {
+    "adapter": "ppe-cloud",
+    "approval_status": "pending",
+    "declared": [
+      { "key": "network_egress:api.ppevendor.com",
+        "label": "Network egress to api.ppevendor.com",
+        "kind": "network_egress",
+        "sovereignty_conflict": false }
+    ],
+    "granted": [],
+    "pending": ["network_egress:api.ppevendor.com"]
+  }
+  ```
+
+  The operator sees one dialog with one grant button. On grant, an
+  `adapter.permission_granted` audit event lands with an
+  `adapter_grant_id`, the operator's identity, and a timestamp — and
+  the adapter starts serving. Any inference attempted before that
+  grant is refused and audited.
+
+### 8.5 Startup-seeded adapters — config-as-consent
+
+> **Status: landing in this PR series.**
+
+Adapters seeded from the operator's own startup configuration (the
+compose overlay / adapter registry the operator wrote by hand) receive
+an automatic grant of their declared keys at seed time, recorded with
+actor `system:startup-config`. Rationale: writing the adapter into
+the deployment config *is* the consent act — re-prompting in the UI
+for a declaration the operator already typed would be friction
+without security. The grant is still a first-class audit event with
+an `adapter_grant_id`, so the receipt chain stays intact; adapters
+registered at runtime (UI, API, community images) always go through
+the full §8.3 pending flow.
 
 ## 9. Fair queuing inside KAI-C
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -348,3 +348,37 @@ OpenNVR's `firmware_health` job (V-014) consumes:
 * CVE-2025-1316 (Edimax; CISA ICSA-25-063-08)
 * CVE-2019-11219 / CVE-2019-11220 (iLnkP2P)
 * CVE-2021-28372 (ThroughTek Kalay SDK; CISA ICSA-21-229-01)
+
+
+## Addendum (Jul 2026) — Adapter permission approval & model-tamper containment
+
+Shipped with the A2.4b operator gate; this is the enforcement half of the
+§8 permission model and, to our knowledge, unique among IP-camera / NVR
+platforms — a candidate highlight for the paper's sovereignty section.
+
+**The claim:** on OpenNVR, an AI model service cannot touch an elevated
+host scope — GPU, a network egress host, a filesystem path, shared memory,
+host metadata — unless a named operator granted that exact scope, and the
+grant has a receipt.
+
+**Mechanism (all fail-closed):**
+1. Adapters self-declare permissions in `/capabilities`; declarations are
+   re-polled every 60s and diffed.
+2. Any declared permission puts the adapter in `pending` — registered and
+   visible, but refused on **every** inference path (governed, streaming,
+   legacy) until granted. Bundled adapters declare nothing and auto-approve,
+   so the default deployment has zero added friction.
+3. Grants are per-scope keys (one per egress host / path), each with a
+   unique `adapter_grant_id`, actor, and timestamp in the append-only audit
+   log; revocation immediately stops serving.
+4. **Model-tamper containment:** a running adapter that *newly* declares a
+   permission — the signature of a swapped or compromised model service,
+   complementing fingerprint-drift detection — flips back to `pending` and
+   stops serving on the next poll, with audit + alert events. Removed
+   permissions prune their stale grants so re-added scopes need fresh
+   approval.
+
+**Residual risk (documented):** the gate governs *declared* scopes; an
+adapter that silently uses undeclared resources is contained by the
+container sandbox layer (declared-scope nftables / mount enforcement,
+roadmap) and by `local_only` refusing declared egress at registration.

--- a/kai-c/README.md
+++ b/kai-c/README.md
@@ -60,10 +60,14 @@ The A2.4b operator approval flow is implemented, **fail-closed**:
   compromised model service), it flips back to `pending` and stops serving
   immediately; removed permissions prune their stale grants so a re-added
   scope needs fresh approval.
-* **Zero-friction default:** every bundled adapter declares an empty
-  permission set and therefore auto-approves — fresh installs and upgrades
-  keep serving with no operator action. The gate binds exactly where risk
-  enters: third-party / cloud / elevated-scope adapters.
+* **Zero-friction default:** bundled adapters that declare no permissions
+  (blip, insightface, bytetrack, fast-plate-ocr, whisper, piper) auto-approve.
+  yolov8 currently declares `gpu` + a weights path, so it meets the gate —
+  covered by the startup-config auto-grant (config-as-consent, audited as
+  actor `system:startup-config`) landing in this PR series, plus a
+  build-accurate declaration fix in ai-adapter (the CPU build should declare
+  `gpu: false`). The gate binds exactly where risk enters: third-party /
+  cloud / elevated-scope adapters added at runtime.
 
 To our knowledge this per-scope, fail-closed, operator-receipted permission
 model for AI inference services is unique among IP-camera / NVR platforms —

--- a/kai-c/README.md
+++ b/kai-c/README.md
@@ -64,7 +64,7 @@ The A2.4b operator approval flow is implemented, **fail-closed**:
   (blip, insightface, bytetrack, fast-plate-ocr, whisper, piper) auto-approve.
   yolov8 currently declares `gpu` + a weights path, so it meets the gate —
   covered by the startup-config auto-grant (config-as-consent, audited as
-  actor `system:startup-config`) landing in this PR series, plus a
+  actor `system:startup-config` — shipped, contract §8.5), plus a
   build-accurate declaration fix in ai-adapter (the CPU build should declare
   `gpu: false`). The gate binds exactly where risk enters: third-party /
   cloud / elevated-scope adapters added at runtime.

--- a/kai-c/README.md
+++ b/kai-c/README.md
@@ -31,20 +31,50 @@ As of v2.0 KAI-C is the registry and audit layer per §11 of the [AI Adapter Con
 |---|---|
 | `model.fingerprint` | `adapter.fingerprint_mismatch` audit, keep serving (operator decides) |
 | `model.version` | `adapter.capability_drift` audit, keep serving |
-| `permissions.*` adds a new permission | **BLOCKING** — de-register adapter, await re-approval |
+| `permissions.*` adds a new permission | **BLOCKING** — adapter flips to `pending`, stops serving, awaits operator re-approval (kept visible in the registry) |
 | `permissions.network_egress` violates `local_only` | De-register + `inference.refused_sovereignty` audit |
 | `endpoints.*` | Audit, no action |
 | `scheduling.*` | Apply silently |
 
 **Audit event vocabulary (subset for v1)**: `adapter.registered`, `adapter.deregistered`, `adapter.fingerprint_mismatch`, `adapter.capability_drift`, `adapter.unavailable`, `inference.completed`, `inference.failed`, `inference.refused_sovereignty`. JSONL format on disk at `$KAI_C_AUDIT_LOG` (defaults to `/var/log/opennvr/kai-c-audit.jsonl`).
 
-**Deferred to a future release** (tracked against the [AI Adapter Contract](../docs/AI_ADAPTER_CONTRACT.md) §11): NATS / SIEM forwarding, operator-UI approval flow, hash-chained audit integrity, fair-queuing per-camera token bucket implementation, full WS streaming proxy.
+**Deferred to a future release** (tracked against the [AI Adapter Contract](../docs/AI_ADAPTER_CONTRACT.md) §11): NATS / SIEM forwarding, hash-chained audit integrity, fair-queuing per-camera token bucket implementation, full WS streaming proxy.
+
+## Permission approval — the §8 operator gate (shipped)
+
+The A2.4b operator approval flow is implemented, **fail-closed**:
+
+* An adapter that declares any permission (`gpu`, `network_egress:<host>`,
+  `host_filesystem:<path>`, `shared_memory_paths:<path>`, `host_metadata`)
+  registers into **`pending`** — stored, polled, visible — and cannot serve
+  a single inference until an operator grants. Enforced on *every* serving
+  path: governed `/api/v1/infer/{name}`, the WS stream (close 4001), and
+  the legacy `/infer` + `/infer/local` passthroughs.
+* Grants are **per-scope keys** (one per egress host / fs path), issued via
+  `GET/POST /api/v1/adapters/{name}/permissions[/grant|/revoke|/approve-all]`,
+  each audited with a unique `adapter_grant_id`, the actor, and a timestamp —
+  incident review answers "who allowed this adapter to reach the internet?"
+  with a receipt.
+* **Model-tamper containment:** if a running, approved adapter starts
+  declaring a new permission on a later poll (the signature of a swapped or
+  compromised model service), it flips back to `pending` and stops serving
+  immediately; removed permissions prune their stale grants so a re-added
+  scope needs fresh approval.
+* **Zero-friction default:** every bundled adapter declares an empty
+  permission set and therefore auto-approves — fresh installs and upgrades
+  keep serving with no operator action. The gate binds exactly where risk
+  enters: third-party / cloud / elevated-scope adapters.
+
+To our knowledge this per-scope, fail-closed, operator-receipted permission
+model for AI inference services is unique among IP-camera / NVR platforms —
+it is a core part of the sovereignty story (see
+`docs/SECURITY_ARCHITECTURE.md` §2 and the paper).
 
 ### Known limitation — legacy `/infer` is unaudited
 
 The legacy endpoints `/infer`, `/infer/local`, and `/infer/cloud` (kept for OpenNVR backend back-compat) **bypass the new audit + registry pipeline**. They read the static `ADAPTER_REGISTRY` env-derived dict, not the live registry; they don't thread `X-Correlation-Id`; they don't emit `inference.completed` / `inference.failed` events.
 
-**Consequence**: an adapter de-registered by the new registry (e.g., for permission drift in §11.3) is still reachable via the legacy `/infer` path because that endpoint only sees the static config. The startup-time loopback check still applies, so the legacy path is safe for the URL-loopback story — it just doesn't get the audit story.
+**Consequence**: the legacy path lacks correlation IDs and completed/failed audit events. (The §8 permission gate DOES cover it — a pending adapter is refused on legacy `/infer` + `/infer/local` too, with an `inference.refused_permission` audit event.) The startup-time loopback check still applies, so the legacy path is safe for the URL-loopback story — it just doesn't get the audit story.
 
 **Fix path**: migrate OpenNVR backend onto `POST /api/v1/infer/{adapter_name}`, which has full audit + sovereignty + correlation_id. Once nothing uses legacy `/infer`, those endpoints retire.
 

--- a/kai-c/kai_c/registry.py
+++ b/kai-c/kai_c/registry.py
@@ -18,17 +18,20 @@ permission grants, and emits the §11.2 audit events on every drift:
 * ``adapter.fingerprint_mismatch`` — ``model.fingerprint`` changed between polls
 * ``adapter.capability_drift``     — any other capability field changed
 * ``adapter.unavailable``          — ≥3 consecutive /health failures
-* ``adapter.deregistered``         — operator removed, or permissions drift
-                                     added a new permission (§11.3 blocking change)
+* ``adapter.deregistered``         — operator removed the adapter
+* ``adapter.permission_granted``   — operator granted permission keys (§8)
+* ``adapter.permission_revoked``   — operator revoked permission keys (§8)
 
-Drift behaviour matches §11.3:
+Drift behaviour matches §11.3 (with the §8 approval-flow refinement for
+permission additions — the adapter stays visible but stops serving):
 
 | Field changed                        | Action                                  |
 |--------------------------------------|-----------------------------------------|
 | ``adapter.{name,version}``           | de-register (treat as new adapter)      |
 | ``model.fingerprint``                | audit, alert, keep serving              |
 | ``model.version``                    | audit, keep serving                     |
-| ``permissions.*`` add new permission | BLOCKING — de-register, await re-approve|
+| ``permissions.*`` add new permission | BLOCKING — back to ``pending``; serving |
+|                                      | stops until the operator re-approves    |
 | ``permissions.*`` remove permission  | allow, audit                            |
 | ``endpoints.*``                      | audit, no action                        |
 | ``scheduling.*``                     | apply silently                          |
@@ -40,6 +43,7 @@ import asyncio
 import logging
 import threading
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -68,12 +72,88 @@ DEFAULT_METRICS_TIMEOUT_SECONDS: float = 2.0
 UNAVAILABLE_THRESHOLD: int = 3  # consecutive health failures → unavailable
 
 # Permissions that are "default-safe" — no operator approval required.
-# Anything outside this set requires explicit grant (§8). For v1 we
-# record the requirement in the audit log but DO NOT block registration;
-# A2.4b will land the operator-UI approval flow. The audit event has
-# ``requires_operator_approval=true`` so a downstream dashboard can
-# surface pending approvals.
+# Anything outside this set requires an explicit operator grant (§8).
+# Registration is NOT blocked: the adapter registers into a *pending*
+# state (stored + polled + visible) but ``proxy_infer`` and the stream
+# proxy fail closed until every declared permission key is granted.
+# The ``adapter.registered`` audit event carries
+# ``requires_operator_approval=true`` so dashboards can surface the
+# pending approval.
 SAFE_PERMISSIONS: frozenset[str] = frozenset()  # nothing is default-safe; §8 is strict
+
+
+# ── Permission-key model (§8 / §11 operator-approval flow) ─────────
+#
+# A permission "key" is a stable string identifying ONE grantable
+# scope, derived from the adapter's declared ``Permissions``. The keys
+# are the unit the operator grants/revokes, and the unit we compare
+# declared-vs-granted to decide whether an adapter is fully approved.
+#
+#   gpu                              — the coarse GPU-access flag
+#   host_metadata                    — the coarse host-metadata flag
+#   network_egress:<host>            — one key per declared egress host
+#   host_filesystem:<path>           — one key per declared fs path
+#   shared_memory_paths:<path>       — one key per declared shm path
+#
+# An adapter is "fully approved" iff every declared key is present in
+# ``granted_permissions``. An adapter that declares NO permissions has
+# an empty declared-key set, which is trivially a subset of the empty
+# granted set → auto-approved.
+
+
+def permission_keys(perms: Permissions) -> list[str]:
+    """Return the stable permission-key list for a declared
+    ``Permissions`` object. Order is deterministic (gpu, host_metadata,
+    then the sorted per-host / per-path keys) so callers can rely on a
+    stable ordering in API responses and audit events."""
+    keys: list[str] = []
+    if perms.gpu:
+        keys.append("gpu")
+    if perms.host_metadata:
+        keys.append("host_metadata")
+    for host in sorted(set(perms.network_egress)):
+        keys.append(f"network_egress:{host}")
+    for path in sorted(set(perms.host_filesystem)):
+        keys.append(f"host_filesystem:{path}")
+    for path in sorted(set(perms.shared_memory_paths)):
+        keys.append(f"shared_memory_paths:{path}")
+    return keys
+
+
+def permission_kind(key: str) -> str:
+    """The scope family a permission key belongs to — the part before
+    the first ``:`` (or the whole key for the flag permissions)."""
+    return key.split(":", 1)[0]
+
+
+def permission_label(key: str) -> str:
+    """Human-facing label for a permission key, for the operator UI."""
+    kind = permission_kind(key)
+    detail = key.split(":", 1)[1] if ":" in key else ""
+    if kind == "gpu":
+        return "GPU access"
+    if kind == "host_metadata":
+        return "Host metadata (hostname, OS, hardware inventory)"
+    if kind == "network_egress":
+        return f"Network egress to {detail}"
+    if kind == "host_filesystem":
+        return f"Host filesystem access: {detail}"
+    if kind == "shared_memory_paths":
+        return f"Shared-memory path: {detail}"
+    return key
+
+
+def permission_sovereignty_conflict(key: str, sovereignty_mode: str) -> bool:
+    """True when granting this key would conflict with the active
+    sovereignty policy — surfaced in the UI so an operator can't
+    silently approve a scope the sovereignty layer will refuse anyway.
+
+    Under ``local_only`` any ``network_egress:*`` key is a conflict
+    (the adapter is a cloud-proxy; sovereignty refuses it outright).
+    ``federated`` / ``cloud_allowed`` impose no per-key conflict here."""
+    if sovereignty_mode == "local_only" and permission_kind(key) == "network_egress":
+        return True
+    return False
 
 
 # ── Drift comparison helpers ───────────────────────────────────────
@@ -141,6 +221,29 @@ class RegisteredAdapter:
     last_polled: float = 0.0
     consecutive_health_failures: int = 0
     granted_permissions: set[str] = field(default_factory=set)
+
+    def declared_keys(self) -> list[str]:
+        """The permission keys this adapter declares in /capabilities."""
+        return permission_keys(self.capabilities.permissions)
+
+    def pending_keys(self) -> list[str]:
+        """Declared keys that have NOT yet been granted by an operator."""
+        granted = self.granted_permissions
+        return [k for k in self.declared_keys() if k not in granted]
+
+    @property
+    def approval_status(self) -> str:
+        """``"approved"`` iff every declared key is granted (an adapter
+        that declares no permission is trivially approved); otherwise
+        ``"pending"``. Derived — never stored — so it can't drift out of
+        sync with ``granted_permissions``."""
+        return "approved" if not self.pending_keys() else "pending"
+
+    @property
+    def is_serving_allowed(self) -> bool:
+        """Fail-closed serving gate: only a fully-approved adapter may
+        serve inference (§8 / §11)."""
+        return self.approval_status == "approved"
 
 
 # ── Async HTTP helpers ─────────────────────────────────────────────
@@ -274,6 +377,11 @@ class AdapterRegistry:
             capabilities=caps,
             fingerprint=caps.model.fingerprint,
         )
+        # §8 / §11 approval gate: do NOT auto-grant. An adapter that
+        # declares any permission starts with an EMPTY granted set →
+        # approval_status "pending" → it is stored + visible but MUST
+        # NOT serve inference until an operator grants. An adapter that
+        # declares no permission is trivially approved (∅ ⊆ ∅).
         with self._lock:
             self._adapters[name] = adapter
 
@@ -287,10 +395,15 @@ class AdapterRegistry:
             model_version=caps.model.version,
             model_fingerprint=caps.model.fingerprint,
             declared_permissions=caps.permissions.model_dump(mode="json"),
+            declared_permission_keys=adapter.declared_keys(),
+            approval_status=adapter.approval_status,
             contract_version=caps.adapter.supported_contract_versions,
             requires_operator_approval=self._requires_approval(caps.permissions),
         )
-        logger.info("adapter registered: %s @ %s", name, url)
+        logger.info(
+            "adapter registered: %s @ %s (approval_status=%s)",
+            name, url, adapter.approval_status,
+        )
         return adapter
 
     async def deregister(self, name: str, *, reason: str = "operator_action") -> None:
@@ -388,17 +501,40 @@ class AdapterRegistry:
             self._metrics.record_fingerprint_change(name)
             adapter.fingerprint = new_caps.model.fingerprint
 
-        # Permissions ADDED — §11.3 blocking change → de-register.
+        # Permissions ADDED — §11.3 blocking change. Rather than making
+        # the adapter VANISH (the old behaviour de-registered it), we
+        # KEEP it but move it back to ``pending`` so the operator UI can
+        # show "new permission requested, re-approve" (§8 / §11 intent).
+        # Concretely: apply the fresh capabilities, then drop any granted
+        # key that is no longer declared or was newly added, so
+        # approval_status re-derives to "pending" and serving stops until
+        # the operator re-grants.
         added = _permissions_added(old_caps.permissions, new_caps.permissions)
         if added:
+            with self._lock:
+                # Re-derive granted against the NEW declared set: keep
+                # only keys that were both already granted AND still in
+                # the OLD declared set (i.e. not newly-added scope). Any
+                # newly-added key is left ungranted → pending.
+                new_declared = set(permission_keys(new_caps.permissions))
+                old_declared = set(permission_keys(old_caps.permissions))
+                previously_granted = adapter.granted_permissions
+                adapter.granted_permissions = {
+                    k
+                    for k in previously_granted
+                    if k in new_declared and k in old_declared
+                }
+                adapter.capabilities = new_caps
+                status = adapter.approval_status
             self._audit.emit(
                 AuditEventType.ADAPTER_CAPABILITY_DRIFT,
                 adapter=name,
                 field_path="permissions",
-                action_taken="de-registered (blocking change)",
+                action_taken="moved to pending (re-approval required)",
                 added_permissions=added,
+                approval_status=status,
             )
-            await self.deregister(name, reason="permissions_added_requires_reapproval")
+            adapter.last_polled = time.time()
             return
 
         # Other drift — audit, keep serving.
@@ -411,9 +547,174 @@ class AdapterRegistry:
                 action_taken="audited",
             )
 
-        # Apply the new snapshot.
-        adapter.capabilities = new_caps
+        # Apply the new snapshot. §11.3: permission REMOVALS are allowed
+        # (scope narrowed) — but any grant for a key the adapter no
+        # longer declares must be dropped, otherwise a later re-add of
+        # the same key would silently inherit the old grant instead of
+        # going back through operator approval. The system revocation is
+        # audited like an operator one ("operator or system revokes").
+        with self._lock:
+            adapter.capabilities = new_caps
+            stale_grants = sorted(
+                adapter.granted_permissions - set(permission_keys(new_caps.permissions))
+            )
+            adapter.granted_permissions.difference_update(stale_grants)
+            status_after = adapter.approval_status
+        if stale_grants:
+            self._emit_grant_event(
+                AuditEventType.ADAPTER_PERMISSION_REVOKED,
+                adapter=name,
+                keys=stale_grants,
+                actor="system:permission_no_longer_declared",
+                approval_status=status_after,
+            )
         adapter.last_polled = time.time()
+
+    # ── Permission grants (§8 / §11 operator-approval flow) ─────────
+
+    def _emit_grant_event(
+        self,
+        event_type: AuditEventType,
+        *,
+        adapter: str,
+        keys: list[str],
+        actor: str,
+        approval_status: str,
+    ) -> str:
+        """Emit a grant/revoke audit event with a fresh
+        ``adapter_grant_id`` (uuid) capturing {adapter, keys, actor, ts}.
+        Returns the grant_id so the HTTP layer can echo it back and the
+        server-side audit log can cross-reference it."""
+        grant_id = uuid.uuid4().hex
+        self._audit.emit(
+            event_type,
+            adapter=adapter,
+            adapter_grant_id=grant_id,
+            keys=keys,
+            actor=actor,
+            approval_status=approval_status,
+        )
+        return grant_id
+
+    def grant_permissions(
+        self, name: str, keys: list[str], actor: str
+    ) -> tuple[RegisteredAdapter, str]:
+        """Grant one or more declared permission keys for an adapter.
+
+        Only DECLARED keys can be granted — granting a key the adapter
+        never asked for is a no-op for that key (it can never affect
+        approval_status, since approval compares against declared keys).
+        Recomputes approval_status (derived) and emits
+        ``adapter.permission_granted`` with an ``adapter_grant_id``.
+        Returns ``(adapter, grant_id)``. Thread-safe. Raises ``KeyError``
+        for an unknown adapter."""
+        with self._lock:
+            adapter = self._adapters.get(name)
+            if adapter is None:
+                raise KeyError(name)
+            declared = set(adapter.declared_keys())
+            granted_now = sorted(set(keys) & declared)
+            adapter.granted_permissions.update(granted_now)
+            status = adapter.approval_status
+        grant_id = self._emit_grant_event(
+            AuditEventType.ADAPTER_PERMISSION_GRANTED,
+            adapter=name,
+            keys=granted_now,
+            actor=actor,
+            approval_status=status,
+        )
+        logger.info(
+            "adapter %s: granted %s by %s (approval_status=%s)",
+            name, granted_now, actor, status,
+        )
+        return adapter, grant_id
+
+    def revoke_permissions(
+        self, name: str, keys: list[str], actor: str
+    ) -> tuple[RegisteredAdapter, str]:
+        """Revoke one or more previously-granted permission keys.
+
+        Revoking any declared key that was granted flips the adapter
+        back to ``pending`` (which immediately stops it serving, since
+        serving is gated on approval_status). Recomputes approval_status
+        and emits ``adapter.permission_revoked`` with an
+        ``adapter_grant_id``. Returns ``(adapter, grant_id)``.
+        Thread-safe. Raises ``KeyError`` for an unknown adapter."""
+        with self._lock:
+            adapter = self._adapters.get(name)
+            if adapter is None:
+                raise KeyError(name)
+            revoked_now = sorted(set(keys) & adapter.granted_permissions)
+            adapter.granted_permissions.difference_update(revoked_now)
+            status = adapter.approval_status
+        grant_id = self._emit_grant_event(
+            AuditEventType.ADAPTER_PERMISSION_REVOKED,
+            adapter=name,
+            keys=revoked_now,
+            actor=actor,
+            approval_status=status,
+        )
+        logger.info(
+            "adapter %s: revoked %s by %s (approval_status=%s)",
+            name, revoked_now, actor, status,
+        )
+        return adapter, grant_id
+
+    def approve_all(self, name: str, actor: str) -> tuple[RegisteredAdapter, str]:
+        """Grant every currently-declared permission key in one action
+        — the operator-UI "approve" button. Emits
+        ``adapter.permission_granted`` with an ``adapter_grant_id``
+        capturing the full declared-key set. Returns
+        ``(adapter, grant_id)``. Thread-safe. Raises ``KeyError`` for an
+        unknown adapter."""
+        with self._lock:
+            adapter = self._adapters.get(name)
+            if adapter is None:
+                raise KeyError(name)
+            declared = adapter.declared_keys()
+            adapter.granted_permissions.update(declared)
+            status = adapter.approval_status
+        grant_id = self._emit_grant_event(
+            AuditEventType.ADAPTER_PERMISSION_GRANTED,
+            adapter=name,
+            keys=declared,
+            actor=actor,
+            approval_status=status,
+        )
+        logger.info(
+            "adapter %s: approve-all (%s keys) by %s (approval_status=%s)",
+            name, len(declared), actor, status,
+        )
+        return adapter, grant_id
+
+    def permissions_view(self, name: str) -> dict[str, Any] | None:
+        """The §11 permission view for one adapter — declared keys with
+        labels/kind/sovereignty-conflict flags, granted keys, pending
+        keys, and the derived approval_status. Returns ``None`` for an
+        unknown adapter so the HTTP layer can map that to a 404."""
+        with self._lock:
+            adapter = self._adapters.get(name)
+            if adapter is None:
+                return None
+            granted = sorted(adapter.granted_permissions)
+            declared = [
+                {
+                    "key": key,
+                    "label": permission_label(key),
+                    "kind": permission_kind(key),
+                    "sovereignty_conflict": permission_sovereignty_conflict(
+                        key, self._sovereignty_mode
+                    ),
+                }
+                for key in adapter.declared_keys()
+            ]
+            return {
+                "adapter": name,
+                "approval_status": adapter.approval_status,
+                "declared": declared,
+                "granted": granted,
+                "pending": adapter.pending_keys(),
+            }
 
     # ── Synchronous lookups (safe to call from the /infer handler) ──
 
@@ -442,6 +743,7 @@ class AdapterRegistry:
                         a.health.status.value if a.health else "unknown"
                     ),
                     "consecutive_health_failures": a.consecutive_health_failures,
+                    "approval_status": a.approval_status,
                 }
                 for a in self._adapters.values()
             ]
@@ -476,6 +778,32 @@ class AdapterRegistry:
         adapter = self.get(adapter_name)
         if adapter is None:
             raise KeyError(adapter_name)
+
+        # §8 / §11 approval gate — fail closed. A pending / not-fully-
+        # approved adapter never reaches the model. We audit the refusal
+        # (inference.refused_permission) and raise PermissionError so the
+        # HTTP route can map it to a clear 403; the caller does NOT emit
+        # its own refusal event for this case (the registry owns it,
+        # because only the registry knows the pending-key set).
+        if not adapter.is_serving_allowed:
+            pending = adapter.pending_keys()
+            self._audit.emit(
+                AuditEventType.INFERENCE_REFUSED_PERMISSION,
+                correlation_id=correlation_id,
+                adapter=adapter_name,
+                approval_status=adapter.approval_status,
+                pending_permissions=pending,
+                reason=(
+                    "adapter is not fully approved; "
+                    f"{len(pending)} permission(s) awaiting operator grant"
+                ),
+            )
+            raise PermissionError(
+                f"adapter {adapter_name!r} is {adapter.approval_status}: "
+                f"{len(pending)} declared permission(s) await operator "
+                f"approval before it may serve inference"
+            )
+
         response = await self._client.post(
             f"{adapter.url}/infer",
             json=payload,

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -294,7 +294,7 @@ async def lifespan(app: FastAPI):
     )
     for name, url in ADAPTER_REGISTRY.items():
         try:
-            await _registry.register(name, url)
+            adapter = await _registry.register(name, url)
         except SovereigntyViolation as exc:
             logger.warning("sovereignty refused %s@%s: %s", name, url, exc)
             _audit.emit(
@@ -309,6 +309,20 @@ async def lifespan(app: FastAPI):
             # continue. Operators can re-register via the v2 endpoint
             # once the adapter is up.
             logger.info("registration deferred for %s@%s: %s", name, url, exc)
+        else:
+            # Contract §8.5 — config-as-consent. This adapter came from
+            # the operator's OWN startup configuration (compose overlay /
+            # ADAPTER_REGISTRY env), and writing it there IS the consent
+            # act — so its declared permission keys are granted here
+            # rather than parked in ``pending`` awaiting a UI click. The
+            # grant is a first-class audit event (adapter_grant_id +
+            # actor "system:startup-config"), keeping the receipt chain
+            # intact. Only THIS seed loop auto-grants: adapters added at
+            # runtime via POST /api/v1/adapters/register keep the human
+            # gate, and permission DRIFT on a later poll still flips a
+            # seeded adapter back to pending (see registry.refresh()).
+            if adapter.pending_keys():
+                _registry.approve_all(name, actor="system:startup-config")
     await _registry.start_polling()
 
     # NATS publisher for the event-bus broadcast surface. Starts AFTER

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -386,6 +386,43 @@ def get_adapter_url(model_name: str = "default") -> str:
     return ADAPTER_REGISTRY.get(model_name, ADAPTER_REGISTRY["default"])
 
 
+def enforce_legacy_serving_gate(model_name: str) -> None:
+    """§8/§11 approval gate for the LEGACY ``/infer`` + ``/infer/local``
+    passthroughs, which resolve adapters via the static ``ADAPTER_REGISTRY``
+    dict and so bypass ``registry.proxy_infer``'s gate. Fail closed: if the
+    live registry knows this adapter and it is not fully approved, refuse
+    with 403 and audit ``inference.refused_permission`` — matching the
+    governed path. If the live registry has no entry (an adapter that never
+    registered with the v2 registry), the legacy escape hatch is preserved.
+    """
+    registry = _registry
+    if registry is None:  # pragma: no cover — guarded by lifespan
+        return
+    adapter = registry.get(model_name)
+    if adapter is None:
+        return
+    if not adapter.is_serving_allowed:
+        pending = adapter.pending_keys()
+        get_audit().emit(
+            AuditEventType.INFERENCE_REFUSED_PERMISSION,
+            adapter=model_name,
+            approval_status=adapter.approval_status,
+            pending_permissions=pending,
+            reason=(
+                "legacy inference path refused; adapter is not fully "
+                f"approved ({len(pending)} permission(s) await operator grant)"
+            ),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"adapter {model_name!r} is {adapter.approval_status}: "
+                f"{len(pending)} declared permission(s) await operator "
+                "approval before it may serve inference"
+            ),
+        )
+
+
 class InferenceRequest(BaseModel):
     """Request model for inference endpoint"""
     camera_id: str
@@ -454,10 +491,15 @@ async def process_inference(request: InferenceRequest):
     
     Flow: OpenNVR Backend → KAI-C → AI Adapter (from registry) → KAI-C → OpenNVR Backend
     """
+    # §8/§11 fail-closed gate (outside the try so its 403 isn't swallowed by
+    # the generic 500 handler below): a pending/not-approved adapter must not
+    # serve via the legacy path either.
+    enforce_legacy_serving_gate(request.model_name)
+
     try:
         # Get AI Adapter URL from internal registry (user never provides this!)
         adapter_url = get_adapter_url(request.model_name)
-        
+
         # Create KAI-C connector for the adapter
         connector = KaiConnector(adapter_url=adapter_url)
         
@@ -528,6 +570,11 @@ async def process_local_inference(request: dict):
 
     Flow: OpenNVR Backend -> KAI-C -> AI Adapter -> KAI-C -> OpenNVR Backend
     """
+    # §8/§11 fail-closed gate for the legacy local path (outside the try so
+    # its 403 survives the generic 500 handler). ``/infer/local`` always
+    # resolves the "default" adapter (get_adapter_url() with no arg).
+    enforce_legacy_serving_gate("default")
+
     try:
         adapter_url = get_adapter_url()
 
@@ -976,6 +1023,107 @@ async def v1_adapter_metrics(name: str):
     return snapshot
 
 
+# ── A2.4b: adapter permission-approval endpoints (§8 / §11) ─────────
+# The operator-UI approval flow the KAI-C README deferred. All behind
+# require_internal_api_key like the rest of the v1 surface. The
+# ``actor`` recorded in KAI-C's audit trail is the OpenNVR user, threaded
+# through the ``X-Actor`` header the server proxy sets; falls back to a
+# generic label when absent (e.g. a direct operator curl).
+
+
+class PermissionKeysRequest(BaseModel):
+    """Body for the grant / revoke endpoints — a list of permission
+    keys (see ``registry.permission_keys``)."""
+    keys: list[str] = Field(default_factory=list)
+
+
+def _actor_from_header(x_actor: Optional[str]) -> str:
+    return x_actor.strip() if x_actor and x_actor.strip() else "operator"
+
+
+@app.get(
+    "/api/v1/adapters/{name}/permissions",
+    dependencies=[Depends(require_internal_api_key)],
+)
+async def v1_adapter_permissions(name: str):
+    """§8 / §11 — the permission view for one adapter: declared keys
+    (with human labels, kind, and sovereignty-conflict flags), the
+    granted set, the still-pending set, and the derived approval_status.
+    404 for an unknown adapter."""
+    view = get_registry().permissions_view(name)
+    if view is None:
+        raise HTTPException(status_code=404, detail=f"unknown adapter: {name}")
+    return view
+
+
+@app.post(
+    "/api/v1/adapters/{name}/permissions/grant",
+    dependencies=[Depends(require_internal_api_key)],
+)
+async def v1_adapter_permissions_grant(
+    name: str,
+    payload: PermissionKeysRequest,
+    x_actor: Optional[str] = Header(None),
+):
+    """Grant a set of declared permission keys. Only keys the adapter
+    actually declares take effect. Returns the updated permission view."""
+    registry = get_registry()
+    try:
+        _, grant_id = registry.grant_permissions(
+            name, payload.keys, _actor_from_header(x_actor)
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"unknown adapter: {name}")
+    view = registry.permissions_view(name)
+    view["grant_id"] = grant_id
+    return view
+
+
+@app.post(
+    "/api/v1/adapters/{name}/permissions/revoke",
+    dependencies=[Depends(require_internal_api_key)],
+)
+async def v1_adapter_permissions_revoke(
+    name: str,
+    payload: PermissionKeysRequest,
+    x_actor: Optional[str] = Header(None),
+):
+    """Revoke a set of granted permission keys. Revoking any key flips
+    the adapter back to ``pending`` and stops it serving. Returns the
+    updated permission view."""
+    registry = get_registry()
+    try:
+        _, grant_id = registry.revoke_permissions(
+            name, payload.keys, _actor_from_header(x_actor)
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"unknown adapter: {name}")
+    view = registry.permissions_view(name)
+    view["grant_id"] = grant_id
+    return view
+
+
+@app.post(
+    "/api/v1/adapters/{name}/permissions/approve-all",
+    dependencies=[Depends(require_internal_api_key)],
+)
+async def v1_adapter_permissions_approve_all(
+    name: str,
+    x_actor: Optional[str] = Header(None),
+):
+    """Grant every declared permission key — the "approve" button.
+    Returns the updated permission view (approval_status="approved"
+    unless the adapter re-declares more scope before this lands)."""
+    registry = get_registry()
+    try:
+        _, grant_id = registry.approve_all(name, _actor_from_header(x_actor))
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"unknown adapter: {name}")
+    view = registry.permissions_view(name)
+    view["grant_id"] = grant_id
+    return view
+
+
 # ── B1 NATS publishing helper ──────────────────────────────────────
 
 
@@ -1094,6 +1242,11 @@ async def v1_infer(
 
     try:
         status_code, body = await registry.proxy_infer(adapter_name, payload, correlation_id)
+    except PermissionError as exc:
+        # §8 / §11 approval gate — fail closed. The registry already
+        # emitted inference.refused_permission (it owns the pending-key
+        # detail); we just translate to a 403 for the caller.
+        raise HTTPException(status_code=403, detail=str(exc))
     except Exception as exc:
         latency_ms = int((time.monotonic() - started) * 1000)
         audit.emit(
@@ -1206,6 +1359,26 @@ async def v1_infer_stream(websocket: WebSocket, adapter_name: str):
         websocket.headers.get(CORRELATION_ID_HEADER.lower())
         or new_correlation_id()
     )
+
+    if not adapter.is_serving_allowed:
+        # §8 / §11 approval gate — fail closed on the streaming path too.
+        # A pending / not-fully-approved adapter never streams. Audit the
+        # refusal (same event type as the HTTP path) and close with
+        # policy_refused.
+        pending = adapter.pending_keys()
+        get_audit().emit(
+            AuditEventType.INFERENCE_REFUSED_PERMISSION,
+            correlation_id=correlation_id,
+            adapter=adapter_name,
+            approval_status=adapter.approval_status,
+            pending_permissions=pending,
+            reason="adapter is not fully approved; streaming refused",
+        )
+        await websocket.close(
+            code=CLOSE_POLICY_REFUSED,
+            reason=f"adapter {adapter_name} awaiting operator approval",
+        )
+        return
 
     proxy = StreamProxy(
         client_ws=websocket,

--- a/kai-c/test/test_permissions.py
+++ b/kai-c/test/test_permissions.py
@@ -1,0 +1,588 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Adapter permission-approval tests (§8 / §11 — A2.4b operator-UI flow).
+
+Covers:
+  * ``permission_keys`` helper derivation.
+  * pending-on-register (with declared perms) vs auto-approve (with none).
+  * serving refused while pending; allowed after approve.
+  * grant / revoke / approve-all transitions, audit emission + grant_id.
+  * drift → moves to pending (not de-registered).
+  * HTTP endpoint auth (401 without key) + the GET permissions JSON shape.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from kai_c.audit import AuditStore
+from kai_c.contract_types import Permissions
+from kai_c.registry import AdapterRegistry, permission_keys
+
+
+# ── permission_keys helper ─────────────────────────────────────────
+
+
+def test_permission_keys_empty():
+    assert permission_keys(Permissions()) == []
+
+
+def test_permission_keys_flags_and_lists():
+    perms = Permissions(
+        gpu=True,
+        host_metadata=True,
+        network_egress=["b.example.com", "a.example.com"],
+        host_filesystem=["/var/data"],
+        shared_memory_paths=["/dev/shm/frames"],
+    )
+    keys = permission_keys(perms)
+    # gpu + host_metadata first, then sorted per-host / per-path keys.
+    assert keys == [
+        "gpu",
+        "host_metadata",
+        "network_egress:a.example.com",
+        "network_egress:b.example.com",
+        "host_filesystem:/var/data",
+        "shared_memory_paths:/dev/shm/frames",
+    ]
+
+
+def test_permission_keys_dedupes_hosts():
+    perms = Permissions(network_egress=["a.example.com", "a.example.com"])
+    assert permission_keys(perms) == ["network_egress:a.example.com"]
+
+
+# ── Registry fixtures (mirror test_registry.py) ─────────────────────
+
+
+def _base_caps(*, gpu: bool = False, egress: list[str] | None = None) -> dict:
+    return {
+        "adapter": {
+            "name": "test-adapter", "version": "1.0.0", "vendor": "open-nvr",
+            "license": "AGPL-3.0", "supported_contract_versions": ["1"],
+        },
+        "model": {"name": "m1", "version": "v1", "framework": "f", "fingerprint": "sha256:aaa"},
+        "endpoints": {
+            "infer": {"supported": True, "input_content_types": ["application/json"]},
+            "infer_stream": {"supported": False},
+        },
+        "tasks_advertised": ["echo"],
+        "permissions": {
+            "gpu": gpu, "network_egress": egress or [],
+            "host_filesystem": [], "shared_memory_paths": [], "host_metadata": False,
+        },
+        "scheduling": {"max_inflight": 1, "preferred_batch_size": 1, "fair_queuing": "none"},
+        "cost": {"currency": "USD", "estimated_per_call": 0.0, "estimated_per_hour": 0.0,
+                 "rate_limit_per_minute": None, "is_metered": False},
+    }
+
+
+class _StubAdapter:
+    def __init__(self, url: str, capabilities: dict) -> None:
+        self.url = url
+        self._caps = capabilities
+
+    def update_capabilities(self, capabilities: dict) -> None:
+        self._caps = capabilities
+
+    async def respond(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/capabilities":
+            return httpx.Response(200, json=self._caps)
+        if path == "/health":
+            return httpx.Response(200, json={
+                "status": "ok", "adapter_name": "test-adapter",
+                "adapter_version": "1.0.0", "model_name": "m1",
+                "model_version": "v1", "started_at": "2026-05-19T00:00:00Z",
+                "uptime_seconds": 1,
+            })
+        if path == "/infer":
+            return httpx.Response(200, json={"status": "ok", "result": {"ok": True}})
+        return httpx.Response(404)
+
+
+@pytest.fixture
+def audit(tmp_path: Path) -> AuditStore:
+    return AuditStore(path=str(tmp_path / "audit.jsonl"))
+
+
+def _make_registry(audit, stub):
+    transport = httpx.MockTransport(stub.respond)
+    client = httpx.AsyncClient(transport=transport)
+    return AdapterRegistry(
+        sovereignty_mode="local_only", audit=audit, http_client=client,
+        poll_interval_seconds=999,
+    )
+
+
+# ── pending-on-register / auto-approve ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_with_perms_starts_pending(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        adapter = await reg.register("yolo", stub.url)
+        assert adapter.approval_status == "pending"
+        assert adapter.granted_permissions == set()
+        assert adapter.pending_keys() == ["gpu"]
+        assert not adapter.is_serving_allowed
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_register_without_perms_auto_approved(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps())
+    reg = _make_registry(audit, stub)
+    try:
+        adapter = await reg.register("yolo", stub.url)
+        assert adapter.approval_status == "approved"
+        assert adapter.is_serving_allowed
+    finally:
+        await reg.aclose()
+
+
+# ── serving gate ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_serving_refused_while_pending(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("yolo", stub.url)
+        with pytest.raises(PermissionError):
+            await reg.proxy_infer("yolo", {"x": 1}, "corr-1")
+        rows = audit.read_all()
+        refused = [r for r in rows if r["type"] == "inference.refused_permission"]
+        assert refused and refused[-1]["pending_permissions"] == ["gpu"]
+        assert refused[-1]["correlation_id"] == "corr-1"
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_serving_allowed_after_approve(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("yolo", stub.url)
+        reg.approve_all("yolo", actor="alice")
+        status_code, body = await reg.proxy_infer("yolo", {"x": 1}, "corr-2")
+        assert status_code == 200
+        assert body["result"]["ok"] is True
+    finally:
+        await reg.aclose()
+
+
+# ── grant / revoke / approve-all transitions ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_grant_partial_then_full(audit):
+    caps = _base_caps(gpu=True)
+    caps["permissions"]["host_metadata"] = True
+    stub = _StubAdapter("http://127.0.0.1:9100", caps)
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("yolo", stub.url)
+        adapter, grant_id = reg.grant_permissions("yolo", ["gpu"], actor="alice")
+        assert grant_id  # uuid hex
+        assert adapter.approval_status == "pending"  # host_metadata still pending
+        assert adapter.pending_keys() == ["host_metadata"]
+
+        adapter, _ = reg.grant_permissions("yolo", ["host_metadata"], actor="alice")
+        assert adapter.approval_status == "approved"
+
+        rows = audit.read_all()
+        grants = [r for r in rows if r["type"] == "adapter.permission_granted"]
+        assert len(grants) == 2
+        assert all("adapter_grant_id" in r and r["actor"] == "alice" for r in grants)
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_grant_ignores_undeclared_keys(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("yolo", stub.url)
+        # host_metadata was never declared → granting it is a no-op.
+        adapter, _ = reg.grant_permissions("yolo", ["host_metadata"], actor="alice")
+        assert adapter.approval_status == "pending"
+        assert "host_metadata" not in adapter.granted_permissions
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_flips_back_to_pending(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("yolo", stub.url)
+        reg.approve_all("yolo", actor="alice")
+        assert reg.get("yolo").approval_status == "approved"
+
+        adapter, grant_id = reg.revoke_permissions("yolo", ["gpu"], actor="bob")
+        assert grant_id
+        assert adapter.approval_status == "pending"
+        assert not adapter.is_serving_allowed
+        # Serving now refused again.
+        with pytest.raises(PermissionError):
+            await reg.proxy_infer("yolo", {"x": 1}, "corr-3")
+
+        rows = audit.read_all()
+        revokes = [r for r in rows if r["type"] == "adapter.permission_revoked"]
+        assert revokes and revokes[-1]["actor"] == "bob"
+        assert "adapter_grant_id" in revokes[-1]
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_grant_revoke_approve_unknown_adapter_raises(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps())
+    reg = _make_registry(audit, stub)
+    try:
+        with pytest.raises(KeyError):
+            reg.grant_permissions("ghost", ["gpu"], actor="alice")
+        with pytest.raises(KeyError):
+            reg.revoke_permissions("ghost", ["gpu"], actor="alice")
+        with pytest.raises(KeyError):
+            reg.approve_all("ghost", actor="alice")
+        assert reg.permissions_view("ghost") is None
+    finally:
+        await reg.aclose()
+
+
+# ── drift → pending (not de-registered) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_new_permission_moves_to_pending(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("yolo", stub.url)
+        reg.approve_all("yolo", actor="alice")
+        assert reg.get("yolo").approval_status == "approved"
+
+        # Adapter re-declares an ADDITIONAL scope (host_metadata) on the
+        # next poll. It must stay registered but flip to pending, keeping
+        # the already-granted gpu grant.
+        caps2 = _base_caps(gpu=True)
+        caps2["permissions"]["host_metadata"] = True
+        stub.update_capabilities(caps2)
+        await reg.refresh("yolo")
+
+        adapter = reg.get("yolo")
+        assert adapter is not None
+        assert adapter.approval_status == "pending"
+        assert adapter.pending_keys() == ["host_metadata"]
+        assert "gpu" in adapter.granted_permissions  # prior grant preserved
+    finally:
+        await reg.aclose()
+
+
+# ── permissions_view shape ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_permissions_view_shape(audit):
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("yolo", stub.url)
+        reg.grant_permissions("yolo", ["gpu"], actor="alice")
+        view = reg.permissions_view("yolo")
+        assert view["adapter"] == "yolo"
+        assert view["approval_status"] == "approved"
+        assert view["granted"] == ["gpu"]
+        assert view["pending"] == []
+        assert view["declared"] == [
+            {"key": "gpu", "label": "GPU access", "kind": "gpu",
+             "sovereignty_conflict": False},
+        ]
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_permissions_view_sovereignty_conflict(audit):
+    # An adapter with egress can't be REGISTERED under local_only
+    # (sovereignty refuses), so use federated mode to exercise the
+    # per-key sovereignty_conflict flag being False under a non-local
+    # mode, and local_only flagging network_egress keys as a conflict.
+    from kai_c.registry import permission_sovereignty_conflict
+
+    assert permission_sovereignty_conflict("network_egress:x.com", "local_only") is True
+    assert permission_sovereignty_conflict("network_egress:x.com", "federated") is False
+    assert permission_sovereignty_conflict("gpu", "local_only") is False
+
+
+# ── HTTP endpoints (auth + JSON shape) ──────────────────────────────
+
+
+@pytest.fixture
+def kaic_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """FastAPI app with a stub adapter registered and INTERNAL_API_KEY
+    set, so we can prove the endpoints 401 without the header."""
+    monkeypatch.setenv("AI_SOVEREIGNTY", "local_only")
+    monkeypatch.setenv("ADAPTER_URL", "http://127.0.0.1:9100")
+    monkeypatch.setenv("KAI_C_AUDIT_LOG", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("INTERNAL_API_KEY", "sekret")
+
+    if "main" in sys.modules:
+        importlib.reload(sys.modules["main"])
+    import main as kaic_main
+
+    caps = _base_caps(gpu=True)
+    stub = _StubAdapter("http://127.0.0.1:9100", caps)
+    transport = httpx.MockTransport(stub.respond)
+
+    from fastapi.testclient import TestClient
+
+    original_init = kaic_main.AdapterRegistry.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["http_client"] = httpx.AsyncClient(transport=transport)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(kaic_main.AdapterRegistry, "__init__", patched_init)
+
+    with TestClient(kaic_main.app) as client:
+        # startup registers "default" → 127.0.0.1:9100 (mocked) as pending.
+        yield client
+
+
+_AUTH = {"X-Internal-Api-Key": "sekret"}
+
+
+def test_endpoints_401_without_key(kaic_client):
+    assert kaic_client.get(
+        "/api/v1/adapters/default/permissions"
+    ).status_code == 401
+    for url in [
+        "/api/v1/adapters/default/permissions/grant",
+        "/api/v1/adapters/default/permissions/revoke",
+        "/api/v1/adapters/default/permissions/approve-all",
+    ]:
+        resp = kaic_client.post(url, json={"keys": []})
+        assert resp.status_code == 401, (url, resp.text)
+
+
+def test_get_permissions_json_shape(kaic_client):
+    resp = kaic_client.get("/api/v1/adapters/default/permissions", headers=_AUTH)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {
+        "adapter": "default",
+        "approval_status": "pending",
+        "declared": [
+            {"key": "gpu", "label": "GPU access", "kind": "gpu",
+             "sovereignty_conflict": False},
+        ],
+        "granted": [],
+        "pending": ["gpu"],
+    }
+
+
+def test_grant_then_approve_all_via_http(kaic_client):
+    grant = kaic_client.post(
+        "/api/v1/adapters/default/permissions/grant",
+        json={"keys": ["gpu"]}, headers=_AUTH,
+    )
+    assert grant.status_code == 200, grant.text
+    body = grant.json()
+    assert body["approval_status"] == "approved"
+    assert body["granted"] == ["gpu"]
+    assert "grant_id" in body
+
+    approve = kaic_client.post(
+        "/api/v1/adapters/default/permissions/approve-all", headers=_AUTH,
+    )
+    assert approve.status_code == 200
+    assert approve.json()["approval_status"] == "approved"
+
+
+def test_permissions_unknown_adapter_404(kaic_client):
+    resp = kaic_client.get("/api/v1/adapters/ghost/permissions", headers=_AUTH)
+    assert resp.status_code == 404
+
+
+def test_serving_refused_via_http_while_pending(kaic_client):
+    # default is pending (declares gpu, nothing granted) → /infer 403.
+    resp = kaic_client.post(
+        "/api/v1/infer/default", json={"camera_id": "cam-1"}, headers=_AUTH,
+    )
+    assert resp.status_code == 403, resp.text
+    # After approve-all, serving is allowed.
+    kaic_client.post("/api/v1/adapters/default/permissions/approve-all", headers=_AUTH)
+    resp2 = kaic_client.post(
+        "/api/v1/infer/default", json={"camera_id": "cam-1"}, headers=_AUTH,
+    )
+    assert resp2.status_code == 200, resp2.text
+
+
+# ── WS streaming gate (§8 — fail closed on the stream path too) ─────
+
+
+def test_stream_refused_while_pending(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A pending adapter must not stream either: the WS upgrade is
+    closed with policy_refused (4001) and the refusal is audited with
+    inference.refused_permission — same event type as the HTTP path."""
+    from starlette.websockets import WebSocketDisconnect
+
+    monkeypatch.setenv("AI_SOVEREIGNTY", "local_only")
+    monkeypatch.setenv("ADAPTER_URL", "http://127.0.0.1:9100")
+    monkeypatch.setenv("KAI_C_AUDIT_LOG", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("INTERNAL_API_KEY", "sekret")
+
+    if "main" in sys.modules:
+        importlib.reload(sys.modules["main"])
+    import main as kaic_main
+
+    # gpu → pending; infer_stream supported so the approval gate (not
+    # the capability check) is what refuses the upgrade.
+    caps = _base_caps(gpu=True)
+    caps["endpoints"]["infer_stream"] = {"supported": True}
+    stub = _StubAdapter("http://127.0.0.1:9100", caps)
+    transport = httpx.MockTransport(stub.respond)
+
+    original_init = kaic_main.AdapterRegistry.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["http_client"] = httpx.AsyncClient(transport=transport)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(kaic_main.AdapterRegistry, "__init__", patched_init)
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(kaic_main.app) as client:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect(
+                "/api/v1/infer/default/stream",
+                headers={"X-Internal-Api-Key": "sekret"},
+            ) as ws:
+                ws.receive_json()
+        assert exc_info.value.code == 4001  # CLOSE_POLICY_REFUSED
+
+        # The refusal landed in the audit trail.
+        audit = client.get(
+            "/api/v1/audit?event_type=inference.refused_permission",
+            headers={"X-Internal-Api-Key": "sekret"},
+        ).json()
+        assert audit["events"], "expected inference.refused_permission audit event"
+        assert audit["events"][-1]["adapter"] == "default"
+        assert "gpu" in audit["events"][-1]["pending_permissions"]
+
+
+# ── Drift: permission REMOVAL prunes the stale grant ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_removed_permission_prunes_grant(audit):
+    """§11.3: removing a permission is allowed — but the grant for the
+    removed key must be dropped (with an audited system revocation), so
+    a later re-add of the same key goes back through operator approval
+    instead of silently inheriting the old grant."""
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("gpu-x", stub.url)
+        reg.approve_all("gpu-x", "alice")
+        adapter = reg.get("gpu-x")
+        assert adapter.granted_permissions == {"gpu"}
+
+        # Adapter narrows scope: drops the gpu declaration.
+        stub.update_capabilities(_base_caps(gpu=False))
+        await reg.refresh("gpu-x")
+
+        adapter = reg.get("gpu-x")
+        assert adapter is not None
+        assert adapter.granted_permissions == set()  # stale grant pruned
+        assert adapter.approval_status == "approved"  # nothing declared → approved
+
+        # The system revocation is in the audit trail.
+        rows = audit.read_all()
+        revoked = [r for r in rows if r["type"] == "adapter.permission_revoked"]
+        assert revoked
+        assert revoked[-1]["keys"] == ["gpu"]
+        assert revoked[-1]["actor"] == "system:permission_no_longer_declared"
+        assert revoked[-1]["adapter_grant_id"]
+
+        # Re-adding the key later requires FRESH approval.
+        stub.update_capabilities(_base_caps(gpu=True))
+        await reg.refresh("gpu-x")
+        adapter = reg.get("gpu-x")
+        assert adapter.approval_status == "pending"
+        assert adapter.pending_keys() == ["gpu"]
+    finally:
+        await reg.aclose()
+
+
+# ── legacy /infer + /infer/local fail-closed gate ───────────────────
+# The legacy passthroughs resolve adapters via the static ADAPTER_REGISTRY
+# dict and bypass registry.proxy_infer's gate. enforce_legacy_serving_gate
+# closes that hole: a pending adapter must not serve by ANY path.
+
+
+@pytest.mark.asyncio
+async def test_legacy_gate_refuses_pending_adapter(audit, monkeypatch):
+    import main as kaic_main
+
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("default", stub.url)  # pending (declares gpu)
+        monkeypatch.setattr(kaic_main, "_registry", reg)
+        monkeypatch.setattr(kaic_main, "_audit", audit)
+        with pytest.raises(kaic_main.HTTPException) as exc:
+            kaic_main.enforce_legacy_serving_gate("default")
+        assert exc.value.status_code == 403
+        refused = [r for r in audit.read_all() if r["type"] == "inference.refused_permission"]
+        assert refused and refused[-1]["pending_permissions"] == ["gpu"]
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_legacy_gate_allows_after_approval(audit, monkeypatch):
+    import main as kaic_main
+
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        await reg.register("default", stub.url)
+        reg.approve_all("default", actor="op")
+        monkeypatch.setattr(kaic_main, "_registry", reg)
+        monkeypatch.setattr(kaic_main, "_audit", audit)
+        # Approved → no raise.
+        kaic_main.enforce_legacy_serving_gate("default")
+    finally:
+        await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_legacy_gate_escape_hatch_for_unregistered(audit, monkeypatch):
+    import main as kaic_main
+
+    stub = _StubAdapter("http://127.0.0.1:9100", _base_caps(gpu=True))
+    reg = _make_registry(audit, stub)
+    try:
+        monkeypatch.setattr(kaic_main, "_registry", reg)
+        # Adapter never registered with the v2 registry → the legacy escape
+        # hatch is preserved (no raise); only KNOWN-pending adapters refuse.
+        kaic_main.enforce_legacy_serving_gate("never-registered")
+    finally:
+        await reg.aclose()

--- a/kai-c/test/test_permissions.py
+++ b/kai-c/test/test_permissions.py
@@ -360,7 +360,10 @@ def kaic_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(kaic_main.AdapterRegistry, "__init__", patched_init)
 
     with TestClient(kaic_main.app) as client:
-        # startup registers "default" → 127.0.0.1:9100 (mocked) as pending.
+        # startup registers "default" → 127.0.0.1:9100 (mocked); §8.5
+        # config-as-consent auto-grants it (actor system:startup-config),
+        # so it comes up APPROVED. Tests that need a PENDING adapter
+        # register one at runtime via the API, which keeps the human gate.
         yield client
 
 
@@ -381,11 +384,31 @@ def test_endpoints_401_without_key(kaic_client):
 
 
 def test_get_permissions_json_shape(kaic_client):
+    # The startup-seeded "default" is §8.5 auto-granted → approved.
     resp = kaic_client.get("/api/v1/adapters/default/permissions", headers=_AUTH)
     assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body == {
+    assert resp.json() == {
         "adapter": "default",
+        "approval_status": "approved",
+        "declared": [
+            {"key": "gpu", "label": "GPU access", "kind": "gpu",
+             "sovereignty_conflict": False},
+        ],
+        "granted": ["gpu"],
+        "pending": [],
+    }
+
+    # A runtime-registered adapter keeps the human gate → pending shape.
+    reg = kaic_client.post(
+        "/api/v1/adapters/register",
+        json={"name": "gated", "url": "http://127.0.0.1:9100"},
+        headers=_AUTH,
+    )
+    assert reg.status_code == 200, reg.text
+    resp2 = kaic_client.get("/api/v1/adapters/gated/permissions", headers=_AUTH)
+    assert resp2.status_code == 200, resp2.text
+    assert resp2.json() == {
+        "adapter": "gated",
         "approval_status": "pending",
         "declared": [
             {"key": "gpu", "label": "GPU access", "kind": "gpu",
@@ -420,15 +443,21 @@ def test_permissions_unknown_adapter_404(kaic_client):
 
 
 def test_serving_refused_via_http_while_pending(kaic_client):
-    # default is pending (declares gpu, nothing granted) → /infer 403.
+    # A runtime-registered adapter (human gate, unlike the §8.5
+    # auto-granted startup seed) is pending → /infer 403.
+    kaic_client.post(
+        "/api/v1/adapters/register",
+        json={"name": "gated", "url": "http://127.0.0.1:9100"},
+        headers=_AUTH,
+    )
     resp = kaic_client.post(
-        "/api/v1/infer/default", json={"camera_id": "cam-1"}, headers=_AUTH,
+        "/api/v1/infer/gated", json={"camera_id": "cam-1"}, headers=_AUTH,
     )
     assert resp.status_code == 403, resp.text
     # After approve-all, serving is allowed.
-    kaic_client.post("/api/v1/adapters/default/permissions/approve-all", headers=_AUTH)
+    kaic_client.post("/api/v1/adapters/gated/permissions/approve-all", headers=_AUTH)
     resp2 = kaic_client.post(
-        "/api/v1/infer/default", json={"camera_id": "cam-1"}, headers=_AUTH,
+        "/api/v1/infer/gated", json={"camera_id": "cam-1"}, headers=_AUTH,
     )
     assert resp2.status_code == 200, resp2.text
 
@@ -469,9 +498,19 @@ def test_stream_refused_while_pending(tmp_path: Path, monkeypatch: pytest.Monkey
     from fastapi.testclient import TestClient
 
     with TestClient(kaic_main.app) as client:
+        # The startup-seeded "default" is §8.5 auto-granted, so use a
+        # runtime-registered adapter — that path keeps the human gate
+        # and stays pending.
+        reg = client.post(
+            "/api/v1/adapters/register",
+            json={"name": "gated", "url": "http://127.0.0.1:9100"},
+            headers={"X-Internal-Api-Key": "sekret"},
+        )
+        assert reg.status_code == 200, reg.text
+
         with pytest.raises(WebSocketDisconnect) as exc_info:
             with client.websocket_connect(
-                "/api/v1/infer/default/stream",
+                "/api/v1/infer/gated/stream",
                 headers={"X-Internal-Api-Key": "sekret"},
             ) as ws:
                 ws.receive_json()
@@ -483,7 +522,7 @@ def test_stream_refused_while_pending(tmp_path: Path, monkeypatch: pytest.Monkey
             headers={"X-Internal-Api-Key": "sekret"},
         ).json()
         assert audit["events"], "expected inference.refused_permission audit event"
-        assert audit["events"][-1]["adapter"] == "default"
+        assert audit["events"][-1]["adapter"] == "gated"
         assert "gpu" in audit["events"][-1]["pending_permissions"]
 
 

--- a/kai-c/test/test_registry.py
+++ b/kai-c/test/test_registry.py
@@ -144,14 +144,19 @@ async def test_refresh_fingerprint_drift_emits_event(registry, adapter_stub, aud
 
 
 @pytest.mark.asyncio
-async def test_refresh_adds_permission_deregisters(registry, adapter_stub, audit):
-    """§11.3 blocking change: adding a permission de-registers the adapter."""
+async def test_refresh_adds_permission_moves_to_pending(registry, adapter_stub, audit):
+    """§8 / §11 blocking change: adding a permission KEEPS the adapter
+    but moves it back to ``pending`` so the operator UI can show
+    "new permission requested, re-approve" (it no longer vanishes)."""
     await registry.register("yolov8", adapter_stub.url)
-    # Adapter now claims it needs GPU permission — under §11.3 this is a
-    # blocking drift event.
+    # Adapter now claims it needs GPU permission — a newly-added scope.
     adapter_stub.update_capabilities(_base_caps(gpu=True))
     await registry.refresh("yolov8")
-    assert registry.get("yolov8") is None  # de-registered
+    adapter = registry.get("yolov8")
+    assert adapter is not None  # kept, not de-registered
+    assert adapter.approval_status == "pending"
+    assert "gpu" in adapter.pending_keys()
+    assert not adapter.is_serving_allowed
     rows = audit.read_all()
     drift = [r for r in rows if r["type"] == "adapter.capability_drift"]
     assert any("gpu" in r.get("added_permissions", []) for r in drift)

--- a/kai-c/test/test_startup_config_consent.py
+++ b/kai-c/test/test_startup_config_consent.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Contract §8.5 — startup-seeded adapters are config-as-consent.
+
+An adapter seeded from ADAPTER_REGISTRY (the operator's own startup
+configuration) that declares permissions must be auto-granted at seed
+time, with the grant audited as actor ``system:startup-config`` and a
+first-class ``adapter_grant_id``. Adapters registered later via
+``POST /api/v1/adapters/register`` keep the human approval gate.
+
+Follows the ``kaic_app`` fixture pattern from test_main_v2.py, but the
+stub adapter here DECLARES permissions (gpu + a host_filesystem path)
+so the startup seed exercises the auto-grant path instead of the
+trivial no-permissions auto-approve.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from test_main_v2 import _StubAdapter, _base_caps
+
+DECLARED_KEYS = {"gpu", "host_filesystem:/models/yolov8"}
+
+
+class _PermissionedStub(_StubAdapter):
+    """Contract-compliant stub that declares permissions, so it
+    registers into the §8 approval gate rather than trivially
+    auto-approving."""
+
+    async def respond(self, request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/capabilities":
+            caps = _base_caps()
+            caps["permissions"]["gpu"] = True
+            caps["permissions"]["host_filesystem"] = ["/models/yolov8"]
+            return httpx.Response(200, json=caps)
+        return await super().respond(request)
+
+
+@pytest.fixture
+def kaic_app_permissioned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Build the FastAPI app with a PERMISSIONED stub adapter wired in.
+
+    The startup seed registers "default" → the stub URL, which declares
+    gpu + host_filesystem, so lifespan's config-as-consent auto-grant
+    fires for it."""
+    monkeypatch.setenv("AI_SOVEREIGNTY", "local_only")
+    monkeypatch.setenv("ADAPTER_URL", "http://127.0.0.1:9100")
+    monkeypatch.setenv("KAI_C_AUDIT_LOG", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("INTERNAL_API_KEY", "")
+
+    if "main" in sys.modules:
+        importlib.reload(sys.modules["main"])
+    import main as kaic_main
+
+    stub = _PermissionedStub()
+    transport = httpx.MockTransport(stub.respond)
+
+    from fastapi.testclient import TestClient
+
+    original_init = kaic_main.AdapterRegistry.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["http_client"] = httpx.AsyncClient(transport=transport)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(kaic_main.AdapterRegistry, "__init__", patched_init)
+
+    with TestClient(kaic_main.app) as client:
+        yield client, stub
+
+
+# ── §8.5 startup seed → auto-grant ─────────────────────────────────
+
+
+def test_startup_seeded_adapter_with_perms_is_approved(kaic_app_permissioned):
+    """The seeded "default" adapter declares gpu + a weights path, yet
+    must come up APPROVED — the operator wrote it into the startup
+    config, which is the consent act."""
+    client, _ = kaic_app_permissioned
+    response = client.get("/api/v1/adapters/default/permissions")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["approval_status"] == "approved"
+    assert body["pending"] == []
+    assert set(body["granted"]) == DECLARED_KEYS
+
+
+def test_startup_auto_grant_is_audited_with_system_actor(kaic_app_permissioned):
+    """Config-as-consent is still a first-class grant: audited as
+    adapter.permission_granted with actor system:startup-config and an
+    adapter_grant_id, so the receipt chain stays intact."""
+    client, _ = kaic_app_permissioned
+    response = client.get(
+        "/api/v1/audit?adapter=default&event_type=adapter.permission_granted"
+    )
+    events = response.json()["events"]
+    assert events, "expected an adapter.permission_granted audit event"
+    grant = events[-1]
+    assert grant["actor"] == "system:startup-config"
+    assert grant["adapter_grant_id"]
+    assert set(grant["keys"]) == DECLARED_KEYS
+    assert grant["approval_status"] == "approved"
+
+
+def test_startup_seeded_adapter_serves_immediately(kaic_app_permissioned):
+    """End-to-end: the auto-granted seed adapter passes the §8 serving
+    gate on the governed infer path without any operator click."""
+    client, _ = kaic_app_permissioned
+    response = client.post("/api/v1/infer/default", json={"camera_id": "cam-1"})
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "ok"
+
+
+# ── runtime registration keeps the human gate ──────────────────────
+
+
+def test_api_registered_adapter_stays_pending(kaic_app_permissioned):
+    """The SAME permissioned adapter registered at runtime via
+    POST /api/v1/adapters/register must NOT be auto-granted — the §8.3
+    pending flow (human approval) still applies."""
+    client, _ = kaic_app_permissioned
+    response = client.post(
+        "/api/v1/adapters/register",
+        json={"name": "runtime-x", "url": "http://127.0.0.1:9100"},
+    )
+    assert response.status_code == 200, response.text
+
+    perms = client.get("/api/v1/adapters/runtime-x/permissions").json()
+    assert perms["approval_status"] == "pending"
+    assert perms["granted"] == []
+    assert set(perms["pending"]) == DECLARED_KEYS
+
+    # And it is refused on the governed serving path until granted.
+    refused = client.post("/api/v1/infer/runtime-x", json={"camera_id": "cam-1"})
+    assert refused.status_code == 403
+
+    # No system:startup-config grant may exist for a runtime-registered
+    # adapter.
+    audit = client.get(
+        "/api/v1/audit?adapter=runtime-x&event_type=adapter.permission_granted"
+    ).json()["events"]
+    assert not [e for e in audit if e.get("actor") == "system:startup-config"]

--- a/server/routers/ai_models.py
+++ b/server/routers/ai_models.py
@@ -207,6 +207,159 @@ async def get_adapter_metrics(
         )
 
 
+class PermissionKeysRequest(BaseModel):
+    """Body for the grant / revoke permission endpoints."""
+
+    keys: list[str] = []
+
+
+def _map_kai_c_permission_error(e: Exception, adapter_name: str) -> HTTPException:
+    """Shared status mapping for the permission proxy routes — KAI-C's
+    404 (unknown adapter) maps to a backend 404; anything else (5xx,
+    connect error, timeout) is a gateway problem → 502. Mirrors the
+    metrics route."""
+    if isinstance(e, httpx.HTTPStatusError):
+        if e.response.status_code == status.HTTP_404_NOT_FOUND:
+            return HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Unknown adapter: {adapter_name}",
+            )
+        return HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"KAI-C returned {e.response.status_code} for adapter permissions",
+        )
+    return HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail=f"Failed to reach KAI-C for adapter permissions: {e!s}",
+    )
+
+
+@router.get("/adapters/{adapter_name}/permissions")
+async def get_adapter_permissions(
+    adapter_name: str,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Fetch the permission-approval view for one adapter (§8 / §11):
+    declared permission keys with labels + sovereignty-conflict flags,
+    the granted set, the still-pending set, and the derived
+    approval_status. Read-only — no audit log.
+
+    Requires authenticated user.
+    """
+    kai_c_service = get_kai_c_service()
+    try:
+        return await kai_c_service.get_adapter_permissions(adapter_name)
+    except Exception as e:
+        raise _map_kai_c_permission_error(e, adapter_name)
+
+
+@router.post("/adapters/{adapter_name}/permissions/grant")
+async def grant_adapter_permissions(
+    adapter_name: str,
+    request: PermissionKeysRequest,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Grant permission keys for an adapter (§8 / §11). Governance
+    mutation — writes an audit log recording the actor, adapter, keys,
+    and the grant_id KAI-C returns.
+
+    Requires authenticated user.
+    """
+    kai_c_service = get_kai_c_service()
+    try:
+        result = await kai_c_service.grant_adapter_permissions(
+            adapter_name, request.keys, actor=current_user.username
+        )
+    except Exception as e:
+        raise _map_kai_c_permission_error(e, adapter_name)
+
+    try:
+        write_audit_log(
+            db,
+            action="adapter.permission.grant",
+            user_id=current_user.id,
+            entity_type="adapter",
+            entity_id=adapter_name,
+            details={"keys": request.keys, "grant_id": (result.get("grant_id") if isinstance(result, dict) else None)},
+        )
+    except Exception:
+        pass  # never fail the mutation on an audit-log hiccup
+    return result
+
+
+@router.post("/adapters/{adapter_name}/permissions/revoke")
+async def revoke_adapter_permissions(
+    adapter_name: str,
+    request: PermissionKeysRequest,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Revoke permission keys for an adapter (§8 / §11). Revoking any
+    key flips the adapter back to pending and stops it serving. Writes
+    an audit log.
+
+    Requires authenticated user.
+    """
+    kai_c_service = get_kai_c_service()
+    try:
+        result = await kai_c_service.revoke_adapter_permissions(
+            adapter_name, request.keys, actor=current_user.username
+        )
+    except Exception as e:
+        raise _map_kai_c_permission_error(e, adapter_name)
+
+    try:
+        write_audit_log(
+            db,
+            action="adapter.permission.revoke",
+            user_id=current_user.id,
+            entity_type="adapter",
+            entity_id=adapter_name,
+            details={"keys": request.keys, "grant_id": (result.get("grant_id") if isinstance(result, dict) else None)},
+        )
+    except Exception:
+        pass
+    return result
+
+
+@router.post("/adapters/{adapter_name}/permissions/approve-all")
+async def approve_all_adapter_permissions(
+    adapter_name: str,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Grant every declared permission key for an adapter — the operator
+    "approve" button (§8 / §11). Writes an audit log.
+
+    Requires authenticated user.
+    """
+    kai_c_service = get_kai_c_service()
+    try:
+        result = await kai_c_service.approve_all_adapter_permissions(
+            adapter_name, actor=current_user.username
+        )
+    except Exception as e:
+        raise _map_kai_c_permission_error(e, adapter_name)
+
+    try:
+        write_audit_log(
+            db,
+            action="adapter.permission.approve",
+            user_id=current_user.id,
+            entity_type="adapter",
+            entity_id=adapter_name,
+            details={
+                "keys": result.get("granted", []) if isinstance(result, dict) else [],
+                "grant_id": (result.get("grant_id") if isinstance(result, dict) else None),
+            },
+        )
+    except Exception:
+        pass
+    return result
+
+
 @router.get("/use-cases", response_model=list[UseCaseEntry])
 async def get_use_cases(
     current_user: User = Depends(get_current_active_user), db: Session = Depends(get_db)

--- a/server/services/kai_c_service.py
+++ b/server/services/kai_c_service.py
@@ -946,6 +946,73 @@ class KaiCService:
         response.raise_for_status()
         return response.json()
 
+    # ── Adapter permission-approval proxy (§8 / §11) ────────────────
+    #
+    # Thin proxies onto KAI-C's governed permission endpoints. Same
+    # X-Internal-Api-Key auth as get_adapter_metrics; the mutating calls
+    # additionally forward an ``X-Actor`` header so KAI-C's own audit
+    # trail records WHICH OpenNVR user made the grant/revoke. All raise
+    # httpx errors verbatim so the router can map 404→404 / down→502.
+
+    def _kai_c_headers(self, *, actor: str | None = None) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        internal_key = self._internal_api_key()
+        if internal_key:
+            headers["X-Internal-Api-Key"] = internal_key
+        if actor:
+            headers["X-Actor"] = actor
+        return headers
+
+    async def get_adapter_permissions(self, adapter_name: str) -> dict[str, Any]:
+        """Fetch the permission view for one adapter (declared / granted
+        / pending / approval_status). Raises httpx errors on failure."""
+        response = await self.http_client.get(
+            f"{self.kai_c_url}/api/v1/adapters/{urlquote(adapter_name, safe='')}/permissions",
+            timeout=10.0,
+            headers=self._kai_c_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def grant_adapter_permissions(
+        self, adapter_name: str, keys: list[str], actor: str | None = None
+    ) -> dict[str, Any]:
+        """Grant permission keys for an adapter. Returns the updated view."""
+        response = await self.http_client.post(
+            f"{self.kai_c_url}/api/v1/adapters/{urlquote(adapter_name, safe='')}/permissions/grant",
+            json={"keys": keys},
+            timeout=10.0,
+            headers=self._kai_c_headers(actor=actor),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def revoke_adapter_permissions(
+        self, adapter_name: str, keys: list[str], actor: str | None = None
+    ) -> dict[str, Any]:
+        """Revoke permission keys for an adapter. Returns the updated view."""
+        response = await self.http_client.post(
+            f"{self.kai_c_url}/api/v1/adapters/{urlquote(adapter_name, safe='')}/permissions/revoke",
+            json={"keys": keys},
+            timeout=10.0,
+            headers=self._kai_c_headers(actor=actor),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def approve_all_adapter_permissions(
+        self, adapter_name: str, actor: str | None = None
+    ) -> dict[str, Any]:
+        """Grant every declared key (the "approve" button). Returns the
+        updated view."""
+        response = await self.http_client.post(
+            f"{self.kai_c_url}/api/v1/adapters/{urlquote(adapter_name, safe='')}/permissions/approve-all",
+            timeout=10.0,
+            headers=self._kai_c_headers(actor=actor),
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def close(self):
         """Cleanup resources."""
         await self.http_client.aclose()

--- a/server/tests/test_ai_models_adapter_permissions.py
+++ b/server/tests/test_ai_models_adapter_permissions.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""
+Tests for the adapter permission-approval proxy routes (§8 / §11):
+
+    GET  /ai-models/adapters/{name}/permissions
+    POST /ai-models/adapters/{name}/permissions/grant
+    POST /ai-models/adapters/{name}/permissions/revoke
+    POST /ai-models/adapters/{name}/permissions/approve-all
+
+Run with:
+
+    cd server && pytest tests/test_ai_models_adapter_permissions.py -v
+
+Coverage:
+
+* Happy path: KAI-C's permission view is proxied through verbatim.
+* Mutations write an audit log (action + adapter + keys + grant_id).
+* Unknown adapter: KAI-C's 404 maps to a backend 404.
+* KAI-C down / 5xx: graceful 502, never a raw 500.
+* The service half sends X-Internal-Api-Key + X-Actor.
+"""
+
+from __future__ import annotations
+
+# Python 3.10 sandbox polyfill (see test_ai_models_adapter_metrics.py).
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def info(self, *a, **kw):
+        pass
+
+    def warning(self, *a, **kw):
+        pass
+
+    def error(self, *a, **kw):
+        pass
+
+    def debug(self, *a, **kw):
+        pass
+
+    def critical(self, *a, **kw):
+        pass
+
+
+for _name in (
+    "main_logger", "auth_logger", "camera_logger",
+    "recording_logger", "cloud_logger", "ai_logger",
+):
+    setattr(_lm, _name, _L())
+sys.modules["core.logging_config"] = _lm
+
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core.auth import get_current_active_user  # noqa: E402
+from core.database import get_db  # noqa: E402
+from routers import ai_models as ai_models_router  # noqa: E402
+
+VIEW = {
+    "adapter": "yolov8",
+    "approval_status": "pending",
+    "declared": [
+        {"key": "gpu", "label": "GPU access", "kind": "gpu",
+         "sovereignty_conflict": False},
+    ],
+    "granted": [],
+    "pending": ["gpu"],
+}
+
+GRANT_RESULT = {**VIEW, "approval_status": "approved", "granted": ["gpu"],
+                "pending": [], "grant_id": "deadbeef"}
+
+
+class _StubUser:
+    id = 1
+    username = "tester"
+
+
+class _StubKaiCService:
+    """Stands in for KaiCService — only the permission methods are used.
+    Records the audit-relevant call args so tests can assert on them."""
+
+    def __init__(self, *, response: dict | None = None, error: Exception | None = None):
+        self._response = response
+        self._error = error
+        self.calls: list[tuple] = []
+
+    async def get_adapter_permissions(self, adapter_name: str) -> dict:
+        self.calls.append(("get", adapter_name))
+        if self._error is not None:
+            raise self._error
+        return self._response or {}
+
+    async def grant_adapter_permissions(self, adapter_name, keys, actor=None) -> dict:
+        self.calls.append(("grant", adapter_name, keys, actor))
+        if self._error is not None:
+            raise self._error
+        return self._response or {}
+
+    async def revoke_adapter_permissions(self, adapter_name, keys, actor=None) -> dict:
+        self.calls.append(("revoke", adapter_name, keys, actor))
+        if self._error is not None:
+            raise self._error
+        return self._response or {}
+
+    async def approve_all_adapter_permissions(self, adapter_name, actor=None) -> dict:
+        self.calls.append(("approve", adapter_name, actor))
+        if self._error is not None:
+            raise self._error
+        return self._response or {}
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request(
+        "GET", "http://localhost:8100/api/v1/adapters/yolov8/permissions"
+    )
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"KAI-C returned {status_code}", request=request, response=response
+    )
+
+
+@pytest.fixture
+def audit_calls(monkeypatch):
+    """Capture write_audit_log calls without a real DB."""
+    calls: list[dict] = []
+
+    def _fake(db, **kwargs):
+        calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(ai_models_router, "write_audit_log", _fake)
+    return calls
+
+
+@pytest.fixture
+def make_client(monkeypatch):
+    def _make(service: _StubKaiCService) -> TestClient:
+        monkeypatch.setattr(
+            ai_models_router, "get_kai_c_service", lambda: service
+        )
+        app = FastAPI()
+        app.include_router(ai_models_router.router)
+        app.dependency_overrides[get_db] = lambda: iter([None])
+        app.dependency_overrides[get_current_active_user] = lambda: _StubUser()
+        return TestClient(app)
+
+    return _make
+
+
+# ── GET permissions ─────────────────────────────────────────────────
+
+
+def test_get_permissions_proxied_verbatim(make_client):
+    service = _StubKaiCService(response=VIEW)
+    client = make_client(service)
+    resp = client.get("/ai-models/adapters/yolov8/permissions")
+    assert resp.status_code == 200
+    assert resp.json() == VIEW
+    assert service.calls == [("get", "yolov8")]
+
+
+def test_get_permissions_unknown_adapter_404(make_client):
+    client = make_client(_StubKaiCService(error=_http_status_error(404)))
+    resp = client.get("/ai-models/adapters/ghost/permissions")
+    assert resp.status_code == 404
+    assert "ghost" in resp.json()["detail"]
+
+
+def test_get_permissions_kai_c_down_502(make_client):
+    client = make_client(
+        _StubKaiCService(error=httpx.ConnectError("connection refused"))
+    )
+    resp = client.get("/ai-models/adapters/yolov8/permissions")
+    assert resp.status_code == 502
+
+
+# ── grant ───────────────────────────────────────────────────────────
+
+
+def test_grant_returns_view_and_audits(make_client, audit_calls):
+    service = _StubKaiCService(response=GRANT_RESULT)
+    client = make_client(service)
+    resp = client.post(
+        "/ai-models/adapters/yolov8/permissions/grant", json={"keys": ["gpu"]}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == GRANT_RESULT
+    # service called with actor = current user's username.
+    assert service.calls == [("grant", "yolov8", ["gpu"], "tester")]
+    # audit log recorded action + keys + grant_id.
+    assert len(audit_calls) == 1
+    a = audit_calls[0]
+    assert a["action"] == "adapter.permission.grant"
+    assert a["entity_id"] == "yolov8"
+    assert a["details"]["keys"] == ["gpu"]
+    assert a["details"]["grant_id"] == "deadbeef"
+
+
+def test_grant_unknown_adapter_404(make_client):
+    client = make_client(_StubKaiCService(error=_http_status_error(404)))
+    resp = client.post(
+        "/ai-models/adapters/ghost/permissions/grant", json={"keys": ["gpu"]}
+    )
+    assert resp.status_code == 404
+
+
+def test_grant_kai_c_5xx_502(make_client):
+    client = make_client(_StubKaiCService(error=_http_status_error(500)))
+    resp = client.post(
+        "/ai-models/adapters/yolov8/permissions/grant", json={"keys": ["gpu"]}
+    )
+    assert resp.status_code == 502
+
+
+# ── revoke ──────────────────────────────────────────────────────────
+
+
+def test_revoke_returns_view_and_audits(make_client, audit_calls):
+    revoked = {**VIEW, "grant_id": "cafe"}
+    service = _StubKaiCService(response=revoked)
+    client = make_client(service)
+    resp = client.post(
+        "/ai-models/adapters/yolov8/permissions/revoke", json={"keys": ["gpu"]}
+    )
+    assert resp.status_code == 200
+    assert service.calls == [("revoke", "yolov8", ["gpu"], "tester")]
+    assert audit_calls[0]["action"] == "adapter.permission.revoke"
+    assert audit_calls[0]["details"]["grant_id"] == "cafe"
+
+
+# ── approve-all ─────────────────────────────────────────────────────
+
+
+def test_approve_all_returns_view_and_audits(make_client, audit_calls):
+    service = _StubKaiCService(response=GRANT_RESULT)
+    client = make_client(service)
+    resp = client.post("/ai-models/adapters/yolov8/permissions/approve-all")
+    assert resp.status_code == 200
+    assert service.calls == [("approve", "yolov8", "tester")]
+    a = audit_calls[0]
+    assert a["action"] == "adapter.permission.approve"
+    assert a["details"]["grant_id"] == "deadbeef"
+    assert a["details"]["keys"] == ["gpu"]  # from result["granted"]
+
+
+def test_approve_all_unknown_adapter_404(make_client):
+    client = make_client(_StubKaiCService(error=_http_status_error(404)))
+    resp = client.post("/ai-models/adapters/ghost/permissions/approve-all")
+    assert resp.status_code == 404
+
+
+# ── service half: headers ───────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_service_grant_sends_key_and_actor(monkeypatch):
+    from services.kai_c_service import KaiCService
+
+    seen: dict = {}
+
+    async def _respond(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["method"] = request.method
+        seen["key"] = request.headers.get("x-internal-api-key")
+        seen["actor"] = request.headers.get("x-actor")
+        import json as _json
+        seen["body"] = _json.loads(request.read())
+        return httpx.Response(200, json=GRANT_RESULT)
+
+    service = KaiCService.__new__(KaiCService)
+    service.kai_c_url = "http://localhost:8100"
+    service.http_client = httpx.AsyncClient(transport=httpx.MockTransport(_respond))
+    monkeypatch.setattr(KaiCService, "_internal_api_key", lambda self: "secret-key")
+
+    body = await service.grant_adapter_permissions("yolov8", ["gpu"], actor="alice")
+    await service.http_client.aclose()
+
+    assert body == GRANT_RESULT
+    assert seen["path"] == "/api/v1/adapters/yolov8/permissions/grant"
+    assert seen["method"] == "POST"
+    assert seen["key"] == "secret-key"
+    assert seen["actor"] == "alice"
+    assert seen["body"] == {"keys": ["gpu"]}
+
+
+@pytest.mark.anyio
+async def test_service_approve_all_no_body(monkeypatch):
+    from services.kai_c_service import KaiCService
+
+    seen: dict = {}
+
+    async def _respond(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["actor"] = request.headers.get("x-actor")
+        return httpx.Response(200, json=GRANT_RESULT)
+
+    service = KaiCService.__new__(KaiCService)
+    service.kai_c_url = "http://localhost:8100"
+    service.http_client = httpx.AsyncClient(transport=httpx.MockTransport(_respond))
+    monkeypatch.setattr(KaiCService, "_internal_api_key", lambda self: "")
+
+    await service.approve_all_adapter_permissions("yolov8", actor="bob")
+    await service.http_client.aclose()
+    assert seen["path"] == "/api/v1/adapters/yolov8/permissions/approve-all"
+    assert seen["actor"] == "bob"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
…8/§11)

Turns declared permissions into an enforced operator approval flow (AI Adapter Contract §8/§11; KAI-C's deferred A2.4b). Fail closed.

KAI-C: adapters declaring any permission register into PENDING (stored, polled, visible) and cannot serve inference until an operator grants. approval_status is derived (declared keys subset of granted), never stored; permission_keys() yields one grantable key per egress host / fs path so granting one host can't approve all. grant/revoke/ approve-all are lock-guarded, each audited with adapter_grant_id + actor. Permission-add drift moves an adapter to pending (kept visible, stops serving) instead of vanishing; permission-removal prunes the stale grant so a re-added key needs fresh approval. Enforcement covers every serving path: governed /api/v1/infer, WS stream (4001), and the legacy /infer + /infer/local passthroughs.

Zero-disruption verified: all bundled adapters declare empty permission sets, so they auto-approve and existing deployments keep serving with no operator action.

Server: proxy routes under /ai-models/adapters/{name}/permissions* (user-auth, X-Actor threaded, grant_id audited, 404/502 mapping). UI: approval badge + permissions panel with per-key grant/revoke, approve-all, sovereignty-conflict warnings, fail-closed messaging.

Peer-reviewed (security focus); findings fixed: legacy /infer and /infer/local bypassed the gate entirely — now gated fail-closed outside the try so the 403 survives (3 new tests); UI badge no longer returns null on fetch error (shows 'approval status unavailable').

Tested: kai-c 124, server 189, frontend tsc + build clean.