### PR TITLE
feat: canonical event store — objects, alarms & incidents on one queryable timeline with evidence 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ DETECT_ONNX_PROVIDERS=     # ort EPs, e.g. OpenVINOExecutionProvider (Intel N100
 DETECT_HWACCEL=cpu         # cpu | vaapi | nvidia | qsv | rpi | rkmpp | jetson
 DETECT_GATE_MODE=shadow    # shadow (default: measure only) | off | enforce (act — validate shadow first, see detect-pipeline/ENABLEMENT.md)
 DETECT_CV_THREADS=2        # detector thread cap (cv2 intra-op + BLAS); 0 = uncapped
+DETECT_VISITS_ENABLED=true # persist finished visits + best-frame evidence to the events store
 DETECT_METRICS_PORT=9109   # Prometheus /metrics on the detect-pipeline (0 disables)
 DETECT_DISPATCH_KAIC_URL=  # set (e.g. http://kai-c:8100) to run the gated model via KAI-C; empty = off
 

--- a/detect-pipeline/detect_pipeline/events_poster.py
+++ b/detect-pipeline/detect_pipeline/events_poster.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Visit persistence — post finished tracks (+ best-frame crop) to core.
+
+The moment a track ends is the moment its best frame is FINAL — so that is
+when the visit becomes history: one POST to core's canonical event store
+(RFC-0001 C1) with the lifecycle summary and the crop as JPEG.
+
+Design constraints honoured here:
+* the worker loop must never block on core → posts go through a small
+  bounded queue drained by one daemon thread; when the queue is full the
+  oldest visit is dropped (and counted) rather than stalling detection;
+* per-track grain, not per-frame — a busy camera posts a handful of visits
+  per hour, so stdlib urllib + one thread is deliberately boring;
+* best-effort: core being down loses history, never detection. Failures
+  are visible via the tier0_visits_dropped_total counter and WARNs.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import queue
+import threading
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+log = logging.getLogger("detect_pipeline.events")
+
+EVENTS_PATH = "/api/v1/internal/camera-agent/events"
+
+
+@dataclass(frozen=True)
+class Visit:
+    """A finished track, wall-clock timed, ready to persist."""
+
+    camera_id: str
+    label: str
+    score: float | None
+    track_id: str
+    started_at: datetime
+    ended_at: datetime
+    stationary: bool | None
+    jpeg: bytes | None
+
+
+class VisitPoster:
+    """Bounded-queue, single-thread poster to core's event store."""
+
+    def __init__(
+        self,
+        core_url: str,
+        api_key: str | None,
+        *,
+        maxsize: int = 256,
+        opener=None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.core_url = core_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self._opener = opener or urllib.request.urlopen
+        self._q: queue.Queue[Visit] = queue.Queue(maxsize=maxsize)
+        self._dropped = 0
+        self._thread: threading.Thread | None = None
+
+    # -- worker-side (never blocks) ---------------------------------
+
+    def submit(self, visit: Visit) -> bool:
+        try:
+            self._q.put_nowait(visit)
+            return True
+        except queue.Full:
+            self._dropped += 1
+            log.warning(
+                "visit queue full — dropped %s/%s (total dropped: %d)",
+                visit.camera_id, visit.track_id, self._dropped,
+            )
+            return False
+
+    # -- drain thread -----------------------------------------------
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target=self._drain, name="tier0-visits", daemon=True
+        )
+        self._thread.start()
+
+    def _drain(self) -> None:
+        while True:
+            visit = self._q.get()
+            try:
+                self._post(visit)
+            except Exception as e:
+                log.warning(
+                    "visit post failed for %s/%s: %s",
+                    visit.camera_id, visit.track_id, e,
+                )
+
+    def _post(self, v: Visit) -> None:
+        body = {
+            "camera_id": int(v.camera_id),
+            "label": v.label,
+            "score": v.score,
+            "track_id": str(v.track_id),
+            "started_at": v.started_at.astimezone(timezone.utc).isoformat(),
+            "ended_at": v.ended_at.astimezone(timezone.utc).isoformat(),
+            "stationary": v.stationary,
+        }
+        if v.jpeg:
+            body["evidence_jpeg_b64"] = base64.b64encode(v.jpeg).decode("ascii")
+        req = urllib.request.Request(
+            f"{self.core_url}{EVENTS_PATH}",
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        if self.api_key:
+            req.add_header("X-Internal-Api-Key", self.api_key)
+        with self._opener(req, timeout=self.timeout) as resp:
+            if getattr(resp, "status", 201) not in (200, 201):
+                raise RuntimeError(f"core answered {resp.status}")
+
+
+class VisitLifecycle:
+    """Pure track-lifecycle bookkeeping (no threads, no I/O — testable).
+
+    Feed it each frame's tracks with a wall-clock timestamp; it returns the
+    visits that just FINISHED (their id vanished). Junk suppression: a visit
+    only counts if its track was confirmed at some point and lasted at least
+    ``min_duration_s`` — flickers never become history rows.
+    """
+
+    def __init__(self, camera_id: str, *, min_duration_s: float = 1.0) -> None:
+        self.camera_id = camera_id
+        self.min_duration_s = min_duration_s
+        self._live: dict = {}
+
+    def observe(self, tracks, now_wall: float) -> list[Visit]:
+        current = set()
+        for tr in tracks:
+            current.add(tr.id)
+            v = self._live.get(tr.id)
+            if v is None:
+                v = self._live[tr.id] = {
+                    "start": now_wall, "label": tr.label, "score": float(tr.score),
+                    "stationary": False, "confirmed": False, "crop": None,
+                }
+            v["end"] = now_wall
+            v["label"] = tr.label
+            v["score"] = max(v["score"], float(tr.score))
+            v["stationary"] = bool(getattr(tr, "stationary", False))
+            v["confirmed"] = v["confirmed"] or bool(getattr(tr, "confirmed", False))
+            crop = getattr(tr, "best_crop", None)
+            if crop is not None:
+                v["crop"] = crop
+        finished = []
+        for tid in [t for t in self._live if t not in current]:
+            visit = self._finish(tid, self._live.pop(tid))
+            if visit is not None:
+                finished.append(visit)
+        return finished
+
+    def flush(self) -> list[Visit]:
+        """Finish everything still live (worker stopping)."""
+        out = []
+        for tid in list(self._live):
+            visit = self._finish(tid, self._live.pop(tid))
+            if visit is not None:
+                out.append(visit)
+        return out
+
+    def _finish(self, tid, v) -> Visit | None:
+        end = v.get("end", v["start"])
+        if not v["confirmed"] or (end - v["start"]) < self.min_duration_s:
+            return None
+        jpeg = None
+        crop = v.get("crop")
+        if crop is not None:
+            try:
+                from .bestframe import _encode_jpeg
+
+                jpeg = _encode_jpeg(crop)
+            except Exception:
+                jpeg = None  # a visit without a photo still beats no history
+        return Visit(
+            camera_id=self.camera_id,
+            label=str(v["label"]),
+            score=v["score"],
+            track_id=str(tid),
+            started_at=datetime.fromtimestamp(v["start"], tz=timezone.utc),
+            ended_at=datetime.fromtimestamp(end, tz=timezone.utc),
+            stationary=v["stationary"],
+            jpeg=jpeg,
+        )

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -69,6 +69,7 @@ class ServiceConfig:
     # #10 Tier-1 dispatch — off unless a KAI-C URL is set; only fires in enforce.
     dispatch_kaic_url: str
     dispatch_task: str
+    visits_enabled: bool = True
 
 
 def _truthy(v: str) -> bool:
@@ -112,6 +113,7 @@ def config_from_env(env: dict) -> ServiceConfig:
         model_id=_derive_model_id(env),
         refresh_seconds=float(env.get("DETECT_REFRESH_SECONDS", "30")),
         gate_mode=env.get("DETECT_GATE_MODE", "shadow").strip().lower(),
+        visits_enabled=_truthy(env.get("DETECT_VISITS_ENABLED", "true")),
         gate_heartbeat_s=float(env.get("DETECT_GATE_HEARTBEAT_S", "0")),
         gate_critical_classes=env.get("DETECT_GATE_CRITICAL_CLASSES", ""),
         gate_cooldown_s=float(env.get("DETECT_GATE_COOLDOWN_S", "30")),
@@ -225,6 +227,13 @@ def build_manager(cfg: ServiceConfig, sink, *, gate_sink=None) -> WorkerManager:
     if cfg.metrics_port:
         from .bestframe import BestFrameStore
         best_frames = BestFrameStore()
+    # Events store (RFC-0001 C1): post finished visits + best-frame evidence
+    # to core. Best-effort by design — core down loses history, not detection.
+    visit_poster = None
+    if cfg.visits_enabled and cfg.core_url:
+        from .events_poster import VisitPoster
+        visit_poster = VisitPoster(cfg.core_url, cfg.api_key)
+        visit_poster.start()
     manager = WorkerManager(
         provider, sink,
         enabled=cfg.enabled,
@@ -237,6 +246,7 @@ def build_manager(cfg: ServiceConfig, sink, *, gate_sink=None) -> WorkerManager:
         gate_sink=gate_sink,
         dispatcher=dispatcher,
         router=router,
+        visit_poster=visit_poster,
     )
     manager.best_frames = best_frames            # expose so main() can serve it
     return manager
@@ -359,6 +369,7 @@ def main() -> int:  # pragma: no cover - integration entrypoint
         "  tier1 dispatch     = %s\n"
         "  event bus          = %s\n"
         "  metrics/health     = %s\n"
+        "  visit persistence  = %s\n"
         "  cv threads         = %s",
         cfg.enabled,
         cfg.detector, detector_actual,
@@ -368,6 +379,7 @@ def main() -> int:  # pragma: no cover - integration entrypoint
         cfg.dispatch_kaic_url or "off",
         cfg.nats_url or "unconfigured",
         f":{cfg.metrics_port}/metrics,/health,/best_frame" if cfg.metrics_port else "off",
+        "on (events store)" if cfg.visits_enabled else "off",
         threads or "uncapped",
     )
 

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -102,6 +102,7 @@ class CameraWorker:
         gate_sink=None,                          # publishes gate decisions (audit)
         dispatcher=None,                         # Tier-1 dispatch (#10); shared, thread-safe
         router=None,                             # escalation → adapter routing
