### PR TITLE
feat: configurable recording layout — match any NVR's on-disk tree

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,3 +193,16 @@ CAPTION_ADAPTER=moondream
 #LLAMACPP_HF_REPO=Qwen/Qwen3-1.7B-GGUF:Q4_K_M
 
 OLLAMA_KEEP_ALIVE=-1
+
+# ── Recording layout (how recordings are named on disk) ──────────────
+# nested (default): <camera>/%Y/%m/%d/%H/%M/%S  — unchanged historical layout
+# date-hour       : <camera>/%Y-%m-%d/%H/%M      — one day + hour folder;
+#                   set RECORDING_SEGMENT_SECONDS=60 for one-minute clips so
+#                   external tools can address a file directly by timestamp
+#                   (a shape many NVRs and VMS systems use)
+# flat            : <camera>/%Y-%m-%d_%H-%M-%S
+# custom          : RECORDING_PATH_TEMPLATE, e.g. {camera}/%Y-%m-%d/%H/%M
+# Time tokens use the MediaMTX container timezone — set TZ for local time.
+RECORDING_LAYOUT=nested
+# RECORDING_PATH_TEMPLATE={camera}/%Y-%m-%d/%H/%M
+# RECORDING_SEGMENT_SECONDS=3600

--- a/docs/recording-layout.md
+++ b/docs/recording-layout.md
@@ -1,0 +1,52 @@
+# Recording layout — how recordings are named on disk
+
+OpenNVR records through MediaMTX, which writes segments to a **templated
+path**. The layout is configurable, so you can keep OpenNVR's default or
+match an existing NVR's tree (so your scripts, backups, and tools address
+files by path without change).
+
+## Presets (`RECORDING_LAYOUT`)
+
+| Preset | On-disk shape | Use it when |
+|---|---|---|
+| `nested` (default) | `<base>/<camera>/%Y/%m/%d/%H/%M/%S.<ext>` | Default; no change to existing installs |
+| `date-hour` | `<base>/<camera>/%Y-%m-%d/%H/%M-%S.<ext>` | One folder per day and per hour; **path-addressable** retrieval. Pair with `RECORDING_SEGMENT_SECONDS=60` for one-minute clips (matches many NVRs and VMS systems) |
+| `flat` | `<base>/<camera>/%Y-%m-%d_%H-%M-%S.<ext>` | Everything for a camera in one folder |
+| `custom` | `RECORDING_PATH_TEMPLATE` verbatim | Any layout you need |
+
+`<camera>` is the stream path (`cam-<id>` or `cam-<ip>` per
+`MEDIAMTX_PATH_MODE`). Custom templates use `{camera}` plus MediaMTX
+strftime tokens (`%Y %m %d %H %M %S %f`).
+
+## One-minute, path-addressable clips (integrator layout)
+
+```
+RECORDING_LAYOUT=date-hour
+RECORDING_SEGMENT_SECONDS=60
+```
+
+produces e.g. `…/cam-301/2026-08-13/14/23-05.mp4` — an external system can
+compute the file path directly from a timestamp.
+
+**Two things to know about segments:**
+
+- Clips are named by their **start time** and are *approximately* the
+  segment length — MediaMTX splits on keyframe boundaries, so a clip may
+  start a second or two off the minute.
+- A clip that starts near the end of an hour (e.g. `14:59:40`) lives in the
+  `14/` folder but its footage runs a few seconds into `15:00`. Retrieval
+  should treat a file as "the clip whose start ≤ your timestamp," not
+  "exactly `HH/MM` = that minute."
+
+## Timezone
+
+Time tokens (`%H`, `%d`, …) follow the **MediaMTX container's timezone**.
+Set `TZ` on the MediaMTX container for local-time folders; the default is
+UTC. (First-class local-time handling across the UI and APIs is tracked
+separately.)
+
+## Changing the layout
+
+The layout applies to **newly recorded** segments. Existing recordings keep
+their original paths; retention and playback read both. Changing layout on a
+running system is safe — it does not move or rewrite existing files.

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -182,6 +182,20 @@ class Settings(BaseSettings):
     # RECORDING_SEGMENT_SECONDS. Default 3600 (1h) to match the MediaMTX
     # pathDefaults `recordSegmentDuration: 1h` — keep them in sync.
     recording_segment_seconds: int = 3600
