### PR TITLE
Rbac fixes - issue - 179 && 176 

### DIFF
--- a/app/src/lib/apiError.ts
+++ b/app/src/lib/apiError.ts
@@ -23,7 +23,11 @@ function toStringSafe(v: unknown): string {
   if (v == null) return ''
   if (typeof v === 'string') return v
   if (Array.isArray(v)) return v.map(toStringSafe).filter(Boolean).join(', ')
-  if (typeof v === 'object' && typeof (v as { msg?: unknown }).msg === 'string') return (v as { msg: string }).msg
+  // Pydantic v2 prefixes custom-validator messages with "Value error, " /
+  // "Assertion error, " — strip it so users see just the human message.
+  if (typeof v === 'object' && typeof (v as { msg?: unknown }).msg === 'string') {
+    return (v as { msg: string }).msg.replace(/^(Value|Assertion) error, /, '')
+  }
   try {
     return JSON.stringify(v)
   } catch {

--- a/app/src/services/userService.ts
+++ b/app/src/services/userService.ts
@@ -24,7 +24,8 @@ export const userService = {
   getUser: (userId: number) => api.get(`/api/v1/users/${userId}`),
   updateUser: (userId: number, payload: any) => api.put(`/api/v1/users/${userId}`, payload),
   createUser: (payload: any) => api.post('/api/v1/users/', payload),
-  deleteUser: (userId: number) => api.delete(`/api/v1/users/${userId}`),
+  // Deleting a user requires the caller's current TOTP code (X-MFA-Code).
+  deleteUser: (userId: number, mfaCode: string) => api.delete(`/api/v1/users/${userId}`, { headers: { 'X-MFA-Code': mfaCode } }),
   
   // Roles
   getRoles: () => api.get('/api/v1/roles/'),

--- a/app/src/services/userService.ts
+++ b/app/src/services/userService.ts
@@ -24,8 +24,9 @@ export const userService = {
   getUser: (userId: number) => api.get(`/api/v1/users/${userId}`),
   updateUser: (userId: number, payload: any) => api.put(`/api/v1/users/${userId}`, payload),
   createUser: (payload: any) => api.post('/api/v1/users/', payload),
-  // Deleting a user requires the caller's current TOTP code (X-MFA-Code).
+  // Deleting or reactivating a user requires the caller's current TOTP code (X-MFA-Code).
   deleteUser: (userId: number, mfaCode: string) => api.delete(`/api/v1/users/${userId}`, { headers: { 'X-MFA-Code': mfaCode } }),
+  activateUser: (userId: number, mfaCode: string) => api.post(`/api/v1/users/${userId}/activate`, undefined, { headers: { 'X-MFA-Code': mfaCode } }),
   
   // Roles
   getRoles: () => api.get('/api/v1/roles/'),

--- a/app/src/views/settings/PasswordPolicy.tsx
+++ b/app/src/views/settings/PasswordPolicy.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useState } from 'react'
 import { apiService } from '../../lib/apiService'
+import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
 
 type Policy = {
@@ -78,14 +79,7 @@ export function PasswordPolicy() {
           require_mfa_for_privileged: data.require_mfa_for_privileged,
         })
       } catch (e: any) {
-        const detail = e?.data?.detail || e?.response?.data?.detail
-        if (Array.isArray(detail)) {
-          setError(detail.map((d: any) => d.msg || JSON.stringify(d)).join(', '))
-        } else if (typeof detail === 'object' && detail !== null) {
-          setError(detail.msg || JSON.stringify(detail))
-        } else {
-          setError(detail || e?.message || 'Failed to load policy')
-        }
+        setError(extractApiError(e, 'Failed to load policy'))
       } finally {
         setLoading(false)
       }
@@ -101,14 +95,7 @@ export function PasswordPolicy() {
         expiration_days: policy.expiration_days ?? null,
       })
     } catch (e: any) {
-      const detail = e?.data?.detail || e?.response?.data?.detail
-      if (Array.isArray(detail)) {
-        setError(detail.map((d: any) => d.msg || JSON.stringify(d)).join(', '))
-      } else if (typeof detail === 'object' && detail !== null) {
-        setError(detail.msg || JSON.stringify(detail))
-      } else {
-        setError(detail || e?.message || 'Failed to save policy')
-      }
+      setError(extractApiError(e, 'Failed to save policy'))
     } finally {
       setLoading(false)
     }

--- a/app/src/views/settings/PermissionsManager.tsx
+++ b/app/src/views/settings/PermissionsManager.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { apiService } from '../../lib/apiService'
+import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
 
 type Role = { id: number; name: string; description?: string }
@@ -54,7 +55,7 @@ export function PermissionsManager() {
           setSelectedRoleId(rolesList[0].id)
         }
       } catch (e: any) {
-        setError(e?.data?.detail || e?.message || 'Failed to load roles/permissions')
+        setError(extractApiError(e, 'Failed to load roles/permissions'))
       } finally {
         setLoading(false)
       }
@@ -71,7 +72,7 @@ export function PermissionsManager() {
         const list = (res.data && (res.data as any).permissions) ? (res.data as any).permissions : (Array.isArray(res.data) ? res.data : [])
         setAssignedIds(list.map((p: Permission) => p.id))
       } catch (e: any) {
-        setError(e?.data?.detail || e?.message || 'Failed to load role permissions')
+        setError(extractApiError(e, 'Failed to load role permissions'))
       } finally {
         setLoading(false)
       }
@@ -89,7 +90,7 @@ export function PermissionsManager() {
       setError(null)
       await apiService.setRolePermissions(selectedRoleId, assignedIds)
     } catch (e: any) {
-      setError(e?.data?.detail || e?.message || 'Failed to save permissions')
+      setError(extractApiError(e, 'Failed to save permissions'))
     } finally {
       setLoading(false)
     }

