### PR TITLE
fix(camera-agent-lite): stop the small model inventing past events

### DIFF
--- a/examples/camera-agent-lite/services.py
+++ b/examples/camera-agent-lite/services.py
@@ -42,7 +42,11 @@ SYSTEM_PROMPT = (
     "recording, just say recording is always on. Prefer tools over guessing. Never "
     "invent camera observations and never claim an action succeeded unless the tool "
     "result says ok. If a tool reports an error, tell the user briefly. State "
-    "uncertainty plainly. When only one camera exists and the user says 'the "
+    "uncertainty plainly. You have NO memory of past events and keep NO history "
+    "of what the cameras saw: the earlier turns are only the conversation so "
+    "far, not a record of events. NEVER reference, recall, invent, or imply "
+    "earlier sightings, people, times, or events -- answer ONLY about the "
+    "CURRENT view from this turn's tool result. When only one camera exists and the user says 'the "
     "camera', use it. You cannot act AFTER replying, so never say 'please wait', "
     "'one moment', or promise to check something later -- call the needed tool NOW "
     "and answer in the same turn. Never mention tool names, function calls, or "
@@ -132,7 +136,7 @@ class AgentBrain:
     def _remember(self, question: str, answer: str) -> None:
         self._history.append({"role": "user", "content": question[:400]})
         self._history.append({"role": "assistant", "content": (answer or "")[:400]})
-        del self._history[:-8]   # last 4 exchanges
+        del self._history[:-6]   # last 3 exchanges (small models confabulate from long history)
 
     # ---- lifecycle ------------------------------------------------------- #
     async def setup(self) -> None:

--- a/examples/camera-agent-lite/tests/test_grounding.py
+++ b/examples/camera-agent-lite/tests/test_grounding.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The lite agent must not invent past events.
+
+QA: with a person sitting live, lite referenced "old events" — but lite has NO
+event store or history at all. The cause is a small LLM confabulating from the
+rolling chat history. These lock in the grounding guardrail (system prompt) and
+the trimmed history window that keep it answering only about the current view.
+"""
+from __future__ import annotations
+
+import services
+
+
+def test_system_prompt_forbids_inventing_past_events():
+    p = services.SYSTEM_PROMPT.lower()
+    # The guardrail phrases must be present — a silent removal reopens the bug.
+    assert "no memory of past events" in p
+    assert "no history" in p
+    assert "current view" in p
+    assert "never reference" in p or "never recall" in p
+
+
+def test_history_window_is_short():
+    # Long history is what a 3B model confabulates from; keep it to 3 exchanges.
+    import re
+    m = re.search(r"del self\._history\[:-(\d+)\]", open("services.py").read())
+    assert m and int(m.group(1)) <= 6
+

--- a/examples/camera-agent-lite/tools.py
+++ b/examples/camera-agent-lite/tools.py
@@ -309,6 +309,14 @@ def register_tools(registry: ToolRegistry, ctx: ToolContext) -> None:
         except CameraContextError as exc:
             return _err("look_at_camera", exc)
 
+        # A blank/again question yields a vague caption; give the small VLM a
+        # concrete default that elicits presence — the "it didn't say someone
+        # was there" symptom is worse with an empty prompt.
+        question = (question or "").strip() or (
+            "Describe what is happening in this camera view, and state plainly "
+            "whether a person is present."
+        )
+
         t0 = time.monotonic()
         try:
             if temporal:


### PR DESCRIPTION
QA (on lite, not full): with a person sitting live the agent (a) didn't say someone was present and (b) referenced 'old events' — but lite has NO event store or history at all. Cause: a small (3B) LLM confabulating from the rolling chat history, unbounded by a system prompt that forbade inventing observations but not inventing a PAST. (Lite already fetches a fresh frame, so this is not the stale-frame bug fixed in the full agent.)

- services.py: system prompt now states plainly the agent has NO memory of past events and keeps NO history — the earlier turns are conversation, not a record of events; answer ONLY about the current view. Rolling history trimmed from 4 exchanges to 3 (less confabulation surface for a small model).
- tools.py: look_at_camera gives the VLM a concrete presence-eliciting default when the question is blank (the empty-prompt case that most often 'missed' the person). Non-empty questions are unchanged (no VQA regression).
- test_grounding.py: locks the no-past-events guardrail + the short history window so a silent removal can't reopen the bug.

The residual 'didn't see the person' is the SmolVLM 2.2B accuracy ceiling (worse in the over/under-exposed frames QA had), not a code bug — noted for expectations, not patched.

Author: xpertvoip