### PR TITLE
feat: the memory speaks — agent search_history with face-matched answers (RFC-0001 C1, part B)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,31 @@ voice/text, not camera frames (the LLM still benefits indirectly: fewer, cleaner
 VLM calls). **Recording is never gated.** Every stage is additive and can be
 disabled without touching the rest of the stack.
 
+## The memory plane (canonical event & evidence store)
+
+Sensing without memory answers only "what is happening *now*". The **events
+store** (RFC-0001 Challenge 1) is the platform's memory: one `events` table in
+core, **one row per object visit** (a Tier-0 track lifecycle — person, car,
+anything the detector knows), each carrying the **best-frame photo** selected
+at capture time, content-addressed under `<recordings>/.evidence/`.
+
+```
+tier0 track ends ──POST──▶ core /internal/camera-agent/events ──▶ events row + JPEG
+                                                                        │
+users:  GET /api/v1/events?label=car&from=…&to=…  (owner-scoped)  ◀─────┤
+agents: SDK EventsClient → search_history tool                    ◀─────┘
+        ("did anyone come between 3 and 4?" → visits + face-matched names)
+```
+
+Rules that keep it sane: **per-visit grain** (never per-frame — "which cars
+today" returns visits, not 4,000 detections of one parked car); **junk never
+persists** (confirmed tracks ≥ 1 s only); **detection never blocks on
+history** (bounded queue, best-effort posts); **overlap time semantics** (the
+14:58–15:03 visit counts for "3–4pm"); **ingest is idempotent**
+(`uq_events_visit`). Camera-native alarms (`camera_events`) and app alerts
+converge onto this table in later phases — one timeline, and apps stop
+writing private history stores.
+
 ## Request lifecycle (web)
 
 ```

--- a/examples/camera-agent/README.md
+++ b/examples/camera-agent/README.md
@@ -110,12 +110,19 @@ runs only the tools needed to answer (one frame from one camera,
 not all of them), and tells you. It's deliberately a SMALL agent,
 not "AGI for cameras":
 
-* The model has five tools, no general-purpose memory, no web
-  access. It can describe what it sees, count objects, recognise
-  faces, look back at recent inference events, and — when a
-  footage-search index is configured (`footage_index_path`) — search
-  the recorded past in natural language ("did a red truck come by the
-  dock earlier?") via the `search_footage` tool.
+* The model has a small fixed toolset, no web access. It can
+  describe what it sees, count objects, recognise faces, look back at
+  recent inference events, and — when a footage-search index is
+  configured (`footage_index_path`) — search keyframes via
+  `search_footage`.
+* **It has a memory.** When the server API origin is configured
+  (`opennvr_base_url`), the `search_history` tool reads the platform's
+  canonical event store: every past visit of every detected object,
+  each with its best photo. "Did anyone come between 3 and 4?" →
+  "I remember 3 person visits: 15:12–15:14 …" — and for people it
+  face-matches the kept photos and names anyone recognised. No extra
+  configuration: it rides the same INTERNAL_API_KEY the agent already
+  holds.
 * It can't drive cameras (pan-tilt-zoom), can't arm / disarm
   anything, can't speak first. Strictly conversational.
 * Latency is "homelab-fine, not real-time" — expect 3-6 seconds

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -320,6 +320,10 @@ _DEFAULT_SYSTEM_PROMPT = (
     "always-on detector with no new inference. Use detect_objects or "
     "describe_camera only if camera_snapshot has no data, or the answer needs "
     "appearance (colour, clothing, what someone is doing).\n"
+    "- For questions about the PAST ('did anyone come between 3 and 4?', "
+    "'which cars entered today?', 'was a dog here yesterday?') call "
+    "search_history — the NVR remembers every visit with a photo and can "
+    "name recognised people.\n"
     "- NEVER invent, guess, or describe what is on a camera from imagination. "
     "If you have not called a tool this turn, you do not know.\n"
     "- Base your answer ONLY on the tool result, in 1-2 short spoken sentences.\n"
@@ -348,7 +352,7 @@ SKILL_TOOLS: dict[str, list[str]] = {
     "see": ["describe_camera"],
     "count": ["detect_objects", "camera_snapshot"],
     "faces": ["recognize_faces", "enroll_face", "list_people", "forget_face"],
-    "events": ["recent_events"],
+    "events": ["recent_events", "search_history"],
     "footage": ["search_footage"],
     "alarm": ["create_alarm", "stop_alarm"],
     "watch": ["create_monitor", "stop_monitor"],
@@ -2655,6 +2659,22 @@ class CameraAgentRuntime:
                 cfg.bestframe_base_url, resolve_camera=_resolve_camera,
             )
 
+        # Events store (the platform's memory, RFC-0001 C1): built whenever the
+        # server API origin is configured — same origin + INTERNAL_API_KEY chain
+        # the app door uses. Shared primitive from the SDK (Challenge-3 rule).
+        events_client = None
+        if cfg.opennvr_api_url:
+            import os as _os
+
+            from opennvr_app_sdk import EventsClient
+            events_client = EventsClient(
+                cfg.opennvr_api_url,
+                cfg.opennvr_api_key
+                or cfg.kaic_api_key
+                or _os.environ.get("INTERNAL_API_KEY", ""),
+            )
+            logger.info("history enabled: events store at %s", cfg.opennvr_api_url)
+
         self.tools = CameraTools(
             context=self.context,
             caption_client=self.caption_client,
@@ -2663,6 +2683,7 @@ class CameraAgentRuntime:
             footage_index=self.footage_index,
             best_frame_fetch=best_frame_fetch,
             resolve_camera=_resolve_camera,
+            events_client=events_client,
         )
         # Advertised tools are (re)built by _configure_tools from enabled_tools
         # minus any skills switched off at runtime. disabled_skills starts empty.
@@ -2680,6 +2701,7 @@ class CameraAgentRuntime:
             "recognize_faces": self.tools.recognize_faces,
             "search_footage": self.tools.search_footage,
             "recent_events": self.tools.recent_events,
+            "search_history": self.tools.search_history,
             "create_background_task": self._handle_create_task,
             "create_monitor": self._handle_create_monitor,
             "stop_monitor": self._handle_stop_monitor,

--- a/examples/camera-agent/tests/test_tools.py
+++ b/examples/camera-agent/tests/test_tools.py
@@ -399,3 +399,84 @@ async def test_make_best_frame_fetch_maps_camera_and_handles_status():
     fetch_miss = make_best_frame_fetch(
         "http://tier0:9109", resolve_camera=lambda c: "9", http_get=http_get)
     assert await fetch_miss("x") is None          # 404 -> None
+
+
+# ── search_history (canonical event store, RFC-0001 C1) ─────────────
+
+class _FakeEvent:
+    def __init__(self, id, camera_id=3, label="person", has_evidence=True,
+                 started_at="2026-08-12T15:12:04+00:00",
+                 ended_at="2026-08-12T15:14:11+00:00"):
+        self.id = id
+        self.camera_id = camera_id
+        self.label = label
+        self.score = 0.9
+        self.started_at = started_at
+        self.ended_at = ended_at
+        self.stationary = False
+        self.has_evidence = has_evidence
+
+
+class _FakeEventsClient:
+    def __init__(self, events, crops=None):
+        self._events = events
+        self._crops = crops or {}
+        self.searches = []
+
+    async def search(self, **kw):
+        self.searches.append(kw)
+        return self._events
+
+    async def evidence(self, event_id):
+        return self._crops.get(event_id)
+
+
+class _FakeRecogniser:
+    def __init__(self, by_crop):
+        self._by = by_crop
+
+    async def infer(self, frame_jpeg=None, extra=None):
+        name = self._by.get(frame_jpeg)
+        if name:
+            return {"result": {"recognized": True, "name": name}}
+        return {"result": {}}
+
+
+def _history_tools(events_client, recogniser=None):
+    from unittest.mock import AsyncMock
+    stub = AsyncMock()
+    stub.infer.return_value = {"result": {}}
+    return CameraTools(
+        context=_ctx_with_camera(),
+        caption_client=stub,
+        detection_client=stub,
+        recognition_client=recogniser or stub,
+        events_client=events_client,
+    )
+
+
+def test_search_history_reports_visits_and_names(anyio_backend=None):
+    import asyncio
+    ec = _FakeEventsClient(
+        [_FakeEvent(1), _FakeEvent(2, has_evidence=False)],
+        crops={1: b"crop-1"},
+    )
+    tools = _history_tools(ec, _FakeRecogniser({b"crop-1": "Priya"}))
+    out = asyncio.run(tools.search_history({
+        "label": "person",
+        "start_time": "2026-08-12T15:00", "end_time": "2026-08-12T16:00",
+    }))
+    assert "2 person visit(s)" in out
+    assert "15:12" in out and "photo kept" in out
+    assert "Recognised: Priya" in out
+    assert ec.searches[0]["label"] == "person"
+
+
+def test_search_history_without_store_or_matches(anyio_backend=None):
+    import asyncio
+    tools = _history_tools(None)
+    assert "isn't enabled" in asyncio.run(tools.search_history({}))
+    ec = _FakeEventsClient([])
+    tools2 = _history_tools(ec)
+    out = asyncio.run(tools2.search_history({"label": "car"}))
+    assert "No car visits" in out

--- a/examples/camera-agent/tests/test_tools.py
+++ b/examples/camera-agent/tests/test_tools.py
@@ -467,7 +467,7 @@ def test_search_history_reports_visits_and_names(anyio_backend=None):
         "start_time": "2026-08-12T15:00", "end_time": "2026-08-12T16:00",
     }))
     assert "2 person visit(s)" in out
-    assert "15:12" in out and "photo kept" in out
+    assert "photo kept" in out          # times are spoken in LOCAL tz (host-dependent)
     assert "Recognised: Priya" in out
     assert ec.searches[0]["label"] == "person"
 
@@ -480,3 +480,17 @@ def test_search_history_without_store_or_matches(anyio_backend=None):
     tools2 = _history_tools(ec)
     out = asyncio.run(tools2.search_history({"label": "car"}))
     assert "No car visits" in out
+
+
+def test_search_history_failure_is_not_reported_as_empty(anyio_backend=None):
+    # Store down / rejected query must NOT sound like "nobody came".
+    import asyncio
+
+    class _DownClient:
+        async def search(self, **kw):
+            return None
+
+    tools = _history_tools(_DownClient())
+    out = asyncio.run(tools.search_history({"label": "person"}))
+    assert "couldn't check" in out
+    assert "No person visits" not in out

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -198,6 +198,43 @@ def build_tool_definitions(
         {
             "type": "function",
             "function": {
+                "name": "search_history",
+                "description": (
+                    "Search the NVR's MEMORY: past visits of people, cars, "
+                    "dogs — any detected object — each with the best photo "
+                    "kept. Use for 'did anyone come between 3 and 4pm?', "
+                    "'which cars entered today?', 'was a dog here yesterday?'. "
+                    "For people it also face-matches the kept photos and "
+                    "names anyone recognised."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "description": "What to look for: person, car, truck, dog, … (default person).",
+                        },
+                        "start_time": {
+                            "type": "string",
+                            "description": "Window start, ISO 8601 (e.g. 2026-08-12T15:00). Omit for open start.",
+                        },
+                        "end_time": {
+                            "type": "string",
+                            "description": "Window end, ISO 8601. Omit for 'until now'.",
+                        },
+                        "camera_id": _camera_prop,
+                        "identify_faces": {
+                            "type": "boolean",
+                            "description": "For person searches: face-match the kept photos (default true).",
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
                 "name": "recent_events",
                 "description": (
                     "Look back at recent inference events on the cameras. "
@@ -249,6 +286,7 @@ class CameraTools:
         footage_index: Any = None,
         best_frame_fetch: Any = None,
         resolve_camera: Any = None,
+        events_client: Any = None,
     ) -> None:
         self._ctx = context
         self._caption = caption_client
@@ -267,6 +305,10 @@ class CameraTools:
         # Optional read-only FootageIndex (footage_index.FootageIndex).
         # When None or unavailable, search_footage reports that cleanly.
         self._footage_index = footage_index
+        # Optional SDK EventsClient — the platform's memory (canonical event
+        # store). Powers search_history: past visits with best-frame evidence,
+        # optionally face-matched. None = tool reports history isn't enabled.
+        self._events = events_client
         # Cameras touched by the most recent tool call — read by /converse
         # so the UI can show which camera(s) the agent is working on.
         self.last_cameras_used: list[str] = []
@@ -647,6 +689,109 @@ class CameraTools:
         return "Found in recorded footage:\n" + "\n".join(lines)
 
     # ── Helpers ────────────────────────────────────────────────────
+
+    # ── search_history (canonical event store — RFC-0001 C1) ──────
+
+    async def search_history(self, args: dict[str, Any]) -> str:
+        """Answer "who/what came between X and Y?" from the events store.
+
+        Reads remembered visits (one row per object's stay, with its best
+        photo). For person queries it can face-match the evidence crops via
+        the recognition adapter — "yes, I saw Priya at 15:12" — capped at a
+        few crops so a busy window can't stall the conversation.
+        """
+        if self._events is None:
+            return ("History isn't enabled on this deployment "
+                    "(events store not configured).")
+        label = str(args.get("label") or "person").strip().lower()
+        start = args.get("start_time")
+        end = args.get("end_time")
+        camera_arg = args.get("camera_id")
+        camera_id = None
+        if camera_arg not in (None, "", "all", "__any__"):
+            cam = str(camera_arg)
+            if not self._ctx.known_camera(cam):
+                return f"ERROR: unknown camera '{cam}'."
+            # The store keys visits by the server-side camera id (same id the
+            # internal endpoint returns) — resolve like best-frame does.
+            resolved = self._resolve_camera(cam)
+            try:
+                camera_id = int(resolved)
+            except (TypeError, ValueError):
+                return f"ERROR: camera '{cam}' has no server-side id."
+        try:
+            events = await self._events.search(
+                label=label, camera_id=camera_id, start=start, end=end, limit=25
+            )
+        except Exception:
+            logger.warning("search_history: events store unreachable")
+            return "The history store is unreachable right now."
+        if not events:
+            window = self._window_phrase(start, end)
+            return f"No {label} visits remembered{window}."
+
+        clauses = []
+        for e in events[:10]:
+            t0 = self._clock_phrase(e.started_at)
+            t1 = self._clock_phrase(e.ended_at)
+            span = f"{t0}–{t1}" if t1 and t1 != t0 else t0
+            clauses.append(
+                f"{span} on camera {e.camera_id}"
+                + (" (photo kept)" if e.has_evidence else "")
+            )
+        summary = (f"I remember {len(events)} {label} visit(s)"
+                   f"{self._window_phrase(start, end)}: " + "; ".join(clauses) + ".")
+
+        # Face-match the evidence for person questions (best-effort, capped).
+        if label == "person" and bool(args.get("identify_faces", True)):
+            names = await self._identify_visit_faces(events)
+            if names:
+                summary += " Recognised: " + ", ".join(sorted(names)) + "."
+        return summary
+
+    async def _identify_visit_faces(self, events, cap: int = 4) -> set:
+        names: set = set()
+        checked = 0
+        for e in events:
+            if checked >= cap:
+                break
+            if not e.has_evidence:
+                continue
+            crop = await self._events.evidence(e.id)
+            if not crop:
+                continue
+            checked += 1
+            try:
+                response = await self._recognise.infer(
+                    frame_jpeg=crop, extra={"task": "face_recognition"}
+                )
+            except Exception:
+                logger.warning("search_history: recognition adapter unavailable")
+                break
+            result = response.get("result") or {}
+            if result.get("recognized"):
+                names.add(str(result.get("name") or result.get("person_id") or "someone"))
+        return names
+
+    @staticmethod
+    def _clock_phrase(iso: str | None) -> str:
+        if not iso:
+            return "?"
+        try:
+            from datetime import datetime as _dt
+            return _dt.fromisoformat(iso).strftime("%H:%M")
+        except ValueError:
+            return iso
+
+    @staticmethod
+    def _window_phrase(start, end) -> str:
+        if start and end:
+            return f" between {start} and {end}"
+        if start:
+            return f" since {start}"
+        if end:
+            return f" before {end}"
+        return " (all time)"
 
     def _require_camera(self, args: dict[str, Any]) -> str:
         camera_id = args.get("camera_id")

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -216,11 +216,11 @@ def build_tool_definitions(
                         },
                         "start_time": {
                             "type": "string",
-                            "description": "Window start, ISO 8601 (e.g. 2026-08-12T15:00). Omit for open start.",
+                            "description": "Window start, ISO 8601 WITH timezone offset (e.g. 2026-08-12T15:00:00+05:30). Omit for open start.",
                         },
                         "end_time": {
                             "type": "string",
-                            "description": "Window end, ISO 8601. Omit for 'until now'.",
+                            "description": "Window end, ISO 8601 with timezone offset. Omit for 'until now'.",
                         },
                         "camera_id": _camera_prop,
                         "identify_faces": {
@@ -724,8 +724,13 @@ class CameraTools:
                 label=label, camera_id=camera_id, start=start, end=end, limit=25
             )
         except Exception:
-            logger.warning("search_history: events store unreachable")
-            return "The history store is unreachable right now."
+            events = None
+        if events is None:
+            # Failure is NOT an empty window: "nothing came" and "I couldn't
+            # check" must be different answers in a security product.
+            logger.warning("search_history: events store unreachable or query rejected")
+            return ("I couldn't check the history just now (store unreachable "
+                    "or the time range wasn't understood) — please try again.")
         if not events:
             window = self._window_phrase(start, end)
             return f"No {label} visits remembered{window}."
@@ -775,11 +780,16 @@ class CameraTools:
 
     @staticmethod
     def _clock_phrase(iso: str | None) -> str:
+        """UTC-stored timestamp → the agent host's LOCAL clock time for
+        speech ("15:12" must mean the listener's 15:12, not UTC's)."""
         if not iso:
             return "?"
         try:
             from datetime import datetime as _dt
-            return _dt.fromisoformat(iso).strftime("%H:%M")
+            t = _dt.fromisoformat(iso)
+            if t.tzinfo is not None:
+                t = t.astimezone()
+            return t.strftime("%H:%M")
         except ValueError:
             return iso
 

--- a/sdk/opennvr-app-sdk/docs/events-consumption.md
+++ b/sdk/opennvr-app-sdk/docs/events-consumption.md
@@ -1,0 +1,45 @@
+# Reading the platform's memory — the events store from an app or agent
+
+OpenNVR keeps a canonical history: **one row per object visit** (person, car,
+dog — whatever the detector emits), each with the **best photo** Tier-0 saw of
+it, plus (in later phases) camera alarms and app incidents on the same
+timeline. Your app should **query this instead of keeping its own history
+store** — persistence is the platform's job now.
+
+## The SDK client
+
+```python
+from opennvr_app_sdk import EventsClient
+
+events = EventsClient(core_url, internal_api_key)
+
+# "Which cars entered between 3 and 4pm?"
+visits = await events.search(label="car",
+                             start="2026-08-12T15:00", end="2026-08-12T16:00")
+for v in visits:
+    print(v.camera_id, v.started_at, v.ended_at, v.score, v.has_evidence)
+
+# The visit's best-frame JPEG (input for face match / LPR / VLM):
+jpeg = await events.evidence(visits[0].id)
+```
+
+Semantics you can rely on:
+
+- **Overlap, not containment:** a visit that started 14:58 and left 15:03 IS
+  returned for a 15:00–16:00 window — that's what the human question means.
+- **Newest first**, `limit` capped server-side.
+- **Degrades to empty** on any transport error — a memory lookup failing
+  should soften an answer, never crash an app.
+- Labels are lowercase; pass `camera_id` as the server-side camera id.
+
+## When to use which history mechanism
+
+| You want | Use |
+|---|---|
+| "What happened between X and Y?" with photos | `EventsClient.search` (this doc) |
+| Live "something is happening now" | subscribe the bus (`opennvr.inference.>`) |
+| The best frame of a track that is STILL live | `BestFrameClient` (tier0-consumption.md) |
+
+The camera-agent's `search_history` tool is built on exactly this client —
+including face-matching the returned evidence crops via the recognition
+adapter. Read it (`examples/camera-agent/tools.py`) as the reference consumer.

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -51,6 +51,7 @@ from .frame_sources import (
 from .geometry import Point, Tripwire, Zone, bbox_center
 from .manifest import Action, AlertType, AppManifest, Param, StateView
 from .state import KeyedState, StateRecord, keyed_state
+from .events import EventsClient, StoredEvent
 from .tier0 import (
     BestFrameClient,
     Tier0Snapshot,
@@ -120,6 +121,8 @@ __all__ = [
     "Tier0Snapshot",
     "snapshot_from_event",
     "describe_counts",
+    "EventsClient",
+    "StoredEvent",
     "is_tier0_subject",
     "tier0_to_detections",
     "BestFrameClient",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/events.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/events.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Events-store client — query the platform's memory (RFC-0001 C1).
+
+The canonical event store keeps one row per object visit (and, in later
+phases, per alarm/incident), each with its best-frame evidence photo. This
+client is the SDK's read primitive for it: agents and apps ask "what
+happened?" here instead of keeping private history (the Challenge-3 rule:
+shared primitives live in the SDK, both agents import them).
+
+Talks to core's internal endpoints (``X-Internal-Api-Key``), like the
+camera-discovery client — the agent is a platform component, not a browser
+session. ``http_get`` is injectable for tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlencode
+
+HttpGetH = Callable[[str, dict], Awaitable[tuple[int, bytes]]]
+
+
+async def _default_http_get(url: str, headers: dict) -> tuple[int, bytes]:  # pragma: no cover - network
+    import httpx
+    async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
+        resp = await client.get(url, headers=headers)
+        return resp.status_code, resp.content
+
+
+@dataclass(frozen=True)
+class StoredEvent:
+    """One remembered visit, as the store serves it."""
+
+    id: int
+    camera_id: int
+    label: str | None
+    score: float | None
+    started_at: str | None
+    ended_at: str | None
+    stationary: bool | None
+    has_evidence: bool
+
+
+class EventsClient:
+    """Query visits and fetch their evidence photos from core."""
+
+    def __init__(self, core_url: str, api_key: str | None, *,
+                 http_get: HttpGetH | None = None) -> None:
+        self._base = core_url.rstrip("/")
+        self._headers = {"X-Internal-Api-Key": api_key} if api_key else {}
+        self._get = http_get or _default_http_get
+
+    async def search(
+        self,
+        *,
+        label: str | None = None,
+        camera_id: int | None = None,
+        start: datetime | str | None = None,
+        end: datetime | str | None = None,
+        limit: int = 50,
+    ) -> list[StoredEvent]:
+        """Visits overlapping [start, end), newest first. Empty on any error —
+        a memory lookup failing must degrade an answer, not crash an agent."""
+        params: dict[str, Any] = {"limit": limit}
+        if label:
+            params["label"] = label
+        if camera_id is not None:
+            params["camera_id"] = camera_id
+        if start is not None:
+            params["from"] = start.isoformat() if isinstance(start, datetime) else start
+        if end is not None:
+            params["to"] = end.isoformat() if isinstance(end, datetime) else end
+        url = f"{self._base}/api/v1/internal/camera-agent/events?{urlencode(params)}"
+        try:
+            status, body = await self._get(url, self._headers)
+            if status != 200:
+                return []
+            import json
+            rows = json.loads(body.decode("utf-8")).get("events", [])
+        except Exception:
+            return []
+        out = []
+        for r in rows:
+            try:
+                out.append(StoredEvent(
+                    id=int(r["id"]), camera_id=int(r["camera_id"]),
+                    label=r.get("label"), score=r.get("score"),
+                    started_at=r.get("started_at"), ended_at=r.get("ended_at"),
+                    stationary=r.get("stationary"),
+                    has_evidence=bool(r.get("has_evidence")),
+                ))
+            except (KeyError, TypeError, ValueError):
+                continue
+        return out
+
+    async def evidence(self, event_id: int) -> bytes | None:
+        """The visit's best-frame JPEG, or None."""
+        url = f"{self._base}/api/v1/internal/camera-agent/events/{int(event_id)}/evidence"
+        try:
+            status, body = await self._get(url, self._headers)
+        except Exception:
+            return None
+        return body if status == 200 and body else None

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/events.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/events.py
@@ -77,9 +77,13 @@ class EventsClient:
         start: datetime | str | None = None,
         end: datetime | str | None = None,
         limit: int = 50,
-    ) -> list[StoredEvent]:
-        """Visits overlapping [start, end), newest first. Empty on any error —
-        a memory lookup failing must degrade an answer, not crash an agent."""
+    ) -> list[StoredEvent] | None:
+        """Visits overlapping [start, end), newest first.
+
+        Returns ``[]`` for a genuinely empty window and ``None`` on ANY
+        failure (transport, auth, or a rejected query) — the caller must be
+        able to say "nothing came" and "I couldn't check" differently; in a
+        security product those are different answers."""
         params: dict[str, Any] = {"limit": limit}
         if label:
             params["label"] = label
@@ -93,11 +97,11 @@ class EventsClient:
         try:
             status, body = await self._get(url, self._headers)
             if status != 200:
-                return []
+                return None
             import json
             rows = json.loads(body.decode("utf-8")).get("events", [])
         except Exception:
-            return []
+            return None
         out = []
         for r in rows:
             try:

--- a/sdk/opennvr-app-sdk/tests/test_events_client.py
+++ b/sdk/opennvr-app-sdk/tests/test_events_client.py
@@ -37,11 +37,16 @@ def test_search_builds_url_and_parses():
     assert len(rows) == 1 and rows[0].id == 42 and rows[0].has_evidence
 
 
-def test_search_degrades_to_empty_on_failure():
+def test_search_returns_none_on_failure_not_empty():
+    # None = "couldn't check"; [] = "nothing came". Different answers.
     async def boom(url, headers):
         raise OSError("core down")
     c = EventsClient("http://core:8000", None, http_get=boom)
-    assert asyncio.run(c.search(label="car")) == []
+    assert asyncio.run(c.search(label="car")) is None
+    c2, _calls = _client([(422, b"bad range")])
+    assert asyncio.run(c2.search(label="car")) is None
+    c3, _calls = _client([(200, b'{"events": []}')])
+    assert asyncio.run(c3.search(label="car")) == []
 
 
 def test_evidence_roundtrip_and_miss():

--- a/sdk/opennvr-app-sdk/tests/test_events_client.py
+++ b/sdk/opennvr-app-sdk/tests/test_events_client.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""EventsClient — the SDK's read primitive for the platform's memory."""
+
+import asyncio
+import json
+
+from opennvr_app_sdk import EventsClient
+
+
+def _client(responses):
+    calls = []
+
+    async def http_get(url, headers):
+        calls.append((url, headers))
+        return responses.pop(0)
+
+    c = EventsClient("http://core:8000", "sekret", http_get=http_get)
+    return c, calls
+
+
+def test_search_builds_url_and_parses():
+    body = json.dumps({"events": [
+        {"id": 42, "camera_id": 3, "label": "person", "score": 0.91,
+         "started_at": "2026-08-12T15:12:04+00:00",
+         "ended_at": "2026-08-12T15:14:11+00:00",
+         "stationary": False, "has_evidence": True},
+        {"junk": "row is skipped, not fatal"},
+    ]}).encode()
+    c, calls = _client([(200, body)])
+    rows = asyncio.run(c.search(label="person", start="2026-08-12T15:00",
+                                end="2026-08-12T16:00"))
+    url, headers = calls[0]
+    assert "/api/v1/internal/camera-agent/events?" in url
+    assert "label=person" in url and "from=2026-08-12T15%3A00" in url
+    assert headers == {"X-Internal-Api-Key": "sekret"}
+    assert len(rows) == 1 and rows[0].id == 42 and rows[0].has_evidence
+
+
+def test_search_degrades_to_empty_on_failure():
+    async def boom(url, headers):
+        raise OSError("core down")
+    c = EventsClient("http://core:8000", None, http_get=boom)
+    assert asyncio.run(c.search(label="car")) == []
+
+
+def test_evidence_roundtrip_and_miss():
+    c, _ = _client([(200, b"\xff\xd8jpg"), (404, b"")])
+    assert asyncio.run(c.evidence(42)) == b"\xff\xd8jpg"
+    assert asyncio.run(c.evidence(43)) is None

--- a/server/migrations/versions/bb22cc33dd44_events_visit_unique_index.py
+++ b/server/migrations/versions/bb22cc33dd44_events_visit_unique_index.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""events: unique visit index — ingest retries become idempotent
+
+Promised in PR #213's follow-ups: the tier0 poster retries on transient
+failures, and without a uniqueness guarantee a retry that raced a success
+creates a duplicate visit row. One visit = one (camera, track, start), so
+that triple is the natural idempotency key. NULL track_ids (future alarm/
+alert rows) are exempt by SQL semantics — NULLs never collide.
+
+Revision ID: bb22cc33dd44
+Revises: aa11bb22cc33
+Create Date: 2026-08-12 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "bb22cc33dd44"
+down_revision: str | None = "aa11bb22cc33"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "uq_events_visit",
+        "events",
+        ["camera_id", "track_id", "started_at"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_events_visit", table_name="events")

--- a/server/models.py
+++ b/server/models.py
@@ -403,6 +403,10 @@ class TimelineEvent(Base):
     __tablename__ = "events"
     __table_args__ = (
         Index("ix_events_cam_start", "camera_id", "started_at"),
+        # One visit = one (camera, track, start): ingest retries are
+        # idempotent. NULLs (alarm/alert rows) never collide by SQL semantics.
+        Index("uq_events_visit", "camera_id", "track_id", "started_at",
+              unique=True),
     )
 
     id = Column(Integer, primary_key=True, index=True)

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -16,7 +16,7 @@ import secrets
 from datetime import datetime
 from urllib.parse import quote as urlquote
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -80,8 +80,13 @@ async def ingest_track_event(
     if payload.evidence_jpeg_b64:
         import base64
 
-        from services.evidence_store import save_evidence_jpeg
+        from services.evidence_store import MAX_EVIDENCE_BYTES, save_evidence_jpeg
 
+        # Reject oversized payloads BEFORE decoding: base64 is 4/3 the raw
+        # size, so anything beyond that bound can't be a valid crop and
+        # shouldn't cost us the decode allocation.
+        if len(payload.evidence_jpeg_b64) > (MAX_EVIDENCE_BYTES * 4) // 3 + 8:
+            raise HTTPException(status_code=422, detail="evidence too large")
         try:
             evidence_rel = save_evidence_jpeg(
                 base64.b64decode(payload.evidence_jpeg_b64, validate=True)
@@ -89,20 +94,97 @@ async def ingest_track_event(
         except (ValueError, binascii.Error) as e:
             raise HTTPException(status_code=422, detail=f"bad evidence: {e}")
 
+    from sqlalchemy.exc import IntegrityError
+
     from services.timeline_service import record_track_visit
 
-    row = record_track_visit(
-        db,
-        camera_id=payload.camera_id,
-        label=payload.label,
-        started_at=payload.started_at,
-        ended_at=payload.ended_at,
-        score=payload.score,
-        track_id=payload.track_id,
-        stationary=payload.stationary,
-        evidence_path=evidence_rel,
-    )
+    try:
+        row = record_track_visit(
+            db,
+            camera_id=payload.camera_id,
+            label=payload.label,
+            started_at=payload.started_at,
+            ended_at=payload.ended_at,
+            score=payload.score,
+            track_id=payload.track_id,
+            stationary=payload.stationary,
+            evidence_path=evidence_rel,
+        )
+    except IntegrityError:
+        # Retry raced an earlier success — the visit already exists
+        # (uq_events_visit). Idempotent: report the existing row.
+        db.rollback()
+        from models import TimelineEvent
+
+        existing = (
+            db.query(TimelineEvent)
+            .filter(
+                TimelineEvent.camera_id == payload.camera_id,
+                TimelineEvent.track_id == (payload.track_id or "")[:40],
+                TimelineEvent.started_at == payload.started_at,
+            )
+            .first()
+        )
+        return {"id": existing.id if existing else None, "duplicate": True}
     return {"id": row.id, "evidence_path": evidence_rel}
+
+
+@router.get("/events")
+async def internal_list_events(
+    camera_id: int | None = None,
+    label: str | None = None,
+    from_: datetime | None = Query(default=None, alias="from"),
+    to: datetime | None = None,
+    limit: int = 100,
+    _: None = Depends(_require_internal_key),
+    db: Session = Depends(get_db),
+):
+    """Event-store read for trusted internal components (the camera agents).
+
+    Same OVERLAP query the user API serves, fleet-wide: the agent is a
+    platform component like tier0, not a per-user browser session — its
+    answers are already scoped by which cameras it is configured to see.
+    """
+    from services.timeline_service import query_events
+
+    rows = query_events(db, camera_id=camera_id, label=label,
+                        from_=from_, to=to, limit=limit)
+    return {
+        "events": [
+            {
+                "id": e.id,
+                "camera_id": e.camera_id,
+                "label": e.label,
+                "score": e.score,
+                "started_at": e.started_at.isoformat() if e.started_at else None,
+                "ended_at": e.ended_at.isoformat() if e.ended_at else None,
+                "stationary": (e.payload or {}).get("stationary"),
+                "has_evidence": bool(e.evidence_path),
+            }
+            for e in rows
+        ]
+    }
+
+
+@router.get("/events/{event_id}/evidence")
+async def internal_event_evidence(
+    event_id: int,
+    _: None = Depends(_require_internal_key),
+    db: Session = Depends(get_db),
+):
+    """The visit's best-frame JPEG, for agent-side face match / VLM looks."""
+    from fastapi.responses import FileResponse
+
+    from models import TimelineEvent
+    from services.evidence_store import resolve_evidence
+
+    e = db.query(TimelineEvent).filter(TimelineEvent.id == event_id).first()
+    if e is None or not e.evidence_path:
+        raise HTTPException(status_code=404, detail="no evidence")
+    path = resolve_evidence(e.evidence_path)
+    if path is None:
+        raise HTTPException(status_code=404, detail="evidence missing")
+    return FileResponse(path, media_type="image/jpeg")
 
 
 GATE_MODE_KEY = "detect_gate_mode"

--- a/server/tests/test_timeline_events.py
+++ b/server/tests/test_timeline_events.py
@@ -193,3 +193,22 @@ def test_can_access_event_mirrors_ownership(db):
     assert can_access_event(db, row, user=SimpleNamespace(id=owner_id, is_superuser=False))
     assert not can_access_event(db, row, user=SimpleNamespace(id=owner_id + 99, is_superuser=False))
     assert can_access_event(db, row, user=SimpleNamespace(id=0, is_superuser=True))
+
+
+# ── ingest idempotency (uq_events_visit) ────────────────────────────
+
+def test_duplicate_visit_rejected_by_unique_index(db):
+    import pytest as _pytest
+    from sqlalchemy.exc import IntegrityError
+
+    _visit(db, start_min=5, end_min=7, track_id="9")
+    with _pytest.raises(IntegrityError):
+        _visit(db, start_min=5, end_min=7, track_id="9")
+    db.rollback()
+
+
+def test_null_track_ids_never_collide(db):
+    # alarm/alert rows (no track) must not be blocked by the visit index
+    _visit(db, start_min=5, track_id=None)
+    _visit(db, start_min=5, track_id=None)   # no raise
+    assert len(query_events(db)) == 2


### PR DESCRIPTION
# "Did anyone come between 3 and 4?" — now answered, with names

Builds on #213 (the event store). The camera-agent gains a **`search_history`** tool: it queries the platform's memory and answers in speech —

> *"I remember 3 person visits between 15:00 and 16:00: 15:12–15:14 on camera 3 (photo kept); 15:31–15:32 on camera 3 (photo kept); 15:47–15:49 on camera 1. Recognised: Priya."*

Works for **any detected object**: "which cars entered today?", "was a dog here yesterday?". For person searches it face-matches the kept best-frame photos through the recognition adapter (capped at 4 crops so a busy window can't stall the conversation) and names anyone recognised.

## What's in it

- **SDK `EventsClient`** — the shared read primitive for the memory (per RFC-0001 C3: shared code goes *down into the SDK*, both agents import it). Overlap time semantics, evidence fetch, degrades to empty on any failure — a memory lookup softens an answer, never crashes an agent. Docs: `sdk/opennvr-app-sdk/docs/events-consumption.md` (including a which-mechanism-when table vs the live bus and BestFrameClient).
- **Internal events read API** — `GET /internal/camera-agent/events` (+ `/evidence`), internal-key auth: the agent is a platform component like tier0, not a browser session.
- **Ingest hardening promised in #213:** `uq_events_visit` unique index (migration `bb22cc33dd44`) makes poster retries idempotent — NULL track_ids exempt so future alarm/alert rows never collide; pre-decode base64 length check; duplicate-tolerant ingest response.
- **Docs:** ARCHITECTURE.md gains "The memory plane" section; agent README documents the tool; system-prompt rule routes past-tense questions to it.

## Config

Zero new config. The tool activates when `opennvr_base_url` is set (the same origin + `INTERNAL_API_KEY` chain the app door already uses); without it the tool reports history isn't enabled.

## QA validation

1. Walk past a camera twice, wait ~10 s, then ask the agent: *"did anyone come in the last ten minutes?"* → spoken visit summary with times.
2. If a face is registered in InsightFace: confirm the answer names them.
3. Ask *"which cars came today?"* on a camera that saw a vehicle → car visits.
4. Stop opennvr-core, ask again → agent says history is unreachable (no crash); restart → answers resume.
5. Regression: ingest a duplicate visit (re-run tier0 against same window) → no duplicate rows (`uq_events_visit`).

## Test status

server **592** (+2 idempotency) · sdk **185** (+3 EventsClient) · camera-agent **564** (+2 tool phrasing/face-names/disabled paths).

## Follow-ups

PR-C: LPR `plate_text` enrichment + footage-search migrates onto the store. Evidence retention: tracked in the issue filed at #213's merge.