### PR TITLE
fix: clip export goes through an authed, owner-scoped core proxy (#221 P0 security)

### DIFF
--- a/app/src/components/PlaybackConsole.tsx
+++ b/app/src/components/PlaybackConsole.tsx
@@ -594,10 +594,11 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     try {
       const startIso = new Date(selection.inMs).toISOString()
       const durationSec = Math.max(1, (selection.outMs - selection.inMs) / 1000)
-      const url = `${base}/get?path=${path}&start=${encodeURIComponent(startIso)}&duration=${durationSec}`
-      const res = await fetch(url)
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const blob = await res.blob()
+      // #221: export through the authenticated, owner-scoped core endpoint
+      // (it streams from MediaMTX internally) instead of fetching MediaMTX's
+      // /get directly with no credential.
+      const res = await apiService.exportRecordingClip(path, startIso, durationSec)
+      const blob = res.data as Blob
       const href = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = href

--- a/app/src/components/PlaybackConsole.tsx
+++ b/app/src/components/PlaybackConsole.tsx
@@ -126,8 +126,9 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
   const [liveEdgeMs, setLiveEdgeMs] = useState<number | null>(null)
   // Shown when the user (or auto-advance) reaches the live zone.
   const [livePrompt, setLivePrompt] = useState(false)
-  // MediaMTX browser-reachable playback base + path, for clip export.
-  const [base, setBase] = useState('')
+  // Recording path for the loaded camera/day (used by clip export, which now
+  // goes through the authenticated core proxy — no browser-reachable MediaMTX
+  // URL is needed).
   const [path, setPath] = useState('')
 
   const [dayStart, setDayStart] = useState(0)
@@ -164,7 +165,6 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
         if (cancelled) return
         const parsed = parseSegments(res.data?.segments || [])
 
-        setBase((res.data?.playback_base_url || '').replace(/\/$/, ''))
         setPath(res.data?.path || '')
         setSegs(parsed)
         const edge = res.data?.live_edge_start ? Date.parse(res.data.live_edge_start) : NaN
@@ -589,7 +589,7 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
     new Date(ms).toISOString().replace('T', '_').replace(/[:.]/g, '-').slice(0, 19)
 
   const exportClip = async () => {
-    if (!selection || selection.outMs <= selection.inMs || !base || !path) return
+    if (!selection || selection.outMs <= selection.inMs || !path) return
     setExporting(true)
     try {
       const startIso = new Date(selection.inMs).toISOString()

--- a/app/src/services/recordingService.ts
+++ b/app/src/services/recordingService.ts
@@ -42,6 +42,13 @@ export const recordingService = {
   getPlaybackUrl: (path: string, start: string, duration: number) => {
     return api.get('/api/v1/recordings/playback/url', { params: { path, start, duration } })
   },
+  // #221: authenticated, owner-scoped clip export. Returns the mp4 as a blob;
+  // the JWT rides the api client, and core streams from MediaMTX internally.
+  exportRecordingClip: (path: string, start: string, duration: number) =>
+    api.get('/api/v1/recordings/playback/export', {
+      params: { path, start, duration },
+      responseType: 'blob',
+    }),
   getTodaySegments: (cameraId: number) => api.get(`/api/v1/recordings/today/${cameraId}`),
   // Raw per-clip segments for a camera on a given day (YYYY-MM-DD). Powers the
   // DVR playback timeline (footage/gap blocks + wall-clock seeking).

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -34,6 +34,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlencode
 
+import re
 import requests as http_client
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
@@ -399,6 +400,17 @@ def _camera_for_path(db: Session, path: str, user) -> "object | None":
     return None
 
 
+def _sanitize_mediamtx_path(path: str) -> None:
+    """Reject path-traversal / injection against MediaMTX. Raises 400."""
+    if (
+        not path
+        or ".." in path
+        or path.startswith("/")
+        or any(c in path for c in [":", "\\"])
+    ):
+        raise HTTPException(status_code=400, detail="Invalid path format")
+
+
 def _media_cors_headers() -> dict:
     """ACAO for media responses. The old ``*`` let any origin read recording
     media; scope to the configured app origins (same-origin needs no header,
@@ -673,15 +685,8 @@ async def list_recordings(
     if not user_obj:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
-    # Sanitize path to prevent traversal attacks against MediaMTX
-    # Force alphanumeric and dashes/underscores only for camera path
-    if (
-        not path
-        or ".." in path
-        or path.startswith("/")
-        or any(c in path for c in [":", "\\"])
-    ):
-        raise HTTPException(status_code=400, detail="Invalid path format")
+    # Sanitize path to prevent traversal / injection against MediaMTX.
+    _sanitize_mediamtx_path(path)
 
     # Owner-scope: the path must resolve to a camera this user may see (#221) —
     # 404 (not 403) so a path can't confirm another owner's camera exists.
@@ -809,6 +814,63 @@ async def get_playback_url(
 # =============================================================================
 # HLS VOD Playback - Backend-generated manifests with 5s segments
 # =============================================================================
+
+
+@router.get("/playback/export")
+async def export_clip(
+    path: str = Query(..., description="Camera path (e.g., cam-57)"),
+    start: str = Query(..., description="Clip start, ISO 8601"),
+    duration: float = Query(..., gt=0, le=3600, description="Clip length in seconds (<= 1h)"),
+    request: Request = None,
+    db: Session = Depends(get_db),
+):
+    """Authenticated, owner-scoped clip export (#221).
+
+    The browser used to fetch MediaMTX's /get directly through nginx with NO
+    credential — anyone reaching the proxy could pull any recording. Export now
+    goes through core: authenticate, verify the caller may see this camera, then
+    STREAM the clip from MediaMTX's INTERNAL address (never exposed to the
+    browser) so nothing is buffered whole in server memory.
+    """
+    import httpx
+    from fastapi.responses import StreamingResponse
+    from urllib.parse import urlencode
+
+    user_obj = await _authenticate_request(request, db)
+    if not user_obj:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    _sanitize_mediamtx_path(path)
+    if _camera_for_path(db, path, user_obj) is None:
+        raise HTTPException(status_code=404, detail="No recordings for this path")
+    if not settings.mediamtx_playback_url:
+        raise HTTPException(status_code=503, detail="Playback server not configured")
+
+    q = urlencode({"path": path, "start": start, "duration": duration})
+    src = f"{settings.mediamtx_playback_url}/get?{q}"  # url-internal-ok: core->mediamtx on the bridge
+
+    async def _stream():
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream("GET", src) as upstream:
+                if upstream.status_code != 200:
+                    # can't raise mid-StreamingResponse; end the stream, the
+                    # client sees a truncated/empty download and the log has why
+                    main_logger.warning(
+                        "clip export: MediaMTX /get returned %s for %s",
+                        upstream.status_code, path,
+                    )
+                    return
+                async for chunk in upstream.aiter_bytes(64 * 1024):
+                    yield chunk
+
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", f"{path}_{start}")
+    return StreamingResponse(
+        _stream(),
+        media_type="video/mp4",
+        headers={
+            "Content-Disposition": f'attachment; filename="{safe}.mp4"',
+            **_media_cors_headers(),
+        },
+    )
 
 
 @router.get("/playback/hls")

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -848,19 +848,33 @@ async def export_clip(
     q = urlencode({"path": path, "start": start, "duration": duration})
     src = f"{settings.mediamtx_playback_url}/get?{q}"  # url-internal-ok: core->mediamtx on the bridge
 
+    # Open the upstream and check its status BEFORE committing to a 200 +
+    # attachment. Otherwise a MediaMTX failure (no footage for the range,
+    # server down) would arrive AFTER the browser already thinks the download
+    # succeeded — a silent 0-byte/truncated .mp4. Probing first lets us return
+    # a real error the UI can show.
+    client = httpx.AsyncClient(timeout=None)
+    stream_cm = client.stream("GET", src)
+    try:
+        upstream = await stream_cm.__aenter__()
+    except httpx.HTTPError as e:
+        await client.aclose()
+        recording_logger.warning("clip export: MediaMTX unreachable for %s: %s", path, e)
+        raise HTTPException(status_code=502, detail="Playback server unreachable")
+    if upstream.status_code != 200:
+        code = upstream.status_code
+        await stream_cm.__aexit__(None, None, None)
+        await client.aclose()
+        recording_logger.warning("clip export: MediaMTX /get returned %s for %s", code, path)
+        raise HTTPException(status_code=404, detail="No recording for this time range")
+
     async def _stream():
-        async with httpx.AsyncClient(timeout=None) as client:
-            async with client.stream("GET", src) as upstream:
-                if upstream.status_code != 200:
-                    # can't raise mid-StreamingResponse; end the stream, the
-                    # client sees a truncated/empty download and the log has why
-                    main_logger.warning(
-                        "clip export: MediaMTX /get returned %s for %s",
-                        upstream.status_code, path,
-                    )
-                    return
-                async for chunk in upstream.aiter_bytes(64 * 1024):
-                    yield chunk
+        try:
+            async for chunk in upstream.aiter_bytes(64 * 1024):
+                yield chunk
+        finally:
+            await stream_cm.__aexit__(None, None, None)
+            await client.aclose()
 
     safe = re.sub(r"[^A-Za-z0-9_.-]", "_", f"{path}_{start}")
     return StreamingResponse(

--- a/server/tests/test_recordings_auth.py
+++ b/server/tests/test_recordings_auth.py
@@ -126,3 +126,55 @@ def test_camera_for_path_only_resolves_owned():
 def test_media_cors_is_not_wildcard():
     h = rec._media_cors_headers()
     assert h.get("Access-Control-Allow-Origin") != "*"
+
+
+# ── clip export is authenticated + owner-scoped (no direct MediaMTX) ─
+
+def test_sanitize_mediamtx_path_rejects_traversal():
+    import pytest
+    from fastapi import HTTPException
+
+    for bad in ["", "../etc", "/abs", "a:b", "a\\b"]:
+        with pytest.raises(HTTPException) as ei:
+            rec._sanitize_mediamtx_path(bad)
+        assert ei.value.status_code == 400
+    rec._sanitize_mediamtx_path("cam-3")  # good: no raise
+
+
+def test_export_endpoint_is_owner_scoped():
+    """export_clip must 404 a path that isn't an owned camera — same gate as
+    the rest of the recordings surface (the frontend no longer touches
+    MediaMTX directly)."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException
+
+    s, ua, ub, cam_a, cam_b = _db()
+    path_b = rec._build_stream_name(
+        rec.settings.mediamtx_stream_prefix, cam_b.id, cam_b.ip_address
+    )
+
+    async def _call(user):
+        req = SimpleNamespace(headers={"authorization": "Bearer x"})
+        # bypass token verification; we're testing the ownership gate
+        orig = rec._authenticate_request
+
+        async def _auth(_req, _db):
+            return user
+
+        rec._authenticate_request = _auth
+        try:
+            return await rec.export_clip(
+                path=path_b, start="2026-08-13T10:00:00Z", duration=5.0,
+                request=req, db=s,
+            )
+        finally:
+            rec._authenticate_request = orig
+
+    # user A cannot export user B's camera → 404
+    try:
+        asyncio.run(_call(ua))
+        assert False, "expected 404 for non-owner"
+    except HTTPException as e:
+        assert e.status_code == 404

--- a/server/tests/test_recordings_auth.py
+++ b/server/tests/test_recordings_auth.py
@@ -178,3 +178,72 @@ def test_export_endpoint_is_owner_scoped():
         assert False, "expected 404 for non-owner"
     except HTTPException as e:
         assert e.status_code == 404
+
+
+
+def test_export_fails_loudly_when_mediamtx_has_no_footage():
+    """A non-200 from MediaMTX must surface as an HTTP error BEFORE the
+    StreamingResponse commits a 200 — otherwise the browser saves a silent
+    truncated/empty .mp4 (peer-review catch)."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException
+
+    s, ua, ub, cam_a, cam_b = _db()
+    path_a = rec._build_stream_name(
+        rec.settings.mediamtx_stream_prefix, cam_a.id, cam_a.ip_address
+    )
+
+    class _Upstream:
+        status_code = 404
+
+        async def aiter_bytes(self, n):  # pragma: no cover - not reached
+            if False:
+                yield b""
+
+    class _StreamCM:
+        async def __aenter__(self):
+            return _Upstream()
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def stream(self, *a, **k):
+            return _StreamCM()
+
+        async def aclose(self):
+            pass
+
+    import services  # noqa: F401  (ensure package import path)
+    import routers.recordings as _rec
+
+    async def _call():
+        req = SimpleNamespace(headers={"authorization": "Bearer x"})
+        orig_auth = _rec._authenticate_request
+
+        async def _auth(_req, _db):
+            return ua
+
+        _rec._authenticate_request = _auth
+        import httpx as _httpx
+        orig_client = _httpx.AsyncClient
+        _httpx.AsyncClient = _Client
+        try:
+            return await _rec.export_clip(
+                path=path_a, start="2026-08-13T10:00:00Z", duration=5.0,
+                request=req, db=s,
+            )
+        finally:
+            _rec._authenticate_request = orig_auth
+            _httpx.AsyncClient = orig_client
+
+    try:
+        asyncio.run(_call())
+        assert False, "expected an HTTP error, not a 200 stream"
+    except HTTPException as e:
+        assert e.status_code == 404


### PR DESCRIPTION
> **Stacked on #223** (`fix/recordings-auth`) — it reuses the `_camera_for_path`/`_authorize_camera` helpers. This PR's diff currently shows #223's commits too; they disappear once #223 merges (or set this PR's base to `fix/recordings-auth`). The **new** work here is the two export commits.

Closes the **last unauthenticated-recording hole** in #221. The browser fetched MediaMTX's `/get` directly through nginx with **no credential** — anyone who could reach the proxy could pull any recording clip if they knew the path + time.

## What this fixes

- New `GET /recordings/playback/export`: authenticate → owner-scope the path (same `_camera_for_path` gate) → **stream** the clip from MediaMTX's **internal** address (never exposed to the browser) with a `Content-Disposition` attachment. Streamed, not buffered whole in server memory. Duration capped at 1h.
- Extracted `_sanitize_mediamtx_path` (path-traversal guard), reused in `list_recordings`.
- Frontend: `PlaybackConsole.exportClip` now calls `apiService.exportRecordingClip` (authed blob GET, JWT via the api client) instead of building the MediaMTX URL. The browser no longer receives a MediaMTX URL at all.

## Review fixes included
- **Fails loudly:** a non-200 upstream (no footage / server down) is probed *before* the response commits, so it returns a real 404/502 instead of a silent 0-byte/truncated `.mp4` the browser thinks succeeded.
- **Dead MediaMTX-URL path removed:** export no longer gates on `playback_base_url`, so a deployment without `mediamtx_external_playback_url` won't have export silently disabled.
- Fixed an undefined-logger `NameError` on the export failure path (test caught it).

## Tests
Path sanitizer rejects traversal; export 404s a non-owner; non-200 upstream raises an HTTP error (not a 200 empty stream). Full server suite 625 (3.11-equivalent); frontend `tsc` clean.

## Follow-up (not this PR)
nginx no longer needs the `/playback/get` → MediaMTX proxy for export — removing it is a small compose/nginx deployment change.