--- a/app/src/views/settings/RolesManager.tsx
+++ b/app/src/views/settings/RolesManager.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { apiService } from '../../lib/apiService'
+import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
 
 type Role = {
@@ -61,7 +62,7 @@ export function RolesManager() {
         setRoles(list)
         setTotal((res.data && (res.data as any).total) ? (res.data as any).total : list.length)
       } catch (e: any) {
-        setError(e?.data?.detail || e?.message || 'Failed to load roles')
+        setError(extractApiError(e, 'Failed to load roles'))
       } finally {
         setLoading(false)
       }
@@ -77,11 +78,13 @@ export function RolesManager() {
     setShowCreateDialog(true)
     setEditing(null)
     resetForm()
+    setError(null)
   }
 
   const startEdit = (r: Role) => {
     setEditing(r)
     setShowCreateDialog(false)
+    setError(null)
     setForm({ name: r.name, description: r.description || '' })
     setShowEditDialog(true)
   }
@@ -103,7 +106,7 @@ export function RolesManager() {
       resetForm()
       await refresh()
     } catch (e: any) {
-      setError(e?.data?.detail || e?.message || 'Failed to create role')
+      setError(extractApiError(e, 'Failed to create role'))
     } finally {
       setLoading(false)
     }
@@ -121,7 +124,7 @@ export function RolesManager() {
       resetForm()
       await refresh()
     } catch (e: any) {
-      setError(e?.data?.detail || e?.message || 'Failed to update role')
+      setError(extractApiError(e, 'Failed to update role'))
     } finally {
       setLoading(false)
     }
@@ -135,7 +138,7 @@ export function RolesManager() {
       await apiService.deleteRole(r.id)
       await refresh()
     } catch (e: any) {
-      setError(e?.data?.detail || e?.message || 'Failed to delete role')
+      setError(extractApiError(e, 'Failed to delete role'))
     } finally {
       setLoading(false)
     }
@@ -173,8 +176,9 @@ export function RolesManager() {
                 <span className="text-[var(--text-dim)]">Description</span>
                 <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.description || ''} onChange={(e) => setForm({ ...form, description: e.target.value })} />
               </label>
+              {error && <div className="text-sm text-red-400">{error}</div>}
               <div className="flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm() }}>Cancel</button>
+                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>Cancel</button>
                 <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Creating...' : 'Create Role'}</button>
               </div>
             </form>
@@ -196,8 +200,9 @@ export function RolesManager() {
                 <span className="text-[var(--text-dim)]">Description</span>
                 <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.description || ''} onChange={(e) => setForm({ ...form, description: e.target.value })} />
               </label>
+              {error && <div className="text-sm text-red-400">{error}</div>}
               <div className="flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm() }}>Cancel</button>
+                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
                 <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Updating...' : 'Update Role'}</button>
               </div>
             </form>

--- a/app/src/views/settings/RolesManager.tsx
+++ b/app/src/views/settings/RolesManager.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
+import { Shield, ShieldPlus, X } from 'lucide-react'
 import { apiService } from '../../lib/apiService'
 import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
@@ -164,22 +165,34 @@ export function RolesManager() {
 
       {/* Create Role Dialog */}
       {showCreateDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-[var(--panel)] border border-neutral-700 p-6 max-w-md w-full mx-4 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Add New Role</h3>
-            <form onSubmit={onCreate} className="space-y-3">
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Name</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} required minLength={1} maxLength={50} />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Description</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.description || ''} onChange={(e) => setForm({ ...form, description: e.target.value })} />
-              </label>
-              {error && <div className="text-sm text-red-400">{error}</div>}
-              <div className="flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>Cancel</button>
-                <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Creating...' : 'Create Role'}</button>
+        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4">
+          <div className="bg-[var(--panel)] border border-neutral-600 w-full max-w-md shadow-xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-neutral-700">
+              <h3 className="font-semibold flex items-center gap-2">
+                <ShieldPlus size={18} />
+                Add New Role
+              </h3>
+              <button className="p-1 hover:bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>
+                <X size={18} />
+              </button>
+            </div>
+            <form onSubmit={onCreate} className="flex flex-col flex-1 min-h-0">
+              <div className="p-4 overflow-auto flex-1 space-y-4">
+                {error && (
+                  <div className="p-2 bg-red-900/20 border border-red-800 text-red-400 text-sm">{error}</div>
+                )}
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs text-[var(--text-dim)]">Name *</span>
+                  <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" placeholder="e.g., operator" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} required minLength={1} maxLength={50} />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs text-[var(--text-dim)]">Description</span>
+                  <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.description || ''} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+                </label>
+              </div>
+              <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
+                <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>Cancel</button>
+                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading}>{loading ? 'Creating...' : 'Create Role'}</button>
               </div>
             </form>
           </div>
@@ -188,22 +201,34 @@ export function RolesManager() {
 
       {/* Edit Role Dialog */}
       {showEditDialog && editing && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-[var(--panel)] border border-neutral-700 p-6 max-w-md w-full mx-4 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Edit Role: {editing.name}</h3>
-            <form onSubmit={onUpdate} className="space-y-3">
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Name</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} required minLength={1} maxLength={50} />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Description</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.description || ''} onChange={(e) => setForm({ ...form, description: e.target.value })} />
-              </label>
-              {error && <div className="text-sm text-red-400">{error}</div>}
-              <div className="flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
-                <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Updating...' : 'Update Role'}</button>
+        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4">
+          <div className="bg-[var(--panel)] border border-neutral-600 w-full max-w-md shadow-xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-neutral-700">
+              <h3 className="font-semibold flex items-center gap-2">
+                <Shield size={18} />
+                Edit Role: {editing.name}
+              </h3>
+              <button className="p-1 hover:bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>
+                <X size={18} />
+              </button>
+            </div>
+            <form onSubmit={onUpdate} className="flex flex-col flex-1 min-h-0">
+              <div className="p-4 overflow-auto flex-1 space-y-4">
+                {error && (
+                  <div className="p-2 bg-red-900/20 border border-red-800 text-red-400 text-sm">{error}</div>
+                )}
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs text-[var(--text-dim)]">Name *</span>
+                  <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} required minLength={1} maxLength={50} />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs text-[var(--text-dim)]">Description</span>
+                  <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.description || ''} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+                </label>
+              </div>
+              <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
+                <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
+                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading}>{loading ? 'Updating...' : 'Update Role'}</button>
               </div>
             </form>
           </div>

--- a/app/src/views/settings/UsersManager.tsx
+++ b/app/src/views/settings/UsersManager.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
-import { Trash2, UserPlus, UserCog, X } from 'lucide-react'
+import { Trash2, UserCheck, UserPlus, UserCog, X } from 'lucide-react'
 import { apiService } from '../../lib/apiService'
 import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
@@ -63,8 +63,9 @@ export function UsersManager() {
   const [editing, setEditing] = useState<User | null>(null)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showEditDialog, setShowEditDialog] = useState(false)
-  const [deleting, setDeleting] = useState<User | null>(null)
-  const [deleteCode, setDeleteCode] = useState('')
+  // Delete and activate both require the admin's TOTP code, confirmed in one dialog.
+  const [confirmAction, setConfirmAction] = useState<{ kind: 'delete' | 'activate'; user: User } | null>(null)
+  const [mfaCode, setMfaCode] = useState('')
 
   const [form, setForm] = useState<UserForm>({ username: '', email: '', password: '', role_id: 1, first_name: '', last_name: '' })
   const [roles, setRoles] = useState<Role[]>([])
@@ -153,20 +154,24 @@ export function UsersManager() {
     }
   }
 
-  const onDelete = async (e: React.FormEvent) => {
+  const onConfirmAction = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!deleting) return
+    if (!confirmAction) return
     try {
       setLoading(true)
       setError(null)
-      await apiService.deleteUser(deleting.id, deleteCode.trim())
-      setDeleting(null)
-      setDeleteCode('')
+      if (confirmAction.kind === 'delete') {
+        await apiService.deleteUser(confirmAction.user.id, mfaCode.trim())
+      } else {
+        await apiService.activateUser(confirmAction.user.id, mfaCode.trim())
+      }
+      setConfirmAction(null)
+      setMfaCode('')
       const { data } = await apiService.getUsers({ skip, limit, active_only: activeOnly })
       setUsers(data.users)
       setTotal(data.total ?? 0)
     } catch (e: any) {
-      setError(extractApiError(e, 'Failed to delete user'))
+      setError(extractApiError(e, confirmAction.kind === 'delete' ? 'Failed to delete user' : 'Failed to activate user'))
     } finally {
       setLoading(false)
     }