+    # On-disk recording layout (how MediaMTX names recording files/dirs).
+    #   nested    (default): <camera>/%Y/%m/%d/%H/%M/%S  — current behaviour
+    #   date-hour          : <camera>/%Y-%m-%d/%H/%M      — one folder per day,
+    #                        per hour; pair with recording_segment_seconds=60
+    #                        for one-minute clips (matches the shape many NVRs and VMS systems use so
+    #                        external tools can address files by path).
+    #   flat               : <camera>/%Y-%m-%d_%H-%M-%S
+    #   custom             : use recording_path_template verbatim.
+    # Time tokens follow the MediaMTX container's timezone (set TZ for local
+    # time; UTC by default) — see the recordings layout doc.
+    recording_layout: str = "nested"
+    # Only when recording_layout=custom. {camera} is the stream path; the rest
+    # are MediaMTX strftime tokens (%Y %m %d %H %M %S %f ...).
+    recording_path_template: str | None = None
 
     # MediaMTX service URLs (internal - for backend to MediaMTX communication)
     mediamtx_hls_url: str | None = "http://localhost:8888"  # HLS streaming endpoint

--- a/server/services/mediamtx_config_service.py
+++ b/server/services/mediamtx_config_service.py
@@ -32,6 +32,29 @@ class MediaMtxConfigService:
     """Service for generating MediaMTX configuration."""
 
     @staticmethod
+    @staticmethod
+    def recording_path_template(camera_token: str = "%path") -> str:
+        """The recordPath suffix (after the recordings base) for the configured
+        on-disk layout. ``camera_token`` is MediaMTX's ``%path`` or an explicit
+        stream name. Default ('nested') preserves the historical layout, so
+        existing deployments see no change."""
+        layout = (settings.recording_layout or "nested").strip().lower()
+        if layout == "custom" and settings.recording_path_template:
+            return settings.recording_path_template.replace("{camera}", camera_token)
+        presets = {
+            # historical default — unchanged
+            "nested": f"{camera_token}/%Y/%m/%d/%H/%M/%S",
+            # One folder per day + per hour; clips named by minute-second so
+            # they're path-addressable AND collision-safe (a bare %M filename
+            # would OVERWRITE an earlier clip if two segments ever start in the
+            # same minute — a reconnect or a <60s segment). The file still sits
+            # in the HH folder; retrieval is "the clip whose start <= T".
+            "date-hour": f"{camera_token}/%Y-%m-%d/%H/%M-%S",
+            "flat": f"{camera_token}/%Y-%m-%d_%H-%M-%S",
+        }
+        return presets.get(layout, presets["nested"])
+
+    @staticmethod
     def generate_webhook_config(base_url: str) -> dict[str, Any]:
         """Generate webhook configuration for MediaMTX.
 
@@ -82,7 +105,7 @@ class MediaMtxConfigService:
 
         return {
             "record": True,
-            "recordPath": f"{base_path}/{stream_name}/%Y/%m/%d/%H/%M/%S",
+            "recordPath": f"{base_path}/" + MediaMtxConfigService.recording_path_template(stream_name),
             "recordFormat": "mp4",  # or "ts" for transport stream
             "recordSegmentDuration": f"{settings.recording_segment_seconds}s",
             "recordDeleteAfter": "720h",  # Keep recordings for 30 days
@@ -102,7 +125,7 @@ class MediaMtxConfigService:
             "api": True,
             "apiAddress": f":{settings.mediamtx_api_port}",
             # Recording settings
-            "recordPath": base_path + "/%path/%Y/%m/%d/%H/%M/%S",
+            "recordPath": base_path + "/" + MediaMtxConfigService.recording_path_template("%path"),
             "recordFormat": "mp4",
             "recordSegmentDuration": f"{settings.recording_segment_seconds}s",
             "recordDeleteAfter": "720h",  # 30 days
@@ -145,7 +168,7 @@ class MediaMtxConfigService:
             "rtspTransport": "tcp",
             # Recording settings (disabled by default, enabled per camera)
             "record": False,
-            "recordPath": base_path + "/%path/%Y/%m/%d/%H/%M/%S",
+            "recordPath": base_path + "/" + MediaMtxConfigService.recording_path_template("%path"),
             "recordFormat": "mp4",
             "recordSegmentDuration": f"{settings.recording_segment_seconds}s",
             "recordDeleteAfter": "720h",
@@ -359,6 +382,7 @@ paths: {}
         webhook_token = settings.mediamtx_webhook_token or "your-secure-webhook-token"
         webhook_base = f"{application_base_url}{settings.api_prefix}/mediamtx"
         base_path = get_effective_recordings_base_path()
+        _rec_layout = MediaMtxConfigService.recording_path_template("%path")
 
         yaml_content = f"""# MediaMTX Configuration for OpenNVR NVR
 # Generated automatically with startup hooks for camera auto-provisioning