+        visit_poster=None,                       # events store: post finished visits (RFC-0001 C1)
     ) -> None:
         self.spec = spec
         self.sink = sink
@@ -115,6 +116,7 @@ class CameraWorker:
         self.gate_sink = gate_sink
         self.dispatcher = dispatcher
         self.router = router
+        self.visit_poster = visit_poster
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -168,6 +170,8 @@ class CameraWorker:
                 "(see detect-pipeline/README.md).",
                 self.spec.camera_id, w, h,
             )
+        from .events_poster import VisitLifecycle
+        lifecycle = VisitLifecycle(self.spec.camera_id)
         motion = MotionDetector((h, w), MotionConfig())
         tracker = Tracker((h, w), TrackConfig(fps=self.spec.fps))
         pipe = DetectPipeline(
@@ -206,6 +210,13 @@ class CameraWorker:
                         crop = getattr(tr, "best_crop", None)
                         if crop is not None:
                             self.best_frames.put(self.spec.camera_id, tr.id, crop, ts)
+                # Visit lifecycle: when a track id vanishes, that visit is over
+                # and its best frame is final — exactly the moment it becomes
+                # history in the canonical event store. Non-blocking: finished
+                # visits go to the poster's bounded queue.
+                if self.visit_poster is not None:
+                    for visit in lifecycle.observe(result.tracks, time.time()):
+                        self.visit_poster.submit(visit)
                 # Sustained fps over a ~1s window — compared to target_fps, this is
                 # the "is the box keeping up with this camera" signal.
                 win_n += 1
@@ -223,6 +234,10 @@ class CameraWorker:
         except Exception:
             log.exception("tier0 %s: worker loop crashed", self.spec.camera_id)
         finally:
+            # Worker stopping: whatever is still live is a finished visit too.
+            if self.visit_poster is not None:
+                for visit in lifecycle.flush():
+                    self.visit_poster.submit(visit)
             record_worker_state(self.spec.camera_id, False)
             log.info("tier0 %s: stopped", self.spec.camera_id)
 
@@ -269,6 +284,7 @@ class WorkerManager:
         gate_sink=None,
         dispatcher=None,                                  # Tier-1 dispatch (#10), shared
         router=None,
+        visit_poster=None,                                # events store (RFC-0001 C1), shared
     ) -> None:
         self.provider = provider
         self.sink = sink
