### PR TITLE
Dvr playback

### DIFF
--- a/app/src/components/PlaybackConsole.tsx
+++ b/app/src/components/PlaybackConsole.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Hls from 'hls.js'
 import {
   Play,
   Pause,
@@ -73,20 +74,20 @@ const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v
 export function PlaybackConsole({ cameraId, cameraName, date, onClose }: PlaybackConsoleProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  // Wall-clock instant (epoch ms) the currently-loaded MediaMTX /get window began at.
+  const hlsRef = useRef<Hls | null>(null)
+  const sessionIdRef = useRef<string | null>(null)
+  // Guards against out-of-order async loads: only the latest load token wins.
+  const loadTokenRef = useRef(0)
+  // Wall-clock instant (epoch ms) the loaded clip begins at, for time mapping.
   const windowStartRef = useRef<number>(0)
-  // The clip currently loaded into the <video>. Seeks that land inside it are
-  // done natively (instant, from buffer); only crossing into another clip hits
-  // the network. Null until the first clip loads.
+  // Bounds of the clip currently loaded into the <video>. Seeks inside it are
+  // native (hls.js fetches the right byte-range fragment → instant); only
+  // crossing into another clip spins up a new session.
   const loadedClipRef = useRef<{ startMs: number; endMs: number } | null>(null)
-  // Offset (seconds) to seek to once the freshly-loaded clip has metadata.
-  const pendingSeekSecRef = useRef<number | null>(null)
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [segs, setSegs] = useState<Seg[]>([])
-  const [base, setBase] = useState('')
-  const [path, setPath] = useState('')
 
   const [dayStart, setDayStart] = useState(0)
   const [dayEnd, setDayEnd] = useState(0)
@@ -129,8 +130,6 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
           .filter((s) => Number.isFinite(s.startMs))
           .sort((a, b) => a.startMs - b.startMs)
 
-        setBase((res.data?.playback_base_url || '').replace(/\/$/, ''))
-        setPath(res.data?.path || '')
         setSegs(parsed)
 
         if (parsed.length === 0) {
@@ -162,54 +161,102 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     }
   }, [cameraId, date])
 
-  // ---- Source loading -------------------------------------------------------
-  const buildUrl = useCallback(
-    (startIso: string, durationSec: number) =>
-      `${base}/get?path=${path}&start=${encodeURIComponent(startIso)}&duration=${durationSec}`,
-    [base, path]
-  )
+  // ---- Clip loading via per-clip byte-range HLS session ---------------------
+  const teardownHls = useCallback(() => {
+    if (hlsRef.current) {
+      hlsRef.current.destroy()
+      hlsRef.current = null
+    }
+    const prev = sessionIdRef.current
+    sessionIdRef.current = null
+    if (prev) apiService.deleteHlsPlaybackSession(prev).catch(() => {})
+  }, [])
 
   /**
-   * Load the WHOLE clip that contains `ms` (or the next clip if `ms` is in a
-   * gap) as one MediaMTX /get window, then seek to the `ms` offset once it has
-   * metadata. Loading the whole clip is what lets subsequent in-clip seeks be
-   * native (buffer) reads instead of a fresh server request each time.
+   * Load `clip` and seek to `offsetSec` within it. Each clip gets its own HLS
+   * session whose manifest is a #EXT-X-BYTERANGE playlist over the single
+   * on-disk file — so hls.js seeks with ranged reads (instant), and gaps
+   * between clips are never crossed in one stream.
    */