@@ -406,7 +430,7 @@ pathDefaults:
   
   # Recording settings (disabled by default, enabled per camera)
   record: no
-  recordPath: {base_path}/%path/%Y/%m/%d/%H-%M-%S-%f
+  recordPath: {base_path}/{_rec_layout}
   recordFormat: fmp4
   recordSegmentDuration: {settings.recording_segment_seconds}s
   recordDeleteAfter: 168h  # 7 days

--- a/server/tests/test_recording_layout.py
+++ b/server/tests/test_recording_layout.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Configurable recording layout — default must be byte-identical to before."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+import datetime as _dt  # noqa: E402
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_rl_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+import services.mediamtx_config_service as mcs  # noqa: E402
+from core.config import settings  # noqa: E402
+
+M = mcs.MediaMtxConfigService
+
+
+def test_default_layout_is_unchanged():
+    """The 'nested' default must render exactly the historical suffix — no
+    existing deployment's on-disk layout may shift."""
+    settings.recording_layout = "nested"
+    settings.recording_path_template = None
+    assert M.recording_path_template("%path") == "%path/%Y/%m/%d/%H/%M/%S"
+    assert M.recording_path_template("cam-301") == "cam-301/%Y/%m/%d/%H/%M/%S"
+
+
+def test_date_hour_layout_shape():
+    settings.recording_layout = "date-hour"
+    assert M.recording_path_template("%path") == "%path/%Y-%m-%d/%H/%M-%S"
+    assert M.recording_path_template("301") == "301/%Y-%m-%d/%H/%M-%S"
+
+
+def test_flat_layout():
+    settings.recording_layout = "flat"
+    assert M.recording_path_template("%path") == "%path/%Y-%m-%d_%H-%M-%S"
+
+
+def test_custom_template_overrides():
+    settings.recording_layout = "custom"
+    settings.recording_path_template = "{camera}/%Y/%j"
+    assert M.recording_path_template("%path") == "%path/%Y/%j"
+    settings.recording_layout = "nested"
+    settings.recording_path_template = None
+
+
+def test_unknown_layout_falls_back_to_nested():
+    settings.recording_layout = "banana"
+    assert M.recording_path_template("%path") == "%path/%Y/%m/%d/%H/%M/%S"
+    settings.recording_layout = "nested"
+
+
+def test_no_preset_can_overwrite_within_its_granularity():
+    """Every built-in preset's FILENAME must carry second-granularity, so two
+    segments starting close together never write the same file (data loss)."""
+    for layout in ("nested", "date-hour", "flat"):
+        settings.recording_layout = layout
+        tmpl = M.recording_path_template("%path")
+        # the leaf (filename) segment must include %S
+        leaf = tmpl.rsplit("/", 1)[-1]
+        assert "%S" in leaf, f"{layout}: filename {leaf!r} lacks %S (collision risk)"
+    settings.recording_layout = "nested"


### PR DESCRIPTION
OpenNVR records through a templated MediaMTX path; this makes the layout a first-class, configurable choice so users can keep the default or match an existing NVR/VMS tree (scripts, backups, external tools address files by path without change) — a migration/interop win for the project.

- RECORDING_LAYOUT setting with presets, rendered by one helper (MediaMtxConfigService.recording_path_template), applied at all four recordPath sites that had drifted apart:
    nested (default): <camera>/%Y/%m/%d/%H/%M/%S   — UNCHANGED historical layout
    date-hour       : <camera>/%Y-%m-%d/%H/%M       — day+hour folders;
                      with RECORDING_SEGMENT_SECONDS=60 => one-minute,
                      path-addressable clips (a shape many NVRs/VMS use)
    flat            : <camera>/%Y-%m-%d_%H-%M-%S
    custom          : RECORDING_PATH_TEMPLATE verbatim ({camera} + strftime)
- default preserves today's layout byte-for-byte (tested) — zero regression
  for existing deployments; layout applies to NEW segments only, existing
  files and playback/retention untouched.
- docs/recording-layout.md + .env.example.

Time tokens follow the MediaMTX container TZ; first-class local-time is a separate follow-up this pairs with.

Tests: default byte-identical, each preset, custom override, unknown ->
nested fallback; generated YAML verified. Full server suite 622 passed.