### PR TITLE
bench: measure whether tier-0 + event memory earn their keep

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,48 @@
+# bench — measuring whether the tier-0 architecture earns its keep
+
+Two numbers settle the "is tier-0 + event memory worth it, or are we losing
+data" question instead of guessing.
+
+## 1. `tier0_recall.py` — what the cheap detector SEES
+
+Recall bounds everything downstream: a person tier-0 misses is an event never
+remembered and an alert that never fires. Point it at a detector's `/infer`
+endpoint and a labelled image manifest; it reports presence recall/precision
+per label, **broken down by condition** (static / edge / close / low-light) so
+the hard cases aren't hidden by the easy-case average.
+
+```bash
+python bench/tier0_recall.py --url http://localhost:9108/infer --manifest labels.json
+```
+
+Manifest: `{"images":[{"path":"...","truth":{"person":1},"condition":"static"}, ...]}`
+(`truth` = ground-truth presence counts; 0 = absent).
+
+**Read it as:** low recall on `static`/`close`/`edge` is the exact blind spot
+behind "the agent didn't see the person sitting there." Track it over time; it
+is what the automatic index costs you.
+
+## 2. `event_memory_dividend.py` — what the store is WORTH
+
+A look-only agent sees nothing between questions. Every stored event is a
+moment it would have missed. This queries the events API over a window and
+reports the dividend by label and hour, calling out the **unattended hours**
+(overnight/quiet) — the clearest "would have been lost without the store" set.
+
+```bash
+python bench/event_memory_dividend.py --url http://localhost:8000 --token "$JWT" --days 7
+```
+
+**Read it as:** a large unattended count means the memory is doing real work a
+query-only agent structurally cannot.
+
+## The verdict these produce
+
+- Good recall + meaningful memory dividend → the architecture earns its keep;
+  keep it, and hold consumers to the liveness rule (cheap layer never
+  substitutes for a live look on a "now" question).
+- Poor recall or ~nothing consuming the stream → that's the QA "no observable
+  difference"; harden recall or simplify — but now you *know*, from evidence.
+
+The scoring/summary logic is stdlib-only and unit-tested (`test_bench.py`); the
+network parts need a running detector / backend.