-  const loadFrom = useCallback(
-    (ms: number, play: boolean) => {
+  const loadClip = useCallback(
+    async (clip: Seg, offsetSec: number, play: boolean) => {
       const el = videoRef.current
-      if (!el || segs.length === 0) return
+      if (!el) return
+      const token = ++loadTokenRef.current
 
-      let clip = segs.find((s) => ms >= s.startMs && ms < s.endMs)
-      let seekMs = ms
-      if (!clip) {
-        // In a gap → jump to the next available clip's start.
-        const next = segs.find((s) => s.startMs >= ms)
-        if (!next) {
-          el.pause()
-          return
-        }
-        clip = next
-        seekMs = next.startMs
-      }
+      teardownHls()
 
       windowStartRef.current = clip.startMs
       loadedClipRef.current = { startMs: clip.startMs, endMs: clip.endMs }
-      pendingSeekSecRef.current = Math.max(0, (seekMs - clip.startMs) / 1000)
-      setCurrentMs(seekMs)
-      el.src = buildUrl(clip.startIso, Math.max(1, clip.duration + 0.5))
-      el.load()
-      el.playbackRate = SPEEDS[rateIdx]
-      el.muted = muted
-      if (play) el.play().catch(() => {})
+      setCurrentMs(clip.startMs + offsetSec * 1000)
+      setBuffering(true)
+
+      let manifestUrl: string
+      try {
+        const res: any = await apiService.createHlsPlaybackSession({
+          camera_id: cameraId,
+          start: clip.startIso,
+          end: new Date(clip.endMs).toISOString(),
+        })
+        if (token !== loadTokenRef.current) return // superseded by a newer load
+        manifestUrl = res.data?.manifest_url
+        sessionIdRef.current = res.data?.session_id || null
+        if (!manifestUrl) throw new Error('No manifest returned')
+      } catch {
+        if (token === loadTokenRef.current) {
+          setBuffering(false)
+          setError('Failed to start playback for this clip.')
+        }
+        return
+      }
+
+      const startAtOffset = () => {
+        if (token !== loadTokenRef.current) return
+        el.playbackRate = SPEEDS[rateIdx]
+        el.muted = muted
+        if (offsetSec > 0.05) {
+          try {
+            el.currentTime = offsetSec
+          } catch {
+            /* seekable range not ready; starts at head */
+          }
+        }
+        if (play) el.play().catch(() => {})
+        setBuffering(false)
+      }
+
+      if (Hls.isSupported()) {
+        const hls = new Hls({
+          enableWorker: true,
+          lowLatencyMode: false,
+          backBufferLength: 30,
+          maxBufferLength: 60,
+          maxMaxBufferLength: 120,
+        })
+        hlsRef.current = hls
+        hls.loadSource(manifestUrl)
+        hls.attachMedia(el)
+        hls.on(Hls.Events.MANIFEST_PARSED, startAtOffset)
+        hls.on(Hls.Events.ERROR, (_evt, data) => {
+          if (!data.fatal) return
+          if (data.type === Hls.ErrorTypes.MEDIA_ERROR) hls.recoverMediaError()
+          else if (data.type === Hls.ErrorTypes.NETWORK_ERROR) hls.startLoad()
+        })
+      } else if (el.canPlayType('application/vnd.apple.mpegurl')) {
+        el.src = manifestUrl
+        el.addEventListener('loadedmetadata', startAtOffset, { once: true })
+      } else {
+        setBuffering(false)
+        setError('HLS is not supported in this browser.')
+      }
     },
-    [segs, buildUrl, rateIdx, muted]
+    [cameraId, rateIdx, muted, teardownHls]
   )
 
-  // Start playback once segments are ready.
+  // Start playback at the first clip once segments are ready.
   useEffect(() => {
-    if (!loading && segs.length > 0 && videoRef.current && !videoRef.current.src) {
-      loadFrom(segs[0].startMs, true)
+    if (!loading && segs.length > 0 && !sessionIdRef.current && !loadedClipRef.current) {
+      loadClip(segs[0], 0, true)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, segs])
@@ -221,35 +268,19 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     const onPlay = () => setIsPlaying(true)
     const onPause = () => setIsPlaying(false)
     const onTime = () => setCurrentMs(windowStartRef.current + el.currentTime * 1000)
-    const onLoadedMeta = () => {
-      // Apply the deferred in-clip seek now that the media is seekable.
-      const off = pendingSeekSecRef.current
-      pendingSeekSecRef.current = null
-      if (off != null && off > 0.05) {
-        try {
-          el.currentTime = off
-        } catch {
-          /* not seekable yet — playback still starts at clip head */
-        }
-      }
-    }
     const onWaiting = () => setBuffering(true)
     const onPlaying = () => setBuffering(false)
     const onCanPlay = () => setBuffering(false)
     const onEnded = () => {
-      // Advance to the next clip after the current window (skips the gap).
-      const after = windowStartRef.current + (el.duration || 0) * 1000
+      // Advance to the next clip (skips the grey gap).
+      const after = loadedClipRef.current?.endMs ?? windowStartRef.current + (el.duration || 0) * 1000
       const next = segs.find((s) => s.startMs >= after - 500)
-      if (next) {
-        loadFrom(next.startMs, true)
-      } else {
-        setIsPlaying(false)
-      }
+      if (next) loadClip(next, 0, true)
+      else setIsPlaying(false)
     }
     el.addEventListener('play', onPlay)
     el.addEventListener('pause', onPause)
     el.addEventListener('timeupdate', onTime)
-    el.addEventListener('loadedmetadata', onLoadedMeta)
     el.addEventListener('waiting', onWaiting)
     el.addEventListener('playing', onPlaying)
     el.addEventListener('canplay', onCanPlay)
@@ -258,17 +289,17 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
       el.removeEventListener('play', onPlay)
       el.removeEventListener('pause', onPause)
       el.removeEventListener('timeupdate', onTime)
-      el.removeEventListener('loadedmetadata', onLoadedMeta)
       el.removeEventListener('waiting', onWaiting)
       el.removeEventListener('playing', onPlaying)
       el.removeEventListener('canplay', onCanPlay)
       el.removeEventListener('ended', onEnded)
     }
-  }, [segs, loadFrom])
+  }, [segs, loadClip])
 
   // Cleanup on unmount.
   useEffect(() => {
     return () => {
+      teardownHls()
       const el = videoRef.current
       if (el) {
         el.pause()
@@ -276,7 +307,7 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
         el.load()
       }
     }
-  }, [])
+  }, [teardownHls])
 
   // Fullscreen tracking.
   useEffect(() => {
@@ -308,16 +339,17 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
   const seekTo = (ms: number) => {
     const el = videoRef.current
     const c = loadedClipRef.current
-    // Target is inside the already-loaded clip → native seek (instant, no
-    // network). Only fall back to a fresh /get when crossing clips or when the
-    // element isn't ready yet.
-    if (el && c && ms >= c.startMs && ms < c.endMs && el.readyState >= 1) {
-      el.currentTime = clamp((ms - c.startMs) / 1000, 0, el.duration || 0)
+    // Inside the loaded clip → native seek. hls.js turns this into a ranged
+    // fragment fetch, so it's instant both directions.
+    if (el && c && ms >= c.startMs && ms < c.endMs) {
+      el.currentTime = clamp((ms - c.startMs) / 1000, 0, el.duration || Number.MAX_SAFE_INTEGER)
       setCurrentMs(ms)
       if (isPlaying) el.play().catch(() => {})
-    } else {
-      loadFrom(ms, isPlaying)
+      return
     }
+    // Otherwise resolve the target clip (or the next one across a gap) and load.
+    const clip = segs.find((s) => ms >= s.startMs && ms < s.endMs) || segs.find((s) => s.startMs >= ms)
+    if (clip) loadClip(clip, Math.max(0, (ms - clip.startMs) / 1000), isPlaying)
   }
 
   const stepFrame = (dir: 1 | -1) => {

--- a/app/src/components/PlaybackConsole.tsx
+++ b/app/src/components/PlaybackConsole.tsx
@@ -32,6 +32,8 @@ import {
   Loader2,
   X,
   AlertCircle,
+  Scissors,
+  Download,
 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
 import { PlaybackTimeline, type TimelineSegment } from './PlaybackTimeline'
@@ -66,10 +68,30 @@ const ZOOMS: { label: string; span: number }[] = [
   { label: '2m', span: 120_000 },
 ]
 
-const SPEEDS = [0.5, 1, 2, 4, 8]
+const SPEEDS = [0.25, 0.5, 1, 2, 4, 8, 16]
+const RATE_1X = 2 // index of 1x in SPEEDS
 const FRAME_STEP = 1 / 25 // ~1 frame at 25fps
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
+
+function parseSegments(raw: RawSegment[]): Seg[] {
+  return raw
+    .map((r) => {
+      const startMs = Date.parse(r.start)
+      return {
+        startMs,
+        endMs: startMs + (r.duration || 0) * 1000,
+        startIso: r.start,
+        duration: r.duration || 0,
+      }
+    })
+    .filter((s) => Number.isFinite(s.startMs))
+    .sort((a, b) => a.startMs - b.startMs)
+}
+
+const sameSegs = (a: Seg[], b: Seg[]) =>
+  a.length === b.length &&
+  a.every((s, i) => s.startMs === b[i].startMs && s.endMs === b[i].endMs)
 
 export function PlaybackConsole({ cameraId, cameraName, date, onClose }: PlaybackConsoleProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
@@ -84,10 +106,16 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
   // native (hls.js fetches the right byte-range fragment → instant); only
   // crossing into another clip spins up a new session.
   const loadedClipRef = useRef<{ startMs: number; endMs: number } | null>(null)
+  // Latest segments, mirrored to a ref so the poll loop reads them without
+  // re-subscribing every update.
+  const segsRef = useRef<Seg[]>([])
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [segs, setSegs] = useState<Seg[]>([])
+  // MediaMTX browser-reachable playback base + path, for clip export.
+  const [base, setBase] = useState('')
+  const [path, setPath] = useState('')
 
   const [dayStart, setDayStart] = useState(0)
   const [dayEnd, setDayEnd] = useState(0)
@@ -97,10 +125,15 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
   const [currentMs, setCurrentMs] = useState(0)
   const [previewMs, setPreviewMs] = useState<number | null>(null)
   const [isPlaying, setIsPlaying] = useState(false)
-  const [rateIdx, setRateIdx] = useState(1) // 1x
+  const [rateIdx, setRateIdx] = useState(RATE_1X)
   const [muted, setMuted] = useState(false)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [buffering, setBuffering] = useState(false)
+
+  // Clip-export state.
+  const [clipMode, setClipMode] = useState(false)
+  const [selection, setSelection] = useState<{ inMs: number; outMs: number } | null>(null)
+  const [exporting, setExporting] = useState(false)
 
   const timelineSegs: TimelineSegment[] = useMemo(
     () => segs.map((s) => ({ startMs: s.startMs, endMs: s.endMs })),
@@ -116,20 +149,10 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
       .getSegments(cameraId, date)
       .then((res: any) => {
         if (cancelled) return
-        const raw: RawSegment[] = res.data?.segments || []
-        const parsed: Seg[] = raw
-          .map((r) => {
-            const startMs = Date.parse(r.start)
-            return {
-              startMs,
-              endMs: startMs + (r.duration || 0) * 1000,
-              startIso: r.start,
-              duration: r.duration || 0,
-            }
-          })
-          .filter((s) => Number.isFinite(s.startMs))
-          .sort((a, b) => a.startMs - b.startMs)
+        const parsed = parseSegments(res.data?.segments || [])
 
+        setBase((res.data?.playback_base_url || '').replace(/\/$/, ''))
+        setPath(res.data?.path || '')
         setSegs(parsed)
 
         if (parsed.length === 0) {
@@ -160,6 +183,37 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
       cancelled = true
     }
   }, [cameraId, date])
+
+  // Mirror segments to a ref for the poll loop.
+  useEffect(() => {
+    segsRef.current = segs
+  }, [segs])
+
+  // Live-follow: while the player is open on a still-recording day, re-fetch the
+  // segment list so the timeline's red blocks grow as new footage lands — no
+  // manual reload. Auto-stops once the newest footage is well in the past.
+  useEffect(() => {
+    if (loading || error) return
+    let stopped = false
+    const id = setInterval(async () => {
+      const cur = segsRef.current
+      const lastEnd = cur.length ? cur[cur.length - 1].endMs : 0
+      // Static (past) day → nothing more will be written; stop polling.
+      if (lastEnd && Date.now() - lastEnd > 15 * 60_000) return
+      try {
+        const res: any = await apiService.getSegments(cameraId, date)
+        if (stopped) return
+        const parsed = parseSegments(res.data?.segments || [])
+        if (parsed.length && !sameSegs(segsRef.current, parsed)) setSegs(parsed)
+      } catch {
+        /* transient — try again next tick */
+      }
+    }, 10_000)
+    return () => {
+      stopped = true
+      clearInterval(id)
+    }
+  }, [loading, error, cameraId, date])
 
   // ---- Clip loading via per-clip byte-range HLS session ---------------------
   const teardownHls = useCallback(() => {
@@ -272,8 +326,15 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     const onPlaying = () => setBuffering(false)
     const onCanPlay = () => setBuffering(false)
     const onEnded = () => {
-      // Advance to the next clip (skips the grey gap).
       const after = loadedClipRef.current?.endMs ?? windowStartRef.current + (el.duration || 0) * 1000
+      // The current clip may have grown since we loaded it (live recording) —
+      // reload it from where we stopped to play into the newly-written tail.
+      const grown = segs.find((s) => s.startMs <= after && after < s.endMs - 500)
+      if (grown) {
+        loadClip(grown, Math.max(0, (after - grown.startMs) / 1000), true)
+        return
+      }
+      // Otherwise advance to the next clip (skips the grey gap).
       const next = segs.find((s) => s.startMs >= after - 500)
       if (next) loadClip(next, 0, true)
       else setIsPlaying(false)
@@ -377,6 +438,50 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     else containerRef.current?.requestFullscreen?.()
   }
 
+  // ---- Clip export ----------------------------------------------------------
+  const toggleClipMode = () => {
+    setClipMode((on) => {
+      if (!on) videoRef.current?.pause() // entering clip mode: pause for precision
+      setSelection(null)
+      return !on
+    })
+  }
+
+  const stamp = (ms: number) =>
+    new Date(ms).toISOString().replace('T', '_').replace(/[:.]/g, '-').slice(0, 19)
+
+  const exportClip = async () => {
+    if (!selection || selection.outMs <= selection.inMs || !base || !path) return
+    setExporting(true)
+    try {
+      const startIso = new Date(selection.inMs).toISOString()
+      const durationSec = Math.max(1, (selection.outMs - selection.inMs) / 1000)
+      const url = `${base}/get?path=${path}&start=${encodeURIComponent(startIso)}&duration=${durationSec}`
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const blob = await res.blob()
+      const href = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = href
+      a.download = `${cameraName.replace(/\s+/g, '-')}_${stamp(selection.inMs)}.mp4`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(href)
+      setClipMode(false)
+      setSelection(null)
+    } catch (e) {
+      console.error('[Playback] Clip export failed:', e)
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const selectionSeconds =
+    selection && selection.outMs > selection.inMs
+      ? Math.round((selection.outMs - selection.inMs) / 1000)
+      : 0
+
   const applyZoom = (idx: number) => {
     const span = ZOOMS[idx].span
     setZoomIdx(idx)
@@ -411,13 +516,21 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
   const effectiveCurrent = previewMs ?? currentMs
 
   return (
-    <div className="fixed inset-0 bg-black/85 flex items-center justify-center z-50 p-4">
+    <div
+      className={`fixed inset-0 bg-black/85 flex items-center justify-center z-50 ${
+        isFullscreen ? '' : 'p-4'
+      }`}
+    >
       <div
         ref={containerRef}
-        className="bg-[var(--panel)] border border-neutral-700 w-full max-w-5xl flex flex-col"
+        className={`flex flex-col ${
+          isFullscreen
+            ? 'bg-black w-screen h-screen'
+            : 'bg-[var(--panel)] border border-neutral-700 w-full max-w-5xl'
+        }`}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-neutral-700 bg-[var(--panel-2)]">
+        <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-neutral-700 bg-[var(--panel-2)]">
           <div className="flex items-center gap-2 min-w-0">
             <Play size={16} className="text-[var(--accent)] shrink-0" />
             <span className="font-medium truncate">{cameraName}</span>
@@ -433,7 +546,11 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
         </div>
 
         {/* Video */}
-        <div className="relative bg-black aspect-video flex items-center justify-center">
+        <div
+          className={`relative bg-black flex items-center justify-center ${
+            isFullscreen ? 'flex-1 min-h-0' : 'aspect-video'
+          }`}
+        >
           {error ? (
             <div className="text-center p-8">
               <AlertCircle size={48} className="mx-auto mb-3 text-amber-400 opacity-70" />
@@ -459,7 +576,7 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
 
         {/* Toolbar */}
         {!error && (
-          <div className="flex items-center gap-1 px-3 py-2 bg-[var(--panel-2)] border-t border-neutral-700">
+          <div className="shrink-0 flex items-center gap-1 px-3 py-2 bg-[var(--panel-2)] border-t border-neutral-700">
             <IconBtn title="Previous frame" onClick={() => stepFrame(-1)}>
               <SkipBack size={16} />
             </IconBtn>
@@ -485,6 +602,18 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
             <IconBtn title={muted ? 'Unmute' : 'Mute'} onClick={toggleMute}>
               {muted ? <VolumeX size={16} /> : <Volume2 size={16} />}
             </IconBtn>
+
+            <button
+              title={clipMode ? 'Exit clip mode' : 'Clip / export'}
+              onClick={toggleClipMode}
+              className={`p-1.5 rounded transition-colors ${
+                clipMode
+                  ? 'bg-[var(--accent)] text-white'
+                  : 'text-[var(--text)] hover:bg-[var(--panel)]'
+              }`}
+            >
+              <Scissors size={16} />
+            </button>
 
             <div className="flex-1" />
 
@@ -514,9 +643,36 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
           </div>
         )}
 
+        {/* Clip action bar */}
+        {!error && clipMode && (
+          <div className="shrink-0 flex items-center gap-3 px-3 py-2 bg-[var(--accent)]/10 border-t border-[var(--accent)]/30 text-sm">
+            <Scissors size={14} className="text-[var(--accent)] shrink-0" />
+            <span className="text-[var(--text-dim)]">
+              {selectionSeconds > 0
+                ? `Selection: ${selectionSeconds}s`
+                : 'Drag across the timeline to select a range to export'}
+            </span>
+            <div className="flex-1" />
+            <button
+              onClick={exportClip}
+              disabled={selectionSeconds <= 0 || exporting}
+              className="flex items-center gap-1.5 px-3 py-1 rounded bg-[var(--accent)] text-white text-xs font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
+            >
+              {exporting ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+              {exporting ? 'Exporting…' : 'Export clip'}
+            </button>
+            <button
+              onClick={toggleClipMode}
+              className="px-3 py-1 rounded border border-neutral-600 text-xs text-[var(--text-dim)] hover:bg-[var(--panel)] transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
         {/* Timeline */}
         {!error && segs.length > 0 && view.end > view.start && (
-          <div className="px-3 pt-1 pb-3 bg-[var(--panel-2)]">
+          <div className="shrink-0 px-3 pt-1 pb-3 bg-[var(--panel-2)]">
             <PlaybackTimeline
               segments={timelineSegs}
               viewStart={view.start}
@@ -525,6 +681,9 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
               onSeek={seekTo}
               onScrubPreview={setPreviewMs}
               onZoomAt={zoomAt}
+              mode={clipMode ? 'clip' : 'seek'}
+              selection={clipMode ? selection : null}
+              onSelectionChange={setSelection}
             />
           </div>
         )}

--- a/app/src/components/PlaybackConsole.tsx
+++ b/app/src/components/PlaybackConsole.tsx
@@ -75,6 +75,12 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
   const containerRef = useRef<HTMLDivElement>(null)
   // Wall-clock instant (epoch ms) the currently-loaded MediaMTX /get window began at.
   const windowStartRef = useRef<number>(0)
+  // The clip currently loaded into the <video>. Seeks that land inside it are
+  // done natively (instant, from buffer); only crossing into another clip hits
+  // the network. Null until the first clip loads.
+  const loadedClipRef = useRef<{ startMs: number; endMs: number } | null>(null)
+  // Offset (seconds) to seek to once the freshly-loaded clip has metadata.
+  const pendingSeekSecRef = useRef<number | null>(null)
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -163,37 +169,35 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     [base, path]
   )
 
-  /** Load a MediaMTX window starting at wall-clock `ms` and (optionally) play. */
+  /**
+   * Load the WHOLE clip that contains `ms` (or the next clip if `ms` is in a
+   * gap) as one MediaMTX /get window, then seek to the `ms` offset once it has
+   * metadata. Loading the whole clip is what lets subsequent in-clip seeks be
+   * native (buffer) reads instead of a fresh server request each time.
+   */
   const loadFrom = useCallback(
     (ms: number, play: boolean) => {
       const el = videoRef.current
       if (!el || segs.length === 0) return
 
-      const containing = segs.find((s) => ms >= s.startMs && ms < s.endMs)
-      let winStart: number
-      let startIso: string
-      let durationSec: number
-
-      if (containing) {
-        const atStart = Math.abs(ms - containing.startMs) < 500
-        winStart = atStart ? containing.startMs : ms
-        startIso = atStart ? containing.startIso : new Date(ms).toISOString()
-        durationSec = Math.max(1, (containing.endMs - winStart) / 1000 + 0.5)
-      } else {
-        // In a gap → jump to the next available clip.
+      let clip = segs.find((s) => ms >= s.startMs && ms < s.endMs)
+      let seekMs = ms
+      if (!clip) {
+        // In a gap → jump to the next available clip's start.
         const next = segs.find((s) => s.startMs >= ms)
         if (!next) {
           el.pause()
           return
         }
-        winStart = next.startMs
-        startIso = next.startIso
-        durationSec = Math.max(1, next.duration + 0.5)
+        clip = next
+        seekMs = next.startMs
       }
 
-      windowStartRef.current = winStart
-      setCurrentMs(winStart)
-      el.src = buildUrl(startIso, durationSec)
+      windowStartRef.current = clip.startMs
+      loadedClipRef.current = { startMs: clip.startMs, endMs: clip.endMs }
+      pendingSeekSecRef.current = Math.max(0, (seekMs - clip.startMs) / 1000)
+      setCurrentMs(seekMs)
+      el.src = buildUrl(clip.startIso, Math.max(1, clip.duration + 0.5))
       el.load()
       el.playbackRate = SPEEDS[rateIdx]
       el.muted = muted
@@ -217,6 +221,18 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     const onPlay = () => setIsPlaying(true)
     const onPause = () => setIsPlaying(false)
     const onTime = () => setCurrentMs(windowStartRef.current + el.currentTime * 1000)
+    const onLoadedMeta = () => {
+      // Apply the deferred in-clip seek now that the media is seekable.
+      const off = pendingSeekSecRef.current
+      pendingSeekSecRef.current = null
+      if (off != null && off > 0.05) {
+        try {
+          el.currentTime = off
+        } catch {
+          /* not seekable yet — playback still starts at clip head */
+        }
+      }
+    }
     const onWaiting = () => setBuffering(true)
     const onPlaying = () => setBuffering(false)
     const onCanPlay = () => setBuffering(false)
@@ -233,6 +249,7 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     el.addEventListener('play', onPlay)
     el.addEventListener('pause', onPause)
     el.addEventListener('timeupdate', onTime)
+    el.addEventListener('loadedmetadata', onLoadedMeta)
     el.addEventListener('waiting', onWaiting)
     el.addEventListener('playing', onPlaying)
     el.addEventListener('canplay', onCanPlay)
@@ -241,6 +258,7 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
       el.removeEventListener('play', onPlay)
       el.removeEventListener('pause', onPause)
       el.removeEventListener('timeupdate', onTime)
+      el.removeEventListener('loadedmetadata', onLoadedMeta)
       el.removeEventListener('waiting', onWaiting)
       el.removeEventListener('playing', onPlaying)
       el.removeEventListener('canplay', onCanPlay)
@@ -287,7 +305,20 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     else el.pause()
   }
 
-  const seekTo = (ms: number) => loadFrom(ms, isPlaying || true)
+  const seekTo = (ms: number) => {
+    const el = videoRef.current
+    const c = loadedClipRef.current
+    // Target is inside the already-loaded clip → native seek (instant, no
+    // network). Only fall back to a fresh /get when crossing clips or when the
+    // element isn't ready yet.
+    if (el && c && ms >= c.startMs && ms < c.endMs && el.readyState >= 1) {
+      el.currentTime = clamp((ms - c.startMs) / 1000, 0, el.duration || 0)
+      setCurrentMs(ms)
+      if (isPlaying) el.play().catch(() => {})
+    } else {
+      loadFrom(ms, isPlaying)
+    }
+  }
 
   const stepFrame = (dir: 1 | -1) => {
     const el = videoRef.current
@@ -326,6 +357,24 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     const start = clamp(center - span / 2, dayStart, dayEnd - span)
     setView({ start, end: start + span })
   }
+
+  // Continuous wheel zoom, anchored so the time under the cursor stays fixed.
+  const zoomAt = useCallback(
+    (anchorMs: number, factor: number) => {
+      setZoomIdx(-1) // no preset exactly matches a free-form zoom
+      setView((v) => {
+        const span = v.end - v.start
+        const total = dayEnd - dayStart
+        const MIN_SPAN = 10_000 // don't zoom tighter than 10s
+        const newSpan = clamp(span * factor, MIN_SPAN, total)
+        if (newSpan >= total) return { start: dayStart, end: dayEnd }
+        const rel = span > 0 ? (anchorMs - v.start) / span : 0.5
+        const start = clamp(anchorMs - rel * newSpan, dayStart, dayEnd - newSpan)
+        return { start, end: start + newSpan }
+      })
+    },
+    [dayStart, dayEnd]
+  )
 
   const effectiveCurrent = previewMs ?? currentMs
 
@@ -443,6 +492,7 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
               currentTime={effectiveCurrent}
               onSeek={seekTo}
               onScrubPreview={setPreviewMs}
+              onZoomAt={zoomAt}
             />
           </div>
         )}

--- a/app/src/components/PlaybackConsole.tsx
+++ b/app/src/components/PlaybackConsole.tsx
@@ -1,0 +1,472 @@
+/**
+ * Copyright (c) 2026 OpenNVR
+ * This file is part of OpenNVR.
+ *
+ * OpenNVR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenNVR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Play,
+  Pause,
+  SkipBack,
+  SkipForward,
+  Rewind,
+  FastForward,
+  Maximize2,
+  Minimize2,
+  Volume2,
+  VolumeX,
+  Loader2,
+  X,
+  AlertCircle,
+} from 'lucide-react'
+import { apiService } from '../lib/apiService'
+import { PlaybackTimeline, type TimelineSegment } from './PlaybackTimeline'
+
+interface RawSegment {
+  start: string
+  duration: number
+  playback_url: string
+}
+
+interface Seg {
+  startMs: number
+  endMs: number
+  startIso: string
+  duration: number
+}
+
+interface PlaybackConsoleProps {
+  cameraId: number
+  cameraName: string
+  /** YYYY-MM-DD */
+  date: string
+  onClose: () => void
+}
+
+// Zoom presets (visible span in ms) — mirrors the "1 Day / …" control.
+const ZOOMS: { label: string; span: number }[] = [
+  { label: '24h', span: 24 * 3600_000 },
+  { label: '6h', span: 6 * 3600_000 },
+  { label: '1h', span: 3600_000 },
+  { label: '10m', span: 600_000 },
+  { label: '2m', span: 120_000 },
+]
+
+const SPEEDS = [0.5, 1, 2, 4, 8]
+const FRAME_STEP = 1 / 25 // ~1 frame at 25fps
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
+
+export function PlaybackConsole({ cameraId, cameraName, date, onClose }: PlaybackConsoleProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Wall-clock instant (epoch ms) the currently-loaded MediaMTX /get window began at.
+  const windowStartRef = useRef<number>(0)
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [segs, setSegs] = useState<Seg[]>([])
+  const [base, setBase] = useState('')
+  const [path, setPath] = useState('')
+
+  const [dayStart, setDayStart] = useState(0)
+  const [dayEnd, setDayEnd] = useState(0)
+  const [view, setView] = useState<{ start: number; end: number }>({ start: 0, end: 0 })
+  const [zoomIdx, setZoomIdx] = useState(0)
+
+  const [currentMs, setCurrentMs] = useState(0)
+  const [previewMs, setPreviewMs] = useState<number | null>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [rateIdx, setRateIdx] = useState(1) // 1x
+  const [muted, setMuted] = useState(false)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [buffering, setBuffering] = useState(false)
+
+  const timelineSegs: TimelineSegment[] = useMemo(
+    () => segs.map((s) => ({ startMs: s.startMs, endMs: s.endMs })),
+    [segs]
+  )
+
+  // ---- Load the day's segments ---------------------------------------------
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    apiService
+      .getSegments(cameraId, date)
+      .then((res: any) => {
+        if (cancelled) return
+        const raw: RawSegment[] = res.data?.segments || []
+        const parsed: Seg[] = raw
+          .map((r) => {
+            const startMs = Date.parse(r.start)
+            return {
+              startMs,
+              endMs: startMs + (r.duration || 0) * 1000,
+              startIso: r.start,
+              duration: r.duration || 0,
+            }
+          })
+          .filter((s) => Number.isFinite(s.startMs))
+          .sort((a, b) => a.startMs - b.startMs)
+
+        setBase((res.data?.playback_base_url || '').replace(/\/$/, ''))
+        setPath(res.data?.path || '')
+        setSegs(parsed)
+
+        if (parsed.length === 0) {
+          setError('No recordings found for this day.')
+          setLoading(false)
+          return
+        }
+
+        // Day window = local calendar day that contains the first clip.
+        const d = new Date(parsed[0].startMs)
+        d.setHours(0, 0, 0, 0)
+        const ds = d.getTime()
+        const de = ds + 24 * 3600_000
+        setDayStart(ds)
+        setDayEnd(de)
+        setView({ start: ds, end: de })
+        setZoomIdx(0)
+        setCurrentMs(parsed[0].startMs)
+        windowStartRef.current = parsed[0].startMs
+        setLoading(false)
+      })
+      .catch((e: any) => {
+        if (cancelled) return
+        setError(e?.message || 'Failed to load recordings')
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [cameraId, date])
+
+  // ---- Source loading -------------------------------------------------------
+  const buildUrl = useCallback(
+    (startIso: string, durationSec: number) =>
+      `${base}/get?path=${path}&start=${encodeURIComponent(startIso)}&duration=${durationSec}`,
+    [base, path]
+  )
+
+  /** Load a MediaMTX window starting at wall-clock `ms` and (optionally) play. */
+  const loadFrom = useCallback(
+    (ms: number, play: boolean) => {
+      const el = videoRef.current
+      if (!el || segs.length === 0) return
+
+      const containing = segs.find((s) => ms >= s.startMs && ms < s.endMs)
+      let winStart: number
+      let startIso: string
+      let durationSec: number
+
+      if (containing) {
+        const atStart = Math.abs(ms - containing.startMs) < 500
+        winStart = atStart ? containing.startMs : ms
+        startIso = atStart ? containing.startIso : new Date(ms).toISOString()
+        durationSec = Math.max(1, (containing.endMs - winStart) / 1000 + 0.5)
+      } else {
+        // In a gap → jump to the next available clip.
+        const next = segs.find((s) => s.startMs >= ms)
+        if (!next) {
+          el.pause()
+          return
+        }
+        winStart = next.startMs
+        startIso = next.startIso
+        durationSec = Math.max(1, next.duration + 0.5)
+      }
+
+      windowStartRef.current = winStart
+      setCurrentMs(winStart)
+      el.src = buildUrl(startIso, durationSec)
+      el.load()
+      el.playbackRate = SPEEDS[rateIdx]
+      el.muted = muted
+      if (play) el.play().catch(() => {})
+    },
+    [segs, buildUrl, rateIdx, muted]
+  )
+
+  // Start playback once segments are ready.
+  useEffect(() => {
+    if (!loading && segs.length > 0 && videoRef.current && !videoRef.current.src) {
+      loadFrom(segs[0].startMs, true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, segs])
+
+  // ---- Video element events -------------------------------------------------
+  useEffect(() => {
+    const el = videoRef.current
+    if (!el) return
+    const onPlay = () => setIsPlaying(true)
+    const onPause = () => setIsPlaying(false)
+    const onTime = () => setCurrentMs(windowStartRef.current + el.currentTime * 1000)
+    const onWaiting = () => setBuffering(true)
+    const onPlaying = () => setBuffering(false)
+    const onCanPlay = () => setBuffering(false)
+    const onEnded = () => {
+      // Advance to the next clip after the current window (skips the gap).
+      const after = windowStartRef.current + (el.duration || 0) * 1000
+      const next = segs.find((s) => s.startMs >= after - 500)
+      if (next) {
+        loadFrom(next.startMs, true)
+      } else {
+        setIsPlaying(false)
+      }
+    }
+    el.addEventListener('play', onPlay)
+    el.addEventListener('pause', onPause)
+    el.addEventListener('timeupdate', onTime)
+    el.addEventListener('waiting', onWaiting)
+    el.addEventListener('playing', onPlaying)
+    el.addEventListener('canplay', onCanPlay)
+    el.addEventListener('ended', onEnded)
+    return () => {
+      el.removeEventListener('play', onPlay)
+      el.removeEventListener('pause', onPause)
+      el.removeEventListener('timeupdate', onTime)
+      el.removeEventListener('waiting', onWaiting)
+      el.removeEventListener('playing', onPlaying)
+      el.removeEventListener('canplay', onCanPlay)
+      el.removeEventListener('ended', onEnded)
+    }
+  }, [segs, loadFrom])
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      const el = videoRef.current
+      if (el) {
+        el.pause()
+        el.removeAttribute('src')
+        el.load()
+      }
+    }
+  }, [])
+
+  // Fullscreen tracking.
+  useEffect(() => {
+    const onFs = () => setIsFullscreen(!!document.fullscreenElement)
+    document.addEventListener('fullscreenchange', onFs)
+    return () => document.removeEventListener('fullscreenchange', onFs)
+  }, [])
+
+  // Keep the playhead within the visible window while playing (auto-follow).
+  useEffect(() => {
+    if (previewMs != null) return
+    if (currentMs < view.start || currentMs > view.end) {
+      const span = view.end - view.start
+      if (span <= 0) return
+      let start = clamp(currentMs - span / 2, dayStart, dayEnd - span)
+      if (span >= dayEnd - dayStart) start = dayStart
+      setView({ start, end: start + span })
+    }
+  }, [currentMs, previewMs, view.start, view.end, dayStart, dayEnd])
+
+  // ---- Controls -------------------------------------------------------------
+  const togglePlay = () => {
+    const el = videoRef.current
+    if (!el) return
+    if (el.paused) el.play().catch(() => {})
+    else el.pause()
+  }
+
+  const seekTo = (ms: number) => loadFrom(ms, isPlaying || true)
+
+  const stepFrame = (dir: 1 | -1) => {
+    const el = videoRef.current
+    if (!el) return
+    el.pause()
+    el.currentTime = clamp(el.currentTime + dir * FRAME_STEP, 0, el.duration || 0)
+  }
+
+  const changeSpeed = (dir: 1 | -1) => {
+    const next = clamp(rateIdx + dir, 0, SPEEDS.length - 1)
+    setRateIdx(next)
+    if (videoRef.current) videoRef.current.playbackRate = SPEEDS[next]
+  }
+
+  const toggleMute = () => {
+    const el = videoRef.current
+    if (!el) return
+    el.muted = !el.muted
+    setMuted(el.muted)
+  }
+
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) document.exitFullscreen?.()
+    else containerRef.current?.requestFullscreen?.()
+  }
+
+  const applyZoom = (idx: number) => {
+    const span = ZOOMS[idx].span
+    setZoomIdx(idx)
+    const center = previewMs ?? currentMs
+    const total = dayEnd - dayStart
+    if (span >= total) {
+      setView({ start: dayStart, end: dayEnd })
+      return
+    }
+    const start = clamp(center - span / 2, dayStart, dayEnd - span)
+    setView({ start, end: start + span })
+  }
+
+  const effectiveCurrent = previewMs ?? currentMs
+
+  return (
+    <div className="fixed inset-0 bg-black/85 flex items-center justify-center z-50 p-4">
+      <div
+        ref={containerRef}
+        className="bg-[var(--panel)] border border-neutral-700 w-full max-w-5xl flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-neutral-700 bg-[var(--panel-2)]">
+          <div className="flex items-center gap-2 min-w-0">
+            <Play size={16} className="text-[var(--accent)] shrink-0" />
+            <span className="font-medium truncate">{cameraName}</span>
+            <span className="text-xs text-[var(--text-dim)] shrink-0">· {date}</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 hover:bg-[var(--panel)] rounded transition-colors"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Video */}
+        <div className="relative bg-black aspect-video flex items-center justify-center">
+          {error ? (
+            <div className="text-center p-8">
+              <AlertCircle size={48} className="mx-auto mb-3 text-amber-400 opacity-70" />
+              <p className="text-neutral-300 text-sm">{error}</p>
+            </div>
+          ) : (
+            <>
+              <video
+                ref={videoRef}
+                className="w-full h-full object-contain"
+                playsInline
+                crossOrigin="anonymous"
+                onClick={togglePlay}
+              />
+              {(loading || buffering) && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/30 pointer-events-none">
+                  <Loader2 size={40} className="animate-spin text-[var(--accent)]" />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Toolbar */}
+        {!error && (
+          <div className="flex items-center gap-1 px-3 py-2 bg-[var(--panel-2)] border-t border-neutral-700">
+            <IconBtn title="Previous frame" onClick={() => stepFrame(-1)}>
+              <SkipBack size={16} />
+            </IconBtn>
+            <IconBtn title={isPlaying ? 'Pause' : 'Play'} onClick={togglePlay}>
+              {isPlaying ? <Pause size={18} /> : <Play size={18} />}
+            </IconBtn>
+            <IconBtn title="Next frame" onClick={() => stepFrame(1)}>
+              <SkipForward size={16} />
+            </IconBtn>
+
+            <div className="mx-1 flex items-center gap-1">
+              <IconBtn title="Slower" onClick={() => changeSpeed(-1)}>
+                <Rewind size={16} />
+              </IconBtn>
+              <span className="text-xs font-mono w-8 text-center tabular-nums">
+                {SPEEDS[rateIdx]}x
+              </span>
+              <IconBtn title="Faster" onClick={() => changeSpeed(1)}>
+                <FastForward size={16} />
+              </IconBtn>
+            </div>
+
+            <IconBtn title={muted ? 'Unmute' : 'Mute'} onClick={toggleMute}>
+              {muted ? <VolumeX size={16} /> : <Volume2 size={16} />}
+            </IconBtn>
+
+            <div className="flex-1" />
+
+            {/* Zoom control */}
+            <div className="flex items-center rounded overflow-hidden border border-neutral-700">
+              {ZOOMS.map((z, i) => (
+                <button
+                  key={z.label}
+                  onClick={() => applyZoom(i)}
+                  className={`px-2 py-1 text-[11px] font-mono transition-colors ${
+                    i === zoomIdx
+                      ? 'bg-[var(--accent)] text-white'
+                      : 'text-[var(--text-dim)] hover:bg-[var(--panel)]'
+                  }`}
+                >
+                  {z.label}
+                </button>
+              ))}
+            </div>
+
+            <IconBtn
+              title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+              onClick={toggleFullscreen}
+            >
+              {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+            </IconBtn>
+          </div>
+        )}
+
+        {/* Timeline */}
+        {!error && segs.length > 0 && view.end > view.start && (
+          <div className="px-3 pt-1 pb-3 bg-[var(--panel-2)]">
+            <PlaybackTimeline
+              segments={timelineSegs}
+              viewStart={view.start}
+              viewEnd={view.end}
+              currentTime={effectiveCurrent}
+              onSeek={seekTo}
+              onScrubPreview={setPreviewMs}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function IconBtn({
+  title,
+  onClick,
+  children,
+}: {
+  title: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      title={title}
+      onClick={onClick}
+      className="p-1.5 rounded text-[var(--text)] hover:bg-[var(--panel)] transition-colors"
+    >
+      {children}
+    </button>
+  )
+}

--- a/app/src/components/PlaybackTimeline.tsx
+++ b/app/src/components/PlaybackTimeline.tsx
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2026 OpenNVR
+ * This file is part of OpenNVR.
+ *
+ * OpenNVR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenNVR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+export interface TimelineSegment {
+  /** epoch ms */
+  startMs: number
+  /** epoch ms */
+  endMs: number
+}
+
+interface PlaybackTimelineProps {
+  /** Footage blocks (red). Everything else in the view is a grey gap. */
+  segments: TimelineSegment[]
+  /** Visible window (epoch ms). */
+  viewStart: number
+  viewEnd: number
+  /** Playhead wall-clock position (epoch ms). */
+  currentTime: number
+  /** Fired once per interaction (click, or drag-release) with the target ms. */
+  onSeek: (ms: number) => void
+  /** Live preview ms while dragging; null on release / mouse-leave. */
+  onScrubPreview?: (ms: number | null) => void
+  className?: string
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
+
+/** Pick a "nice" tick interval (ms) aiming for ~10 ticks across the span. */
+function pickTickInterval(spanMs: number): number {
+  const candidates = [
+    1, 5, 10, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 21600,
+  ] // seconds
+  const target = spanMs / 1000 / 10
+  for (const c of candidates) {
+    if (c >= target) return c * 1000
+  }
+  return candidates[candidates.length - 1] * 1000
+}
+
+function fmtTick(ms: number, intervalMs: number): string {
+  return new Date(ms).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(intervalMs < 60000 ? { second: '2-digit' } : {}),
+    hour12: false,
+  })
+}
+
+function fmtFull(ms: number): string {
+  return new Date(ms).toLocaleString(undefined, {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+}
+
+export function PlaybackTimeline({
+  segments,
+  viewStart,
+  viewEnd,
+  currentTime,
+  onSeek,
+  onScrubPreview,
+  className = '',
+}: PlaybackTimelineProps) {
+  const trackRef = useRef<HTMLDivElement>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const [hoverMs, setHoverMs] = useState<number | null>(null)
+  const [hoverX, setHoverX] = useState(0)
+
+  const span = Math.max(1, viewEnd - viewStart)
+  const toPct = useCallback(
+    (ms: number) => clamp(((ms - viewStart) / span) * 100, 0, 100),
+    [viewStart, span]
+  )
+
+  const xToMs = useCallback(
+    (clientX: number): number => {
+      const rect = trackRef.current?.getBoundingClientRect()
+      if (!rect) return viewStart
+      const ratio = clamp((clientX - rect.left) / rect.width, 0, 1)
+      return viewStart + ratio * span
+    },
+    [viewStart, span]
+  )
+
+  const inFootage = useCallback(
+    (ms: number) => segments.some((s) => ms >= s.startMs && ms < s.endMs),
+    [segments]
+  )
+
+  /** Snap a click that lands in a gap to the nearest footage edge. */
+  const snap = useCallback(
+    (ms: number): number => {
+      if (inFootage(ms)) return ms
+      let best = ms
+      let bestDist = Infinity
+      for (const s of segments) {
+        for (const edge of [s.startMs, s.endMs - 1]) {
+          const d = Math.abs(edge - ms)
+          if (d < bestDist) {
+            bestDist = d
+            best = edge
+          }
+        }
+      }
+      return best
+    },
+    [segments, inFootage]
+  )
+
+  const blocks = useMemo(
+    () =>
+      segments
+        .filter((s) => s.endMs > viewStart && s.startMs < viewEnd)
+        .map((s) => {
+          const left = toPct(s.startMs)
+          const right = toPct(s.endMs)
+          return { left, width: Math.max(0.2, right - left) }
+        }),
+    [segments, viewStart, viewEnd, toPct]
+  )
+
+  const ticks = useMemo(() => {
+    const interval = pickTickInterval(span)
+    const first = Math.ceil(viewStart / interval) * interval
+    const out: { ms: number; pct: number; label: string }[] = []
+    for (let t = first; t <= viewEnd; t += interval) {
+      out.push({ ms: t, pct: toPct(t), label: fmtTick(t, interval) })
+    }
+    return out
+  }, [span, viewStart, viewEnd, toPct])
+
+  const setHover = (clientX: number) => {
+    const rect = wrapRef.current?.getBoundingClientRect()
+    setHoverX(clientX - (rect?.left ?? 0))
+    setHoverMs(xToMs(clientX))
+  }
+
+  const handleDown = (e: React.MouseEvent) => {
+    setDragging(true)
+    setHover(e.clientX)
+    onScrubPreview?.(snap(xToMs(e.clientX)))
+  }
+  const handleMove = (e: React.MouseEvent) => {
+    setHover(e.clientX)
+    if (dragging) onScrubPreview?.(snap(xToMs(e.clientX)))
+  }
+  const commit = (clientX: number) => {
+    onSeek(snap(xToMs(clientX)))
+    onScrubPreview?.(null)
+  }
+  const handleUp = (e: React.MouseEvent) => {
+    if (dragging) {
+      setDragging(false)
+      commit(e.clientX)
+    }
+  }
+  const handleLeave = () => {
+    setHoverMs(null)
+    if (dragging) {
+      setDragging(false)
+      onScrubPreview?.(null)
+    }
+  }
+
+  const currentPct = toPct(currentTime)
+  const currentVisible = currentTime >= viewStart && currentTime <= viewEnd
+  const hoverInGap = hoverMs != null && !inFootage(hoverMs)
+
+  return (
+    <div ref={wrapRef} className={`relative select-none ${className}`}>
+      {/* Playhead time readout */}
+      <div className="h-5 relative text-[11px] font-mono">
+        {currentVisible && (
+          <span
+            className="absolute -translate-x-1/2 px-1 rounded bg-[var(--accent)] text-white whitespace-nowrap"
+            style={{ left: `${currentPct}%` }}
+          >
+            {fmtFull(currentTime)}
+          </span>
+        )}
+      </div>
+
+      {/* Track */}
+      <div
+        ref={trackRef}
+        className="relative h-9 bg-neutral-800 cursor-pointer overflow-hidden rounded-sm"
+        onMouseDown={handleDown}
+        onMouseMove={handleMove}
+        onMouseUp={handleUp}
+        onMouseLeave={handleLeave}
+      >
+        {/* Footage (red) */}
+        {blocks.map((b, i) => (
+          <div
+            key={i}
+            className="absolute top-0 bottom-0"
+            style={{ left: `${b.left}%`, width: `${b.width}%`, background: '#dc2626' }}
+          />
+        ))}
+
+        {/* Ticks */}
+        {ticks.map((t, i) => (
+          <div
+            key={i}
+            className="absolute top-0 h-2 w-px bg-white/25 pointer-events-none"
+            style={{ left: `${t.pct}%` }}
+          />
+        ))}
+
+        {/* Hover guide */}
+        {hoverMs != null && (
+          <div
+            className="absolute top-0 bottom-0 w-px bg-white/40 pointer-events-none"
+            style={{ left: `${toPct(hoverMs)}%` }}
+          />
+        )}
+
+        {/* Playhead */}
+        {currentVisible && (
+          <div
+            className="absolute top-0 bottom-0 w-0.5 bg-white z-10 pointer-events-none"
+            style={{ left: `${currentPct}%` }}
+          >
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 w-2 h-2 bg-white rotate-45" />
+          </div>
+        )}
+      </div>
+
+      {/* Tick labels */}
+      <div className="relative h-4 text-[10px] text-[var(--text-dim)] font-mono">
+        {ticks.map((t, i) => (
+          <span
+            key={i}
+            className="absolute -translate-x-1/2 whitespace-nowrap"
+            style={{ left: `${t.pct}%` }}
+          >
+            {t.label}
+          </span>
+        ))}
+      </div>
+
+      {/* Hover tooltip */}
+      {hoverMs != null && (
+        <div
+          className="pointer-events-none absolute top-0 z-20 px-1.5 py-0.5 rounded bg-black/85 text-white text-[10px] font-mono whitespace-nowrap"
+          style={{ left: hoverX, transform: 'translate(-50%, -1.2rem)' }}
+        >
+          {fmtFull(hoverMs)}
+          {hoverInGap && <span className="text-neutral-400 ml-1">· no recording</span>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/components/PlaybackTimeline.tsx
+++ b/app/src/components/PlaybackTimeline.tsx
@@ -40,6 +40,12 @@ interface PlaybackTimelineProps {
   /** Wheel zoom: `anchorMs` is the time under the cursor (kept fixed), `factor`
    *  < 1 zooms in (shrinks the visible span), > 1 zooms out. */
   onZoomAt?: (anchorMs: number, factor: number) => void
+  /** 'seek' (default): drag scrubs. 'clip': drag paints an export selection. */
+  mode?: 'seek' | 'clip'
+  /** Current clip selection (epoch ms), shown as a highlighted band. */
+  selection?: { inMs: number; outMs: number } | null
+  /** Fired as the selection is painted (null while empty). */
+  onSelectionChange?: (sel: { inMs: number; outMs: number } | null) => void
   className?: string
 }
 
@@ -85,10 +91,14 @@ export function PlaybackTimeline({
   onSeek,
   onScrubPreview,
   onZoomAt,
+  mode = 'seek',
+  selection,
+  onSelectionChange,
   className = '',
 }: PlaybackTimelineProps) {
   const trackRef = useRef<HTMLDivElement>(null)
   const wrapRef = useRef<HTMLDivElement>(null)
+  const selAnchorRef = useRef<number | null>(null)
   const [dragging, setDragging] = useState(false)
   const [hoverMs, setHoverMs] = useState<number | null>(null)
   const [hoverX, setHoverX] = useState(0)
@@ -181,27 +191,44 @@ export function PlaybackTimeline({
   const handleDown = (e: React.MouseEvent) => {
     setDragging(true)
     setHover(e.clientX)
-    onScrubPreview?.(snap(xToMs(e.clientX)))
+    if (mode === 'clip') {
+      const t = xToMs(e.clientX)
+      selAnchorRef.current = t
+      onSelectionChange?.({ inMs: t, outMs: t })
+    } else {
+      onScrubPreview?.(snap(xToMs(e.clientX)))
+    }
   }
   const handleMove = (e: React.MouseEvent) => {
     setHover(e.clientX)
-    if (dragging) onScrubPreview?.(snap(xToMs(e.clientX)))
-  }
-  const commit = (clientX: number) => {
-    onSeek(snap(xToMs(clientX)))
-    onScrubPreview?.(null)
+    if (!dragging) return
+    if (mode === 'clip' && selAnchorRef.current != null) {
+      const t = xToMs(e.clientX)
+      const a = selAnchorRef.current
+      onSelectionChange?.({ inMs: Math.min(a, t), outMs: Math.max(a, t) })
+    } else if (mode === 'seek') {
+      onScrubPreview?.(snap(xToMs(e.clientX)))
+    }
   }
   const handleUp = (e: React.MouseEvent) => {
-    if (dragging) {
-      setDragging(false)
-      commit(e.clientX)
+    if (!dragging) return
+    setDragging(false)
+    if (mode === 'clip') {
+      const a = selAnchorRef.current
+      selAnchorRef.current = null
+      const t = xToMs(e.clientX)
+      if (a == null || Math.abs(t - a) < 1000) onSelectionChange?.(null) // a click clears
+      else onSelectionChange?.({ inMs: Math.min(a, t), outMs: Math.max(a, t) })
+    } else {
+      onSeek(snap(xToMs(e.clientX)))
+      onScrubPreview?.(null)
     }
   }
   const handleLeave = () => {
     setHoverMs(null)
     if (dragging) {
       setDragging(false)
-      onScrubPreview?.(null)
+      if (mode === 'seek') onScrubPreview?.(null)
     }
   }
 
@@ -226,7 +253,9 @@ export function PlaybackTimeline({
       {/* Track */}
       <div
         ref={trackRef}
-        className="relative h-9 bg-neutral-800 cursor-pointer overflow-hidden rounded-sm"
+        className={`relative h-9 bg-neutral-800 overflow-hidden rounded-sm ${
+          mode === 'clip' ? 'cursor-crosshair' : 'cursor-pointer'
+        }`}
         onMouseDown={handleDown}
         onMouseMove={handleMove}
         onMouseUp={handleUp}
@@ -240,6 +269,17 @@ export function PlaybackTimeline({
             style={{ left: `${b.left}%`, width: `${b.width}%`, background: '#dc2626' }}
           />
         ))}
+
+        {/* Clip selection band */}
+        {selection && selection.outMs > selection.inMs && (
+          <div
+            className="absolute top-0 bottom-0 bg-[var(--accent)]/35 border-x-2 border-[var(--accent)] pointer-events-none"
+            style={{
+              left: `${toPct(selection.inMs)}%`,
+              width: `${toPct(selection.outMs) - toPct(selection.inMs)}%`,
+            }}
+          />
+        )}
 
         {/* Ticks */}
         {ticks.map((t, i) => (

--- a/app/src/components/PlaybackTimeline.tsx
+++ b/app/src/components/PlaybackTimeline.tsx
@@ -16,7 +16,7 @@
  * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 export interface TimelineSegment {
   /** epoch ms */
@@ -37,6 +37,9 @@ interface PlaybackTimelineProps {
   onSeek: (ms: number) => void
   /** Live preview ms while dragging; null on release / mouse-leave. */
   onScrubPreview?: (ms: number | null) => void
+  /** Wheel zoom: `anchorMs` is the time under the cursor (kept fixed), `factor`
+   *  < 1 zooms in (shrinks the visible span), > 1 zooms out. */
+  onZoomAt?: (anchorMs: number, factor: number) => void
   className?: string
 }
 
@@ -81,6 +84,7 @@ export function PlaybackTimeline({
   currentTime,
   onSeek,
   onScrubPreview,
+  onZoomAt,
   className = '',
 }: PlaybackTimelineProps) {
   const trackRef = useRef<HTMLDivElement>(null)
@@ -151,6 +155,22 @@ export function PlaybackTimeline({
     }
     return out
   }, [span, viewStart, viewEnd, toPct])
+
+  // Wheel zoom — native non-passive listener so we can preventDefault the page
+  // scroll. Anchored on the cursor so the time under the pointer stays put.
+  useEffect(() => {
+    const el = trackRef.current
+    if (!el || !onZoomAt) return
+    const handler = (e: WheelEvent) => {
+      e.preventDefault()
+      const rect = el.getBoundingClientRect()
+      const ratio = clamp((e.clientX - rect.left) / rect.width, 0, 1)
+      const anchor = viewStart + ratio * span
+      onZoomAt(anchor, e.deltaY < 0 ? 0.8 : 1.25)
+    }
+    el.addEventListener('wheel', handler, { passive: false })
+    return () => el.removeEventListener('wheel', handler)
+  }, [onZoomAt, viewStart, span])
 
   const setHover = (clientX: number) => {
     const rect = wrapRef.current?.getBoundingClientRect()

--- a/app/src/services/recordingService.ts
+++ b/app/src/services/recordingService.ts
@@ -43,6 +43,10 @@ export const recordingService = {
     return api.get('/api/v1/recordings/playback/url', { params: { path, start, duration } })
   },
   getTodaySegments: (cameraId: number) => api.get(`/api/v1/recordings/today/${cameraId}`),
+  // Raw per-clip segments for a camera on a given day (YYYY-MM-DD). Powers the
+  // DVR playback timeline (footage/gap blocks + wall-clock seeking).
+  getSegments: (cameraId: number, date?: string) =>
+    api.get(`/api/v1/recordings/segments/${cameraId}`, { params: date ? { date } : {} }),
 
   // HLS VOD
   createHlsPlaybackSession: (params: { camera_id: number; start: string; end: string }) => {

--- a/app/src/views/Cameras.tsx
+++ b/app/src/views/Cameras.tsx
@@ -549,47 +549,9 @@ export function Cameras() {
                       )}
                       {c.mediamtx_provisioned === true && (
                         <>
-                          {canManageCameras && (
-                            <button
-                              className={`p-1.5 border rounded transition-colors ${c.recording_enabled ? 'border-red-600 bg-red-900/20 text-red-400 hover:bg-red-900/40' : 'border-neutral-600 bg-neutral-800 text-neutral-400 hover:bg-neutral-700'}`}
-                              onClick={async () => {
-                                const targetState = !c.recording_enabled
-                                try {
-                                  // Optimistic update
-                                  setCameras(prev => prev.map(cam => cam.id === c.id ? { ...cam, recording_enabled: targetState } : cam))
-                                  
-                                  const { data } = await apiService.toggleCameraRecording(c.id, targetState)
-                                  if (data.status === 'ok' || data.recording_enabled !== undefined) {
-                                    if (targetState) {
-                                      showSuccess(`Recording enabled for ${c.name}`)
-                                    } else {
-                                      showError(`Recording disabled for ${c.name}`)
-                                    }
-                                    await refreshCameras()
-                                  } else {
-                                    // Revert
-                                    setCameras(prev => prev.map(cam => cam.id === c.id ? { ...cam, recording_enabled: !targetState } : cam))
-                                    showError('Failed to toggle recording')
-                                  }
-                                } catch (e: any) {
-                                  // Revert
-                                  setCameras(prev => prev.map(cam => cam.id === c.id ? { ...cam, recording_enabled: !targetState } : cam))
-                                  showError(e?.data?.detail || e?.message || 'Failed to toggle recording')
-                                }
-                              }}
-                              title={c.recording_enabled ? "Stop Recording" : "Start Recording"}
-                            >
-                              {c.recording_enabled ? (
-                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                                  <rect x="6" y="6" width="12" height="12" rx="1" />
-                                </svg>
-                              ) : (
-                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                                  <circle cx="12" cy="12" r="8" />
-                                </svg>
-                              )}
-                            </button>
-                          )}
+                          {/* Recording is automatic on an NVR — no manual
+                              start/stop control. The Recording column shows its
+                              live status. */}
                           <button
                             className="p-1.5 border border-blue-600 bg-blue-900/20 text-blue-400 hover:bg-blue-900/40 transition-colors rounded"
                             onClick={() => navigate(`/live?camera=${c.id}`)}

--- a/app/src/views/LiveView.tsx
+++ b/app/src/views/LiveView.tsx
@@ -1199,7 +1199,7 @@ export function AddCameraDialog({
       // Auto-provision to MediaMTX
       if (newCameraId) {
         try {
-          await apiService.provisionCameraMediaMTX(newCameraId, { enable_recording: false })
+          await apiService.provisionCameraMediaMTX(newCameraId, { enable_recording: true })
         } catch (e) {
           console.warn('Auto-provision failed, camera added but not streaming:', e)
         }
@@ -1241,7 +1241,7 @@ export function AddCameraDialog({
       // Auto-provision to MediaMTX
       if (newCameraId) {
         try {
-          await apiService.provisionCameraMediaMTX(newCameraId, { enable_recording: false })
+          await apiService.provisionCameraMediaMTX(newCameraId, { enable_recording: true })
         } catch (e) {
           console.warn('Auto-provision failed, camera added but not streaming:', e)
         }

--- a/app/src/views/PlaybackView.tsx
+++ b/app/src/views/PlaybackView.tsx
@@ -37,6 +37,7 @@ import {
 } from 'lucide-react'
 import { useSnackbar } from '../components/Snackbar'
 import { VideoPlayer } from '../components/VideoPlayer/VideoPlayer'
+import { PlaybackConsole } from '../components/PlaybackConsole'
 
 // Daily recording - one entry per camera per day
 interface DailyRecording {
@@ -108,6 +109,8 @@ export function PlaybackView() {
   const [hlsSessionId, setHlsSessionId] = useState<string | null>(null)
   const [playbackMode, setPlaybackMode] = useState<'hls' | 'mp4'>('hls')
   const [playingRecording, setPlayingRecording] = useState<{ camera: string; date: string; duration: number; cameraId: number; firstStart: string } | null>(null)
+  // DVR playback console target (preferred path when MediaMTX is available).
+  const [consoleTarget, setConsoleTarget] = useState<{ cameraId: number; cameraName: string; date: string } | null>(null)
   const [playbackError, setPlaybackError] = useState<string | null>(null)
   const [playbackLoading, setPlaybackLoading] = useState(false)
   const [cloudUploadStatus, setCloudUploadStatus] = useState<CloudUploadStatus | null>(null)
@@ -249,51 +252,16 @@ export function PlaybackView() {
       setShowPlayer(true)
       return
     }
-    
-    setPlaybackError(null)
-    setPlaybackLoading(true)
-    setPlaybackMode('hls')
-    setPlayingRecording({
-      camera: camera.camera_name,
-      date: recording.date,
-      duration: recording.total_duration,
+
+    // MediaMTX is available → open the full DVR playback console (timeline,
+    // scrubbing, per-clip seeking, gap-aware auto-advance). The console fetches
+    // the day's raw segments itself.
+    setConsoleTarget({
       cameraId: camera.camera_id,
-      firstStart: recording.first_start,
+      cameraName: camera.camera_name,
+      date: recording.date,
     })
     setShowPlayer(true)
-    
-    try {
-      // Calculate end time from first_start + total_duration
-      const startDate = new Date(recording.first_start)
-      const endDate = new Date(startDate.getTime() + (recording.total_duration * 1000))
-      
-      // Request HLS session from backend
-      const response = await apiService.createHlsPlaybackSession({
-        camera_id: camera.camera_id,
-        start: recording.first_start,
-        end: endDate.toISOString(),
-      })
-      
-      if (response.data && response.data.manifest_url) {
-        const session = response.data as HlsPlaybackSession
-        setHlsSessionId(session.session_id)
-        setHlsPlaybackUrl(session.manifest_url)
-        setPlaybackUrl(recording.playback_url) // Keep MP4 URL for fallback
-        console.log('[Playback] HLS session created:', session.session_id)
-      } else {
-        // Fallback to MP4 if HLS session fails
-        console.warn('[Playback] HLS session creation returned empty, falling back to MP4')
-        setPlaybackMode('mp4')
-        setPlaybackUrl(recording.playback_url)
-      }
-    } catch (err: any) {
-      console.warn('[Playback] HLS session creation failed, falling back to MP4:', err?.message)
-      // Fallback to direct MP4 URL
-      setPlaybackMode('mp4')
-      setPlaybackUrl(recording.playback_url)
-    } finally {
-      setPlaybackLoading(false)
-    }
   }
 
   const uploadRecordingDay = async (camera: CameraWithRecordings, recording: DailyRecording) => {
@@ -351,6 +319,7 @@ export function PlaybackView() {
     setHlsPlaybackUrl(null)
     setHlsSessionId(null)
     setPlayingRecording(null)
+    setConsoleTarget(null)
     setPlaybackMode('hls')
     if (videoRef.current) {
       videoRef.current.pause()
@@ -593,8 +562,18 @@ export function PlaybackView() {
         )}
       </div>
 
-      {/* Video Player Modal */}
-      {showPlayer && (playbackUrl || hlsPlaybackUrl || playbackError) && (
+      {/* DVR Playback Console (preferred — MediaMTX available) */}
+      {showPlayer && consoleTarget && (
+        <PlaybackConsole
+          cameraId={consoleTarget.cameraId}
+          cameraName={consoleTarget.cameraName}
+          date={consoleTarget.date}
+          onClose={closePlayer}
+        />
+      )}
+
+      {/* Video Player Modal (fallback — MediaMTX offline / error) */}
+      {showPlayer && !consoleTarget && (playbackUrl || hlsPlaybackUrl || playbackError) && (
         <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
           <div className="bg-[var(--panel)] border border-neutral-700 w-full max-w-5xl">
             {/* Header */}

--- a/app/src/views/settings/CameraConfigManager.tsx
+++ b/app/src/views/settings/CameraConfigManager.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { apiService } from '../../lib/apiService'
+import { useSnackbar } from '../../components/Snackbar'
 
 type Camera = {
   id: number
@@ -43,9 +44,11 @@ type CameraConfig = {
 
 export function CameraConfigManager() {
   const navigate = useNavigate()
+  const { showError } = useSnackbar()
   const [cameras, setCameras] = useState<Camera[]>([])
   const [selectedCamId, setSelectedCamId] = useState<number | ''>('')
-  const [cfg, setCfg] = useState<Partial<CameraConfig>>({ stream_protocol: 'rtsp', recording_enabled: false })
+  // Recording is mandatory on an NVR — always on, never operator-toggled.
+  const [cfg, setCfg] = useState<Partial<CameraConfig>>({ stream_protocol: 'rtsp', recording_enabled: true })
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
@@ -83,17 +86,18 @@ export function CameraConfigManager() {
       if (!data.source_url && selectedCamera?.rtsp_url) {
         data.source_url = selectedCamera.rtsp_url
       }
-      
-      setCfg(data)
+
+      // Recording is always on for an NVR — never surface it as off.
+      setCfg({ ...data, recording_enabled: true })
     } catch (e: any) {
       if (e?.status === 404) {
         // config not found: reset to defaults but keep camera_id
         // Auto-populate source URL if camera has RTSP URL
         const selectedCamera = cameras.find(c => c.id === camId)
-        setCfg({ 
-          camera_id: camId, 
-          stream_protocol: 'rtsp', 
-          recording_enabled: false,
+        setCfg({
+          camera_id: camId,
+          stream_protocol: 'rtsp',
+          recording_enabled: true,
           source_url: selectedCamera?.rtsp_url || null
         })
       } else {
@@ -120,7 +124,7 @@ export function CameraConfigManager() {
         await apiService.updateCameraConfig(selectedCamId, {
           stream_protocol: cfg.stream_protocol,
           source_url: cfg.source_url || null,
-          recording_enabled: !!cfg.recording_enabled,
+          recording_enabled: true, // NVR: recording is mandatory, never disabled here
           recording_path: cfg.recording_path || null,
           webrtc_publisher: !!cfg.webrtc_publisher,
           rtmp_publisher: !!cfg.rtmp_publisher,
@@ -134,7 +138,7 @@ export function CameraConfigManager() {
           camera_id: selectedCamId,
           stream_protocol: (cfg.stream_protocol as any) || 'rtsp',
           source_url: cfg.source_url || null,
-          recording_enabled: !!cfg.recording_enabled,
+          recording_enabled: true, // NVR: recording is mandatory, never disabled here
           recording_path: cfg.recording_path || null,
           webrtc_publisher: !!cfg.webrtc_publisher,
           rtmp_publisher: !!cfg.rtmp_publisher,
@@ -259,11 +263,16 @@ export function CameraConfigManager() {
                 <h4 className="text-[var(--text-dim)] font-medium mb-2">Recording Settings</h4>
                 <div className="grid grid-cols-2 gap-3">
                   <label className="flex items-center gap-2">
-                    <input 
-                      type="checkbox" 
-                      className="accent-[var(--accent)]" 
-                      checked={!!cfg.recording_enabled} 
-                      onChange={(e) => setCfg({ ...cfg, recording_enabled: e.target.checked })} 
+                    <input
+                      type="checkbox"
+                      className="accent-[var(--accent)]"
+                      checked={true}
+                      onChange={(e) => {
+                        // NVR: recording can't be turned off from the UI.
+                        if (!e.target.checked) {
+                          showError('Restricted action. Contact support.')
+                        }
+                      }}
                     />
                     <span>Enable Recording</span>
                   </label>

--- a/app/src/views/settings/CamerasManager.tsx
+++ b/app/src/views/settings/CamerasManager.tsx
@@ -77,7 +77,7 @@ export function CamerasManager() {
   const [showProvisionDialog, setShowProvisionDialog] = useState(false)
   const [provisioningCamera, setProvisioningCamera] = useState<Camera | null>(null)
   const [provisionConfig, setProvisionConfig] = useState({
-    enable_recording: false,
+    enable_recording: true, // NVR: recording is mandatory
     rtsp_transport: 'tcp',
     recording_path: ''
   })
@@ -311,7 +311,7 @@ export function CamerasManager() {
   const openProvisionDialog = (camera: Camera) => {
     setProvisioningCamera(camera)
     setProvisionConfig({
-      enable_recording: false,
+      enable_recording: true, // NVR: recording is mandatory
       rtsp_transport: 'tcp',
       recording_path: ''
     })
@@ -729,8 +729,11 @@ export function CamerasManager() {
                   <input
                     type="checkbox"
                     className="accent-[var(--accent)]"
-                    checked={provisionConfig.enable_recording}
-                    onChange={(e) => setProvisionConfig(prev => ({ ...prev, enable_recording: e.target.checked }))}
+                    checked={true}
+                    onChange={(e) => {
+                      // NVR: recording is mandatory and can't be turned off.
+                      if (!e.target.checked) showError('Restricted action. Contact support.')
+                    }}
                   />
                   Enable Recording
                 </label>

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -1042,7 +1042,14 @@ def _update_camera_recording_config(db: Session, camera_id: int, enable: bool):
     db.commit()
 
 
-@router.post("/{camera_id}/toggle-recording")
+# DISABLED — this is a Network Video RECORDER: recording is automatic and must
+# not be switchable off by anyone, including via the API. The route is
+# intentionally commented out so a direct `curl` cannot enable/disable
+# recording. Recording is turned on once at camera-configure time (see
+# CameraService, enable_recording=True). The handler is kept (not deleted) so
+# the behaviour can be restored by re-enabling the decorator if the product
+# decision ever changes.
+# @router.post("/{camera_id}/toggle-recording")
 async def toggle_camera_recording(
     camera_id: int,
     enable: bool,
@@ -1050,7 +1057,7 @@ async def toggle_camera_recording(
     current_user: User = Depends(get_current_active_user),
     request: Request = None,
 ):
-    """Toggle recording for a camera."""
+    """Enable/disable recording for a camera. (Route disabled — see note above.)"""
     # Check permissions
     if not CameraService.user_has_permission(
         db, camera_id, current_user.id, require_manage=True

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -888,8 +888,17 @@ async def provision_camera_mediamtx(
     current_user: User = Depends(get_current_active_user),
     request: Request = None,
 ):
-    """Manually provision camera in MediaMTX with optional recording configuration."""
+    """Manually provision a camera in MediaMTX.
+
+    NVR policy: recording is mandatory, so ``enable_recording`` is forced on here
+    regardless of the query param — a `curl` with ``?enable_recording=false``
+    still provisions with recording enabled. Enforcement also lives at the
+    service choke point (push_rtsp_stream); this keeps the response/logs honest.
+    """
     from services.mediamtx_admin_service import MediaMtxAdminService
+
+    # Recording cannot be opted out of on an NVR. See docstring.
+    enable_recording = True
 
     _log_provision_start(
         current_user.id,

--- a/server/routers/mediamtx_admin.py
+++ b/server/routers/mediamtx_admin.py
@@ -174,7 +174,14 @@ async def push_rtsp_stream(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_superuser),
 ):
-    """Push RTSP stream to MediaMTX."""
+    """Push RTSP stream to MediaMTX.
+
+    NVR policy: recording is mandatory, so ``enable_recording`` is forced on
+    here regardless of the query param — a `curl` cannot provision a camera
+    without recording. Enforced at the HTTP entry point (not in the shared
+    service, which stays policy-neutral and DB-free for unit tests).
+    """
+    enable_recording = True  # NVR: recording can't be opted out of
     cam = db.query(Camera).filter(Camera.id == camera_id).first()
     if not cam:
         raise HTTPException(status_code=404, detail="Camera not found")

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -485,13 +485,18 @@ async def update_retention(
 # =============================================================================
 
 
-@router.post("/start/{camera_id}")
+# DISABLED — recording is automatic on this NVR and cannot be started/stopped
+# on demand, including via the API. Route intentionally commented out so a
+# direct `curl` cannot control recording. Recording is enabled at camera-
+# configure time (see CameraService). Re-enable the decorator only if the
+# product decision changes. See also cameras.toggle_camera_recording.
+# @router.post("/start/{camera_id}")
 async def start_recording(
     camera_id: int,
     db: Session = Depends(get_db),
     current_user=Depends(get_current_superuser),
 ):
-    """Start recording for a camera via MediaMTX."""
+    """Start recording for a camera via MediaMTX. (Route disabled — see above.)"""
     try:
         result = await MediaMtxAdminService.enable_recording(camera_id)
         recording_logger.info(
@@ -503,13 +508,16 @@ async def start_recording(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/stop/{camera_id}")
+# DISABLED — recording is automatic and cannot be stopped on demand, including
+# via the API. Route intentionally commented out so a direct `curl` cannot stop
+# recording. Re-enable the decorator only if the product decision changes.
+# @router.post("/stop/{camera_id}")
 async def stop_recording(
     camera_id: int,
     db: Session = Depends(get_db),
     current_user=Depends(get_current_superuser),
 ):
-    """Stop recording for a camera via MediaMTX."""
+    """Stop recording for a camera via MediaMTX. (Route disabled — see above.)"""
     try:
         result = await MediaMtxAdminService.disable_recording(camera_id)
         recording_logger.info(

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -1105,6 +1105,112 @@ async def get_today_segments(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/segments/{camera_id}")
+async def get_day_segments(
+    camera_id: int,
+    date: str | None = Query(
+        default=None, description="Day in YYYY-MM-DD (UTC). Defaults to today."
+    ),
+    request: Request = None,
+    db: Session = Depends(get_db),
+):
+    """
+    Get the raw per-clip recording segments for a camera on a given day.
+
+    Unlike ``/list`` (which aggregates a whole day into one entry), this returns
+    every continuous MediaMTX recording as its own segment with an absolute
+    ``start``, ``duration`` and a browser-reachable ``playback_url``. The DVR
+    playback timeline uses this to draw footage/gap blocks and to seek to any
+    wall-clock instant via ``playback_base_url``/``path``.
+    """
+    from datetime import datetime
+    from urllib.parse import quote
+
+    user_obj = await _authenticate_request(request, db)
+    if not user_obj:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    camera = (
+        db.query(Camera)
+        .filter(Camera.id == camera_id, Camera.is_active == True)
+        .first()
+    )
+    if not camera:
+        raise HTTPException(status_code=404, detail="Camera not found")
+
+    # Default to today (UTC) — same basis MediaMTX labels its segment starts on.
+    target_date = date or datetime.now(UTC).strftime("%Y-%m-%d")
+
+    path = _build_stream_name(
+        settings.mediamtx_stream_prefix, camera.id, camera.ip_address
+    )
+
+    # The LIST call stays internal; every URL handed to the browser uses the
+    # external fallback chain (matches the other playback routes).
+    browser_playback_base = (
+        settings.mediamtx_external_playback_url
+        or settings.mediamtx_playback_url
+        or "http://127.0.0.1:9996"
+    ).rstrip("/")
+
+    empty = {
+        "segments": [],
+        "camera_id": camera_id,
+        "camera_name": camera.name or f"Camera {camera_id}",
+        "path": path,
+        "date": target_date,
+        "total_duration": 0,
+        "segment_count": 0,
+        "playback_base_url": browser_playback_base,
+    }
+
+    try:
+        url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
+        response = http_client.get(url, timeout=10)
+        if response.status_code != 200:
+            return empty
+
+        all_segments = response.json() or []
+        day_segments = []
+        for seg in all_segments:
+            start_str = seg.get("start", "")
+            if not start_str:
+                continue
+            try:
+                dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+            except Exception:
+                continue
+            # Match the UTC date basis used by /list's day grouping so the
+            # timeline shows exactly the clips behind the card the user clicked.
+            if dt.strftime("%Y-%m-%d") != target_date:
+                continue
+
+            duration = seg.get("duration", 0)
+            encoded_start = quote(start_str, safe="")
+            day_segments.append(
+                {
+                    "start": start_str,
+                    "duration": duration,
+                    "playback_url": (
+                        f"{browser_playback_base}/get?path={path}"
+                        f"&start={encoded_start}&duration={duration}"
+                    ),
+                }
+            )
+
+        day_segments.sort(key=lambda s: s.get("start", ""))
+        result = dict(empty)
+        result["segments"] = day_segments
+        result["total_duration"] = sum(s.get("duration", 0) for s in day_segments)
+        result["segment_count"] = len(day_segments)
+        return result
+    except Exception as e:
+        recording_logger.error(
+            f"Failed to get day segments for camera {camera_id}: {e}"
+        )
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 # =============================================================================
 # Date-Grouped Recordings - User-friendly aggregation
 # =============================================================================

--- a/server/services/camera_service.py
+++ b/server/services/camera_service.py
@@ -107,13 +107,15 @@ class CameraService:
             # Auto-provision if RTSP URL is present
             if db_camera.rtsp_url:
                 try:
-                    # Default settings for auto-provisioning
-                    # Recording disabled by default, TCP transport, 5 min segments
+                    # Default settings for auto-provisioning.
+                    # This is a Network Video RECORDER: recording is always on by
+                    # default the moment a camera is configured — it is not an
+                    # operator opt-in. TCP transport, configured segment length.
                     provision_result = await MediaMtxAdminService.push_rtsp_stream(
                         camera_id=db_camera.id,
                         camera_ip=db_camera.ip_address,
                         rtsp_url=db_camera.rtsp_url,
-                        enable_recording=False,
+                        enable_recording=True,
                         rtsp_transport="tcp",
                         recording_segment_seconds=settings.recording_segment_seconds,
                     )
@@ -155,7 +157,7 @@ class CameraService:
                                 camera_id=db_camera.id,
                                 stream_protocol="rtsp",
                                 source_url=db_camera.rtsp_url,
-                                recording_enabled=False,
+                                recording_enabled=True,
                                 rtsp_transport="tcp",
                                 recording_segment_seconds=settings.recording_segment_seconds,
                                 last_provisioned_at=func.now(),

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -663,18 +663,17 @@ class MediaMtxAdminService:
         recording_path: str | None = None,
         transport_security: str | None = None,
     ) -> dict[str, Any]:
-        """Push RTSP stream to MediaMTX with recording enabled.
+        """Push RTSP stream to MediaMTX and optionally enable recording.
 
         ``transport_security`` is threaded through to ``provision_path``, where
         the enforcement gate lives (this is one of its four callers). See V-003.
 
-        NVR policy: recording is MANDATORY. This is the single choke point every
-        camera-provisioning path funnels through, so ``enable_recording`` is
-        forced on here regardless of what any caller (UI, API, or ``curl``)
-        passes — there is no supported way to provision a camera without
-        recording. The parameter is kept for signature compatibility only.
+        NVR policy note: recording is mandatory, but that is enforced at the
+        HTTP entry points (the provisioning routers) rather than here — this
+        service stays policy-neutral so unit tests can exercise it without a DB,
+        and so ``enable_recording`` keeps meaning what it says. Callers that
+        provision a real camera (routers, CameraService) pass True.
         """
-        enable_recording = True
         name = _build_stream_name(settings.mediamtx_stream_prefix, camera_id, camera_ip)
 
         # First provision the path with RTSP source

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -663,11 +663,18 @@ class MediaMtxAdminService:
         recording_path: str | None = None,
         transport_security: str | None = None,
     ) -> dict[str, Any]:
-        """Push RTSP stream to MediaMTX and optionally enable recording.
+        """Push RTSP stream to MediaMTX with recording enabled.
 
         ``transport_security`` is threaded through to ``provision_path``, where
         the enforcement gate lives (this is one of its four callers). See V-003.
+
+        NVR policy: recording is MANDATORY. This is the single choke point every
+        camera-provisioning path funnels through, so ``enable_recording`` is
+        forced on here regardless of what any caller (UI, API, or ``curl``)
+        passes — there is no supported way to provision a camera without
+        recording. The parameter is kept for signature compatibility only.
         """
+        enable_recording = True
         name = _build_stream_name(settings.mediamtx_stream_prefix, camera_id, camera_ip)
 
         # First provision the path with RTSP source


### PR DESCRIPTION
DVR-style recording playback + mandatory recording
Replaces the broken day-level recording playback with a proper DVR timeline console, and enforces that this is a recorder — recording is always on.

Commits

=============================================

a65c075 — fully functional DVR style playback

Issue: a day's recording was collapsed into one entry that truncated playback at the first gap (UI showed 3m, only ~34s played).
Did: built a DVR timeline console (red footage / grey gaps, scrub + jump-to) backed by a new per-clip segments API.

=========================================

1e6fdd0 — per-clip seeking, zoom, segments API

Issue: playback couldn't move across the day's discontinuous clips and had no way to zoom the timeline.
Did: per-clip seeking with gap-aware auto-advance, plus wheel + preset (24h→2m) timeline zoom.

=====================================

da6a5be — instant per-clip byte-range HLS seeking

Issue: MediaMTX /get is non-seekable (Accept-Ranges: none), so seeking was slow/broken.
Did: play each clip through a per-clip byte-range HLS session (hls.js) for instant back/forth seeking.

======================================

2652cc1 — DVR console polish + mandatory recording

Issue: recording could be stopped (UI + API) and wasn't automatic — wrong for an NVR; playback also lacked live-follow and export.
Did: auto-record on camera configure, locked all recording toggles (UI + disabled start/stop/toggle API routes), added live-follow, clip export, 0.25–16× speed, and a fullscreen fix.