@@ -309,8 +314,8 @@ export function UsersManager() {
                       {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
                     </select>
                   </label>
-                  <label className="flex items-center gap-2 mt-5 text-sm" title={me?.id === editing.id ? 'You cannot deactivate your own account' : undefined}>
-                    <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} disabled={me?.id === editing.id} /> Active
+                  <label className="flex items-center gap-2 mt-5 text-sm" title={me?.id === editing.id ? 'You cannot deactivate your own account' : !editing.is_active ? 'Use the Activate button to reactivate (requires MFA code)' : undefined}>
+                    <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} disabled={me?.id === editing.id || !editing.is_active} /> Active
                   </label>
                 </div>
               </div>
@@ -323,27 +328,30 @@ export function UsersManager() {
         </div>
       )}
 
-      {/* Delete User Dialog */}
-      {deleting && (
+      {/* Delete / Activate confirmation dialog (both MFA-gated) */}
+      {confirmAction && (
         <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4">
           <div className="bg-[var(--panel)] border border-neutral-600 w-full max-w-md shadow-xl max-h-[90vh] flex flex-col">
             <div className="flex items-center justify-between p-4 border-b border-neutral-700">
-              <h3 className="font-semibold flex items-center gap-2 text-red-400">
-                <Trash2 size={18} />
-                Delete User
+              <h3 className={`font-semibold flex items-center gap-2 ${confirmAction.kind === 'delete' ? 'text-red-400' : 'text-green-400'}`}>
+                {confirmAction.kind === 'delete' ? <Trash2 size={18} /> : <UserCheck size={18} />}
+                {confirmAction.kind === 'delete' ? 'Delete User' : 'Activate User'}
               </h3>
-              <button className="p-1 hover:bg-[var(--panel-2)] rounded" onClick={() => { setDeleting(null); setDeleteCode(''); setError(null) }}>
+              <button className="p-1 hover:bg-[var(--panel-2)] rounded" onClick={() => { setConfirmAction(null); setMfaCode(''); setError(null) }}>
                 <X size={18} />
               </button>
             </div>
-            <form onSubmit={onDelete} className="flex flex-col flex-1 min-h-0">
+            <form onSubmit={onConfirmAction} className="flex flex-col flex-1 min-h-0">
               <div className="p-4 overflow-auto flex-1 space-y-4">
                 {error && (
                   <div className="p-2 bg-red-900/20 border border-red-800 text-red-400 text-sm">{error}</div>
                 )}
                 <div className="p-3 bg-[var(--bg-2)] border border-neutral-700 text-sm">
-                  You are about to delete <span className="font-semibold">{deleting.username}</span> ({deleting.email}).
-                  They will no longer be able to log in.
+                  {confirmAction.kind === 'delete' ? (
+                    <>You are about to delete <span className="font-semibold">{confirmAction.user.username}</span> ({confirmAction.user.email}). They will no longer be able to log in.</>
+                  ) : (
+                    <>You are about to reactivate <span className="font-semibold">{confirmAction.user.username}</span> ({confirmAction.user.email}). They will be able to log in again.</>
+                  )}
                 </div>
                 <label className="flex flex-col gap-1">
                   <span className="text-xs text-[var(--text-dim)]">Your MFA code *</span>
@@ -354,8 +362,8 @@ export function UsersManager() {
                     maxLength={6}
                     className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm tracking-widest"
                     placeholder="123456"
-                    value={deleteCode}
-                    onChange={(e) => setDeleteCode(e.target.value.replace(/\D/g, ''))}
+                    value={mfaCode}
+                    onChange={(e) => setMfaCode(e.target.value.replace(/\D/g, ''))}
                     autoFocus
                     required
                   />
@@ -363,8 +371,10 @@ export function UsersManager() {
                 </label>
               </div>
               <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
-                <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setDeleting(null); setDeleteCode(''); setError(null) }}>Cancel</button>
-                <button type="submit" className="px-4 py-2 text-sm bg-red-600 hover:bg-red-700 text-white disabled:opacity-50" disabled={loading || deleteCode.length !== 6}>{loading ? 'Deleting...' : 'Delete User'}</button>
+                <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setConfirmAction(null); setMfaCode(''); setError(null) }}>Cancel</button>
+                <button type="submit" className={`px-4 py-2 text-sm text-white disabled:opacity-50 ${confirmAction.kind === 'delete' ? 'bg-red-600 hover:bg-red-700' : 'bg-green-700 hover:bg-green-800'}`} disabled={loading || mfaCode.length !== 6}>
+                  {confirmAction.kind === 'delete' ? (loading ? 'Deleting...' : 'Delete User') : (loading ? 'Activating...' : 'Activate User')}
+                </button>
               </div>
             </form>
           </div>
@@ -389,12 +399,20 @@ export function UsersManager() {
                 <td className="p-2">{u.username}</td>
                 <td className="p-2">{u.email}</td>
                 <td className="p-2">{roles.find(r => r.id === u.role_id)?.name ?? u.role_id}</td>
-                <td className="p-2">{u.is_active ? 'Yes' : 'No'}</td>
+                <td className="p-2">
+                  <span className={`inline-flex items-center text-xs px-2 py-0.5 rounded ${u.is_active ? 'bg-green-900/50 text-green-400' : 'bg-gray-800 text-gray-400'}`}>
+                    {u.is_active ? 'Active' : 'Inactive'}
+                  </span>
+                </td>
                 <td className="p-2">{u.is_superuser ? 'Yes' : 'No'}</td>
                 <td className="p-2 space-x-2">
                   <button className="px-2 py-1 border border-neutral-700 bg-[var(--panel-2)]" onClick={() => startEdit(u)}>Edit</button>
-                  {me?.id !== u.id && (
-                    <button className="px-2 py-1 border border-neutral-700 bg-[var(--panel-2)]" onClick={() => { setDeleting(u); setDeleteCode(''); setError(null) }}>Delete</button>
+                  {u.is_active ? (
+                    me?.id !== u.id && (
+                      <button className="px-2 py-1 border border-neutral-700 bg-[var(--panel-2)]" onClick={() => { setConfirmAction({ kind: 'delete', user: u }); setMfaCode(''); setError(null) }}>Delete</button>
+                    )
+                  ) : (
+                    <button className="px-2 py-1 border border-green-800 bg-green-900/30 text-green-400" onClick={() => { setConfirmAction({ kind: 'activate', user: u }); setMfaCode(''); setError(null) }}>Activate</button>
                   )}
                 </td>
               </tr>

--- a/app/src/views/settings/UsersManager.tsx
+++ b/app/src/views/settings/UsersManager.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { apiService } from '../../lib/apiService'
+import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
 
 type User = {
@@ -82,7 +83,7 @@ export function UsersManager() {
   const rolesRes = await apiService.getRoles()
   setRoles((rolesRes.data && (rolesRes.data as any).roles) ? (rolesRes.data as any).roles : (Array.isArray(rolesRes.data) ? rolesRes.data : []))
       } catch (e: any) {
-        setError(e?.data?.detail || e?.message || 'Failed to load users')
+        setError(extractApiError(e, 'Failed to load users'))
       } finally {
         setLoading(false)
       }
@@ -113,7 +114,7 @@ export function UsersManager() {
   setUsers(data.users)
   setTotal(data.total ?? 0)
     } catch (e: any) {
-      setError(e?.data?.detail || e?.message || 'Failed to create user')
+      setError(extractApiError(e, 'Failed to create user'))
     } finally {
       setLoading(false)
     }
@@ -143,7 +144,7 @@ export function UsersManager() {
   setUsers(data.users)
   setTotal(data.total ?? 0)
     } catch (e: any) {
-      setError(e?.data?.detail || e?.message || 'Failed to update user')
+      setError(extractApiError(e, 'Failed to update user'))
     } finally {
       setLoading(false)
     }
@@ -159,7 +160,7 @@ export function UsersManager() {
       setUsers(data.users)
       setTotal(data.total)
     } catch (e: any) {
-      setError(e?.data?.detail || e?.message || 'Failed to delete user')
+      setError(extractApiError(e, 'Failed to delete user'))
     } finally {
       setLoading(false)
     }
@@ -168,6 +169,7 @@ export function UsersManager() {
   const startEdit = (u: User) => {
     setEditing(u)
     setShowCreateDialog(false)
+    setError(null)
     setForm({
       username: u.username,
       email: u.email,
@@ -197,7 +199,7 @@ export function UsersManager() {
           <select className="bg-[var(--panel-2)] border border-neutral-700 px-2 py-1" value={limit} onChange={(e) => { setPage(1); setLimit(Number(e.target.value)) }}>
             {[10, 20, 50].map(n => <option key={n} value={n}>{n}/page</option>)}
           </select>
-          <button className="px-2 py-1 bg-[var(--accent)] text-white rounded" onClick={() => { setShowCreateDialog(true); setEditing(null); resetForm() }}>Add User</button>
+          <button className="px-2 py-1 bg-[var(--accent)] text-white rounded" onClick={() => { setShowCreateDialog(true); setEditing(null); resetForm(); setError(null) }}>Add User</button>
         </div>
       </div>
 
@@ -228,6 +230,7 @@ export function UsersManager() {
               <label className="flex flex-col gap-1">
                 <span className="text-[var(--text-dim)]">Password</span>
                 <input type="password" className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.password || ''} onChange={(e) => setForm({ ...form, password: e.target.value })} required minLength={8} />
+                <span className="text-xs text-[var(--text-dim)]">At least 8 characters, with an uppercase letter, a lowercase letter, and a number.</span>
               </label>
               <label className="flex flex-col gap-1">
                 <span className="text-[var(--text-dim)]">Role</span>
@@ -235,8 +238,9 @@ export function UsersManager() {
                   {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
                 </select>
               </label>
+              {error && <div className="col-span-2 text-sm text-red-400">{error}</div>}
               <div className="col-span-2 flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm() }}>Cancel</button>
+                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>Cancel</button>
                 <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Creating...' : 'Create User'}</button>
               </div>
             </form>
@@ -275,8 +279,9 @@ export function UsersManager() {
               <label className="flex items-center gap-2 mt-6">
                 <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} /> Active
               </label>
+              {error && <div className="col-span-2 text-sm text-red-400">{error}</div>}
               <div className="col-span-2 flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm() }}>Cancel</button>
+                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
                 <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Updating...' : 'Update User'}</button>
               </div>
             </form>

--- a/app/src/views/settings/UsersManager.tsx
+++ b/app/src/views/settings/UsersManager.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
+import { UserPlus, UserCog, X } from 'lucide-react'
 import { apiService } from '../../lib/apiService'
 import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
@@ -207,41 +208,55 @@ export function UsersManager() {
 
       {/* Create User Dialog */}
       {showCreateDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-[var(--panel)] border border-neutral-700 p-6 max-w-lg w-full mx-4 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Add New User</h3>
-            <form onSubmit={onCreate} className="grid grid-cols-2 gap-3">
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Username</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.username} onChange={(e) => setForm({ ...form, username: e.target.value })} required />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Email</span>
-                <input type="email" className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">First Name</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.first_name || ''} onChange={(e) => setForm({ ...form, first_name: e.target.value })} />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Last Name</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.last_name || ''} onChange={(e) => setForm({ ...form, last_name: e.target.value })} />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Password</span>
-                <input type="password" className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.password || ''} onChange={(e) => setForm({ ...form, password: e.target.value })} required minLength={8} />
-                <span className="text-xs text-[var(--text-dim)]">At least 8 characters, with an uppercase letter, a lowercase letter, and a number.</span>
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Role</span>
-                <select className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.role_id} onChange={(e) => setForm({ ...form, role_id: Number(e.target.value) })} required>
-                  {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
-                </select>
-              </label>
-              {error && <div className="col-span-2 text-sm text-red-400">{error}</div>}
-              <div className="col-span-2 flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>Cancel</button>
-                <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Creating...' : 'Create User'}</button>
+        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4">
+          <div className="bg-[var(--panel)] border border-neutral-600 w-full max-w-lg shadow-xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-neutral-700">
+              <h3 className="font-semibold flex items-center gap-2">
+                <UserPlus size={18} />
+                Add New User
+              </h3>
+              <button className="p-1 hover:bg-[var(--panel-2)] rounded" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>
+                <X size={18} />
+              </button>
+            </div>
+            <form onSubmit={onCreate} className="flex flex-col flex-1 min-h-0">
+              <div className="p-4 overflow-auto flex-1 space-y-4">
+                {error && (
+                  <div className="p-2 bg-red-900/20 border border-red-800 text-red-400 text-sm">{error}</div>
+                )}
+                <div className="grid grid-cols-2 gap-3">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Username *</span>
+                    <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" placeholder="e.g., jsmith" value={form.username} onChange={(e) => setForm({ ...form, username: e.target.value })} required />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Email *</span>
+                    <input type="email" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" placeholder="user@example.com" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">First Name</span>
+                    <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.first_name || ''} onChange={(e) => setForm({ ...form, first_name: e.target.value })} />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Last Name</span>
+                    <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.last_name || ''} onChange={(e) => setForm({ ...form, last_name: e.target.value })} />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Password *</span>
+                    <input type="password" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.password || ''} onChange={(e) => setForm({ ...form, password: e.target.value })} required minLength={8} />
+                    <span className="text-[10px] text-[var(--text-dim)]">At least 8 characters, with an uppercase letter, a lowercase letter, and a number.</span>
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Role *</span>
+                    <select className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.role_id} onChange={(e) => setForm({ ...form, role_id: Number(e.target.value) })} required>
+                      {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+                    </select>
+                  </label>
+                </div>
+              </div>
+              <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
+                <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>Cancel</button>
+                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading}>{loading ? 'Creating...' : 'Create User'}</button>
               </div>
             </form>
           </div>
@@ -250,39 +265,53 @@ export function UsersManager() {
 
       {/* Edit User Dialog */}
       {showEditDialog && editing && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-[var(--panel)] border border-neutral-700 p-6 max-w-lg w-full mx-4 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Edit User: {editing.username}</h3>
-            <form onSubmit={onUpdate} className="grid grid-cols-2 gap-3">
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Username</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded opacity-50" value={form.username} disabled />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Email</span>
-                <input type="email" className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">First Name</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.first_name || ''} onChange={(e) => setForm({ ...form, first_name: e.target.value })} />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Last Name</span>
-                <input className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.last_name || ''} onChange={(e) => setForm({ ...form, last_name: e.target.value })} />
-              </label>
-              <label className="flex flex-col gap-1">
-                <span className="text-[var(--text-dim)]">Role</span>
-                <select className="bg-[var(--panel-2)] border border-neutral-700 px-3 py-2 rounded" value={form.role_id} onChange={(e) => setForm({ ...form, role_id: Number(e.target.value) })} required>
-                  {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
-                </select>
-              </label>
-              <label className="flex items-center gap-2 mt-6">
-                <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} /> Active
-              </label>
-              {error && <div className="col-span-2 text-sm text-red-400">{error}</div>}
-              <div className="col-span-2 flex justify-end gap-2 mt-4">
-                <button type="button" className="px-4 py-2 border border-neutral-700 bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
-                <button type="submit" className="px-4 py-2 bg-[var(--accent)] text-white rounded" disabled={loading}>{loading ? 'Updating...' : 'Update User'}</button>
+        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4">
+          <div className="bg-[var(--panel)] border border-neutral-600 w-full max-w-lg shadow-xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-neutral-700">
+              <h3 className="font-semibold flex items-center gap-2">
+                <UserCog size={18} />
+                Edit User: {editing.username}
+              </h3>
+              <button className="p-1 hover:bg-[var(--panel-2)] rounded" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>
+                <X size={18} />
+              </button>
+            </div>
+            <form onSubmit={onUpdate} className="flex flex-col flex-1 min-h-0">
+              <div className="p-4 overflow-auto flex-1 space-y-4">
+                {error && (
+                  <div className="p-2 bg-red-900/20 border border-red-800 text-red-400 text-sm">{error}</div>
+                )}
+                <div className="grid grid-cols-2 gap-3">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Username</span>
+                    <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm opacity-50" value={form.username} disabled />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Email *</span>
+                    <input type="email" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">First Name</span>
+                    <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.first_name || ''} onChange={(e) => setForm({ ...form, first_name: e.target.value })} />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Last Name</span>
+                    <input type="text" className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.last_name || ''} onChange={(e) => setForm({ ...form, last_name: e.target.value })} />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-[var(--text-dim)]">Role *</span>
+                    <select className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm" value={form.role_id} onChange={(e) => setForm({ ...form, role_id: Number(e.target.value) })} required>
+                      {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+                    </select>
+                  </label>
+                  <label className="flex items-center gap-2 mt-5 text-sm">
+                    <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} /> Active
+                  </label>
+                </div>
+              </div>
+              <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
+                <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
+                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading}>{loading ? 'Updating...' : 'Update User'}</button>
               </div>
             </form>
           </div>

--- a/app/src/views/settings/UsersManager.tsx
+++ b/app/src/views/settings/UsersManager.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
-import { UserPlus, UserCog, X } from 'lucide-react'
+import { Trash2, UserPlus, UserCog, X } from 'lucide-react'
 import { apiService } from '../../lib/apiService'
 import { extractApiError } from '../../lib/apiError'
 import { useAuth } from '../../auth/AuthContext'
@@ -63,6 +63,8 @@ export function UsersManager() {
   const [editing, setEditing] = useState<User | null>(null)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showEditDialog, setShowEditDialog] = useState(false)
+  const [deleting, setDeleting] = useState<User | null>(null)
+  const [deleteCode, setDeleteCode] = useState('')
 
   const [form, setForm] = useState<UserForm>({ username: '', email: '', password: '', role_id: 1, first_name: '', last_name: '' })
   const [roles, setRoles] = useState<Role[]>([])
@@ -151,15 +153,18 @@ export function UsersManager() {
     }
   }
 
-  const onDelete = async (u: User) => {
-    if (!confirm(`Delete user "${u.username}"?`)) return
+  const onDelete = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!deleting) return
     try {
       setLoading(true)
       setError(null)
-      await apiService.deleteUser(u.id)
+      await apiService.deleteUser(deleting.id, deleteCode.trim())
+      setDeleting(null)
+      setDeleteCode('')
       const { data } = await apiService.getUsers({ skip, limit, active_only: activeOnly })
       setUsers(data.users)
-      setTotal(data.total)
+      setTotal(data.total ?? 0)
     } catch (e: any) {
       setError(extractApiError(e, 'Failed to delete user'))
     } finally {
@@ -304,14 +309,62 @@ export function UsersManager() {
                       {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
                     </select>
                   </label>
-                  <label className="flex items-center gap-2 mt-5 text-sm">
-                    <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} /> Active
+                  <label className="flex items-center gap-2 mt-5 text-sm" title={me?.id === editing.id ? 'You cannot deactivate your own account' : undefined}>
+                    <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} disabled={me?.id === editing.id} /> Active
                   </label>
                 </div>
               </div>
               <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
                 <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
                 <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading}>{loading ? 'Updating...' : 'Update User'}</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Delete User Dialog */}
+      {deleting && (
+        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4">
+          <div className="bg-[var(--panel)] border border-neutral-600 w-full max-w-md shadow-xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-neutral-700">
+              <h3 className="font-semibold flex items-center gap-2 text-red-400">
+                <Trash2 size={18} />
+                Delete User
+              </h3>
+              <button className="p-1 hover:bg-[var(--panel-2)] rounded" onClick={() => { setDeleting(null); setDeleteCode(''); setError(null) }}>
+                <X size={18} />
+              </button>
+            </div>
+            <form onSubmit={onDelete} className="flex flex-col flex-1 min-h-0">
+              <div className="p-4 overflow-auto flex-1 space-y-4">
+                {error && (
+                  <div className="p-2 bg-red-900/20 border border-red-800 text-red-400 text-sm">{error}</div>
+                )}
+                <div className="p-3 bg-[var(--bg-2)] border border-neutral-700 text-sm">
+                  You are about to delete <span className="font-semibold">{deleting.username}</span> ({deleting.email}).
+                  They will no longer be able to log in.
+                </div>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs text-[var(--text-dim)]">Your MFA code *</span>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    maxLength={6}
+                    className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm tracking-widest"
+                    placeholder="123456"
+                    value={deleteCode}
+                    onChange={(e) => setDeleteCode(e.target.value.replace(/\D/g, ''))}
+                    autoFocus
+                    required
+                  />
+                  <span className="text-[10px] text-[var(--text-dim)]">Enter the 6-digit code from your authenticator app to confirm this action.</span>
+                </label>
+              </div>
+              <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
+                <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setDeleting(null); setDeleteCode(''); setError(null) }}>Cancel</button>
+                <button type="submit" className="px-4 py-2 text-sm bg-red-600 hover:bg-red-700 text-white disabled:opacity-50" disabled={loading || deleteCode.length !== 6}>{loading ? 'Deleting...' : 'Delete User'}</button>
               </div>
             </form>
           </div>
@@ -340,7 +393,9 @@ export function UsersManager() {
                 <td className="p-2">{u.is_superuser ? 'Yes' : 'No'}</td>
                 <td className="p-2 space-x-2">
                   <button className="px-2 py-1 border border-neutral-700 bg-[var(--panel-2)]" onClick={() => startEdit(u)}>Edit</button>
-                  <button className="px-2 py-1 border border-neutral-700 bg-[var(--panel-2)]" onClick={() => onDelete(u)}>Delete</button>
+                  {me?.id !== u.id && (
+                    <button className="px-2 py-1 border border-neutral-700 bg-[var(--panel-2)]" onClick={() => { setDeleting(u); setDeleteCode(''); setError(null) }}>Delete</button>
+                  )}
                 </td>
               </tr>
             ))}

--- a/server/models.py
+++ b/server/models.py
@@ -80,7 +80,11 @@ class User(Base):
     password_set = Column(
         Boolean, default=False
     )  # Track if initial password setup is complete
-    mfa_enabled = Column(Boolean, default=True)  # MFA enabled by default for security
+    # True only once the user has enrolled a TOTP secret (/auth/mfa/verify).
+    # New accounts start False; the client blocks app access until enrollment
+    # completes (MFA wall), so MFA is still mandatory — just set up by the
+    # account owner on first login, not assumed at creation.
+    mfa_enabled = Column(Boolean, default=False)
 
     # Store encrypted MFA secret
     encrypted_mfa_secret = Column(String(500), nullable=True)

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -246,6 +246,32 @@ def _enroll_device(db, request, response, user_id: int | None) -> str | None:
         return None
 
 
+def _mfa_login_required(db: Session, user: User) -> bool:
+    """Whether this login must present a TOTP code.
+
+    Accounts can carry mfa_enabled=True without a secret (rows created before
+    the default changed, or a provisioned bootstrap admin). No valid code can
+    exist for them, so demanding one locks the account forever. Normalize the
+    flag to False so the client shows the MFA-setup wall after this password
+    login; /auth/mfa/verify turns it back on once enrollment completes.
+    """
+    if user.mfa_enabled and not user.mfa_secret:
+        user.mfa_enabled = False
+        db.add(user)
+        db.commit()
+        auth_logger.log_action(
+            "auth.mfa_enrollment_pending",
+            user_id=user.id,
+            message=(
+                f"User {user.username} flagged for MFA without an enrolled "
+                "secret; allowing password login, enrollment enforced on client"
+            ),
+            extra_data={"username": user.username},
+        )
+        return False
+    return user.mfa_enabled
+
+
 @router.post("/login", response_model=Token)
 async def login_for_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -363,7 +389,7 @@ async def login_for_access_token(
             },
         )
 
-    if user.mfa_enabled:
+    if _mfa_login_required(db, user):
         auth_logger.log_action(
             "auth.login_mfa_required",
             user_id=user.id,
@@ -480,7 +506,7 @@ async def login_with_json(
             },
         )
 
-    if user.mfa_enabled:
+    if _mfa_login_required(db, user):
         if not user_credentials.code or not verify_totp_code(
             user.mfa_secret, user_credentials.code
         ):

--- a/server/routers/users.py
+++ b/server/routers/users.py
@@ -137,6 +137,15 @@ def update_user(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="You cannot deactivate your own account.",
         )
+    # Reactivation is MFA-gated via /users/{id}/activate; without this guard
+    # the plain update would be a bypass around that check.
+    if user_update.is_active is True:
+        target = db.query(User).filter(User.id == user_id).first()
+        if target and not target.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Reactivating a user requires an MFA code — use the Activate action.",
+            )
     user = UserService.update_user(db=db, user_id=user_id, user_update=user_update)
     if not user:
         raise HTTPException(
@@ -162,6 +171,20 @@ def update_user(
     return user
 
 
+def _require_mfa_code(current_user: User, mfa_code: str | None) -> None:
+    """Verify the caller's current TOTP code for sensitive user actions."""
+    if not current_user.mfa_secret:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Set up MFA before performing this action.",
+        )
+    if not mfa_code or not verify_totp_code(current_user.mfa_secret, mfa_code):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing MFA code.",
+        )
+
+
 @router.delete("/{user_id}")
 def delete_user(
     user_id: int,
@@ -182,16 +205,7 @@ def delete_user(
             detail="You cannot delete your own account.",
         )
 
-    if not current_user.mfa_secret:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Set up MFA before deleting users.",
-        )
-    if not mfa_code or not verify_totp_code(current_user.mfa_secret, mfa_code):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or missing MFA code.",
-        )
+    _require_mfa_code(current_user, mfa_code)
 
     success = UserService.delete_user(db=db, user_id=user_id)
     if not success:
