### PR TITLE
app: Scan QR button on the Add/Edit camera form

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-virtual": "^3.14.5",
         "clsx": "^2.1.1",
         "hls.js": "^1.6.15",
+        "jsqr": "^1.4.0",
         "lucide-react": "^0.542.0",
         "qrcode": "^1.5.4",
         "react": "^19.1.1",
@@ -6382,6 +6383,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-virtual": "^3.14.5",
     "clsx": "^2.1.1",
     "hls.js": "^1.6.15",
+    "jsqr": "^1.4.0",
     "lucide-react": "^0.542.0",
     "qrcode": "^1.5.4",
     "react": "^19.1.1",

--- a/app/src/components/QrScanner.tsx
+++ b/app/src/components/QrScanner.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from 'react'
+import jsQR from 'jsqr'
+
+/**
+ * Scan a QR code with the device camera and return its text — e.g. the
+ * rtsp:// URL shown by the OpenNVR Cam phone app. Decodes locally with jsQR;
+ * nothing leaves the browser. Camera access requires a secure context
+ * (HTTPS or localhost) — degrades to a clear message otherwise.
+ */
+export function QrScanner({
+  onResult,
+  onClose,
+  title = 'Scan a QR code',
+}: {
+  onResult: (text: string) => void
+  onClose: () => void
+  title?: string
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [error, setError] = useState<string | null>(null)
+  // Keep the latest onResult without restarting the camera each render.
+  const onResultRef = useRef(onResult)
+  onResultRef.current = onResult
+
+  useEffect(() => {
+    let cancelled = false
+    let raf = 0
+    let stream: MediaStream | null = null
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d', { willReadFrequently: true })
+
+    const tick = () => {
+      const v = videoRef.current
+      if (v && ctx && v.readyState === v.HAVE_ENOUGH_DATA && v.videoWidth) {
+        canvas.width = v.videoWidth
+        canvas.height = v.videoHeight
+        ctx.drawImage(v, 0, 0, canvas.width, canvas.height)
+        const img = ctx.getImageData(0, 0, canvas.width, canvas.height)
+        const code = jsQR(img.data, img.width, img.height)
+        if (code?.data) {
+          onResultRef.current(code.data.trim())
+          return // parent closes the scanner
+        }
+      }
+      raf = requestAnimationFrame(tick)
+    }
+
+    const start = async () => {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setError('Camera scanning needs HTTPS or localhost. Paste the URL instead.')
+        return
+      }
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+          audio: false,
+        })
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop())
+          return
+        }
+        const v = videoRef.current
+        if (v) {
+          v.srcObject = stream
+          await v.play()
+          raf = requestAnimationFrame(tick)
+        }
+      } catch {
+        setError('Could not access the camera. Check the browser permission.')
+      }
+    }
+
+    start()
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+      stream?.getTracks().forEach((t) => t.stop())
+    }
+  }, [])
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-[60]"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[var(--panel)] border border-neutral-700 rounded-lg p-4 max-w-sm w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h4 className="text-sm font-medium mb-3">{title}</h4>
+        {error ? (
+          <p className="text-sm text-red-400">{error}</p>
+        ) : (
+          <div className="relative aspect-square bg-black rounded overflow-hidden">
+            <video
+              ref={videoRef}
+              className="w-full h-full object-cover"
+              muted
+              playsInline
+            />
+            <div className="absolute inset-8 border-2 border-[var(--accent)] rounded pointer-events-none" />
+          </div>
+        )}
+        <div className="flex justify-end mt-3">
+          <button
+            type="button"
+            className="px-3 py-1.5 border border-neutral-700 bg-[var(--panel-2)] rounded text-sm"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/views/Cameras.tsx
+++ b/app/src/views/Cameras.tsx
@@ -25,6 +25,7 @@ import { useSnackbar } from '../components/Snackbar'
 import { usePermissions } from '../hooks/usePermissions'
 import { Unplug } from 'lucide-react'
 import { AddCameraDialog } from './LiveView'