@@ -286,6 +302,7 @@ class WorkerManager:
         # The dispatcher is thread-safe (semaphore + pool) → shared across workers.
         self._dispatcher = dispatcher
         self._router = router
+        self._visit_poster = visit_poster
         self._factory = worker_factory or self._default_factory
         self._workers: dict[str, Worker] = {}
 
@@ -297,6 +314,7 @@ class WorkerManager:
             gate=self._gate_factory() if self._gate_factory else None,
             gate_sink=self._gate_sink,
             dispatcher=self._dispatcher, router=self._router,
+            visit_poster=self._visit_poster,
         )
 
     def running_ids(self) -> set[str]:

--- a/detect-pipeline/test/test_events_poster.py
+++ b/detect-pipeline/test/test_events_poster.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Visit lifecycle + poster — the tier0 half of the events store (RFC-0001 C1)."""
+
+import io
+import json
+from dataclasses import dataclass, field
+
+from detect_pipeline.events_poster import Visit, VisitLifecycle, VisitPoster
+
+T0 = 1_700_000_000.0
+
+
+@dataclass
+class _Tr:
+    id: int
+    label: str = "person"
+    score: float = 0.8
+    stationary: bool = False
+    confirmed: bool = True
+    best_crop: object = field(default=None)
+
+
+# ── lifecycle ───────────────────────────────────────────────────────
+
+def test_visit_finishes_when_track_vanishes():
+    lc = VisitLifecycle("3")
+    assert lc.observe([_Tr(1)], T0) == []
+    assert lc.observe([_Tr(1, score=0.9)], T0 + 5) == []      # still here
+    done = lc.observe([], T0 + 6)                              # gone
+    assert len(done) == 1
+    v = done[0]
+    assert (v.camera_id, v.label, v.track_id) == ("3", "person", "1")
+    assert v.score == 0.9                                      # max over life
+    assert (v.ended_at - v.started_at).total_seconds() == 5.0
+
+
+def test_flickers_never_become_history():
+    lc = VisitLifecycle("3", min_duration_s=1.0)
+    lc.observe([_Tr(1, confirmed=False)], T0)
+    assert lc.observe([], T0 + 10) == []                       # never confirmed
+    lc.observe([_Tr(2)], T0)
+    assert lc.observe([], T0 + 0.3) == []                      # too short
+
+
+def test_flush_finishes_live_visits():
+    lc = VisitLifecycle("3")
+    lc.observe([_Tr(1), _Tr(2)], T0)
+    lc.observe([_Tr(1), _Tr(2)], T0 + 3)
+    assert {v.track_id for v in lc.flush()} == {"1", "2"}
+    assert lc.flush() == []
+
+
+def test_crop_encoded_via_bestframe(monkeypatch):
+    import detect_pipeline.bestframe as bf
+    monkeypatch.setattr(bf, "_encode_jpeg", lambda crop, quality=85: b"\xff\xd8jpg")
+    lc = VisitLifecycle("3")
+    lc.observe([_Tr(1, best_crop=object())], T0)
+    lc.observe([_Tr(1, best_crop=object())], T0 + 2)
+    done = lc.observe([], T0 + 3)
+    assert done[0].jpeg == b"\xff\xd8jpg"
+
+
+# ── poster ──────────────────────────────────────────────────────────
+
+def _visit(jpeg=None):
+    from datetime import datetime, timezone
+    t = datetime.fromtimestamp(T0, tz=timezone.utc)
+    return Visit("3", "person", 0.9, "7", t, t, False, jpeg)
+
+
+class _Resp(io.BytesIO):
+    status = 201
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+
+def test_post_carries_auth_and_evidence():
+    seen = {}
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["key"] = req.get_header("X-internal-api-key")
+        seen["body"] = json.loads(req.data.decode())
+        return _Resp()
+    p = VisitPoster("http://core:8000", "sekret", opener=opener)
+    p._post(_visit(jpeg=b"\xff\xd8x"))
+    assert seen["url"].endswith("/api/v1/internal/camera-agent/events")
+    assert seen["key"] == "sekret"
+    assert seen["body"]["camera_id"] == 3
+    assert seen["body"]["label"] == "person"
+    assert "evidence_jpeg_b64" in seen["body"]
+
+
+def test_full_queue_drops_not_blocks():
+    p = VisitPoster("http://core:8000", None, maxsize=1)
+    assert p.submit(_visit()) is True
+    assert p.submit(_visit()) is False                          # dropped, no block
+    assert p._dropped == 1

--- a/server/main.py
+++ b/server/main.py
@@ -59,6 +59,7 @@ from routers import (
     camera_settings,
     cameras,
     internal_camera_agent,
+    timeline_events,
     cloud as cloud_router,
     cloud_inference,
     cloud_providers,
@@ -512,6 +513,7 @@ app.include_router(users.router, prefix=settings.api_prefix)
 app.include_router(cameras.router, prefix=settings.api_prefix)
 app.include_router(camera_settings.router, prefix=settings.api_prefix)
 app.include_router(internal_camera_agent.router, prefix=settings.api_prefix)
+app.include_router(timeline_events.router, prefix=settings.api_prefix)
 app.include_router(streams.router, prefix=settings.api_prefix)
 app.include_router(camera_config.router, prefix=settings.api_prefix)
 app.include_router(roles.router, prefix=settings.api_prefix)

--- a/server/migrations/versions/aa11bb22cc33_add_events_evidence_store.py
+++ b/server/migrations/versions/aa11bb22cc33_add_events_evidence_store.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""add events table — the canonical event & evidence store (RFC-0001 C1)
+
+One row per object VISIT (a Tier-0 track lifecycle), not per frame: the
+grain a human question uses ("who came between 3 and 4?" = a handful of
+visits, not thousands of detections). Evidence (the track's best frame,
+selected at capture time) is stored as a small JPEG on disk next to the
+recordings; the row carries its path. Purely additive; existing stores
+(camera_events, footage-search) migrate onto this in later phases.
+
+Revision ID: aa11bb22cc33
+Revises: d5e6f7a8b9c0
+Create Date: 2026-08-07 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "aa11bb22cc33"
+down_revision: str | None = "d5e6f7a8b9c0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "camera_id", sa.Integer(), sa.ForeignKey("cameras.id"), nullable=False
+        ),
+        # Producer family: tier0 | camera | app | adapter. One table for all
+        # of them is the point (RFC-0001 Challenge 1).
+        sa.Column("source", sa.String(length=30), nullable=False),
+        # track (an object's visit) | alarm | alert
+        sa.Column("event_type", sa.String(length=30), nullable=False),
+        sa.Column("label", sa.String(length=60), nullable=True),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("track_id", sa.String(length=40), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        # Filled when the recording resolver can anchor the visit to a file.
+        sa.Column("recording_ref", sa.String(length=500), nullable=True),
+        # Relative path (under the evidence root) of the best-frame JPEG.
+        sa.Column("evidence_path", sa.String(length=500), nullable=True),
+        # PR-C: fast-plate-ocr enrichment lands here.
+        sa.Column("plate_text", sa.String(length=32), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_events_id", "events", ["id"])
+    op.create_index("ix_events_cam_start", "events", ["camera_id", "started_at"])
+    op.create_index("ix_events_label", "events", ["label"])
+    op.create_index("ix_events_source", "events", ["source"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_events_source", table_name="events")
+    op.drop_index("ix_events_label", table_name="events")
+    op.drop_index("ix_events_cam_start", table_name="events")
+    op.drop_index("ix_events_id", table_name="events")
+    op.drop_table("events")

--- a/server/models.py
+++ b/server/models.py
@@ -390,6 +390,37 @@ class CameraCapability(Base):
     camera = relationship("Camera", back_populates="capability")
 
 
+class TimelineEvent(Base):
+    """Canonical event & evidence store (RFC-0001 Challenge 1) — one row per
+    object VISIT (a Tier-0 track lifecycle), alarm, or app alert.
+
+    The question-shaped store: "who came between 3 and 4pm?" is a range scan
+    here, each row carrying its best-frame evidence JPEG (selected at capture
+    time — the sharpest look Tier-0 had at the object) and, later, the
+    recording anchor and LPR plate text. All producers share this table; apps
+    query it instead of keeping private stores."""
+
+    __tablename__ = "events"
+    __table_args__ = (
+        Index("ix_events_cam_start", "camera_id", "started_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    camera_id = Column(Integer, ForeignKey("cameras.id"), nullable=False)
+    source = Column(String(30), nullable=False)        # tier0 | camera | app | adapter
+    event_type = Column(String(30), nullable=False)    # track | alarm | alert
+    label = Column(String(60), nullable=True, index=True)
+    score = Column(Float, nullable=True)
+    track_id = Column(String(40), nullable=True)
+    started_at = Column(DateTime(timezone=True), nullable=False)
+    ended_at = Column(DateTime(timezone=True), nullable=True)
+    recording_ref = Column(String(500), nullable=True)
+    evidence_path = Column(String(500), nullable=True)
+    plate_text = Column(String(32), nullable=True)
+    payload = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
 class CameraEvent(Base):
     """A camera-native alarm (motion / tamper / video-loss / IO) received from
     the device's event stream. History store parallel to AIDetectionResult; the

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -10,11 +10,14 @@ passwords or requiring an operator login token.
 
 from __future__ import annotations
 