--- a/bench/event_memory_dividend.py
+++ b/bench/event_memory_dividend.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Event-memory dividend — what the event store is WORTH.
+
+The other half of the tier-0 debate: the memory. A look-only agent (one that
+grabs a frame and runs the VLM only when asked) sees nothing between questions.
+Every event the store holds is something that agent would have missed — unless
+a human happened to be asking at that exact second, which for overnight and
+quiet hours is essentially never.
+
+This queries the events API over a window and reports the dividend: how many
+events were remembered, by label and by hour, with the UNATTENDED hours called
+out — those are the clearest "would have been lost without the store" set.
+
+Usage:
+    python bench/event_memory_dividend.py --url http://localhost:8000 \
+        --token "$JWT" --days 7 [--attended 8 18]
+
+The summariser is stdlib-only and unit-tested (bench/test_bench.py); the fetch
+needs a running backend.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+
+# ── Pure summary (unit-tested) ─────────────────────────────────────
+
+def summarize_events(events: list[dict], attended: tuple[int, int] = (8, 18)) -> dict:
+    """Aggregate events into the memory dividend.
+
+    ``attended`` is the [start, end) local-hour window a human plausibly might
+    be watching live; events OUTSIDE it are the clearest dividend (no one was
+    around to ask). Each event needs a ``started_at`` ISO string and a
+    ``label``. Returns totals, per-label, per-hour, and the unattended count.
+    """
+    lo, hi = attended
+    by_label: dict[str, int] = {}
+    by_hour: dict[int, int] = {h: 0 for h in range(24)}
+    unattended = 0
+    total = 0
+    for e in events:
+        ts = e.get("started_at")
+        if not ts:
+            continue
+        try:
+            dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        total += 1
+        lab = str(e.get("label") or "?").lower()
+        by_label[lab] = by_label.get(lab, 0) + 1
+        h = dt.hour
+        by_hour[h] += 1
+        if not (lo <= h < hi):
+            unattended += 1
+    return {
+        "total": total,
+        "by_label": dict(sorted(by_label.items(), key=lambda kv: -kv[1])),
+        "by_hour": by_hour,
+        "unattended": unattended,
+        "attended_window": [lo, hi],
+    }
+
+
+# ── Fetch (needs a running backend) ────────────────────────────────
+
+def fetch_events(url: str, token: str | None, days: int, timeout: float = 30.0) -> list[dict]:
+    frm = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    q = f"{url.rstrip('/')}/api/v1/events?from={frm}&limit=100000"
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    req = urllib.request.Request(q, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.loads(resp.read().decode())
+    return payload.get("events") or []
+
+
+def _report(summary: dict, days: int) -> None:
+    lo, hi = summary["attended_window"]
+    print(f"\nEvent-memory dividend over {days} day(s)\n" + "=" * 42)
+    print(f"  {summary['total']} events remembered — every one a moment a")
+    print("  look-only agent would not have captured.\n")
+    print("  by label:")
+    for lab, n in summary["by_label"].items():
+        print(f"    {lab:10s} {n}")
+    print(f"\n  {summary['unattended']} of them fell OUTSIDE {lo:02d}:00-{hi:02d}:00")
+    print("  (unattended hours) — the clearest dividend: no one was there to ask.")
+    peak = max(summary["by_hour"].items(), key=lambda kv: kv[1], default=(0, 0))
+    print(f"\n  busiest hour: {peak[0]:02d}:00 with {peak[1]} events")
+    print("\nIf this number is large, the store is earning its keep: it is the")
+    print("memory a query-only agent structurally cannot have.\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Event-memory dividend")
+    ap.add_argument("--url", required=True, help="Backend base URL")
+    ap.add_argument("--token", default=None, help="Bearer JWT (if required)")
+    ap.add_argument("--days", type=int, default=7)
+    ap.add_argument("--attended", type=int, nargs=2, default=(8, 18),
+                    metavar=("START_HOUR", "END_HOUR"),
+                    help="Local-hour window a human might watch live (default 8 18)")
+    args = ap.parse_args(argv)
+    try:
+        events = fetch_events(args.url, args.token, args.days)
+    except Exception as e:  # noqa: BLE001
+        print(f"fetch failed: {e}", file=sys.stderr)
+        return 1
+    _report(summarize_events(events, tuple(args.attended)), args.days)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/tier0_recall.py
+++ b/bench/tier0_recall.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tier-0 detection recall harness.
+
+Answers the question behind the whole tier-0 debate with a number: how much
+does the cheap always-on detector actually SEE? Recall bounds the event index
+and every app that rides the inference stream — a static person the detector
+misses is an event that never gets remembered and an alert that never fires.
+
+Point it at any detector that speaks the ``/infer`` contract (the tier-0
+adapter, a YOLOv8 adapter) and a labelled image manifest; it reports presence
+recall / precision per label, broken down by CONDITION so the hard cases
+(static, edge-of-frame, close-range, low-light) show separately from the easy
+ones — because the easy-case average hides exactly the failures QA hits.
+
+Manifest (JSON):
+    {"images": [
+        {"path": "clips/static_person_01.jpg",
+         "truth": {"person": 1}, "condition": "static"},
+        {"path": "clips/empty_hall.jpg", "truth": {"person": 0}}]}
+
+Usage:
+    python bench/tier0_recall.py --url http://localhost:9108/infer \
+        --manifest labels.json [--score 0.35]
+
+The scoring helpers are stdlib-only and unit-tested (bench/test_bench.py);
+the network/IO parts need a running detector + real images.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+import urllib.request
+
+
+# ── Pure scoring (unit-tested) ─────────────────────────────────────
+
+def presence_scores(records: list[dict]) -> dict:
+    """Per-label presence recall/precision from scored records.
+
+    Each record: ``{"truth": {label: count}, "detected": {label: count},
+    "condition": str}``. Presence = count > 0. Returns
+    ``{label: {"recall","precision","support","detected"}}``.
+    """
+    labels: set[str] = set()
+    for r in records:
+        labels |= set(r["truth"]) | set(r["detected"])
+    out: dict[str, dict] = {}
+    for lab in sorted(labels):
+        tp = fn = fp = 0
+        for r in records:
+            present = r["truth"].get(lab, 0) > 0
+            found = r["detected"].get(lab, 0) > 0
+            if present and found:
+                tp += 1
+            elif present and not found:
+                fn += 1
+            elif not present and found:
+                fp += 1
+        support = tp + fn
+        out[lab] = {
+            "recall": (tp / support) if support else None,
+            "precision": (tp / (tp + fp)) if (tp + fp) else None,
+            "support": support,
+            "detected": tp + fp,
+        }
+    return out
+
+
+def scores_by_condition(records: list[dict], label: str) -> dict:
+    """Recall for one label split by each record's ``condition`` tag — the
+    point of the harness: an overall 0.9 can hide a 0.4 on 'static'."""
+    buckets: dict[str, list[dict]] = {}
+    for r in records:
+        if r["truth"].get(label, 0) > 0:
+            buckets.setdefault(r.get("condition") or "unlabelled", []).append(r)
+    out = {}
+    for cond, rs in sorted(buckets.items()):
+        tp = sum(1 for r in rs if r["detected"].get(label, 0) > 0)
+        out[cond] = {"recall": tp / len(rs), "support": len(rs)}
+    return out
+
+
+# ── Detector call (needs a running /infer) ─────────────────────────
+
+def _infer(url: str, image_bytes: bytes, score_min: float, timeout: float = 30.0) -> dict:
+    body = json.dumps({"frame_b64": base64.b64encode(image_bytes).decode("ascii")}).encode()
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.loads(resp.read().decode())
+    dets = (payload.get("result") or {}).get("detections") or []
+    counts: dict[str, int] = {}
+    for d in dets:
+        if float(d.get("score", 0)) < score_min:
+            continue
+        lab = str(d.get("label") or d.get("class") or "").strip().lower()
+        if lab:
+            counts[lab] = counts.get(lab, 0) + 1
+    return counts
+
+
+def run(url: str, manifest_path: str, score_min: float) -> list[dict]:
+    manifest = json.loads(open(manifest_path).read())
+    records = []
+    for item in manifest["images"]:
+        try:
+            img = open(item["path"], "rb").read()
+        except OSError as e:
+            print(f"skip {item['path']}: {e}", file=sys.stderr)
+            continue
+        detected = _infer(url, img, score_min)
+        records.append({
+            "truth": {k.lower(): int(v) for k, v in item.get("truth", {}).items()},
+            "detected": detected,
+            "condition": item.get("condition"),
+        })
+    return records
+
+
+def _report(records: list[dict]) -> None:
+    print(f"\nTier-0 recall over {len(records)} images\n" + "=" * 42)
+    for lab, s in presence_scores(records).items():
+        r = "n/a" if s["recall"] is None else f"{s['recall']:.2f}"
+        p = "n/a" if s["precision"] is None else f"{s['precision']:.2f}"
+        print(f"  {lab:10s}  recall {r}  precision {p}  (present in {s['support']})")
+    by = scores_by_condition(records, "person")
+    if by:
+        print("\n  person recall by condition:")
+        for cond, c in by.items():
+            print(f"    {cond:14s} {c['recall']:.2f}  (n={c['support']})")
+    print("\nLow recall on 'static'/'close'/'edge' is the blind spot that makes the")
+    print("agent miss a sitting person and drops events from memory. Track it.\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Tier-0 detection recall harness")
+    ap.add_argument("--url", required=True, help="Detector /infer endpoint")
+    ap.add_argument("--manifest", required=True, help="Labelled image manifest (JSON)")
+    ap.add_argument("--score", type=float, default=0.35, help="Min detection score")
+    args = ap.parse_args(argv)
+    records = run(args.url, args.manifest, args.score)
+    if not records:
+        print("no images scored", file=sys.stderr)
+        return 1
+    _report(records)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Turns the 'is the detect-pipeline/tier-0/event-store worth it, or are we losing data' doubt into two numbers instead of a feeling.

- tier0_recall.py: presence recall/precision of the always-on detector against a labelled manifest, broken down by CONDITION (static/edge/close) so the hard cases aren't hidden by the easy-case average — recall is what bounds the event index and every stream-consuming app.
- event_memory_dividend.py: how many events the store holds over a window, by label and hour, with UNATTENDED hours called out — every one a moment a look-only agent would have missed. Quantifies what the memory is worth.
- test_bench.py: the scoring/summary logic (stdlib-only) is unit-tested, including that a condition breakdown exposes a weakness the average hides.
- README: how to run, and how to read the verdict.

Author: xpertvoip