@@ -212,6 +226,45 @@ def delete_user(
     except Exception as e:
         main_logger.warning(f"Failed to write audit log (user.delete): {e}")
     return {"message": "User deleted successfully"}
+
+
+@router.post("/{user_id}/activate", response_model=UserResponse)
+def activate_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_superuser),
+    request: Request = None,
+    mfa_code: str | None = Header(None, alias="X-MFA-Code"),
+):
+    """Reactivate a soft-deleted user (superuser only).
+
+    Undoes a delete: the account can log in again. Requires the caller's
+    current TOTP code in the X-MFA-Code header, same as deletion.
+    """
+    _require_mfa_code(current_user, mfa_code)
+
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    user.is_active = True
+    db.commit()
+    db.refresh(user)
+    try:
+        write_audit_log(
+            db,
+            action="user.activate",
+            user_id=current_user.id,
+            entity_type="user",
+            entity_id=user.id,
+            details={"username": user.username},
+            ip=request.client.host if request and request.client else None,
+            user_agent=request.headers.get("user-agent") if request else None,
+        )
+    except Exception as e:
+        main_logger.warning(f"Failed to write audit log (user.activate): {e}")
+    return user
 
 
 @router.put("/me", response_model=UserResponse)

--- a/server/routers/users.py
+++ b/server/routers/users.py
@@ -19,10 +19,10 @@ Users router for user management operations.
 Handles CRUD operations for users with proper authentication and authorization.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