+import binascii
 import logging
 import secrets
+from datetime import datetime
 from urllib.parse import quote as urlquote
 
 from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from core.config import settings
@@ -39,6 +42,67 @@ def _require_internal_key(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="invalid internal api key",
         )
+
+
+class TrackEventIn(BaseModel):
+    """One finished object visit, posted by the detect-pipeline at track end."""
+
+    camera_id: int
+    label: str
+    score: float | None = None
+    track_id: str | None = None
+    started_at: datetime
+    ended_at: datetime | None = None
+    stationary: bool | None = None
+    # Best-frame crop (JPEG, base64). Optional: a visit with no retained crop
+    # is still history worth keeping.
+    evidence_jpeg_b64: str | None = None
+
+
+@router.post("/events", status_code=201)
+async def ingest_track_event(
+    payload: TrackEventIn,
+    _: None = Depends(_require_internal_key),
+    db: Session = Depends(get_db),
+):
+    """Canonical-store ingest (RFC-0001 C1): persist a visit + its evidence.
+
+    Called by the detect-pipeline when a track ends — the moment its best
+    frame is final. Idempotent enough for retries: identical evidence
+    content-addresses to the same file; duplicate rows are tolerated and
+    cheap to de-dup at query time via (camera_id, track_id, started_at).
+    """
+    camera = db.query(Camera).filter(Camera.id == payload.camera_id).first()
+    if camera is None:
+        raise HTTPException(status_code=404, detail="unknown camera_id")
+
+    evidence_rel = None
+    if payload.evidence_jpeg_b64:
+        import base64
+
+        from services.evidence_store import save_evidence_jpeg
+
+        try:
+            evidence_rel = save_evidence_jpeg(
+                base64.b64decode(payload.evidence_jpeg_b64, validate=True)
+            )
+        except (ValueError, binascii.Error) as e:
+            raise HTTPException(status_code=422, detail=f"bad evidence: {e}")
+
+    from services.timeline_service import record_track_visit
+
+    row = record_track_visit(
+        db,
+        camera_id=payload.camera_id,
+        label=payload.label,
+        started_at=payload.started_at,
+        ended_at=payload.ended_at,
+        score=payload.score,
+        track_id=payload.track_id,
+        stationary=payload.stationary,
+        evidence_path=evidence_rel,
+    )
+    return {"id": row.id, "evidence_path": evidence_rel}
 
 
 GATE_MODE_KEY = "detect_gate_mode"

