### PR TITLE
withhold only the last minute of a still-recording file, not the whol…

### DIFF
--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -61,6 +61,27 @@ from services.stream_service import _build_stream_name
 
 router = APIRouter(prefix="/recordings", tags=["recordings"])
 
+# How far behind "now" the playable edge of a still-recording file sits. Only the
+# unfinished tail is withheld: MediaMTX flushes fragments continuously, so
+# footage older than this is complete and plays as ordinary VOD. One minute is a
+# deliberately generous margin over the sub-second write cadence — it costs the
+# viewer nothing noticeable and leaves no chance of serving a half-written tail.
+LIVE_EDGE_LAG_SECONDS = 60
+
+
+def _live_edge_iso(
+    file_start: datetime, now: datetime, lag_seconds: int = LIVE_EDGE_LAG_SECONDS
+) -> str:
+    """The instant from which footage is treated as LIVE (not yet playable).
+
+    ``lag_seconds`` behind ``now``, but never earlier than ``file_start`` — a
+    recording that just began is live in its entirety. Both arguments are naive
+    server-local wall clock, the same basis MediaMTX names its files on; the
+    ``Z`` suffix matches what the rest of this router emits.
+    """
+    edge = max(file_start, now - timedelta(seconds=lag_seconds))
+    return edge.isoformat() + "Z"
+
 
 def _parse_byte_range(range_header: str | None, file_size: int) -> tuple[int, int] | None:
     """Parse a single HTTP ``Range: bytes=start-end`` header.
@@ -953,7 +974,10 @@ async def get_browser_playable_recording(
     if not session or not session.file_path:
         raise HTTPException(status_code=404, detail="Session not found or expired")
 
-    index = await get_remux_index(session.file_path)
+    # Prefer the snapshot frozen when the session was created: a still-recording
+    # file grows, and re-indexing mid-playback would move every byte offset under
+    # the player. Falling back to a fresh index keeps older sessions working.
+    index = session.remux_index or await get_remux_index(session.file_path)
     if index is None:
         raise HTTPException(
             status_code=500, detail="Could not prepare this recording for playback"
@@ -1232,10 +1256,13 @@ async def get_day_segments(
         or "http://127.0.0.1:9996"
     ).rstrip("/")
 
-    # Live edge: the start instant of the newest on-disk file that is STILL
-    # BEING WRITTEN. VOD playback of a growing file is unreliable (its bytes
-    # shift under the player), so the UI renders everything from this instant
-    # on as LIVE and routes the user to Live View instead of a VOD session.
+    # Live edge: the instant after which footage is NOT yet safely playable.
+    # Only the unfinished tail of a still-being-written file qualifies — the
+    # footage already flushed to it plays fine — so the edge sits
+    # LIVE_EDGE_LAG_SECONDS behind now rather than at the file's start. Anything
+    # older is served as normal VOD; the UI paints the remainder as LIVE and
+    # sends the user to Live View for it. Clamped to the file start, so a file
+    # only seconds old is entirely live.
     live_edge_start = None
     try:
         from services.hls_playback_service import HlsPlaybackService
@@ -1247,8 +1274,8 @@ async def get_day_segments(
         if resolved is not None:
             live_path, file_start = resolved
             if now.timestamp() - live_path.stat().st_mtime < 60:
-                live_edge_start = (
-                    file_start.replace(tzinfo=None).isoformat() + "Z"
+                live_edge_start = _live_edge_iso(
+                    file_start.replace(tzinfo=None), datetime.now()
                 )
     except Exception:
         live_edge_start = None

--- a/server/services/hevc_remux_service.py
+++ b/server/services/hevc_remux_service.py
@@ -87,7 +87,14 @@ def _read_box_header(f: BinaryIO, pos: int) -> tuple[bytes, int, int] | None:
 
 
 def _iter_top_level(f: BinaryIO):
-    """Yield (type, box_start, header_size, box_size) for each top-level box."""
+    """Yield (type, box_start, header_size, box_size) for each top-level box.
+
+    A box that runs past EOF is NOT yielded: while MediaMTX is still writing a
+    recording, the final fragment is half-flushed (its header already claims a
+    size the file doesn't hold yet). Indexing it would map samples past the end
+    of the file and truncate playback, so the scan stops at the last COMPLETE
+    box — which is exactly the "everything finished so far" boundary.
+    """
     size_total = os.fstat(f.fileno()).st_size
     pos = 0
     while pos + 8 <= size_total:
@@ -95,6 +102,8 @@ def _iter_top_level(f: BinaryIO):
         if info is None:
             break
         typ, hdr, size = info
+        if pos + size > size_total:
+            break  # still being written — treat as not there yet
         yield typ, pos, hdr, size
         pos += size
 
@@ -282,12 +291,21 @@ def build_remux_index(src_path: str | Path) -> RemuxIndex:
         sample_durs: list[int] = []
         sync_samples: list[int] = []  # 1-based indices
         runs: list[tuple[int, int]] = []  # (file_offset, run_length) video-only
-        sample_no = 0
+        file_size = os.fstat(f.fileno()).st_size
         for typ, pos, hdr, size in _iter_top_level(f):
             if typ != b"moof":
                 continue
             f.seek(pos)
             moof = f.read(size)
+            # Buffer this fragment and commit it only once its sample data is
+            # verified present. A moof is written before its mdat, so a
+            # still-recording file ends with a COMPLETE header describing bytes
+            # that have not landed yet; committing those would map samples past
+            # EOF and truncate playback mid-stream.
+            frag_sizes: list[int] = []
+            frag_durs: list[int] = []
+            frag_sync: list[int] = []
+            frag_runs: list[tuple[int, int]] = []
             for tro, trh, trs in _find_all(moof, hdr, size, b"traf"):
                 tfhd = _find(moof, tro + trh, tro + trs, (b"tfhd",))
                 to2, th2, _ts2 = tfhd
@@ -344,14 +362,24 @@ def build_remux_index(src_path: str | Path) -> RemuxIndex:
                         q += 4
                     if idx == 0 and first_flags is not None:
                         sfl = first_flags
-                    sample_no += 1
-                    sample_sizes.append(ssz)
-                    sample_durs.append(sdur)
+                    frag_sizes.append(ssz)
+                    frag_durs.append(sdur)
                     if (sfl & 0x10000) == 0:  # sync (not non-sync)
-                        sync_samples.append(sample_no)
+                        # 1-based index once this fragment is committed
+                        frag_sync.append(len(sample_sizes) + len(frag_sizes))
                     run_len += ssz
                 if run_len:
-                    runs.append((run_start, run_len))
+                    frag_runs.append((run_start, run_len))
+
+            # Commit the fragment only if every byte it describes is on disk.
+            # Otherwise the recording is still being written here: stop, and the
+            # index covers exactly the footage that has finished.
+            if any(rs + rl > file_size for rs, rl in frag_runs):
+                break
+            sample_sizes.extend(frag_sizes)
+            sample_durs.extend(frag_durs)
+            sync_samples.extend(frag_sync)
+            runs.extend(frag_runs)
 
         if not sample_sizes:
             raise ValueError("no video samples")

--- a/server/services/hls_playback_service.py
+++ b/server/services/hls_playback_service.py
@@ -87,6 +87,13 @@ class PlaybackSession:
     # timeline by this to map wall-clock time <-> video time (and to seek
     # natively across the whole file without re-loading).
     file_offset_seconds: float = 0.0
+    # Frozen H.265 remux recipe for this session (see hevc_remux_service).
+    # Pinned at session creation ON PURPOSE: a still-recording file grows, and
+    # re-indexing mid-playback would move every byte offset under the player —
+    # the browser would then stitch together two different versions of the same
+    # URL and stall. A session therefore serves one consistent snapshot; picking
+    # up newly finished footage happens when the client starts a new session.
+    remux_index: Any = None
 
 
 class HlsPlaybackService:
@@ -405,6 +412,23 @@ class HlsPlaybackService:
             session.video_codec = probe_video_codec(path)
         except Exception:
             session.video_codec = None
+
+        # For H.265, freeze the remux recipe NOW (see PlaybackSession.remux_index):
+        # the file may still be growing, and re-indexing mid-playback would shift
+        # every byte offset under the player.
+        try:
+            from services.hevc_remux_service import (
+                build_remux_index,
+                is_browser_incompatible_video,
+            )
+
+            if is_browser_incompatible_video(session.video_codec):
+                session.remux_index = build_remux_index(path)
+        except Exception as e:
+            session.remux_index = None
+            recording_logger.warning(
+                f"[HLS] Could not pre-index {path.name} for remux: {e}"
+            )
         recording_logger.info(
             f"[HLS] Indexed {path.name}: {n} fragments -> "
             f"{len(byte_segments)} byte-range segments (init={init_length}B, "

--- a/server/tests/test_hevc_remux.py
+++ b/server/tests/test_hevc_remux.py
@@ -230,6 +230,30 @@ def test_virtual_ranges_match_materialized_remux(tmp_path):
     assert b"".join(hrs.iter_index_range(index, 5, 4)) == b""
 
 
+def test_growing_file_indexes_only_completed_fragments(tmp_path):
+    """While MediaMTX writes, the final fragment is half-flushed: its header
+    already claims a size the file doesn't hold. Indexing must stop at the last
+    COMPLETE fragment — that boundary is what makes the finished part of a
+    still-recording file playable instead of the whole file being withheld."""
+    whole = _build_fmp4_multi(
+        ([b"AAAA_ONE"], [b"a"]),
+        ([b"BBBB_TWO"], [b"b"]),
+        ([b"CCCC_THREE"], [b"c"]),
+    )
+    complete = tmp_path / "complete.mp4"
+    complete.write_bytes(whole)
+    full = hrs.build_remux_index(complete)
+    assert len(full.runs) == 3
+
+    # Same file with the last fragment cut mid-write.
+    partial = tmp_path / "growing.mp4"
+    partial.write_bytes(whole[:-6])
+    grown = hrs.build_remux_index(partial)
+    assert len(grown.runs) == 2  # the half-written fragment is skipped
+    body = b"".join(hrs.iter_index_range(grown, len(grown.header), grown.total_size - 1))
+    assert body == b"AAAA_ONE" + b"BBBB_TWO"  # complete samples only, no short read
+
+
 @pytest.mark.asyncio
 async def test_index_rebuilds_when_source_grows(tmp_path):
     """A still-recording file is transparently re-indexed on change — and

--- a/server/tests/test_live_edge.py
+++ b/server/tests/test_live_edge.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""The playback live edge.
+
+Only the unfinished TAIL of a still-recording file is withheld from playback.
+An earlier revision treated the whole in-progress file as live, which hid ~35
+minutes of perfectly playable footage behind a "still recording" notice.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from routers.recordings import (  # noqa: E402
+    LIVE_EDGE_LAG_SECONDS,
+    _live_edge_iso,
+)
+
+NOW = datetime(2026, 7, 26, 10, 30, 0)
+
+
+def _parse(iso: str) -> datetime:
+    return datetime.fromisoformat(iso.rstrip("Z"))
+
+
+def test_edge_trails_now_by_the_lag():
+    """A 35-minute-old recording keeps all but its last minute playable."""
+    file_start = NOW - timedelta(minutes=35)
+    edge = _parse(_live_edge_iso(file_start, NOW))
+    assert edge == NOW - timedelta(seconds=LIVE_EDGE_LAG_SECONDS)
+    # 34 of the 35 minutes are on the playable side of the edge
+    assert (edge - file_start).total_seconds() == 34 * 60
+
+
+def test_lag_is_one_minute():
+    assert LIVE_EDGE_LAG_SECONDS == 60
+
+
+def test_edge_never_precedes_the_file_start():
+    """A recording that just began is live in its entirety — the edge must not
+    point before footage exists."""
+    file_start = NOW - timedelta(seconds=10)
+    assert _parse(_live_edge_iso(file_start, NOW)) == file_start
+
+
+def test_edge_at_exactly_the_lag_boundary():
+    file_start = NOW - timedelta(seconds=LIVE_EDGE_LAG_SECONDS)
+    assert _parse(_live_edge_iso(file_start, NOW)) == file_start
+
+
+def test_edge_advances_with_wall_clock():
+    """The green zone slides forward as recording continues, so footage becomes
+    playable as it ages past the lag."""
+    file_start = NOW - timedelta(minutes=10)
+    first = _parse(_live_edge_iso(file_start, NOW))
+    later = _parse(_live_edge_iso(file_start, NOW + timedelta(minutes=5)))
+    assert later - first == timedelta(minutes=5)
+
+
+def test_custom_lag_is_honoured():
+    file_start = NOW - timedelta(minutes=10)
+    edge = _parse(_live_edge_iso(file_start, NOW, lag_seconds=180))
+    assert edge == NOW - timedelta(seconds=180)
+
+
+def test_emits_utc_marker_like_the_rest_of_the_router():
+    assert _live_edge_iso(NOW - timedelta(minutes=5), NOW).endswith("Z")


### PR DESCRIPTION
Playing back a day that is still recording locked away the entire in-progress file — around 35 minutes of perfectly playable footage sat behind a "still recording" notice, because the whole file was treated as off-limits while it grew.

Now only the unfinished tail is withheld: the cutoff trails 1 minute behind now (clamped to the file's start), a fragment is indexed only once its data is confirmed on disk, and the remux layout is frozen per playback session so byte offsets can't shift under the player mid-stream.