-from core.auth import get_current_active_user, get_current_superuser
+from core.auth import get_current_active_user, get_current_superuser, verify_totp_code
 from core.database import get_db
 from core.logging_config import main_logger
 from models import Permission, User
@@ -131,6 +131,12 @@ def update_user(
     request: Request = None,
 ):
     """Update user information (superuser only)."""
+    # Deactivating yourself is the same lockout as self-deletion (issue #176).
+    if user_id == current_user.id and user_update.is_active is False:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You cannot deactivate your own account.",
+        )
     user = UserService.update_user(db=db, user_id=user_id, user_update=user_update)
     if not user:
         raise HTTPException(
@@ -162,8 +168,31 @@ def delete_user(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_superuser),
     request: Request = None,
+    mfa_code: str | None = Header(None, alias="X-MFA-Code"),
 ):
-    """Delete a user (soft delete, superuser only)."""
+    """Delete a user (soft delete, superuser only).
+
+    Requires the caller's current TOTP code in the X-MFA-Code header, and a
+    user can never delete their own account — a soft-deleted user cannot log
+    in, so self-deletion bricks single-admin deployments (issue #176).
+    """
+    if user_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You cannot delete your own account.",
+        )
+
+    if not current_user.mfa_secret:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Set up MFA before deleting users.",
+        )
+    if not mfa_code or not verify_totp_code(current_user.mfa_secret, mfa_code):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing MFA code.",
+        )
+
     success = UserService.delete_user(db=db, user_id=user_id)
     if not success:
         raise HTTPException(

--- a/server/services/user_service.py
+++ b/server/services/user_service.py
@@ -66,6 +66,7 @@ class UserService:
                     last_name=user_create.last_name,
                     is_active=user_create.is_active,
                     password_set=True,  # Normal user creation has password set
+                    mfa_enabled=False,  # User enrolls TOTP at first login (MFA wall)
                     role_id=user_create.role_id,
                 )
                 db.add(db_user)