--- a/server/routers/timeline_events.py
+++ b/server/routers/timeline_events.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Timeline query API — the read side of the canonical event & evidence store.
+
+"Who came between 3 and 4pm?" is `GET /events?label=person&from=&to=` — a
+range scan over visits, each row linking its best-frame evidence JPEG. This
+is the API the agent's search tools, the UI timeline, and every app query
+instead of keeping private stores (RFC-0001 Challenge 1).
+
+Distinct from routers/events.py, which is the LIVE WebSocket feed; this is
+history. Same nouns, different tense.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+
+from core.auth import get_current_active_user
+from core.database import get_db
+from models import TimelineEvent, User
+
+router = APIRouter(tags=["timeline"])
+
+
+def _serialize(e: TimelineEvent) -> dict:
+    return {
+        "id": e.id,
+        "camera_id": e.camera_id,
+        "source": e.source,
+        "event_type": e.event_type,
+        "label": e.label,
+        "score": e.score,
+        "track_id": e.track_id,
+        "started_at": e.started_at.isoformat() if e.started_at else None,
+        "ended_at": e.ended_at.isoformat() if e.ended_at else None,
+        "recording_ref": e.recording_ref,
+        "plate_text": e.plate_text,
+        "has_evidence": bool(e.evidence_path),
+        "evidence_url": f"/api/v1/events/{e.id}/evidence" if e.evidence_path else None,
+        "payload": e.payload,
+    }
+
+
+@router.get("/events")
+async def list_events(
+    camera_id: int | None = None,
+    label: str | None = None,
+    source: str | None = None,
+    from_: datetime | None = Query(default=None, alias="from"),
+    to: datetime | None = None,
+    limit: int = 100,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Query visits/alarms/alerts, newest first.
+
+    Time filters use the OVERLAP rule — an event counts if any part of it
+    intersects [from, to) — because "who was here 3-4pm" must include the
+    visit that started 14:58 and left 15:03.
+    """
+    from services.timeline_service import query_events
+
+    rows = query_events(
+        db, camera_id=camera_id, label=label, source=source,
+        from_=from_, to=to, limit=limit,
+    )
+    return {"events": [_serialize(e) for e in rows], "count": len(rows)}
+
+
+@router.get("/events/{event_id}/evidence")
+async def get_event_evidence(
+    event_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """The visit's best-frame JPEG — the sharpest look Tier-0 had at it."""
+    e = db.query(TimelineEvent).filter(TimelineEvent.id == event_id).first()
+    if e is None or not e.evidence_path:
+        raise HTTPException(status_code=404, detail="no evidence for this event")
+    from services.evidence_store import resolve_evidence
+
+    path = resolve_evidence(e.evidence_path)
+    if path is None:
+        raise HTTPException(status_code=404, detail="evidence file missing")
+    return FileResponse(path, media_type="image/jpeg",
+                        headers={"Cache-Control": "max-age=86400"})

--- a/server/routers/timeline_events.py
+++ b/server/routers/timeline_events.py
@@ -82,6 +82,10 @@ async def list_events(
     rows = query_events(
         db, camera_id=camera_id, label=label, source=source,
         from_=from_, to=to, limit=limit,
+        # Camera data is owner-scoped everywhere in OpenNVR; history and
+        # evidence photos are the MOST sensitive camera data, so the same
+        # rule applies here. Superusers see the fleet.
+        owner_id=None if current_user.is_superuser else current_user.id,
     )
     return {"events": [_serialize(e) for e in rows], "count": len(rows)}
 
@@ -95,6 +99,11 @@ async def get_event_evidence(
     """The visit's best-frame JPEG — the sharpest look Tier-0 had at it."""
     e = db.query(TimelineEvent).filter(TimelineEvent.id == event_id).first()
     if e is None or not e.evidence_path:
+        raise HTTPException(status_code=404, detail="no evidence for this event")
+    from services.timeline_service import can_access_event
+
+    if not can_access_event(db, e, user=current_user):
+        # 404, not 403: don't confirm the event exists on someone else's camera.
         raise HTTPException(status_code=404, detail="no evidence for this event")
     from services.evidence_store import resolve_evidence
 

--- a/server/services/evidence_store.py
+++ b/server/services/evidence_store.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Evidence blob store — the JPEGs behind the events table.
+
+Content-addressed (sha256-named) JPEGs under ``<recordings>/.evidence/``, so
+they live on the same volume as the footage they explain, share its capacity
+planning, and a re-posted identical crop costs nothing. Paths stored in the
+DB are RELATIVE to the evidence root — the root can move with the recordings
+volume without a data migration.
+
+Size sanity: one visit = one crop (~30-80 KB). A busy camera seeing 500
+visits/day stores ~25 MB/day — noise next to the recordings themselves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from core.config import settings
+
+_EVIDENCE_DIR = ".evidence"
+# One JPEG per visit; anything above this is not a crop we produced.
+MAX_EVIDENCE_BYTES = 2 * 1024 * 1024
+
+
+def evidence_root() -> Path:
+    root = Path(settings.recordings_base_path) / _EVIDENCE_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def save_evidence_jpeg(data: bytes) -> str:
+    """Store a JPEG, return its relative path. Content-addressed: idempotent."""
+    if not data or len(data) > MAX_EVIDENCE_BYTES:
+        raise ValueError(f"evidence must be 1..{MAX_EVIDENCE_BYTES} bytes")
+    # Cheap magic check — we only ever store JPEGs.
+    if not data.startswith(b"\xff\xd8"):
+        raise ValueError("evidence is not a JPEG")
+    digest = hashlib.sha256(data).hexdigest()
+    rel = f"{digest[:2]}/{digest}.jpg"
+    path = evidence_root() / rel
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".partial")
+        tmp.write_bytes(data)
+        tmp.replace(path)
+    return rel
+
+
+def resolve_evidence(rel_path: str) -> Path | None:
+    """Relative DB path -> absolute file path, refusing traversal outside the
+    evidence root (same discipline as the recordings resolver)."""
+    root = evidence_root().resolve()
+    try:
+        p = (root / rel_path).resolve()
+    except OSError:
+        return None
+    if root not in p.parents:
+        return None
+    return p if p.is_file() else None

--- a/server/services/timeline_service.py
+++ b/server/services/timeline_service.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Timeline service — write and read the canonical event store (RFC-0001 C1).
+
+Routes stay thin; the semantics live here where tests can reach them:
+* one row per visit (track lifecycle), alarm, or alert;
+* the OVERLAP rule for time filters ("who was here 3-4pm" includes the
+  visit that started 14:58 and left 15:03).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from models import TimelineEvent
+
+
+def record_track_visit(
+    db: Session,
+    *,
+    camera_id: int,
+    label: str,
+    started_at: datetime,
+    ended_at: datetime | None = None,
+    score: float | None = None,
+    track_id: str | None = None,
+    stationary: bool | None = None,
+    evidence_path: str | None = None,
+) -> TimelineEvent:
+    """Persist one finished visit (source=tier0, event_type=track)."""
+    row = TimelineEvent(
+        camera_id=camera_id,
+        source="tier0",
+        event_type="track",
+        label=(label or "")[:60].lower() or None,
+        score=score,
+        track_id=(track_id or "")[:40] or None,
+        started_at=started_at,
+        ended_at=ended_at,
+        evidence_path=evidence_path,
+        payload={"stationary": stationary} if stationary is not None else None,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def query_events(
+    db: Session,
+    *,
+    camera_id: int | None = None,
+    label: str | None = None,
+    source: str | None = None,
+    from_: datetime | None = None,
+    to: datetime | None = None,
+    limit: int = 100,
+) -> list[TimelineEvent]:
+    """Newest-first visits/alarms/alerts intersecting [from, to)."""
+    limit = max(1, min(500, limit))
+    q = db.query(TimelineEvent)
+    if camera_id is not None:
+        q = q.filter(TimelineEvent.camera_id == camera_id)
+    if label:
+        q = q.filter(TimelineEvent.label == label.strip().lower())
+    if source:
+        q = q.filter(TimelineEvent.source == source)
+    if to is not None:
+        q = q.filter(TimelineEvent.started_at < to)
+    if from_ is not None:
+        # Overlap: an event with an end must end at/after `from`; an
+        # instantaneous event (no end) must start at/after `from`.
+        q = q.filter(
+            ((TimelineEvent.ended_at.isnot(None)) & (TimelineEvent.ended_at >= from_))
+            | ((TimelineEvent.ended_at.is_(None)) & (TimelineEvent.started_at >= from_))
+        )
+    return q.order_by(TimelineEvent.started_at.desc()).limit(limit).all()

--- a/server/services/timeline_service.py
+++ b/server/services/timeline_service.py
@@ -29,7 +29,7 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 
-from models import TimelineEvent
+from models import Camera, TimelineEvent
 
 
 def record_track_visit(
@@ -72,10 +72,19 @@ def query_events(
     from_: datetime | None = None,
     to: datetime | None = None,
     limit: int = 100,
+    owner_id: int | None = None,
 ) -> list[TimelineEvent]:
-    """Newest-first visits/alarms/alerts intersecting [from, to)."""
+    """Newest-first visits/alarms/alerts intersecting [from, to).
+
+    ``owner_id`` scopes results to that user's cameras — the same ownership
+    rule every camera route enforces. Pass None ONLY for superusers.
+    """
     limit = max(1, min(500, limit))
     q = db.query(TimelineEvent)
+    if owner_id is not None:
+        q = q.join(Camera, Camera.id == TimelineEvent.camera_id).filter(
+            Camera.owner_id == owner_id
+        )
     if camera_id is not None:
         q = q.filter(TimelineEvent.camera_id == camera_id)
     if label:
@@ -92,3 +101,11 @@ def query_events(
             | ((TimelineEvent.ended_at.is_(None)) & (TimelineEvent.started_at >= from_))
         )
     return q.order_by(TimelineEvent.started_at.desc()).limit(limit).all()
+
+
+def can_access_event(db: Session, event: TimelineEvent, *, user) -> bool:
+    """Ownership check for a single event — mirrors get_camera_or_403."""
+    if getattr(user, "is_superuser", False):
+        return True
+    cam = db.query(Camera).filter(Camera.id == event.camera_id).first()
+    return bool(cam and cam.owner_id == user.id)

--- a/server/tests/test_timeline_events.py
+++ b/server/tests/test_timeline_events.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Canonical event & evidence store (RFC-0001 C1) — service-level tests."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_tl_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from core.database import Base  # noqa: E402
+from models import Camera, Role, User  # noqa: E402
+from services import evidence_store  # noqa: E402
+from services.timeline_service import query_events, record_track_visit  # noqa: E402
+
+UTC = timezone.utc
+T = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)  # "3pm"
+
+
+@pytest.fixture
+def db():
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    s = sessionmaker(bind=eng)()
+    role = Role(name="admin")
+    s.add(role)
+    s.commit()
+    owner = User(username="t", email="t@t.io", hashed_password="x", role_id=role.id)
+    s.add(owner)
+    s.commit()
+    cam = Camera(name="gate", ip_address="10.0.0.9", port=80, owner_id=owner.id)
+    s.add(cam)
+    s.commit()
+    s.refresh(cam)
+    s.cam_id = cam.id
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _visit(db, *, start_min, end_min=None, label="person", cam=None, **kw):
+    return record_track_visit(
+        db, camera_id=cam or db.cam_id, label=label,
+        started_at=T + timedelta(minutes=start_min),
+        ended_at=None if end_min is None else T + timedelta(minutes=end_min),
+        **kw,
+    )
+
+
+# ── write side ──────────────────────────────────────────────────────
+
+def test_visit_row_shape(db):
+    row = _visit(db, start_min=12, end_min=14, score=0.91,
+                 track_id="7", stationary=False, evidence_path="ab/x.jpg")
+    assert (row.source, row.event_type, row.label) == ("tier0", "track", "person")
+    assert row.evidence_path == "ab/x.jpg"
+    assert row.payload == {"stationary": False}
+
+
+def test_label_normalized_lowercase(db):
+    assert _visit(db, start_min=0, label="Person").label == "person"
+
+
+# ── read side: the 3-4pm question ───────────────────────────────────
+
+def test_window_query_uses_overlap_not_containment(db):
+    _visit(db, start_min=-2, end_min=3)     # started 14:58, left 15:03 — counts
+    _visit(db, start_min=12, end_min=14)    # fully inside — counts
+    _visit(db, start_min=-30, end_min=-10)  # long gone — no
+    _visit(db, start_min=70, end_min=75)    # after the window — no
+    rows = query_events(db, label="person", from_=T, to=T + timedelta(hours=1))
+    starts = sorted(r.started_at.replace(tzinfo=UTC) for r in rows)
+    assert len(rows) == 2
+    assert starts[0] == T + timedelta(minutes=-2)
+
+
+def test_filters_by_label_and_camera(db):
+    _visit(db, start_min=1, label="car")
+    _visit(db, start_min=2, label="person")
+    assert [r.label for r in query_events(db, label="car")] == ["car"]
+    assert query_events(db, camera_id=db.cam_id + 999) == []
+
+
+def test_newest_first_and_limit(db):
+    for m in range(5):
+        _visit(db, start_min=m)
+    rows = query_events(db, limit=3)
+    assert len(rows) == 3
+    assert rows[0].started_at >= rows[-1].started_at
+
+
+# ── evidence store ──────────────────────────────────────────────────
+
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 64
+
+
+def _point_evidence_at(monkeypatch, tmp_path):
+    """Patch the evidence module's settings reference (not the pydantic
+    object — validate_assignment makes attribute patching order-dependent
+    across the suite)."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        evidence_store, "settings",
+        SimpleNamespace(recordings_base_path=str(tmp_path)),
+    )
+
+
+def test_evidence_roundtrip(tmp_path, monkeypatch):
+    _point_evidence_at(monkeypatch, tmp_path)
+    rel = evidence_store.save_evidence_jpeg(JPEG)
+    assert rel.endswith(".jpg")
+    p = evidence_store.resolve_evidence(rel)
+    assert p is not None and p.read_bytes() == JPEG
+    # content-addressed: same bytes, same path, no duplicate write
+    assert evidence_store.save_evidence_jpeg(JPEG) == rel
+
+
+def test_evidence_rejects_non_jpeg_and_oversize(tmp_path, monkeypatch):
+    _point_evidence_at(monkeypatch, tmp_path)
+    with pytest.raises(ValueError):
+        evidence_store.save_evidence_jpeg(b"PNG-not-jpeg")
+    with pytest.raises(ValueError):
+        evidence_store.save_evidence_jpeg(
+            b"\xff\xd8" + b"\x00" * evidence_store.MAX_EVIDENCE_BYTES)
+
+
+def test_evidence_resolver_refuses_traversal(tmp_path, monkeypatch):
+    _point_evidence_at(monkeypatch, tmp_path)
+    (tmp_path / "secret.txt").write_text("no")
+    assert evidence_store.resolve_evidence("../secret.txt") is None
+    assert evidence_store.resolve_evidence("nope/missing.jpg") is None

--- a/server/tests/test_timeline_events.py
+++ b/server/tests/test_timeline_events.py
@@ -160,3 +160,36 @@ def test_evidence_resolver_refuses_traversal(tmp_path, monkeypatch):
     (tmp_path / "secret.txt").write_text("no")
     assert evidence_store.resolve_evidence("../secret.txt") is None
     assert evidence_store.resolve_evidence("nope/missing.jpg") is None
+
+
+# ── ownership scoping (cameras are owner-scoped; so is their history) ─
+
+def test_query_scoped_to_owners_cameras(db):
+    from models import User as _User
+    other = _User(username="o", email="o@t.io", hashed_password="x",
+                  role_id=db.query(Role).first().id)
+    db.add(other)
+    db.commit()
+    other_cam = Camera(name="their-gate", ip_address="10.0.0.8", port=80,
+                       owner_id=other.id)
+    db.add(other_cam)
+    db.commit()
+    _visit(db, start_min=1)                       # mine
+    _visit(db, start_min=2, cam=other_cam.id)     # theirs
+
+    owner_id = db.query(Camera).filter(Camera.id == db.cam_id).first().owner_id
+    mine = query_events(db, owner_id=owner_id)
+    assert [r.camera_id for r in mine] == [db.cam_id]
+    fleet = query_events(db)                      # superuser path (no scope)
+    assert len(fleet) == 2
+
+
+def test_can_access_event_mirrors_ownership(db):
+    from types import SimpleNamespace
+
+    from services.timeline_service import can_access_event
+    row = _visit(db, start_min=1)
+    owner_id = db.query(Camera).filter(Camera.id == db.cam_id).first().owner_id
+    assert can_access_event(db, row, user=SimpleNamespace(id=owner_id, is_superuser=False))
+    assert not can_access_event(db, row, user=SimpleNamespace(id=owner_id + 99, is_superuser=False))
+    assert can_access_event(db, row, user=SimpleNamespace(id=0, is_superuser=True))


### PR DESCRIPTION
# Your NVR now remembers what happened — every object, alarm, and incident, queryable, with evidence

**RFC-0001 Challenge 1, part A.** One `events` table for everything the platform notices:

| `event_type` | What it is | Producer (`source`) |
|---|---|---|
| `track` (a **visit**) | an object's stay in view — person, car, truck, dog, *anything the detector knows* — with its best-frame photo | `tier0` (**this PR**) |
| `alarm` | camera-native alarms: motion, tamper, video-loss (driver layer) | `camera` (converges in a later phase) |
| `alert` | app incidents: line-crossing, loitering, intrusion, occupancy | `app` (converges in a later phase) |

This PR builds the table + query API and wires the first producer: Tier-0 visits, each row carrying the sharpest frame it saw of that object, chosen at capture time. Questions that used to mean scrubbing footage become one query:

```
"Who came between 3 and 4pm?"
GET /api/v1/events?label=person&from=2026-08-07T15:00&to=2026-08-07T16:00

"Which vehicles entered today?"
GET /api/v1/events?label=car&from=2026-08-07T00:00
→ { "events": [ { "label": "car", "camera_id": 3, "score": 0.94,
                  "started_at": "15:12:04", "ended_at": "15:14:11",
                  "evidence_url": "/api/v1/events/42/evidence" } ], … }
```

`evidence_url` serves that visit's best-frame JPEG — for a car, the frame where it was largest and sharpest (the right input for LPR, which lands on this same row in PR-C; the `plate_text` column already exists).

**Label-agnostic by construction:** the store persists whatever the configured detector emits. Default YOLOv8 = all 80 COCO classes; swap the detector and the store follows — zero code changes. Time filters use **overlap semantics**: the visit that started 14:58 and left 15:03 counts for "3–4pm", because that is what the question means.

## What this improves in OpenNVR

| Before this PR | After |
|---|---|
| Historical questions meant scrubbing recordings or hoping a heavy adapter was running at the time | Any past window is answerable in milliseconds from indexed rows — **whether or not anyone was watching or asking at the time** |
| Tier-0's best frames lived in RAM and expired — the sharpest look at every object was thrown away | Every confirmed object's best photo is kept, tied to its time window and camera |
| Expensive follow-ups (face match, LPR) had to run on video or live grabs | They run on **one curated crop per object** — the cheapest and most accurate possible input (PR-B/C plug into exactly this) |
| Each app persisted its own history (private SQLite, ad-hoc tables) — five stores, five schemas, no shared timeline | One schema, one query API; apps stop writing persistence code (RFC-0001's "no duplication" made structural) |
| History access wasn't defined | Owner-scoped from day one, like every camera route |
| The tier0 debate: "detection runs but what do we keep?" | Detection now produces a permanent, searchable, evidence-backed record — the always-on layer finally has a memory |

## How it works

- **One row per VISIT, not per frame.** Tier-0 already tracks object lifecycles; the moment a track ends its best frame is *final* — that is when the pipeline posts the summary + crop to core (`VisitLifecycle` → bounded-queue `VisitPoster` → internal ingest). A busy camera writes a handful of rows per hour, not thousands — "which cars today" returns visits, not 4,000 detections of the same parked car.
- **Junk never becomes history:** only confirmed tracks lasting ≥ 1 s persist; flickers and false blips are dropped in the pipeline. Score is the max over the visit; `stationary` rides along in the payload.
- **Evidence is content-addressed** (sha256 JPEGs, ~30–80 KB) under `<recordings>/.evidence/` — same volume as the footage it explains, idempotent on retry, traversal-safe resolver.
- **Detection can never stall on history:** worker loop → bounded queue → one drain thread. Core down = history pauses, detection continues; drops are counted and logged.
- **Owner-scoped like every camera route:** users see only their own cameras' events; foreign evidence probes get 404 (not 403), so an id scan can't even confirm an event exists.

## One table for the whole platform (where this is going)

This is the canonical store from RFC-0001. The `alarm` and `alert` rows in the table above arrive in later phases: driver alarms migrate from `camera_events`, app incidents from per-app private stores (footage-search's SQLite is first) — after which "what happened on camera 3 yesterday?" returns visits, alarms, and incidents interleaved on one timeline, and apps stop writing persistence code entirely; they query. The agent's conversational search ("did you see anyone around 3?" → face-matched answers from these evidence crops) is PR-B on this exact API.

## Defaults / config

On by default, zero configuration. `DETECT_VISITS_ENABLED=false` opts out. Additive migration (`aa11bb22cc33`); no existing store is touched.

## QA validation (no .env changes)

1. `docker compose up -d`; walk past a camera; drive/roll something wheeled past it too. Wait ~10 s after each exit.
2. `GET /api/v1/events?label=person` and `?label=car` → visit rows with correct windows; open each `evidence_url` → recognizable photos.
3. Ownership: a second (non-superuser) account must see none of the above, and fetching those `evidence_url`s must 404.
4. Resilience: stop opennvr-core for a minute → detect-pipeline keeps detecting (post WARNs only); start core → new visits persist again.

## Test status

server **590** (11 new: row shape, label normalization, overlap-vs-containment, filters/ordering, evidence roundtrip/validation/traversal, ownership ×2) · detect-pipeline **186** (6 new: visit finish/flicker-suppression/flush/crop-encode, poster auth+payload, queue-full drop).

## Known follow-ups (deliberate)

- **PR-B:** agent `search_events` tool + face-match over evidence crops; unique index on `(camera_id, track_id, started_at)`; pre-decode base64 length check on ingest.
- **PR-C:** LPR `plate_text` enrichment; footage-search migrates onto the store.
- **Retention:** prune `.evidence/` with the recordings-retention job (issue filed at merge).