### PR TITLE
fix #241: Live tile permanently stuck after a stream hiccup once the 60-min token expires

### DIFF
--- a/app/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/app/src/components/VideoPlayer/VideoPlayer.tsx
@@ -62,6 +62,10 @@ export interface VideoPlayerProps {
   onSnapshot?: (dataUrl: string) => void
   /** Callback on error */
   onError?: (error: string) => void
+  /** Live mode: a stream request was rejected as unauthorized — the
+      mediamtxToken has expired. The parent owns the token, so it must
+      refetch stream URLs; the changed token prop re-runs setup here. */
+  onAuthExpired?: () => void
   /** Callback when HLS playback fails (to trigger fallback) */
   onHlsPlaybackError?: () => void
   /** Present only when the camera supports PTZ; toggles the PTZ pad */
@@ -98,6 +102,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       className = '',
       onSnapshot,
       onError,
+      onAuthExpired,
       onHlsPlaybackError,
       onTogglePtz,
       ptzActive = false,
@@ -147,6 +152,11 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     // offline overlay stays up while probe attempts run.
     const offlinePollTimerRef = useRef<number | null>(null)
     const offlinePollingRef = useRef(false)
+    // Via a ref so the setup callbacks don't take the parent's callback
+    // identity as a dependency — an unstable identity would tear down and
+    // rebuild the stream on every parent render.
+    const onAuthExpiredRef = useRef(onAuthExpired)
+    onAuthExpiredRef.current = onAuthExpired
     const [isReconnecting, setIsReconnecting] = useState(false)
     // Real aspect ratio of the incoming stream (width/height), read from the
     // video metadata. null until known (or after the source is torn down).
@@ -397,6 +407,14 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           if (resp.status === 404) {
             throw new Error('Camera offline')
           }
+          // MediaMTX rejects an expired/invalid stream JWT with 400/401 on
+          // the WHEP POST (observed: 400 for "token is expired"). Retrying
+          // with the same token can never succeed, so ask the parent for a
+          // fresh one — the changed token prop re-runs setup. The bounded
+          // auto-retry below still runs as a fallback for non-auth 400s.
+          if (resp.status === 400 || resp.status === 401 || resp.status === 403) {
+            onAuthExpiredRef.current?.()
+          }
           throw new Error(`WHEP connection failed: ${resp.status}`)
         }
 
@@ -512,6 +530,14 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
               console.log('[HLS] Attempting media error recovery...')
               hls.recoverMediaError()
             } else if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
+              // An expired stream JWT surfaces here as a 400/401 on the
+              // manifest/fragment request — same recovery as the WHEP path:
+              // a fresh token from the parent, since retrying with the
+              // stale one can never succeed.
+              const code = data.response?.code
+              if (code === 400 || code === 401 || code === 403) {
+                onAuthExpiredRef.current?.()
+              }
               // Full restart with backoff (a bare startLoad() retry keeps
               // failing while MediaMTX is briefly unreachable).
               console.log('[HLS] Attempting network error recovery...')

--- a/app/src/views/LiveView.tsx
+++ b/app/src/views/LiveView.tsx
@@ -16,7 +16,7 @@
  * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useRef, useState, useMemo } from 'react'
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
 import { apiService } from '../lib/apiService'
 import { VideoPlayer, type VideoPlayerHandle } from '../components/VideoPlayer'
 import { QrScanner } from '../components/QrScanner'
@@ -652,6 +652,19 @@ function Tile({
   // 60-min stream token) and remounting the player so the stream resumes
   // without any user action.
   const { status: connectivity, version: streamVersion } = useCameraStatus(assignedCameraId)
+  // Bumped when the player reports an auth-rejected stream request — the
+  // 60-min token expired mid-session (e.g. a stream hiccup hours in; the
+  // backend never saw the camera go offline, so streamVersion won't bump).
+  // Re-runs the URL fetch below for a fresh token. Throttled so a
+  // persistent non-auth 400 can't hammer the token endpoint.
+  const [tokenVersion, setTokenVersion] = useState(0)
+  const lastTokenRefreshRef = useRef(0)
+  const handleAuthExpired = useCallback(() => {
+    const now = Date.now()
+    if (now - lastTokenRefreshRef.current < 10000) return
+    lastTokenRefreshRef.current = now
+    setTokenVersion((v) => v + 1)
+  }, [])
 
   useEffect(() => {
     let alive = true
@@ -682,7 +695,7 @@ function Tile({
       setUrls(null)
     }
     return () => { alive = false }
-  }, [assignedCameraId, availableCameras, streamVersion])
+  }, [assignedCameraId, availableCameras, streamVersion, tokenVersion])
 
   const hasLink = !!urls?.whep || !!urls?.hls
   const displayName = cameraName || `Camera ${cameraId || index + 1}`
@@ -730,6 +743,7 @@ function Tile({
               whepUrl={urls?.whep}
               hlsUrl={urls?.hls}
               mediamtxToken={urls?.token}
+              onAuthExpired={handleAuthExpired}
               title={displayName}
               preferredStreamType="webrtc"
               autoPlay


### PR DESCRIPTION
Fixes #241.

## Problem

A Live View tile fetches its MediaMTX stream JWT once at mount (60-minute expiry), but MediaMTX only authenticates at connection time — an established WebRTC session is never re-checked. So under any session older than an hour, every tile is silently running on an expired token. The first RTSP hiccup after expiry kills the session, and the reconnect handshake gets rejected (`400`, `token has invalid claims: token is expired`). The auto-retry loop and the manual **Retry Connection** button both reuse the same stale token, so the tile is permanently stuck until a full page reload. The backend-pushed `streamVersion` remount can't help: a short stream glitch never marks the camera offline, so it never fires.

Observed live: cam-2 RTSP glitch at 21:18:47 → five retries all rejected with expired-token → tile stuck on "WHEP connection failed: 400" while the stream itself was healthy and recording. cam-1 had the identical glitch at 19:07 but reconnected fine because its token was still inside the 60-minute window.

## Fix

- `VideoPlayer`: new optional `onAuthExpired` callback, fired when the WHEP POST returns 400/401/403, or a fatal HLS network error carries one of those codes. Held in a ref so a parent callback with unstable identity can't tear down the stream on every render. The existing bounded auto-retry (2s→30s, 5 attempts) still runs as a fallback for non-auth 400s.
- `LiveView` tile: responds by bumping a `tokenVersion` that re-runs the existing stream-URL fetch — a fresh 60-minute token — and the changed token prop re-runs player setup automatically (no remount needed). Throttled to one refresh per 10s so a persistent non-auth 400 can't hammer the token endpoint.

Net effect: a mid-session token expiry now costs one extra round-trip on the first post-expiry reconnect and the tile self-heals; the manual Retry button also works again, since its failing attempt triggers the same refresh.

## Verification

- `tsc --noEmit` clean (the `DeviceFirewall.tsx` error pre-exists on main)
- `npm run build` succeeds
