### PR TITLE
fix: recordings are owner-scoped, like every camera route (#221 P0 security)

### DIFF
--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -170,7 +170,7 @@ async def queue_cloud_upload_for_day(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera:
+    if not camera or not _authorize_camera(camera, user_obj):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     rows = (
@@ -334,6 +334,47 @@ def _get_or_init(db: Session, key: str, default_obj) -> SecuritySetting:
         db.commit()
         db.refresh(row)
     return row
+
+
+def _owned_cameras_query(db: Session, user: "User"):
+    """Active cameras the user may see: their own, or all for a superuser.
+
+    Recordings and their playback are the most sensitive camera data — same
+    owner-scoping rule as every camera route and the events store (#221)."""
+    from models import Camera
+
+    q = db.query(Camera).filter(Camera.is_active == True)  # noqa: E712
+    if not getattr(user, "is_superuser", False):
+        q = q.filter(Camera.owner_id == user.id)
+    return q
+
+
+def _authorize_camera(camera, user) -> bool:
+    """True iff ``user`` may access ``camera``'s recordings (superuser or owner)."""
+    if camera is None:
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    return camera.owner_id == user.id
+
+
+def _camera_for_path(db: Session, path: str, user) -> "object | None":
+    """Resolve a MediaMTX path (cam-<id> / cam-<ip>) back to a camera the user
+    is allowed to see. Returns None if it doesn't resolve to an owned camera —
+    callers must 403/404 so a path can't be used to reach another owner's
+    recordings."""
+    for cam in _owned_cameras_query(db, user).all():
+        if _build_stream_name(settings.mediamtx_stream_prefix, cam.id, cam.ip_address) == path:
+            return cam
+    return None
+
+
+def _media_cors_headers() -> dict:
+    """ACAO for media responses. The old ``*`` let any origin read recording
+    media; scope to the configured app origins (same-origin needs no header,
+    but hls.js cross-tab / configured fronts do)."""
+    origins = [o.strip() for o in (settings.cors_origins or "").split(",") if o.strip()]
+    return {"Access-Control-Allow-Origin": origins[0]} if origins else {}
 
 
 async def _authenticate_request(request: Request, db: Session) -> User | None:
@@ -561,6 +602,12 @@ async def recording_status(
     current_user=Depends(get_current_user),
 ):
     """Get recording status for a camera."""
+    # Owner-scope (#221): don't reveal another owner's camera recording state.
+    camera = (
+        db.query(Camera).filter(Camera.id == camera_id, Camera.is_active == True).first()
+    )
+    if not camera or not _authorize_camera(camera, current_user):
+        raise HTTPException(status_code=404, detail="Camera not found")
     try:
         status = await MediaMtxAdminService.get_recording_status(camera_id, db)
         return {
@@ -606,6 +653,11 @@ async def list_recordings(
     ):
         raise HTTPException(status_code=400, detail="Invalid path format")
 
+    # Owner-scope: the path must resolve to a camera this user may see (#221) —
+    # 404 (not 403) so a path can't confirm another owner's camera exists.
+    if _camera_for_path(db, path, user_obj) is None:
+        raise HTTPException(status_code=404, detail="No recordings for this path")
+
     try:
         url = f"{settings.mediamtx_playback_url}/list?path={path}"  # url-internal-ok: server-side LIST call to mediamtx admin API
         response = http_client.get(url, timeout=10)
@@ -649,7 +701,8 @@ async def list_recording_cameras(
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
-    cameras = db.query(Camera).filter(Camera.is_active == True).all()
+    # Owner-scoped: a user only sees recordings for cameras they own (#221).
+    cameras = _owned_cameras_query(db, user_obj).all()
     result = []
 
     for cam in cameras:
@@ -704,6 +757,11 @@ async def get_playback_url(
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
+    # Owner-scope (#221): this endpoint hands out the browser-fetchable clip
+    # URL, so the requested path must belong to a camera the user may see.
+    if _camera_for_path(db, path, user_obj) is None:
+        raise HTTPException(status_code=404, detail="No recordings for this path")
+
     # Build the playback URL the BROWSER fetches — use the external fallback
     # chain (the browser can't reach the Docker-internal mediamtx host; the
     # external URL is nginx-TLS-fronted). Mirrors streams.py's pattern.
@@ -756,7 +814,11 @@ async def create_hls_session(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera:
+    if not camera or not _authorize_camera(camera, user_obj):
+        raise HTTPException(status_code=404, detail="Camera not found")
+    # Owner-scope (#221): creating a session is the gateway to the capability
+    # media URLs, so a non-owner must not be able to mint one. 404, not 403.
+    if not _authorize_camera(camera, user_obj):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     # Parse time range
@@ -853,7 +915,7 @@ async def get_hls_manifest(
         media_type="application/vnd.apple.mpegurl",
         headers={
             "Cache-Control": "no-cache, no-store, must-revalidate",
-            "Access-Control-Allow-Origin": "*",
+            **_media_cors_headers(),
         },
     )
 
@@ -882,7 +944,7 @@ async def get_hls_init_segment(
     return Response(
         content=init_data,
         media_type="video/mp4",
-        headers={"Cache-Control": "max-age=3600", "Access-Control-Allow-Origin": "*"},
+        headers={"Cache-Control": "max-age=3600", **_media_cors_headers()},
     )
 
 
@@ -943,7 +1005,7 @@ async def get_hls_media(
         "Accept-Ranges": "bytes",
         "Content-Length": str(length),
         "Cache-Control": "max-age=86400",
-        "Access-Control-Allow-Origin": "*",
+        **_media_cors_headers(),
     }
     if status_code == 206:
         headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
@@ -1001,7 +1063,7 @@ async def get_browser_playable_recording(
         "Accept-Ranges": "bytes",
         "Content-Length": str(length),
         "Cache-Control": "max-age=86400",
-        "Access-Control-Allow-Origin": "*",
+        **_media_cors_headers(),
     }
     if status_code == 206:
         headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
@@ -1043,7 +1105,7 @@ async def get_hls_segment(
         media_type="video/mp4",
         headers={
             "Cache-Control": "max-age=86400",  # Cache segments for 24h
-            "Access-Control-Allow-Origin": "*",
+            **_media_cors_headers(),
         },
     )
 
@@ -1127,7 +1189,7 @@ async def get_today_segments(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera:
+    if not camera or not _authorize_camera(camera, user_obj):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     path = _build_stream_name(
@@ -1242,7 +1304,7 @@ async def get_day_segments(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera:
+    if not camera or not _authorize_camera(camera, user_obj):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     # Default to today (UTC) — same basis MediaMTX labels its segment starts on.

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -170,7 +170,7 @@ async def queue_cloud_upload_for_day(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera or not _authorize_camera(camera, user_obj):
+    if not camera or not _authorize_camera(camera, user_obj, db):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     rows = (
@@ -336,26 +336,56 @@ def _get_or_init(db: Session, key: str, default_obj) -> SecuritySetting:
     return row
 
 
-def _owned_cameras_query(db: Session, user: "User"):
-    """Active cameras the user may see: their own, or all for a superuser.
+def _viewable_cameras_query(db: Session, user: "User"):
+    """Active cameras the user may see: superuser -> all; otherwise cameras
+    they OWN or have been granted can_view on.
 
-    Recordings and their playback are the most sensitive camera data — same
-    owner-scoping rule as every camera route and the events store (#221)."""
-    from models import Camera
+    Mirrors the exact model cameras.py uses to list cameras (owner_id OR a
+    CameraPermission.can_view grant) — recordings must not be stricter than
+    live view, or a user shared a camera could watch it live but not its
+    recordings (#221)."""
+    from models import Camera, CameraPermission
 
     q = db.query(Camera).filter(Camera.is_active == True)  # noqa: E712
-    if not getattr(user, "is_superuser", False):
-        q = q.filter(Camera.owner_id == user.id)
-    return q
+    if getattr(user, "is_superuser", False):
+        return q
+    permitted = (
+        db.query(CameraPermission.camera_id)
+        .filter(CameraPermission.user_id == user.id, CameraPermission.can_view == True)  # noqa: E712
+        .subquery()
+    )
+    return q.filter(
+        (Camera.owner_id == user.id) | (Camera.id.in_(permitted))
+    )
 
 
-def _authorize_camera(camera, user) -> bool:
-    """True iff ``user`` may access ``camera``'s recordings (superuser or owner)."""
+# Back-compat alias (older call sites) -> viewable set.
+_owned_cameras_query = _viewable_cameras_query
+
+
+def _authorize_camera(camera, user, db: "Session | None" = None) -> bool:
+    """True iff ``user`` may access ``camera``'s recordings: superuser, owner,
+    or a can_view grant (grant check needs ``db``)."""
     if camera is None:
         return False
     if getattr(user, "is_superuser", False):
         return True
-    return camera.owner_id == user.id
+    if camera.owner_id == getattr(user, "id", None):
+        return True
+    if db is not None:
+        from models import CameraPermission
+
+        grant = (
+            db.query(CameraPermission)
+            .filter(
+                CameraPermission.user_id == user.id,
+                CameraPermission.camera_id == camera.id,
+                CameraPermission.can_view == True,  # noqa: E712
+            )
+            .first()
+        )
+        return grant is not None
+    return False
 
 
 def _camera_for_path(db: Session, path: str, user) -> "object | None":
@@ -606,7 +636,7 @@ async def recording_status(
     camera = (
         db.query(Camera).filter(Camera.id == camera_id, Camera.is_active == True).first()
     )
-    if not camera or not _authorize_camera(camera, current_user):
+    if not camera or not _authorize_camera(camera, current_user, db):
         raise HTTPException(status_code=404, detail="Camera not found")
     try:
         status = await MediaMtxAdminService.get_recording_status(camera_id, db)
@@ -814,11 +844,11 @@ async def create_hls_session(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera or not _authorize_camera(camera, user_obj):
+    if not camera or not _authorize_camera(camera, user_obj, db):
         raise HTTPException(status_code=404, detail="Camera not found")
     # Owner-scope (#221): creating a session is the gateway to the capability
     # media URLs, so a non-owner must not be able to mint one. 404, not 403.
-    if not _authorize_camera(camera, user_obj):
+    if not _authorize_camera(camera, user_obj, db):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     # Parse time range
@@ -1189,7 +1219,7 @@ async def get_today_segments(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera or not _authorize_camera(camera, user_obj):
+    if not camera or not _authorize_camera(camera, user_obj, db):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     path = _build_stream_name(
@@ -1304,7 +1334,7 @@ async def get_day_segments(
         .filter(Camera.id == camera_id, Camera.is_active == True)
         .first()
     )
-    if not camera or not _authorize_camera(camera, user_obj):
+    if not camera or not _authorize_camera(camera, user_obj, db):
         raise HTTPException(status_code=404, detail="Camera not found")
 
     # Default to today (UTC) — same basis MediaMTX labels its segment starts on.

--- a/server/tests/test_recordings_auth.py
+++ b/server/tests/test_recordings_auth.py
@@ -46,7 +46,7 @@ from sqlalchemy.orm import sessionmaker  # noqa: E402
 
 import routers.recordings as rec  # noqa: E402
 from core.database import Base  # noqa: E402
-from models import Camera, Role, User  # noqa: E402
+from models import Camera, CameraPermission, Role, User  # noqa: E402
 
 _ADMIN = SimpleNamespace(id=1, is_superuser=True)
 
@@ -71,19 +71,35 @@ def _db():
 
 def test_owned_cameras_query_scopes_to_owner():
     s, ua, ub, cam_a, cam_b = _db()
-    a_ids = [c.id for c in rec._owned_cameras_query(s, ua).all()]
+    a_ids = [c.id for c in rec._viewable_cameras_query(s, ua).all()]
     assert a_ids == [cam_a.id]
     # superuser sees all
     su = SimpleNamespace(id=99, is_superuser=True)
-    assert len(rec._owned_cameras_query(s, su).all()) == 2
+    assert len(rec._viewable_cameras_query(s, su).all()) == 2
 
 
 def test_authorize_camera_owner_and_superuser():
     s, ua, ub, cam_a, cam_b = _db()
-    assert rec._authorize_camera(cam_a, ua) is True
-    assert rec._authorize_camera(cam_a, ub) is False          # other owner
-    assert rec._authorize_camera(cam_a, SimpleNamespace(id=0, is_superuser=True)) is True
-    assert rec._authorize_camera(None, ua) is False
+    assert rec._authorize_camera(cam_a, ua, s) is True
+    assert rec._authorize_camera(cam_a, ub, s) is False          # other owner
+    assert rec._authorize_camera(cam_a, SimpleNamespace(id=0, is_superuser=True), s) is True
+    assert rec._authorize_camera(None, ua, s) is False
+
+
+def test_shared_camera_via_can_view_is_authorized():
+    """A user granted can_view on someone else's camera must see its
+    recordings too — recordings must not be stricter than live view (#221)."""
+    s, ua, ub, cam_a, cam_b = _db()
+    # grant user A view access to user B's camera
+    s.add(CameraPermission(user_id=ua.id, camera_id=cam_b.id, can_view=True))
+    s.commit()
+    assert rec._authorize_camera(cam_b, ua, s) is True
+    ids = sorted(c.id for c in rec._viewable_cameras_query(s, ua).all())
+    assert ids == sorted([cam_a.id, cam_b.id])
+    # a revoked / can_view=False grant does NOT authorize
+    s.add(CameraPermission(user_id=ub.id, camera_id=cam_a.id, can_view=False))
+    s.commit()
+    assert rec._authorize_camera(cam_a, ub, s) is False
 
 
 def test_camera_for_path_only_resolves_owned():

--- a/server/tests/test_recordings_auth.py
+++ b/server/tests/test_recordings_auth.py
@@ -104,11 +104,17 @@ def test_shared_camera_via_can_view_is_authorized():
 
 def test_camera_for_path_only_resolves_owned():
     s, ua, ub, cam_a, cam_b = _db()
-    from services.stream_service import _build_stream_name
-    from core.config import settings
+    # Build the expected path from the EXACT references _camera_for_path uses
+    # (rec's own settings + stream-name fn), not fresh imports — otherwise a
+    # prior test that reloaded core.config makes the two settings instances
+    # diverge and the paths won't match (test-ordering flake, not a bug).
+    def _path(cam):
+        return rec._build_stream_name(
+            rec.settings.mediamtx_stream_prefix, cam.id, cam.ip_address
+        )
 
-    path_a = _build_stream_name(settings.mediamtx_stream_prefix, cam_a.id, cam_a.ip_address)
-    path_b = _build_stream_name(settings.mediamtx_stream_prefix, cam_b.id, cam_b.ip_address)
+    path_a = _path(cam_a)
+    path_b = _path(cam_b)
     # owner A resolves their own path, not B's
     assert rec._camera_for_path(s, path_a, ua) is not None
     assert rec._camera_for_path(s, path_b, ua) is None

--- a/server/tests/test_recordings_auth.py
+++ b/server/tests/test_recordings_auth.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#221 P0 security: recordings are owner-scoped, like every camera route."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+from types import SimpleNamespace
+
+from cryptography.fernet import Fernet
+
+import datetime as _dt  # noqa: E402
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_rauth_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+os.environ.setdefault("MEDIAMTX_BASE_URL", "http://127.0.0.1:8889")
+os.environ.setdefault("MEDIAMTX_ADMIN_API", "http://127.0.0.1:9997/v3")
+os.environ.setdefault("MEDIAMTX_HLS_URL", "http://127.0.0.1:8888")
+os.environ.setdefault("MEDIAMTX_PLAYBACK_URL", "http://127.0.0.1:9996")
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+import routers.recordings as rec  # noqa: E402
+from core.database import Base  # noqa: E402
+from models import Camera, Role, User  # noqa: E402
+
+_ADMIN = SimpleNamespace(id=1, is_superuser=True)
+
+
+def _db():
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    s = sessionmaker(bind=eng)()
+    role = Role(name="admin")
+    s.add(role)
+    s.commit()
+    ua = User(username="a", email="a@t.io", hashed_password="x", role_id=role.id)
+    ub = User(username="b", email="b@t.io", hashed_password="x", role_id=role.id)
+    s.add_all([ua, ub])
+    s.commit()
+    cam_a = Camera(name="a-cam", ip_address="10.0.0.1", port=80, owner_id=ua.id)
+    cam_b = Camera(name="b-cam", ip_address="10.0.0.2", port=80, owner_id=ub.id)
+    s.add_all([cam_a, cam_b])
+    s.commit()
+    return s, ua, ub, cam_a, cam_b
+
+
+def test_owned_cameras_query_scopes_to_owner():
+    s, ua, ub, cam_a, cam_b = _db()
+    a_ids = [c.id for c in rec._owned_cameras_query(s, ua).all()]
+    assert a_ids == [cam_a.id]
+    # superuser sees all
+    su = SimpleNamespace(id=99, is_superuser=True)
+    assert len(rec._owned_cameras_query(s, su).all()) == 2
+
+
+def test_authorize_camera_owner_and_superuser():
+    s, ua, ub, cam_a, cam_b = _db()
+    assert rec._authorize_camera(cam_a, ua) is True
+    assert rec._authorize_camera(cam_a, ub) is False          # other owner
+    assert rec._authorize_camera(cam_a, SimpleNamespace(id=0, is_superuser=True)) is True
+    assert rec._authorize_camera(None, ua) is False
+
+
+def test_camera_for_path_only_resolves_owned():
+    s, ua, ub, cam_a, cam_b = _db()
+    from services.stream_service import _build_stream_name
+    from core.config import settings
+
+    path_a = _build_stream_name(settings.mediamtx_stream_prefix, cam_a.id, cam_a.ip_address)
+    path_b = _build_stream_name(settings.mediamtx_stream_prefix, cam_b.id, cam_b.ip_address)
+    # owner A resolves their own path, not B's
+    assert rec._camera_for_path(s, path_a, ua) is not None
+    assert rec._camera_for_path(s, path_b, ua) is None
+    # superuser resolves either
+    su = SimpleNamespace(id=0, is_superuser=True)
+    assert rec._camera_for_path(s, path_b, su) is not None
+
+
+def test_media_cors_is_not_wildcard():
+    h = rec._media_cors_headers()
+    assert h.get("Access-Control-Allow-Origin") != "*"


### PR DESCRIPTION
Second #221 slice — **P0 security.** Recordings and their playback are the most sensitive camera data, but the endpoints authenticated the *user* without checking *which* cameras they may see — **any logged-in user could list, play, and mint playback sessions for any camera.** This applies the same owner-scoping rule used everywhere else (events store, camera routes).

## What this fixes

- Helpers: `_viewable_cameras_query` (cameras the user owns **or** has a `can_view` grant on — mirrors `cameras.py` exactly), `_authorize_camera` (owner / superuser / grant gate), `_camera_for_path` (resolve a MediaMTX path only to a viewable camera), `_media_cors_headers`.
- **Session creation (`/playback/hls`)** — the gateway to the capability media URLs — now enforces the ownership its own comment already promised. A non-owner can't mint a session, which makes the session-UUID-as-capability model for the media segments sound.
- Owner-scoped: `/playback/list`, `/playback/cameras` (lists only viewable), `/playback/url`, `/today/{id}`, `/segments/{id}`, `/list-by-date`, `/sessions-for-ai`, `/status/{id}`. **404 (not 403)** so a `camera_id`/path can't confirm another owner's camera exists.
- Media `ACAO` tightened from `*` to the configured app origin (5 endpoints). Safe: media is fetched same-origin, so this only restricts cross-origin embeds.

## Review note
First pass checked only `owner_id`, which made recordings *stricter* than live view (a user granted `can_view` on a shared camera could watch it live but not its recordings — a regression). Fixed to honor `can_view` grants, matching the app's real permission model. Test covers a grant authorizing recordings and a `can_view=False` row not.

## Tests
Viewable-cameras query, authorize gate (owner/superuser/grant), path resolves only to viewable cameras, ACAO not wildcard. Full server suite green (622, verified under a Python-3.11-equivalent run).

## Out of scope
Clip-export `/playback/get` still proxies to MediaMTX unauthenticated → closed in **#224** (its own reviewable slice, frontend + backend).