--- a/server/tests/test_login_mfa_wall.py
+++ b/server/tests/test_login_mfa_wall.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Login vs. MFA enrollment state.
+
+An account can be flagged mfa_enabled without ever enrolling a TOTP secret
+(admin-created users before the default changed, provisioned bootstrap admins).
+No valid code can exist for such an account, so demanding one at login locks it
+out forever. These tests pin the intended flow: password login succeeds, the
+flag is normalized to False so the client shows the MFA-setup wall, and only
+genuinely enrolled users are asked for a code.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pyotp
+import pytest
+from cryptography.fernet import Fernet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_mfa_wall_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as core_auth  # noqa: E402
+from core.auth import get_password_hash  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Role, User  # noqa: E402
+from routers import auth as auth_router  # noqa: E402
+from schemas import UserCreate  # noqa: E402
+from services.user_service import UserService  # noqa: E402
+
+PASSWORD = "Str0ng!passw0rd"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    # In full-suite runs, whichever sibling stubbed core.logging_config first
+    # wins the sys.modules race, and some stubs lack log_action. The login
+    # endpoints log liberally, so give the modules under test a logger that
+    # accepts anything.
+    monkeypatch.setattr(auth_router, "auth_logger", _L(), raising=False)
+    monkeypatch.setattr(core_auth, "auth_logger", _L(), raising=False)
+    eng = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    session_factory = sessionmaker(bind=eng)
+
+    app = FastAPI()
+    app.include_router(auth_router.router, prefix="/api/v1")
+
+    def _get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _get_db
+
+    db = session_factory()
+    role = Role(name="admin", description="test role")
+    db.add(role)
+    db.flush()
+
+    hashed = get_password_hash(PASSWORD)
+    # Flagged for MFA but never enrolled — the broken state under test.
+    unenrolled = User(
+        username="unenrolled",
+        email="unenrolled@example.com",
+        hashed_password=hashed,
+        is_active=True,
+        password_set=True,
+        mfa_enabled=True,
+        role_id=role.id,
+    )
+    # Genuinely enrolled: has a TOTP secret.
+    totp_secret = pyotp.random_base32()
+    enrolled = User(
+        username="enrolled",
+        email="enrolled@example.com",
+        hashed_password=hashed,
+        is_active=True,
+        password_set=True,
+        mfa_enabled=True,
+        role_id=role.id,
+    )
+    enrolled.mfa_secret = totp_secret
+    db.add_all([unenrolled, enrolled])
+    db.commit()
+
+    client = TestClient(app)
+    try:
+        yield _types.SimpleNamespace(
+            client=client,
+            db=db,
+            role=role,
+            totp_secret=totp_secret,
+        )
+    finally:
+        db.close()
+
+
+def _login_json(client, username, password, code=None):
+    body = {"username": username, "password": password}
+    if code is not None:
+        body["code"] = code
+    return client.post("/api/v1/auth/login-json", json=body)
+
+
+def test_unenrolled_user_logs_in_with_password_only(env):
+    resp = _login_json(env.client, "unenrolled", PASSWORD)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["access_token"]
+
+
+def test_unenrolled_login_normalizes_flag_for_mfa_wall(env):
+    _login_json(env.client, "unenrolled", PASSWORD)
+    env.db.expire_all()
+    user = env.db.query(User).filter(User.username == "unenrolled").first()
+    # False → the SPA routes the session to the MFA-setup wall.
+    assert user.mfa_enabled is False
+
+
+def test_unenrolled_login_does_not_count_failed_attempts(env):
+    _login_json(env.client, "unenrolled", PASSWORD)
+    env.db.expire_all()
+    user = env.db.query(User).filter(User.username == "unenrolled").first()
+    assert user.failed_login_attempts == 0
+    assert user.locked_until is None
+
+
+def test_unenrolled_user_logs_in_via_form_endpoint(env):
+    resp = env.client.post(
+        "/api/v1/auth/login",
+        data={"username": "unenrolled", "password": PASSWORD},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_enrolled_user_still_needs_code(env):
+    resp = _login_json(env.client, "enrolled", PASSWORD)
+    assert resp.status_code == 401
+    assert "mfa" in str(resp.json()["detail"]).lower()
+
+
+def test_enrolled_user_logs_in_with_valid_code(env):
+    code = pyotp.TOTP(env.totp_secret).now()
+    resp = _login_json(env.client, "enrolled", PASSWORD, code=code)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["access_token"]
+
+
+def test_enrolled_flag_survives_successful_login(env):
+    code = pyotp.TOTP(env.totp_secret).now()
+    _login_json(env.client, "enrolled", PASSWORD, code=code)
+    env.db.expire_all()
+    user = env.db.query(User).filter(User.username == "enrolled").first()
+    assert user.mfa_enabled is True
+
+
+def test_admin_created_user_starts_unenrolled(env):
+    user = UserService.create_user(
+        env.db,
+        UserCreate(
+            username="fresh",
+            email="fresh@example.com",
+            password=PASSWORD,
+            role_id=env.role.id,
+        ),
+    )
+    assert user.mfa_enabled is False
+    assert user.mfa_secret is None

--- a/server/tests/test_user_delete_guard.py
+++ b/server/tests/test_user_delete_guard.py
@@ -214,3 +214,48 @@ def test_deactivating_another_user_via_update_still_works(env):
     assert resp.status_code == 200, resp.text
     env.db.expire_all()
     assert env.db.get(User, env.victim.id).is_active is False
+
+
+def _deactivate_victim(env):
+    victim = env.db.get(User, env.victim.id)
+    victim.is_active = False
+    env.db.commit()
+
+
+def test_activate_requires_valid_code(env):
+    _deactivate_victim(env)
+    resp = env.client.post(
+        f"/api/v1/users/{env.victim.id}/activate", headers=_auth("admin")
+    )
+    assert resp.status_code == 401
+    resp = env.client.post(
+        f"/api/v1/users/{env.victim.id}/activate",
+        headers={**_auth("admin"), "X-MFA-Code": "000000"},
+    )
+    assert resp.status_code == 401
+    env.db.expire_all()
+    assert env.db.get(User, env.victim.id).is_active is False
+
+
+def test_activate_with_valid_code_succeeds(env):
+    _deactivate_victim(env)
+    resp = env.client.post(
+        f"/api/v1/users/{env.victim.id}/activate",
+        headers={**_auth("admin"), "X-MFA-Code": _code(env)},
+    )
+    assert resp.status_code == 200, resp.text
+    env.db.expire_all()
+    assert env.db.get(User, env.victim.id).is_active is True
+
+
+def test_update_cannot_bypass_mfa_gated_reactivation(env):
+    _deactivate_victim(env)
+    resp = env.client.put(
+        f"/api/v1/users/{env.victim.id}",
+        json={"is_active": True},
+        headers=_auth("admin"),
+    )
+    assert resp.status_code == 400
+    assert "MFA" in resp.json()["detail"]
+    env.db.expire_all()
+    assert env.db.get(User, env.victim.id).is_active is False

--- a/server/tests/test_user_delete_guard.py
+++ b/server/tests/test_user_delete_guard.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Self-deletion / self-deactivation guards and MFA-confirmed user deletion.
+
+Issue #176: the default admin could delete their own account from the UI;
+the soft delete flips is_active, so the next login says "Account is inactive"
+and a single-admin install is bricked. These tests pin the guards: no user may
+delete or deactivate themselves, and deleting anyone requires the caller's
+current TOTP code in the X-MFA-Code header.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pyotp
+import pytest
+from cryptography.fernet import Fernet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_delete_guard_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as core_auth  # noqa: E402
+from core.auth import create_access_token, get_password_hash  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Role, User  # noqa: E402
+from routers import users as users_router  # noqa: E402
+
+PASSWORD = "Str0ng!passw0rd"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setattr(core_auth, "auth_logger", _L(), raising=False)
+    monkeypatch.setattr(users_router, "main_logger", _L(), raising=False)
+
+    eng = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    session_factory = sessionmaker(bind=eng)
+
+    app = FastAPI()
+    app.include_router(users_router.router, prefix="/api/v1")
+
+    def _get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _get_db
+
+    db = session_factory()
+    role = Role(name="admin", description="test role")
+    db.add(role)
+    db.flush()
+
+    hashed = get_password_hash(PASSWORD)
+    totp_secret = pyotp.random_base32()
+    admin = User(
+        username="admin",
+        email="admin@example.com",
+        hashed_password=hashed,
+        is_active=True,
+        is_superuser=True,
+        password_set=True,
+        mfa_enabled=True,
+        role_id=role.id,
+    )
+    admin.mfa_secret = totp_secret
+    # A superuser who never enrolled MFA — must not be able to delete anyone.
+    admin_no_mfa = User(
+        username="admin2",
+        email="admin2@example.com",
+        hashed_password=hashed,
+        is_active=True,
+        is_superuser=True,
+        password_set=True,
+        mfa_enabled=False,
+        role_id=role.id,
+    )
+    victim = User(
+        username="victim",
+        email="victim@example.com",
+        hashed_password=hashed,
+        is_active=True,
+        password_set=True,
+        role_id=role.id,
+    )
+    db.add_all([admin, admin_no_mfa, victim])
+    db.commit()
+
+    client = TestClient(app)
+    try:
+        yield _types.SimpleNamespace(
+            client=client,
+            db=db,
+            admin=admin,
+            admin_no_mfa=admin_no_mfa,
+            victim=victim,
+            totp_secret=totp_secret,
+        )
+    finally:
+        db.close()
+
+
+def _auth(username: str) -> dict:
+    return {"Authorization": f"Bearer {create_access_token({'sub': username})}"}
+
+
+def _code(env) -> str:
+    return pyotp.TOTP(env.totp_secret).now()
+
+
+def test_self_delete_is_blocked_even_with_valid_code(env):
+    resp = env.client.delete(
+        f"/api/v1/users/{env.admin.id}",
+        headers={**_auth("admin"), "X-MFA-Code": _code(env)},
+    )
+    assert resp.status_code == 400
+    assert "own account" in resp.json()["detail"]
+    env.db.expire_all()
+    assert env.db.get(User, env.admin.id).is_active is True
+
+
+def test_delete_without_code_is_rejected(env):
+    resp = env.client.delete(
+        f"/api/v1/users/{env.victim.id}", headers=_auth("admin")
+    )
+    assert resp.status_code == 401
+    env.db.expire_all()
+    assert env.db.get(User, env.victim.id).is_active is True
+
+
+def test_delete_with_wrong_code_is_rejected(env):
+    resp = env.client.delete(
+        f"/api/v1/users/{env.victim.id}",
+        headers={**_auth("admin"), "X-MFA-Code": "000000"},
+    )
+    assert resp.status_code == 401
+    env.db.expire_all()
+    assert env.db.get(User, env.victim.id).is_active is True
+
+
+def test_delete_with_valid_code_succeeds(env):
+    resp = env.client.delete(
+        f"/api/v1/users/{env.victim.id}",
+        headers={**_auth("admin"), "X-MFA-Code": _code(env)},
+    )
+    assert resp.status_code == 200, resp.text
+    env.db.expire_all()
+    assert env.db.get(User, env.victim.id).is_active is False
+
+
+def test_superuser_without_mfa_cannot_delete(env):
+    resp = env.client.delete(
+        f"/api/v1/users/{env.victim.id}",
+        headers={**_auth("admin2"), "X-MFA-Code": "123456"},
+    )
+    assert resp.status_code == 400
+    assert "MFA" in resp.json()["detail"]
+
+
+def test_self_deactivation_via_update_is_blocked(env):
+    resp = env.client.put(
+        f"/api/v1/users/{env.admin.id}",
+        json={"is_active": False},
+        headers=_auth("admin"),
+    )
+    assert resp.status_code == 400
+    assert "own account" in resp.json()["detail"]
+    env.db.expire_all()
+    assert env.db.get(User, env.admin.id).is_active is True
+
+
+def test_deactivating_another_user_via_update_still_works(env):
+    resp = env.client.put(
+        f"/api/v1/users/{env.victim.id}",
+        json={"is_active": False},
+        headers=_auth("admin"),
+    )
+    assert resp.status_code == 200, resp.text
+    env.db.expire_all()
+    assert env.db.get(User, env.victim.id).is_active is False


### PR DESCRIPTION
readable validation errors, first-login MFA enrollment, dialog redesign
Fixes the 422 crash on user creation, unblocks admin-created users locked out by unenrolled MFA, and restyles user/role dialogs to match the Add Camera design.

the default admin could delete their own account from the UI. The delete is a soft delete (sets is_active = false), so the next login failed with "Account is inactive" and a single-admin install was permanently locked out.

show inactive badge and MFA-gated activate action for deactivated users instead of delete