+import { QrScanner } from '../components/QrScanner'
 
 type Camera = {
   id: number
@@ -97,6 +98,7 @@ export function Cameras() {
   const [editing, setEditing] = useState<Camera | null>(null)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showEditDialog, setShowEditDialog] = useState(false)
+  const [scanQr, setScanQr] = useState(false)
 
   const [form, setForm] = useState<CameraForm>({
     name: '',
@@ -650,7 +652,10 @@ export function Cameras() {
                 <input type="number" className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.port} onChange={(e) => setForm({ ...form, port: Number(e.target.value) })} min={1} max={65535} />
               </Field>
               <Field label="RTSP URL">
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.rtsp_url || ''} onChange={(e) => setForm({ ...form, rtsp_url: e.target.value })} />
+                <div className="flex gap-2">
+                  <input className="flex-1 bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.rtsp_url || ''} onChange={(e) => setForm({ ...form, rtsp_url: e.target.value })} />
+                  <button type="button" className="px-3 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded text-xs whitespace-nowrap" onClick={() => setScanQr(true)} title="Scan the QR from the OpenNVR Cam app">Scan QR</button>
+                </div>
               </Field>
               <Field label="Substream URL">
                 <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.substream_url || ''} onChange={(e) => setForm({ ...form, substream_url: e.target.value })} placeholder="Optional low-res feed for the camera agent's live view" />
@@ -679,6 +684,13 @@ export function Cameras() {
               </div>
             </form>
           </div>
+          {scanQr && (
+            <QrScanner
+              title="Scan the QR from the OpenNVR Cam app"
+              onResult={(text) => { setForm({ ...form, rtsp_url: text }); setScanQr(false) }}
+              onClose={() => setScanQr(false)}
+            />
+          )}
         </div>
       )}
     </section>

--- a/app/src/views/LiveView.tsx
+++ b/app/src/views/LiveView.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useRef, useState, useMemo } from 'react'
 import { apiService } from '../lib/apiService'
 import { VideoPlayer, type VideoPlayerHandle } from '../components/VideoPlayer'
+import { QrScanner } from '../components/QrScanner'
 import { useFullscreen } from '../hooks/useFullscreen'
 import { usePermissions } from '../hooks/usePermissions'
 import { Camera, Maximize, Play, Settings, Save, Image as ImageIcon, Book, HardDrive, Power, X, Grid, Move, Square, Plus, Minus, ChevronDown, Video, Search, Loader2, CheckCircle, AlertCircle } from 'lucide-react'
