### PR TITLE
ISSUE fix #218: Camera loses its MediaMTX path permanently when dupli…

### DIFF
--- a/app/src/views/LiveView.tsx
+++ b/app/src/views/LiveView.tsx
@@ -1186,8 +1186,11 @@ export function AddCameraDialog({
       })
       const newCameraId = response?.data?.id
       
-      // Auto-provision to MediaMTX
-      if (newCameraId) {
+      // The server already auto-provisions on create; only retry from here
+      // if that didn't stick (e.g. MediaMTX was briefly unreachable).
+      // Unconditionally re-provisioning an already-provisioned camera forces
+      // a path replace that can drop the stream it just started.
+      if (newCameraId && response?.data?.mediamtx_provisioned !== true) {
         try {
           await apiService.provisionCameraMediaMTX(newCameraId, { enable_recording: true })
         } catch (e) {
@@ -1228,8 +1231,11 @@ export function AddCameraDialog({
       })
       const newCameraId = response?.data?.id
       
-      // Auto-provision to MediaMTX
-      if (newCameraId) {
+      // The server already auto-provisions on create; only retry from here
+      // if that didn't stick (e.g. MediaMTX was briefly unreachable).
+      // Unconditionally re-provisioning an already-provisioned camera forces
+      // a path replace that can drop the stream it just started.
+      if (newCameraId && response?.data?.mediamtx_provisioned !== true) {
         try {
           await apiService.provisionCameraMediaMTX(newCameraId, { enable_recording: true })
         } catch (e) {

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -307,10 +307,14 @@ def _check_mediamtx_available() -> bool:
         # - 401: JWT auth required (server is running!)
         # - 404: path not found
         # - 500: server error
+        # Probe the server root, NOT /list?path=__health__: listing a
+        # nonexistent path made MediaMTX log 'ERR path __health__ is not
+        # configured' on every probe (#218's log noise). Any HTTP answer
+        # (200/404/401/...) means the playback server is up — which is all
+        # this check ever asserted.
         response = http_client.get(
-            f"{settings.mediamtx_playback_url}/list?path=__health__", timeout=2  # url-internal-ok: server-side health probe to mediamtx admin API
+            f"{settings.mediamtx_playback_url}/", timeout=2  # url-internal-ok: server-side health probe to mediamtx playback server
         )
-        # Any response means the server is responding (including 401 for JWT auth)
         return response.status_code in (200, 400, 401, 404, 500)
     except Exception:
         return False

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -746,7 +746,10 @@ class MediaMtxAdminService:
                 transport_security=transport_security,
             )
             if result.get("status") == "ok":
-                result["action"] = "rtsp_stream_replaced"
+                result["action"] = (
+                    "rtsp_stream_unchanged" if result.get("unchanged")
+                    else "rtsp_stream_replaced"
+                )
             else:
                 result["action"] = "replace_failed"
 
@@ -987,6 +990,38 @@ class MediaMtxAdminService:
 
         try:
             async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                # Idempotence guard: a replace triggers a config reload and
+                # restarts the path's source — a visible stream/recording blip.
+                # If the running config already matches everything we'd set,
+                # skip the replace entirely: identical re-provisions (repeat
+                # clicks, reconciles with unchanged URLs) become true no-ops.
+                # Best-effort — any failure here just falls through to the
+                # replace, which is always correct.
+                try:
+                    cur = await client.get(
+                        MediaMtxAdminService._base() + f"/config/paths/get/{name}",
+                        headers=MediaMtxAdminService._headers(),
+                    )
+                    if cur.is_success:
+                        current = cur.json()
+                        if isinstance(current, dict) and all(
+                            current.get(k) == v for k, v in payload.items()
+                        ):
+                            mediamtx_logger.log_action(
+                                "mediamtx.replace_path_skipped_unchanged",
+                                camera_id=camera_id,
+                                message=f"MediaMTX path config unchanged; replace skipped: {name}",
+                                extra_data={"path": name},
+                            )
+                            return {
+                                "status": "ok",
+                                "path": name,
+                                "http_status": 200,
+                                "unchanged": True,
+                                "details": {"message": "config unchanged; no reload, no stream interruption"},
+                            }
+                except Exception:  # pragma: no cover - optimization only
+                    pass
                 resp = await client.post(
                     url, json=payload, headers=MediaMtxAdminService._headers()
                 )

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -730,28 +730,25 @@ class MediaMtxAdminService:
             camera_id, camera_ip, config, transport_security=transport_security
         )
 
-        # If path already exists, try to unprovision and re-provision
+        # If path already exists, atomically replace its configuration.
+        # NOTE: this used to be unprovision + re-provision, i.e. two config
+        # reloads with a window where the path didn't exist at all — a re-add
+        # that lost the race with MediaMTX's listener reload left the camera
+        # with NO path (no live view, no recording) until manual repair.
         if (
             result.get("status") == "error"
             and result.get("details", {}).get("error") == "path already exists"
         ):
-            # First, unprovision the existing path
-            unprovision_result = await MediaMtxAdminService.unprovision_path(
-                camera_id, camera_ip
+            result = await MediaMtxAdminService.replace_path(
+                camera_id,
+                camera_ip,
+                config,
+                transport_security=transport_security,
             )
-
-            # Then try to provision again
-            if unprovision_result.get("status") == "ok":
-                result = await MediaMtxAdminService.provision_path(
-                    camera_id,
-                    camera_ip,
-                    config,
-                    transport_security=transport_security,
-                )
+            if result.get("status") == "ok":
                 result["action"] = "rtsp_stream_replaced"
             else:
-                result["action"] = "unprovision_failed"
-                result["unprovision_result"] = unprovision_result
+                result["action"] = "replace_failed"
 
         if result.get("status") == "ok":
             if "action" not in result:
@@ -950,6 +947,118 @@ class MediaMtxAdminService:
             }
 
     @staticmethod
+    async def replace_path(
+        camera_id: int,
+        camera_ip: str,
+        config: dict[str, Any],
+        *,
+        transport_security: str | None = None,
+    ) -> dict[str, Any]:
+        """Atomically replace a path's whole configuration.
+
+        POST /config/paths/replace/{name} is a single config transaction in
+        MediaMTX, so unlike unprovision + provision there is no window where
+        the path is absent — a failure leaves the previous configuration
+        running instead of leaving the camera with no path at all. Falls back
+        to a plain add if the path vanished in the meantime (concurrent
+        unprovision).
+        """
+        # Same enforcement gate as provision_path: refuse before any HTTP.
+        if transport_security is not None:
+            from services.transport_probe_service import enforce_transport_policy
+
+            enforce_transport_policy(
+                transport_security,
+                config.get("source_url") if isinstance(config, dict) else None,
+                camera_id=camera_id,
+            )
+
+        name = _build_stream_name(settings.mediamtx_stream_prefix, camera_id, camera_ip)
+
+        if not MediaMtxAdminService.is_configured():
+            return {
+                "status": "no_admin_api",
+                "path": name,
+                "details": {"message": "mediamtx_admin_api not configured; no-op"},
+            }
+
+        url = MediaMtxAdminService._base() + f"/config/paths/replace/{name}"
+        payload = MediaMtxAdminService._map_conf(config)
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.post(
+                    url, json=payload, headers=MediaMtxAdminService._headers()
+                )
+            result = MediaMtxAdminService._to_result(name, resp)
+
+            # Path was deleted between the add-conflict and this replace —
+            # add it instead of failing.
+            error_text = str(result.get("details", {}).get("error", "")).lower()
+            if result.get("status") == "error" and "not found" in error_text:
+                return await MediaMtxAdminService.provision_path(
+                    camera_id,
+                    camera_ip,
+                    config,
+                    transport_security=transport_security,
+                )
+
+            if result.get("status") == "ok":
+                mediamtx_logger.log_action(
+                    "mediamtx.replace_path_success",
+                    camera_id=camera_id,
+                    message=f"MediaMTX path replaced in place: {name}",
+                    extra_data={
+                        "path": name,
+                        "http_status": result.get("http_status"),
+                    },
+                )
+                # Keep the agent substream in sync with the (possibly new)
+                # source URL. Best-effort, same contract as provision_path.
+                if settings.agent_live_use_substream:
+                    try:
+                        await MediaMtxAdminService._provision_substream(
+                            camera_id, camera_ip, config
+                        )
+                    except Exception:  # pragma: no cover - defensive
+                        mediamtx_logger.warning(
+                            f"substream refresh raised for {name}; main path unaffected",
+                            extra={"camera_id": camera_id, "path": name,
+                                   "action": "mediamtx.substream_provision_error"},
+                        )
+            else:
+                mediamtx_logger.error(
+                    f"MediaMTX path replace failed: {name}",
+                    extra={
+                        "camera_id": camera_id,
+                        "path": name,
+                        "http_status": result.get("http_status"),
+                        "result": result,
+                        "action": "mediamtx.replace_path_failed",
+                    },
+                )
+
+            return result
+
+        except Exception as e:
+            mediamtx_logger.error(
+                f"MediaMTX path replace error: {name}",
+                extra={
+                    "camera_id": camera_id,
+                    "path": name,
+                    "url": url,
+                    "error_type": type(e).__name__,
+                    "action": "mediamtx.replace_path_exception",
+                },
+                exc_info=True,
+            )
+            return {
+                "status": "error",
+                "path": name,
+                "details": {"error": str(e), "error_type": type(e).__name__},
+            }
+
+    @staticmethod
     async def _provision_substream(
         camera_id: int, camera_ip: str, config: dict[str, Any]
     ) -> None:
@@ -990,6 +1099,14 @@ class MediaMtxAdminService:
             resp = await client.post(
                 url, json=payload, headers=MediaMtxAdminService._headers()
             )
+            # Sub already provisioned by an earlier add — refresh it in place
+            # so a changed substream URL/transport actually takes effect.
+            if not resp.is_success and "already exists" in resp.text:
+                resp = await client.post(
+                    MediaMtxAdminService._base() + f"/config/paths/replace/{sub}",
+                    json=payload,
+                    headers=MediaMtxAdminService._headers(),
+                )
         mediamtx_logger.log_action(
             "mediamtx.substream_provisioned",
             camera_id=camera_id,

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -994,6 +994,11 @@ class MediaMtxAdminService:
 
             # Path was deleted between the add-conflict and this replace —
             # add it instead of failing.
+            # NB: substring match on MediaMTX's error text (same style as the
+            # "already exists" checks). If a MediaMTX upgrade rewords it, the
+            # fallback quietly stops matching — which degrades SAFELY (the
+            # error is surfaced and the old path keeps running), but check
+            # these strings when bumping the MediaMTX image.
             error_text = str(result.get("details", {}).get("error", "")).lower()
             if result.get("status") == "error" and "not found" in error_text:
                 return await MediaMtxAdminService.provision_path(

--- a/server/services/mediamtx_config_service.py
+++ b/server/services/mediamtx_config_service.py
@@ -272,7 +272,7 @@ paths: {}
             "critical_setup": {
                 "startup_hook": {
                     "description": "Essential for automatic camera provisioning after MediaMTX restarts",
-                    "config": f'runOnInit: curl -X GET "{application_base_url}{settings.api_prefix}/mediamtx/startup/hook?delay=5&t={webhook_token}"',
+                    "config": "runOnInit: " + 'sh -c \'for i in $(seq 1 60); do curl -fsS -X GET "{url}" && exit 0; echo "[startup-hook] core not reachable (attempt $i/60); retrying in 5s" >&2; sleep 5; done; echo "[startup-hook] FAILED after 60 attempts — cameras are NOT provisioned; restart mediamtx or fix connectivity" >&2\''.format(url=f"{application_base_url}{settings.api_prefix}/mediamtx/startup/hook?delay=5&t={webhook_token}"),
                     "importance": "Without this, cameras won't be re-provisioned automatically after MediaMTX restart",
                 }
             },
@@ -371,7 +371,11 @@ api: yes
 apiAddress: :9997
 
 # Startup hook - CRITICAL for automatic camera provisioning after restart
-runOnInit: curl -X GET "{webhook_base}/startup/hook?delay=5&t={webhook_token}"
+# Retries for ~5 min: in compose, MediaMTX often starts before core's DNS/API
+# is up — a single un-retried curl here meant ZERO cameras provisioned until
+# someone restarted MediaMTX (#218's log). Loud on every failure and on final
+# give-up, so the failure mode is a log line, never a silent empty NVR.
+runOnInit: sh -c 'for i in $(seq 1 60); do curl -fsS -X GET "{webhook_base}/startup/hook?delay=5&t={webhook_token}" && exit 0; echo "[startup-hook] core not reachable (attempt $i/60); retrying in 5s" >&2; sleep 5; done; echo "[startup-hook] FAILED after 60 attempts — cameras are NOT provisioned; restart mediamtx or fix connectivity" >&2'
 runOnInitRestart: no
 
 # RTSP settings

--- a/server/tests/test_agent_substream.py
+++ b/server/tests/test_agent_substream.py
@@ -99,6 +99,8 @@ def test_provision_substream_adds_on_demand_path(monkeypatch):
 
     class _Resp:
         status_code = 200
+        is_success = True
+        text = "{}"
 
     class _Client:
         async def __aenter__(self): return self
@@ -132,6 +134,8 @@ def test_provision_substream_prefers_stored_url(monkeypatch):
 
     class _Resp:
         status_code = 200
+        is_success = True
+        text = "{}"
 
     class _Client:
         async def __aenter__(self): return self
@@ -151,6 +155,47 @@ def test_provision_substream_prefers_stored_url(monkeypatch):
 
     assert len(posts) == 1
     assert posts[0][1]["source"] == "rtsp://1.2.3.4:554/vendor/lowres"
+
+
+def test_provision_substream_replaces_on_conflict(monkeypatch):
+    # A sub that already exists is refreshed in place via /replace so a
+    # changed substream URL/transport actually takes effect — mirrors the
+    # atomic replace flow of the main path (no delete window).
+    mod = mmadmin
+    MediaMtxAdminService = mmadmin.MediaMtxAdminService
+    posts: list[tuple[str, dict]] = []
+
+    class _ConflictResp:
+        status_code = 400
+        is_success = False
+        text = '{"error": "path already exists"}'
+
+    class _OkResp:
+        status_code = 200
+        is_success = True
+        text = "{}"
+
+    class _Client:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def post(self, url, json=None, headers=None):
+            posts.append((url, json))
+            return _ConflictResp() if "/add/" in url else _OkResp()
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda *a, **k: _Client())
+    monkeypatch.setattr(MediaMtxAdminService, "_base", staticmethod(lambda: "http://mtx/v3"))
+    monkeypatch.setattr(MediaMtxAdminService, "_headers", staticmethod(lambda: {}))
+    monkeypatch.setattr(mod.settings, "mediamtx_stream_prefix", "cam-")
+    monkeypatch.setattr(mod.settings, "mediamtx_path_mode", "id", raising=False)
+
+    cfg = {"source_url": "rtsp://1.2.3.4:554/Streaming/Channels/101",
+           "rtsp_transport": "tcp"}
+    asyncio.run(MediaMtxAdminService._provision_substream(1, "1.2.3.4", cfg))
+
+    assert len(posts) == 2
+    assert posts[0][0].endswith("/config/paths/add/cam-1-sub")
+    assert posts[1][0].endswith("/config/paths/replace/cam-1-sub")
+    assert posts[1][1]["source"] == "rtsp://1.2.3.4:554/Streaming/Channels/102"
 
 
 def test_provision_substream_skips_when_not_derivable(monkeypatch):

--- a/server/tests/test_m1b_mediamtx_hardening.py
+++ b/server/tests/test_m1b_mediamtx_hardening.py
@@ -812,9 +812,16 @@ def test_startup_hook_retries_instead_of_dying_once(monkeypatch):
     }.items():
         monkeypatch.setenv(_k, os.environ.get(_k) or _v)
 
-    from services.mediamtx_config_service import MediaMtxConfigService
+    import services.mediamtx_config_service as mcs
 
-    content = MediaMtxConfigService.generate_complete_mediamtx_yml(
+    # The recordings base path is a DB-backed setting; this test is about
+    # the generated YAML, not the database — stub it so the test needs no
+    # DB (CI's server job has no postgres for this module).
+    monkeypatch.setattr(
+        mcs, "get_effective_recordings_base_path", lambda: "/recordings"
+    )
+
+    content = mcs.MediaMtxConfigService.generate_complete_mediamtx_yml(
         "http://opennvr_core:8000"
     )
     parsed = _yaml.safe_load(content)

--- a/server/tests/test_m1b_mediamtx_hardening.py
+++ b/server/tests/test_m1b_mediamtx_hardening.py
@@ -788,3 +788,39 @@ def test_cert_script_is_idempotent() -> None:
         assert crt.read_bytes() != first_crt_bytes, (
             "cert script did not regenerate under --force"
         )
+
+
+# ── #218 related: startup hook must survive core booting after MediaMTX ─
+
+def test_startup_hook_retries_instead_of_dying_once(monkeypatch):
+    """The runOnInit hook is the ONLY thing that re-provisions cameras after
+    a MediaMTX restart. A single un-retried curl meant 'could not resolve
+    host: opennvr_core' -> zero cameras until manual restart (#218's log).
+    The generated config must retry with backoff and fail LOUDLY."""
+    import secrets as _secrets
+
+    import yaml as _yaml
+    from cryptography.fernet import Fernet as _Fernet
+
+    # This module's earlier tests pop core.config from sys.modules, so the
+    # import below may reconstruct Settings — give it valid secrets.
+    for _k, _v in {
+        "SECRET_KEY": _secrets.token_urlsafe(48),
+        "MEDIAMTX_SECRET": _secrets.token_hex(32),
+        "INTERNAL_API_KEY": _secrets.token_urlsafe(48),
+        "CREDENTIAL_ENCRYPTION_KEY": _Fernet.generate_key().decode(),
+    }.items():
+        monkeypatch.setenv(_k, os.environ.get(_k) or _v)
+
+    from services.mediamtx_config_service import MediaMtxConfigService
+
+    content = MediaMtxConfigService.generate_complete_mediamtx_yml(
+        "http://opennvr_core:8000"
+    )
+    parsed = _yaml.safe_load(content)
+    hook = parsed["runOnInit"]
+    assert hook.startswith("sh -c"), "hook must be a shell loop, not a bare curl"
+    assert "seq 1 60" in hook and "sleep 5" in hook, "bounded retry with backoff"
+    assert "startup/hook" in hook and "opennvr_core" in hook
+    assert "FAILED after 60 attempts" in hook, "final give-up must be loud"
+    assert parsed["runOnInitRestart"] is False

--- a/server/tests/test_provision_replace.py
+++ b/server/tests/test_provision_replace.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for the atomic path-replace provisioning flow.
+
+Background: push_rtsp_stream used to resolve a "path already exists"
+conflict with unprovision + re-provision — two MediaMTX config reloads
+with a window where the path didn't exist. A re-add that lost the race
+with MediaMTX's API-listener reload left the camera with NO path at all
+(no live view, no recording) until manual repair. The fix routes the
+conflict through POST /config/paths/replace/{name}, a single config
+transaction. These tests pin that behavior.
+"""
+
+import pytest
+
+from services.mediamtx_admin_service import MediaMtxAdminService
+
+
+@pytest.mark.asyncio
+async def test_push_rtsp_stream_replaces_in_place_on_conflict(monkeypatch):
+    """On 'path already exists', push_rtsp_stream must go through
+    replace_path and must NEVER delete the existing path first."""
+    calls = {"replace": 0}
+
+    async def _conflict(*a, **kw):
+        return {
+            "status": "error",
+            "http_status": 400,
+            "details": {"error": "path already exists"},
+        }
+
+    async def _replace(*a, **kw):
+        calls["replace"] += 1
+        return {"status": "ok", "http_status": 200, "details": {}}
+
+    async def _forbidden_unprovision(*a, **kw):
+        raise AssertionError(
+            "unprovision_path called during conflict resolution — the "
+            "delete + re-add window is exactly the bug this flow fixes"
+        )
+
+    monkeypatch.setattr(MediaMtxAdminService, "provision_path", _conflict)
+    monkeypatch.setattr(MediaMtxAdminService, "replace_path", _replace)
+    monkeypatch.setattr(
+        MediaMtxAdminService, "unprovision_path", _forbidden_unprovision
+    )
+
+    result = await MediaMtxAdminService.push_rtsp_stream(
+        camera_id=3,
+        camera_ip="192.168.0.103",
+        rtsp_url="rtsp://192.168.0.103:554/stream",
+    )
+
+    assert calls["replace"] == 1
+    assert result.get("status") == "ok"
+    assert result.get("action") == "rtsp_stream_replaced"
+
+
+@pytest.mark.asyncio
+async def test_push_rtsp_stream_surfaces_replace_failure(monkeypatch):
+    """A failed replace must be reported as such — and the old path is
+    still intact, unlike the old flow where failure meant no path."""
+
+    async def _conflict(*a, **kw):
+        return {
+            "status": "error",
+            "http_status": 400,
+            "details": {"error": "path already exists"},
+        }
+
+    async def _replace_fails(*a, **kw):
+        return {
+            "status": "error",
+            "http_status": 500,
+            "details": {"error": "boom"},
+        }
+
+    monkeypatch.setattr(MediaMtxAdminService, "provision_path", _conflict)
+    monkeypatch.setattr(MediaMtxAdminService, "replace_path", _replace_fails)
+
+    result = await MediaMtxAdminService.push_rtsp_stream(
+        camera_id=3,
+        camera_ip="192.168.0.103",
+        rtsp_url="rtsp://192.168.0.103:554/stream",
+    )
+
+    assert result.get("status") == "error"
+    assert result.get("action") == "replace_failed"
+
+
+@pytest.mark.asyncio
+async def test_replace_path_falls_back_to_add_when_path_missing(monkeypatch):
+    """If the path vanished between the add-conflict and the replace
+    (concurrent unprovision), replace_path retries as a plain add."""
+    reached = {"provision": 0}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def post(self, *a, **kw):
+            class _R:
+                status_code = 404
+                is_success = False
+
+                def json(self):
+                    return {"error": "path not found: 'cam-3'"}
+
+                @property
+                def text(self):
+                    return '{"error": "path not found"}'
+
+            return _R()
+
+    async def _record_provision(*a, **kw):
+        reached["provision"] += 1
+        return {"status": "ok", "http_status": 200, "details": {}}
+
+    import services.mediamtx_admin_service as mam
+
+    monkeypatch.setattr(mam.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(
+        MediaMtxAdminService, "is_configured", staticmethod(lambda: True)
+    )
+    monkeypatch.setattr(
+        MediaMtxAdminService,
+        "_base",
+        staticmethod(lambda: "http://stub.mediamtx.invalid"),
+    )
+    monkeypatch.setattr(MediaMtxAdminService, "provision_path", _record_provision)
+
+    result = await MediaMtxAdminService.replace_path(
+        camera_id=3,
+        camera_ip="192.168.0.103",
+        config={"source_url": "rtsp://192.168.0.103:554/stream"},
+    )
+
+    assert reached["provision"] == 1, "missing path must fall back to add"
+    assert result.get("status") == "ok"
+
+
+@pytest.mark.asyncio
+async def test_replace_path_enforces_policy_before_http(monkeypatch):
+    """replace_path is a new MediaMTX entry point, so it must run the
+    same transport-policy gate as provision_path — before any HTTP."""
+    from services.transport_probe_service import TransportPolicyViolation
+
+    class _ForbiddenHttpx:
+        def __init__(self, *a, **kw):
+            raise AssertionError("HTTP reached despite policy violation")
+
+    import services.mediamtx_admin_service as mam
+
+    monkeypatch.setattr(mam.httpx, "AsyncClient", _ForbiddenHttpx)
+    monkeypatch.setattr(
+        MediaMtxAdminService, "is_configured", staticmethod(lambda: True)
+    )
+
+    with pytest.raises(TransportPolicyViolation):
+        await MediaMtxAdminService.replace_path(
+            camera_id=3,
+            camera_ip="192.168.0.103",
+            config={"source_url": "rtsp://192.168.0.103:554/stream"},
+            transport_security="rtsps_required",
+        )

--- a/server/tests/test_provision_replace.py
+++ b/server/tests/test_provision_replace.py
@@ -201,3 +201,116 @@ async def test_replace_path_enforces_policy_before_http(monkeypatch):
             config={"source_url": "rtsp://192.168.0.103:554/stream"},
             transport_security="rtsps_required",
         )
+
+
+@pytest.mark.asyncio
+async def test_replace_skips_when_config_unchanged(monkeypatch):
+    """Identical config must be a true no-op: no replace POST, no config
+    reload, no stream blip — repeat provisions become free."""
+    posts = {"n": 0}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get(self, url, **kw):
+            class _R:
+                is_success = True
+
+                def json(self):
+                    # exactly what _map_conf produces for this config
+                    return {"source": "rtsp://192.168.0.103:554/stream",
+                            "extra_mediamtx_default": "untouched"}
+
+            return _R()
+
+        async def post(self, *a, **kw):
+            posts["n"] += 1
+            raise AssertionError("replace POSTed despite unchanged config")
+
+    import services.mediamtx_admin_service as mam
+
+    monkeypatch.setattr(mam.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(
+        MediaMtxAdminService, "is_configured", staticmethod(lambda: True)
+    )
+    monkeypatch.setattr(
+        MediaMtxAdminService, "_base",
+        staticmethod(lambda: "http://stub.mediamtx.invalid"),
+    )
+
+    result = await MediaMtxAdminService.replace_path(
+        camera_id=3,
+        camera_ip="192.168.0.103",
+        config={"source_url": "rtsp://192.168.0.103:554/stream"},
+    )
+    assert posts["n"] == 0
+    assert result.get("status") == "ok"
+    assert result.get("unchanged") is True
+
+
+@pytest.mark.asyncio
+async def test_replace_proceeds_when_config_differs(monkeypatch):
+    """A changed source URL must still replace (the blip is then necessary)."""
+    posts = {"n": 0}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get(self, url, **kw):
+            class _R:
+                is_success = True
+
+                def json(self):
+                    return {"source": "rtsp://OLD-URL:554/stream"}
+
+            return _R()
+
+        async def post(self, url, **kw):
+            posts["n"] += 1
+
+            class _R:
+                status_code = 200
+                is_success = True
+
+                def json(self):
+                    return {}
+
+                @property
+                def text(self):
+                    return "{}"
+
+            return _R()
+
+    import services.mediamtx_admin_service as mam
+
+    monkeypatch.setattr(mam.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(
+        MediaMtxAdminService, "is_configured", staticmethod(lambda: True)
+    )
+    monkeypatch.setattr(
+        MediaMtxAdminService, "_base",
+        staticmethod(lambda: "http://stub.mediamtx.invalid"),
+    )
+
+    result = await MediaMtxAdminService.replace_path(
+        camera_id=3,
+        camera_ip="192.168.0.103",
+        config={"source_url": "rtsp://192.168.0.103:554/stream"},
+    )
+    assert posts["n"] == 1
+    assert result.get("status") == "ok"
+    assert not result.get("unchanged")

--- a/server/tests/test_provision_replace.py
+++ b/server/tests/test_provision_replace.py
@@ -25,6 +25,24 @@ conflict through POST /config/paths/replace/{name}, a single config
 transaction. These tests pin that behavior.
 """
 
+import os
+import secrets
+import sys
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+# Standard test-module env bootstrap (see test_device_firewall.py): lets this
+# file run STANDALONE (pytest tests/test_provision_replace.py) instead of
+# depending on an alphabetically-earlier module having built Settings first.
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_mtx_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
 import pytest
 
 from services.mediamtx_admin_service import MediaMtxAdminService


### PR DESCRIPTION
…cate provisioning races a config reload (delete + re-add is not atomic)