### PR TITLE
fix: playback P0 hotfixes — event-loop freeze, disk-blind, silent recording stop, SPA 404 (#221)

### DIFF
--- a/nginx/opennvr.conf
+++ b/nginx/opennvr.conf
@@ -117,32 +117,26 @@ server {
     }
 
     # The bare /playback/ is the SPA page route, not a MediaMTX request
-    # (MediaMTX playback uses /playback/get). Serve the app for the exact path
-    # so a browser refresh loads the UI instead of the media proxy 404ing.
-    # Exact match (=) wins over the /playback/ prefix below; no redirect, so it
-    # can't loop with the app's routing.
-    location = /playback/ {
-        proxy_pass http://opennvr-core:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Host              $host;
-        proxy_set_header X-Real-IP         $remote_addr;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-    }
-
-    # Recording playback — MediaMTX's playback server (default :9996) serves
-    # /get and HLS-shaped recording segments; opennvr-core emits browser URLs
-    # against this proxy path. Plaintext on the bridge; nginx is the TLS edge.
-    location /playback/ {
-        proxy_pass http://mediamtx:9996/;
+    # #221: /playback/ is BOTH an SPA route namespace (/playback, /playback/sync)
+    # AND MediaMTX's recording-media path. The only browser-facing MediaMTX path
+    # under here is /playback/get (clip export; the API's HLS media is served
+    # under /api/.../recordings/playback/... by core, not here). So route ONLY
+    # /playback/get to MediaMTX and let every other /playback/* fall through to
+    # the SPA (location / below) — which is why a hard reload of /playback/sync
+    # now loads the app instead of 404ing on the media proxy.
+    #
+    # NB: if MediaMTX ever serves another browser-facing path under /playback/,
+    # add it here explicitly — do NOT widen this back to the /playback/ prefix.
+    location /playback/get {
+        proxy_pass http://mediamtx:9996/get;
         proxy_http_version 1.1;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_buffering on;
-        # Recording segments can be a few MB; allow a generous read
-        # timeout for slow client connections (mobile on cellular).
+        # Recording clips can be a few MB; generous read timeout for slow
+        # client connections (mobile on cellular).
         proxy_read_timeout 300;
     }
 

--- a/server/main.py
+++ b/server/main.py
@@ -353,7 +353,11 @@ async def lifespan(app: FastAPI):
     #     disk pressure within the hour. (The heavy rglob is made incremental/
     #     indexed in the recordings-source-of-truth work; hourly is the safe
     #     stopgap.)
-    _RETENTION_INTERVAL_S = 60 * 60  # was 24h
+    # Configurable for big estates where even the off-loop walk is heavy;
+    # floor of 5 min prevents foot-gun values.
+    _RETENTION_INTERVAL_S = max(
+        300, int(os.environ.get("RETENTION_CLEANUP_INTERVAL_S", str(60 * 60)))
+    )
 
     async def background_retention_cleanup():
         """Background task for retention + disk-pressure cleanup (hourly)."""

--- a/server/main.py
+++ b/server/main.py
@@ -342,27 +342,37 @@ async def lifespan(app: FastAPI):
 
     asyncio.create_task(background_mediamtx_provisioning())
 
-    # Start retention cleanup scheduler
+    # Start retention cleanup scheduler.
+    #
+    # Two #221 hotfixes here:
+    #  1) cleanup_old_recordings() is synchronous and does filesystem walks —
+    #     running it directly on the event loop froze all request handling.
+    #     asyncio.to_thread moves it to a worker thread.
+    #  2) it ran at most once every 24h, so a disk near full would fill and
+    #     RECORDING WOULD STOP before the next check. Running hourly catches
+    #     disk pressure within the hour. (The heavy rglob is made incremental/
+    #     indexed in the recordings-source-of-truth work; hourly is the safe
+    #     stopgap.)
+    _RETENTION_INTERVAL_S = 60 * 60  # was 24h
+
     async def background_retention_cleanup():
-        """Background task for daily retention cleanup."""
+        """Background task for retention + disk-pressure cleanup (hourly)."""
         try:
             from services.retention_service import retention_service
 
-            # Wait a bit before first cleanup (allow system to fully start)
-            await asyncio.sleep(60)  # Wait 60 seconds after startup
-
-            main_logger.info("Starting retention cleanup scheduler (runs daily)")
+            await asyncio.sleep(60)  # let the system finish starting
+            main_logger.info("Starting retention cleanup scheduler (runs hourly)")
 
             while True:
                 try:
-                    main_logger.info("Running scheduled retention cleanup...")
-                    stats = retention_service.cleanup_old_recordings()
+                    stats = await asyncio.to_thread(
+                        retention_service.cleanup_old_recordings
+                    )
                     main_logger.info(f"Retention cleanup completed: {stats}")
                 except Exception as e:
                     main_logger.error(f"Retention cleanup failed: {e}", exc_info=True)
 
-                # Wait 24 hours before next cleanup
-                await asyncio.sleep(24 * 60 * 60)
+                await asyncio.sleep(_RETENTION_INTERVAL_S)
         except Exception as e:
             main_logger.error(f"Retention cleanup scheduler failed: {e}", exc_info=True)
 

--- a/server/routers/compliance.py
+++ b/server/routers/compliance.py
@@ -134,10 +134,17 @@ async def get_compliance_summary(
             # Fetch recordings (still need for total_recordings count)
             if settings.mediamtx_playback_url:
                 try:
+                    import asyncio
+
                     import requests as http_client
 
                     url = f"{settings.mediamtx_playback_url}/list?path={stream_name}"
-                    resp = http_client.get(url, timeout=0.5)
+                    # #221: sync GET inside an async handler, per camera in a
+                    # loop — 0.5s x N cameras of frozen event loop when
+                    # MediaMTX is slow. Run it off-loop.
+                    resp = await asyncio.to_thread(
+                        lambda: http_client.get(url, timeout=0.5)
+                    )
                     if resp.status_code == 200:
                         segs = resp.json()
                         if segs:

--- a/server/routers/mediamtx_hooks.py
+++ b/server/routers/mediamtx_hooks.py
@@ -33,7 +33,6 @@ import subprocess
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-import requests
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -309,7 +309,7 @@ async def get_cloud_upload_status(
     return status
 
 
-def _check_mediamtx_available() -> bool:
+async def _check_mediamtx_available() -> bool:
     """Check if MediaMTX playback server is available."""
     if not settings.mediamtx_playback_url:  # url-internal-ok: guard check on backend-side config, never returned to browser
         return False
@@ -326,7 +326,7 @@ def _check_mediamtx_available() -> bool:
         # configured' on every probe (#218's log noise). Any HTTP answer
         # (200/404/401/...) means the playback server is up — which is all
         # this check ever asserted.
-        response = http_client.get(
+        response = await _mediamtx_get(
             f"{settings.mediamtx_playback_url}/", timeout=2  # url-internal-ok: server-side health probe to mediamtx playback server
         )
         return response.status_code in (200, 400, 401, 404, 500)
@@ -672,7 +672,7 @@ async def list_recording_cameras(
         )
         try:
             url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
-            response = http_client.get(url, timeout=5)
+            response = await _mediamtx_get(url, timeout=5)
 
             if response.status_code == 200:
                 recordings = response.json()
@@ -1502,7 +1502,7 @@ async def list_recordings_by_date(
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     # Check if MediaMTX is available
-    mediamtx_available = _check_mediamtx_available()
+    mediamtx_available = await _check_mediamtx_available()
 
     # Get cameras to query
     if camera_id:
@@ -1609,7 +1609,7 @@ async def get_recording_stats(
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     cameras = db.query(Camera).filter(Camera.is_active == True).all()
-    mediamtx_available = _check_mediamtx_available()
+    mediamtx_available = await _check_mediamtx_available()
 
     total_recordings = 0  # Camera-days
     total_duration = 0
@@ -1622,7 +1622,7 @@ async def get_recording_stats(
             )
             try:
                 url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
-                response = http_client.get(url, timeout=5)
+                response = await _mediamtx_get(url, timeout=5)
 
                 if response.status_code == 200:
                     segments = response.json()
@@ -1900,7 +1900,7 @@ async def get_recording_sessions_for_ai(
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     # Check if MediaMTX is available
-    mediamtx_available = _check_mediamtx_available()
+    mediamtx_available = await _check_mediamtx_available()
 
     # Get cameras to query
     if camera_id:

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -34,7 +34,21 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlencode
 
+import asyncio
 import requests as http_client
+
+
+async def _mediamtx_get(url: str, *, timeout: int = 10):
+    """Run a blocking MediaMTX metadata GET off the event loop.
+
+    These are synchronous ``requests`` calls; issued directly inside an
+    ``async def`` (as they were) each one froze the WHOLE event loop for up
+    to ``timeout`` seconds — stalling every other request, including live
+    video byte-ranges (issue #221). asyncio.to_thread moves the blocking
+    call to a worker thread so the loop keeps serving. Response handling is
+    unchanged (.json()/.status_code)."""
+    return await asyncio.to_thread(lambda: http_client.get(url, timeout=timeout))
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
@@ -608,7 +622,7 @@ async def list_recordings(
 
     try:
         url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
-        response = http_client.get(url, timeout=10)
+        response = await _mediamtx_get(url, timeout=10)
 
         if response.status_code != 200:
             return {
@@ -1145,7 +1159,7 @@ async def get_today_segments(
 
     try:
         url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
-        response = http_client.get(url, timeout=10)
+        response = await _mediamtx_get(url, timeout=10)
 
         if response.status_code != 200:
             return {
@@ -1298,7 +1312,7 @@ async def get_day_segments(
 
     try:
         url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
-        response = http_client.get(url, timeout=10)
+        response = await _mediamtx_get(url, timeout=10)
         if response.status_code != 200:
             return empty
 
@@ -1512,7 +1526,7 @@ async def list_recordings_by_date(
             )
             try:
                 url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
-                response = http_client.get(url, timeout=10)
+                response = await _mediamtx_get(url, timeout=10)
 
                 if response.status_code == 200:
                     segments = response.json()
@@ -1908,7 +1922,7 @@ async def get_recording_sessions_for_ai(
             )
             try:
                 url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
-                response = http_client.get(url, timeout=10)
+                response = await _mediamtx_get(url, timeout=10)
 
                 if response.status_code == 200:
                     segments = response.json()

--- a/server/services/storage_service.py
+++ b/server/services/storage_service.py
@@ -440,21 +440,22 @@ class StorageService:
             "segment_seconds": store.segment_seconds,
         }
 
-        # Get disk usage if possible
+        # Get disk usage if possible.
+        # NB: os.statvfs() returns a 10-field struct, NOT (total, used, free) —
+        # the old unpack raised ValueError on every Linux call and was swallowed,
+        # so disk usage was never reported and the disk-full guard was blind
+        # (issue #221). shutil.disk_usage() returns a proper (total, used, free)
+        # named tuple and works on Linux AND Windows.
         try:
             if root.exists():
-                total, used, free = (
-                    os.statvfs(str(root)) if hasattr(os, "statvfs") else (0, 0, 0)
-                )
-                if total == 0:  # Windows fallback
-                    import shutil
+                import shutil
 
-                    total, used, free = shutil.disk_usage(str(root))
+                usage = shutil.disk_usage(str(root))
                 info.update(
                     {
-                        "disk_total": total,
-                        "disk_used": used,
-                        "disk_free": free,
+                        "disk_total": usage.total,
+                        "disk_used": usage.used,
+                        "disk_free": usage.free,
                     }
                 )
         except Exception as e:

--- a/server/tests/test_playback_hotfixes.py
+++ b/server/tests/test_playback_hotfixes.py
@@ -105,3 +105,28 @@ def test_mediamtx_get_runs_off_the_event_loop():
     assert resp.json() == {"ok": True}
     # ran off the event-loop thread → cannot freeze the loop
     assert seen["thread"] != seen["loop_thread"]
+
+
+# ── regression guard: no blocking MediaMTX GET left in async handlers ──
+
+def test_no_bare_blocking_mediamtx_get_in_recordings():
+    """#221 said 'same pattern at 8 call sites'. Guard against a new one
+    sneaking in: recordings.py must not call http_client.get(...) directly —
+    every MediaMTX metadata fetch goes through _mediamtx_get (off-loop) or
+    asyncio.to_thread. (StreamingResponse byte-range proxying is a separate
+    concern and lives in hls_playback_service, not here.)"""
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "routers" / "recordings.py"
+    text = src.read_text()
+    # allow the definition of the helper itself; forbid bare call sites
+    # exclude the one legitimate use: inside _mediamtx_get, wrapped in to_thread
+    call_sites = [
+        m for m in re.finditer(r"http_client\.get\(", text)
+        if "asyncio.to_thread" not in text[max(0, m.start() - 40):m.start()]
+    ]
+    assert call_sites == [], (
+        f"bare blocking http_client.get found: {len(call_sites)} site(s) — "
+        "route MediaMTX GETs through _mediamtx_get / asyncio.to_thread"
+    )

--- a/server/tests/test_playback_hotfixes.py
+++ b/server/tests/test_playback_hotfixes.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#221 P0 hotfixes: disk usage reporting + off-loop MediaMTX calls."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+# Portability shim: some source modules do `from datetime import UTC`
+# (Python 3.11+). Make the suite runnable on 3.10 too; no-op on 3.11.
+import datetime as _dt  # noqa: E402
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_pb_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+# MediaMTX URLs on loopback so the trust-zone validator (V-015) passes
+# whenever Settings() is rebuilt mid-suite (module-pollution safe).
+os.environ.setdefault("MEDIAMTX_BASE_URL", "http://127.0.0.1:8889")
+os.environ.setdefault("MEDIAMTX_ADMIN_API", "http://127.0.0.1:9997/v3")
+os.environ.setdefault("MEDIAMTX_HLS_URL", "http://127.0.0.1:8888")
+os.environ.setdefault("MEDIAMTX_PLAYBACK_URL", "http://127.0.0.1:9996")
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+import routers.recordings as rec  # noqa: E402
+import services.storage_service as ss  # noqa: E402
+
+
+# ── disk usage reporting (the statvfs unpack bug) ───────────────────
+
+def test_get_storage_info_reports_disk_usage(tmp_path, monkeypatch):
+    """Regression for #221: os.statvfs() unpack raised on Linux and was
+    swallowed, so disk_total/used/free were never populated. shutil.disk_usage
+    must now return real numbers."""
+    monkeypatch.setattr(ss, "_effective_root", lambda store: tmp_path)
+
+    class _Store:
+        segment_seconds = 60
+
+    monkeypatch.setattr(ss, "_load_storage_config", lambda db: _Store())
+
+    info = ss.StorageService().get_storage_info(db=None)
+    assert info["disk_total"] > 0
+    assert info["disk_free"] > 0
+    assert info["disk_free"] <= info["disk_total"]
+    # used + free need not equal total exactly (reserved blocks), but must be sane
+    assert info["disk_used"] >= 0
+
+
+# ── blocking MediaMTX calls run off the event loop ──────────────────
+
+def test_mediamtx_get_runs_off_the_event_loop():
+    """_mediamtx_get must run the blocking GET in a WORKER thread, not on the
+    event-loop thread. Deterministic (no timing): capture the thread the fake
+    GET executes on and assert it differs from the loop thread."""
+    import threading
+
+    seen = {}
+
+    def _fake_get(url, timeout=10):
+        seen["thread"] = threading.get_ident()
+
+        class _R:
+            status_code = 200
+
+            def json(self):
+                return {"ok": True}
+
+        return _R()
+
+    async def _scenario():
+        seen["loop_thread"] = threading.get_ident()
+        return await rec._mediamtx_get("http://x/list")
+
+    orig = rec.http_client.get
+    rec.http_client.get = _fake_get
+    try:
+        resp = asyncio.run(_scenario())
+    finally:
+        rec.http_client.get = orig
+
+    assert resp.json() == {"ok": True}
+    # ran off the event-loop thread → cannot freeze the loop
+    assert seen["thread"] != seen["loop_thread"]


### PR DESCRIPTION
First slice of the #221 recording/playback review — the **ship-now stability and correctness** fixes. Performance, security, data-model, and timezone are separate PRs (see the triage on #221).

## What this fixes

- **Event loop no longer freezes on playback.** All **8** MediaMTX metadata GETs were synchronous `requests` calls inside `async` handlers — each froze the *entire* event loop for up to its timeout, stalling every request including live video byte-ranges. All now run off-loop (`_mediamtx_get` / `asyncio.to_thread`). Includes `_check_mediamtx_available()` (a sync helper called from 3 async handlers) and a per-camera blocking loop in `compliance.py`.
- **Disk usage is reported again.** `os.statvfs()` returns a 10-field struct, not `(total, used, free)` — the old unpack raised on every Linux call and was swallowed, so disk usage was never populated and the disk-full guard was blind. Switched to `shutil.disk_usage()` (correct + cross-platform).
- **Recording can't silently stop on a full disk.** Retention ran synchronously on the event loop and only every 24h; a near-full disk would fill and stop recording before the next check. Now off-loop and hourly (env-tunable `RETENTION_CLEANUP_INTERVAL_S`, 5-min floor).
- **`/playback/sync` loads on hard reload.** The SPA route collided with the MediaMTX media prefix in nginx; only `/playback/get` is browser-facing MediaMTX, so route just that and let SPA routes fall through.

## Tests
`test_playback_hotfixes.py`: disk usage reports real numbers; `_mediamtx_get` runs on a worker thread (deterministic thread-identity, not timing); a regression guard forbids any bare `http_client.get` returning to `recordings.py`. Full server suite green.

## Out of scope (later #221 slices)
- `mediamtx_hooks.py`'s `requests` import is the faststart-remux path → **P2 source-of-truth**.
- Hourly retention still does a full `rglob` walk → **P2** makes it incremental. Hourly off-loop is the safe stopgap.
- Unauthenticated playback/media/export → **P0 security** (#223, #224).