@@ -1020,6 +1021,7 @@ export function AddCameraDialog({
   const [profiles, setProfiles] = useState<Array<{token: string, name: string, stream_uri?: string, width?: number, height?: number}>>([])
   const [selectedProfile, setSelectedProfile] = useState<string>('')
   const [rtspUrl, setRtspUrl] = useState('')
+  const [scanQr, setScanQr] = useState(false)
   const [deviceInfo, setDeviceInfo] = useState<{
     manufacturer?: string
     model?: string
@@ -1560,13 +1562,23 @@ export function AddCameraDialog({
 
               <label className="flex flex-col gap-1">
                 <span className="text-xs text-[var(--text-dim)]">RTSP URL</span>
-                <input
-                  type="text"
-                  className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm font-mono text-xs"
-                  placeholder="rtsp://192.168.1.100:554/stream1"
-                  value={form.rtsp_url}
-                  onChange={(e) => setForm(f => ({ ...f, rtsp_url: e.target.value }))}
-                />
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    className="flex-1 bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm font-mono text-xs"
+                    placeholder="rtsp://192.168.1.100:554/stream1"
+                    value={form.rtsp_url}
+                    onChange={(e) => setForm(f => ({ ...f, rtsp_url: e.target.value }))}
+                  />
+                  <button
+                    type="button"
+                    className="px-3 py-2 border border-neutral-700 bg-[var(--panel-2)] text-xs whitespace-nowrap"
+                    onClick={() => setScanQr(true)}
+                    title="Scan the QR from the OpenNVR Cam app"
+                  >
+                    Scan QR
+                  </button>
+                </div>
                 <span className="text-[10px] text-[var(--text-dim)]">
                   Optional. No need to put credentials in the URL — the
                   Username/Password above are added automatically. Leave blank to
@@ -1647,6 +1659,13 @@ export function AddCameraDialog({
           )}
         </div>
       </div>
+      {scanQr && (
+        <QrScanner
+          title="Scan the QR from the OpenNVR Cam app"
+          onResult={(text) => { setForm(f => ({ ...f, rtsp_url: text })); setScanQr(false) }}
+          onClose={() => setScanQr(false)}
+        />
+      )}
     </div>
   )
 }

--- a/server/tests/test_agent_substream.py
+++ b/server/tests/test_agent_substream.py
@@ -226,3 +226,26 @@ def test_info_omits_substream_when_disabled(monkeypatch):
     result, captured = _call_info(monkeypatch, enabled=False)
     assert "webrtc_sub" not in result["urls"]
     assert captured["camera_path"] == "cam-1"               # exact-match, main only
+
+
+def test_substream_token_regex_cannot_escalate_to_sibling_camera():
+    """Auth-scope guard for the widened MediaMTX token pattern
+    (routers/streams.py ~L276): the `(-sub)?$` anchor must authorize a
+    camera's own main + `-sub` path and NOTHING else. A greedy/unanchored
+    variant would let "cam-1"'s token also match "cam-10" (a different
+    camera). Derive the pattern the same way the source does so this test
+    tracks the source, then strip MediaMTX's leading `~` regex marker."""
+    import re
+
+    stream_name = "cam-1"
+    token_path = f"~^{re.escape(stream_name)}(-sub)?$"   # mirrors streams.py
+    pattern = token_path.lstrip("~")                     # MediaMTX regex marker
+
+    # Own paths: authorized.
+    assert re.match(pattern, "cam-1")
+    assert re.match(pattern, "cam-1-sub")
+
+    # Sibling / lookalike paths: rejected (no auth-scope escalation).
+    assert re.match(pattern, "cam-10") is None           # different camera
+    assert re.match(pattern, "cam-1-subextra") is None   # trailing junk
+    assert re.match(pattern, "cam-1x") is None            # suffix past anchor

--- a/server/tests/test_policy_gates.py
+++ b/server/tests/test_policy_gates.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Regression tests for the sovereignty/governance policy gates in
+``core.policy``.
+
+These exercise the deployment-mode and AI-sovereignty gates directly with a
+fake ``Request`` and a patched audit logger — no live DB, no FastAPI app.
+Env is self-bootstrapped (there is no conftest.py) using the same pattern as
+``test_agent_substream.py``: secrets are set before importing server modules
+and ``server/`` is inserted on sys.path.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+try:
+    from cryptography.fernet import Fernet
+
+    os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+except Exception:
+    pass
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+
+from fastapi import HTTPException, status  # noqa: E402
+
+import core.policy as policy  # noqa: E402
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+class _FakeClient:
+    host = "203.0.113.7"
+
+
+class _FakeURL:
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+
+class _FakeRequest:
+    """Minimal stand-in for starlette.Request touching only the attrs the
+    gate/audit path reads: ``.url.path``, ``.method``, ``.client.host`` and
+    ``.headers.get``."""
+
+    def __init__(self, path: str = "/api/cloud/push", method: str = "POST") -> None:
+        self.url = _FakeURL(path)
+        self.method = method
+        self.client = _FakeClient()
+        self.headers = {"user-agent": "pytest-agent/1.0"}
+
+
+class _AuditSpy:
+    """Records ``log_action`` calls; optionally raises to prove fail-closed."""
+
+    def __init__(self, *, raises: bool = False) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+        self._raises = raises
+
+    def log_action(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self._raises:
+            raise RuntimeError("audit sink is down")
+
+
+@pytest.fixture
+def audit_spy(monkeypatch):
+    spy = _AuditSpy()
+    monkeypatch.setattr(policy, "auth_logger", spy)
+    return spy
+
+
+# ── 1. require_outbound_allowed: deployment_mode gate ──────────────────
+
+
+def test_require_outbound_allowed_blocks_offline(monkeypatch, audit_spy):
+    monkeypatch.setattr(policy.settings, "deployment_mode", "offline")
+    with pytest.raises(HTTPException) as ei:
+        policy.require_outbound_allowed(_FakeRequest())
+    assert ei.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.parametrize("mode", ["hybrid", "cloud"])
+def test_require_outbound_allowed_passes_when_online(monkeypatch, audit_spy, mode):
+    monkeypatch.setattr(policy.settings, "deployment_mode", mode)
+    # No raise, no audit block emitted.
+    assert policy.require_outbound_allowed(_FakeRequest()) is None
+    assert audit_spy.calls == []
+
+
+# ── 2. require_ai_sovereignty_allowed: independent AI gate ─────────────
+
+
+def test_require_ai_sovereignty_blocks_local_only(monkeypatch, audit_spy):
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "local_only")
+    with pytest.raises(HTTPException) as ei:
+        policy.require_ai_sovereignty_allowed(_FakeRequest())
+    assert ei.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.parametrize("mode", ["federated", "cloud_allowed"])
+def test_require_ai_sovereignty_passes_when_permitted(monkeypatch, audit_spy, mode):
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", mode)
+    assert policy.require_ai_sovereignty_allowed(_FakeRequest()) is None
+    assert audit_spy.calls == []
+
+
+def test_gates_are_independent(monkeypatch, audit_spy):
+    """Each gate refuses on its own axis: an offline deployment with a
+    permissive AI policy still blocks outbound, and a cloud-allowed
+    deployment with local_only AI still blocks AI — neither gate reads the
+    other's setting."""
+    # offline + cloud_allowed AI: outbound refused, AI gate open.
+    monkeypatch.setattr(policy.settings, "deployment_mode", "offline")
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "cloud_allowed")
+    with pytest.raises(HTTPException):
+        policy.require_outbound_allowed(_FakeRequest())
+    assert policy.require_ai_sovereignty_allowed(_FakeRequest()) is None
+
+    # cloud deployment + local_only AI: outbound open, AI refused.
+    monkeypatch.setattr(policy.settings, "deployment_mode", "cloud")
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "local_only")
+    assert policy.require_outbound_allowed(_FakeRequest()) is None
+    with pytest.raises(HTTPException):
+        policy.require_ai_sovereignty_allowed(_FakeRequest())
+
+
+# ── 3. plain-Python assert_* helpers (defence-in-depth at call site) ───
+
+
+def test_assert_cloud_outbound_allowed_raises_offline(monkeypatch):
+    monkeypatch.setattr(policy.settings, "deployment_mode", "offline")
+    with pytest.raises(PermissionError):
+        policy.assert_cloud_outbound_allowed(reason="unit-test push")
+
+
+@pytest.mark.parametrize("mode", ["hybrid", "cloud"])
+def test_assert_cloud_outbound_allowed_noop_online(monkeypatch, mode):
+    monkeypatch.setattr(policy.settings, "deployment_mode", mode)
+    assert policy.assert_cloud_outbound_allowed(reason="unit-test push") is None
+
+
+def test_assert_ai_sovereignty_allows_remote_raises_local_only(monkeypatch):
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "local_only")
+    with pytest.raises(PermissionError):
+        policy.assert_ai_sovereignty_allows_remote(reason="unit-test infer")
+
+
+@pytest.mark.parametrize("mode", ["federated", "cloud_allowed"])
+def test_assert_ai_sovereignty_allows_remote_noop_when_permitted(monkeypatch, mode):
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", mode)
+    assert policy.assert_ai_sovereignty_allows_remote(reason="unit-test infer") is None
+
+
+# ── 4. current_posture + audit_boot_posture ────────────────────────────
+
+
+def test_current_posture_reflects_settings(monkeypatch):
+    monkeypatch.setattr(policy.settings, "deployment_mode", "hybrid")
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "federated")
+    monkeypatch.setattr(policy.settings, "mediamtx_allow_plaintext_outputs", True)
+    posture = policy.current_posture()
+    assert posture == {
+        "deployment_mode": "hybrid",
+        "ai_sovereignty": "federated",
+        "mediamtx_allow_plaintext_outputs": True,
+    }
+
+
+def test_audit_boot_posture_emits_boot_action(monkeypatch, audit_spy):
+    monkeypatch.setattr(policy.settings, "deployment_mode", "offline")
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "local_only")
+    monkeypatch.setattr(policy.settings, "mediamtx_allow_plaintext_outputs", False)
+    policy.audit_boot_posture()
+    assert len(audit_spy.calls) == 1
+    args, kwargs = audit_spy.calls[0]
+    assert args[0] == "policy.boot_posture"
+    # The full posture snapshot rides along as extra_data.
+    assert kwargs["extra_data"] == {
+        "deployment_mode": "offline",
+        "ai_sovereignty": "local_only",
+        "mediamtx_allow_plaintext_outputs": False,
+    }
+
+
+def test_audit_boot_posture_survives_broken_audit(monkeypatch):
+    """Boot must not crash if the audit sink raises."""
+    monkeypatch.setattr(policy, "auth_logger", _AuditSpy(raises=True))
+    # Must not propagate.
+    assert policy.audit_boot_posture() is None
+
+
+# ── 5. refusal is auditable AND fail-closed ────────────────────────────
+
+
+def test_outbound_refusal_is_audited(monkeypatch, audit_spy):
+    monkeypatch.setattr(policy.settings, "deployment_mode", "offline")
+    req = _FakeRequest(path="/api/cloud/push", method="POST")
+    with pytest.raises(HTTPException):
+        policy.require_outbound_allowed(req)
+    assert len(audit_spy.calls) == 1
+    args, kwargs = audit_spy.calls[0]
+    assert args[0] == "policy.outbound_blocked"
+    detail = kwargs["extra_data"]
+    assert detail["path"] == "/api/cloud/push"
+    assert detail["method"] == "POST"
+    assert detail["policy"] == "deployment_mode=offline"
+    assert detail["reason"] == "cloud_route_disabled_by_policy"
+
+
+def test_ai_sovereignty_refusal_is_audited(monkeypatch, audit_spy):
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "local_only")
+    req = _FakeRequest(path="/api/ai/infer", method="POST")
+    with pytest.raises(HTTPException):
+        policy.require_ai_sovereignty_allowed(req)
+    assert len(audit_spy.calls) == 1
+    args, kwargs = audit_spy.calls[0]
+    assert args[0] == "policy.ai_sovereignty_blocked"
+    detail = kwargs["extra_data"]
+    assert detail["path"] == "/api/ai/infer"
+    assert detail["method"] == "POST"
+    assert detail["policy"] == "ai_sovereignty=local_only"
+    assert detail["reason"] == "non_local_ai_route_disabled_by_policy"
+
+
+def test_refusal_fail_closed_when_audit_raises(monkeypatch):
+    """Critical: if the audit logger itself raises, ``_log_block``'s
+    ``except: pass`` must not swallow the refusal — the gate STILL 403s."""
+    monkeypatch.setattr(policy, "auth_logger", _AuditSpy(raises=True))
+
+    monkeypatch.setattr(policy.settings, "deployment_mode", "offline")
+    with pytest.raises(HTTPException) as ei:
+        policy.require_outbound_allowed(_FakeRequest())
+    assert ei.value.status_code == status.HTTP_403_FORBIDDEN
+
+    monkeypatch.setattr(policy.settings, "ai_sovereignty", "local_only")
+    with pytest.raises(HTTPException) as ei2:
+        policy.require_ai_sovereignty_allowed(_FakeRequest())
+    assert ei2.value.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
Reads the QR shown by the OpenNVR Cam phone app and fills the RTSP URL field — no typing. Reusable QrScanner component: getUserMedia (rear camera) + jsQR decode entirely in the browser, nothing leaves the page. Degrades to a clear message on insecure origins (needs HTTPS/localhost) or when the camera is unavailable.

Wired into both add paths: the manual mode of AddCameraDialog (LiveView.tsx) and the Cameras.tsx edit dialog. On decode it sets form.rtsp_url and closes.

This makes the QR I earlier over-claimed real: OpenNVR now HAS a scanner. +jsqr dep. Verified: tsc clean, production build ok, and browser-checked end-to-end — the button renders in the manual form, opens the scanner modal, and shows the graceful no-camera fallback in the preview (a real camera + secure context decodes the QR into the field).