### PR TITLE
ARM64 install support: multi-arch images, arch preflight, ADAPTER_TAG…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,11 +122,11 @@ INFERENCE_USE_MEDIAMTX_TAP=true
 # Image tag for ghcr.io/open-nvr/core. Pinned to the current release so a
 # fresh install gets the tested core↔adapter pairing. Set "latest" or "main"
 # for bleeding-edge main builds.
-CORE_TAG=0.1.2
+CORE_TAG=main
 
 # Image tag for all GHCR adapter images (whisper, piper, yolov8, blip,
 # moondream, …). Pinned to the current release; set "latest" for bleeding edge.
-ADAPTER_TAG=0.1.1
+ADAPTER_TAG=0.1.3
 
 # Optional example selected by the interactive installer. Leave blank for core only.
 OPENNVR_EXAMPLE=

--- a/.env.example
+++ b/.env.example
@@ -122,7 +122,7 @@ INFERENCE_USE_MEDIAMTX_TAP=true
 # Image tag for ghcr.io/open-nvr/core. Pinned to the current release so a
 # fresh install gets the tested core↔adapter pairing. Set "latest" or "main"
 # for bleeding-edge main builds.
-CORE_TAG=main
+CORE_TAG=0.1.2
 
 # Image tag for all GHCR adapter images (whisper, piper, yolov8, blip,
 # moondream, …). Pinned to the current release; set "latest" for bleeding edge.

--- a/.github/workflows/publish-detect-pipeline.yml
+++ b/.github/workflows/publish-detect-pipeline.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU (cross-arch emulation for the arm64 build)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -97,7 +102,13 @@ jobs:
         with:
           context: ./detect-pipeline
           file: detect-pipeline/Dockerfile
-          platforms: linux/amd64
+          # Multi-arch on push, single-arch on pull_request. ``load: true``
+          # imports the result into the local docker daemon, which cannot
+          # hold a multi-platform image — so the PR smoke test builds
+          # linux/amd64 only. Release/main builds publish a manifest list
+          # covering both, which is what Apple Silicon and Raspberry Pi
+          # hosts resolve against at pull time.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           tags: |

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -19,10 +19,20 @@
 #   - Tag matching ``v*``    → build + push :<version>, :latest,
 #     :sha-<short>. The release path.
 #
-# Architecture: linux/amd64 only for v0.1. The opennvr-core image
-# Python deps include opencv + psycopg which have arm64 wheels, so
-# arm64 is a fast-follow once we've validated the Pi 5 path end-to-
-# end. Documented in the Tier 0 README.
+# Architecture: linux/amd64 + linux/arm64. Apple Silicon Macs and
+# Raspberry Pi 5 class hardware are a primary Tier 0 target, and an
+# amd64-only manifest list makes ``docker compose pull`` fail there
+# with a bare daemon error ("no matching manifest for
+# linux/arm64/v8"), which reads as a broken install rather than an
+# unsupported platform. Every runtime dep (opencv, psycopg, uv,
+# python:3.11-slim, node:23-alpine) publishes arm64 artifacts, so
+# the arm64 leg is a plain cross-build.
+#
+# The arm64 leg is built under QEMU on the amd64 runner. The only
+# genuinely slow step under emulation would be the Node frontend
+# build, and that is pinned to $BUILDPLATFORM in the Dockerfile
+# (the Vite output is architecture-independent), so it runs natively
+# once and is reused by both legs.
 
 name: publish-images
 
@@ -74,6 +84,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU (cross-arch emulation for the arm64 build)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -116,7 +131,13 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64
+          # Multi-arch on push, single-arch on pull_request. ``load: true``
+          # imports the result into the local docker daemon, which cannot
+          # hold a multi-platform image — so the PR smoke test builds
+          # linux/amd64 only. Release/main builds publish a manifest list
+          # covering both, which is what Apple Silicon and Raspberry Pi
+          # hosts resolve against at pull time.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           tags: |
@@ -266,6 +287,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU (cross-arch emulation for the arm64 build)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -304,7 +330,12 @@ jobs:
           # (see the build instructions at the top of each Dockerfile).
           context: .
           file: ${{ matrix.agent.dir }}/Dockerfile
-          platforms: linux/amd64
+          # Multi-arch on push, single-arch on pull_request — a PR build
+          # only needs to prove the Dockerfile still resolves, and paying
+          # for the emulated arm64 leg on every PR doubles the wall time
+          # for no extra signal. Release/main builds publish a manifest
+          # list covering both.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **ARM64 (Apple Silicon / Raspberry Pi 5) install support.**
+  `ghcr.io/open-nvr/core`, `detect-pipeline`, `camera-agent`, and
+  `camera-agent-lite` now publish `linux/amd64` + `linux/arm64` manifest
+  lists, and the default adapter pin moves to `ADAPTER_TAG=0.1.3` — the
+  first [ai-adapter](https://github.com/open-nvr/ai-adapter) release with
+  ARM64 images. Previously a fresh install on an M-series Mac died in
+  `docker compose pull` with a bare
+  ``no matching manifest for linux/arm64/v8``.
+  `llamacpp-adapter`/`smolvlm-adapter` (camera-agent-lite) remain
+  amd64-only pending upstream ggml-org/llama.cpp#19177.
+- **Installer architecture preflight.** `install.sh`/`install.ps1` now
+  check every pinned image's manifest list against the host architecture
+  before pulling, and name the unsupported images instead of surfacing
+  the daemon's error. `OPENNVR_ALLOW_EMULATION=1` opts into running the
+  amd64 images under emulation (exports
+  ``DOCKER_DEFAULT_PLATFORM=linux/amd64`` for the whole stack).
+
 ## [0.1.2] — 2026-08-12
 
 ### Added

--- a/DOCKER_QUICKSTART.md
+++ b/DOCKER_QUICKSTART.md
@@ -6,6 +6,13 @@ Five minutes from `git clone` to YOLOv8 detection running on your camera feed, u
 
 - **Docker Engine 24+** with Compose v2 (Linux) or **Docker Desktop**
   (macOS / Windows).
+- **x86-64 (amd64) or ARM64.** `opennvr-core`, `detect-pipeline`,
+  `camera-agent` and `yolov8-weights` publish both. The AI adapter images
+  (`yolov8-adapter`, `moondream-adapter`, `whisper-adapter`,
+  `piper-adapter`, ...) are built in the separate
+  [`open-nvr/ai-adapter`](https://github.com/open-nvr/ai-adapter) repo and
+  **older pinned tags are amd64-only** — see
+  [ARM64 / Apple Silicon](#no-matching-manifest-for-linuxarm64v8-apple-silicon--arm) below.
 - **8 GB RAM** recommended (4 GB will work, but YOLOv8 cold-start is
   tight).
 - **20 GB free disk** — most of it is the AI adapter images and YOLO
@@ -203,6 +210,69 @@ in `.env`, then restart `opennvr-core`. Note this is verbose — only flip
 it for troubleshooting.
 
 ## Troubleshooting
+
+### "no matching manifest for linux/arm64/v8" (Apple Silicon / ARM)
+
+The pull aborts partway through with something like:
+
+```
+ ✘ Image ghcr.io/open-nvr/yolov8-adapter:0.1.1  Error no matching manifest
+   for linux/arm64/v8 in the manifest list entries
+Error response from daemon: no matching manifest for linux/arm64/v8 in the
+manifest list entries: no match for platform in manifest: not found
+```
+
+That image has no ARM64 build. The daemon names the platform but not the
+cause, and every other image in the pull reports `Interrupted` — which
+looks like a network failure and is not.
+
+`./scripts/install.sh` (and `install.ps1`) now check every pinned image's
+manifest list *before* pulling and print the full list of images that lack
+a build for your architecture, so you find out in one shot rather than one
+image at a time.
+
+**Fixing it depends on which image is named:**
+
+- **`core`, `detect-pipeline`, `camera-agent`, `camera-agent-lite`** — built
+  in this repo and published for `linux/amd64` **and** `linux/arm64`. If one
+  of these is named, you are on a tag published before ARM64 support landed;
+  move to `:main`/`:latest` or a release tag newer than that.
+- **`*-adapter`** — built in
+  [`open-nvr/ai-adapter`](https://github.com/open-nvr/ai-adapter).
+  ARM64 manifest lists start at adapter tag **0.1.3** (the current
+  `.env.example` pin); tags 0.1.1 and earlier are amd64-only. If you are
+  named one of these, your `.env` carries a stale `ADAPTER_TAG` — raise it
+  to `0.1.3` or later, or run the adapters emulated.
+- **`llamacpp-adapter` / `smolvlm-adapter`** (camera-agent-lite only) — these
+  two have no ARM64 build and will not get one soon: they derive from
+  `ghcr.io/ggml-org/llama.cpp:server`, which upstream publishes for amd64
+  only ([ggml-org/llama.cpp#19177](https://github.com/ggml-org/llama.cpp/issues/19177)).
+  The core NVR and the standard YOLOv8 stack are unaffected — only the
+  camera-agent-lite overlay needs emulation on ARM.
+
+**Running the amd64 images under emulation** works and is the fastest way to
+get a demo up on an M-series Mac, at a real cost in inference latency:
+
+1. Docker Desktop → **Settings → General → "Use Rosetta for x86_64/amd64
+   emulation on Apple Silicon"** → Apply & restart. (Without this, emulated
+   containers frequently fail to start at all rather than merely running
+   slowly.)
+2. Re-run the installer with the opt-in flag:
+
+   ```bash
+   OPENNVR_ALLOW_EMULATION=1 ./scripts/install.sh
+   ```
+
+   ```powershell
+   $env:OPENNVR_ALLOW_EMULATION = "1"; .\scripts\install.ps1
+   ```
+
+   This exports `DOCKER_DEFAULT_PLATFORM=linux/amd64` for the pull and every
+   subsequent `docker compose` call, so the stack does not come up half
+   emulated and half native.
+
+Emulation is a workaround, not a supported configuration — treat detection
+throughput numbers measured this way as meaningless.
 
 ### Core refuses to start: "Refusing to boot on placeholder secret"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 # ==========================================
 # STAGE 1: Frontend Build (Node.js)
 # ==========================================
-FROM node:23-alpine AS frontend-builder
+# --platform=$BUILDPLATFORM pins this stage to the ARCHITECTURE OF THE
+# BUILDER, not the target. Vite emits static JS/CSS/HTML that is
+# architecture-independent, so there is nothing to gain from running
+# `npm ci` + `npm run build` under QEMU for the linux/arm64 leg of a
+# multi-arch build — and plenty to lose: an emulated Node build is
+# roughly an order of magnitude slower and is the single step that
+# would make arm64 publishing impractical. The dist/ output is copied
+# into the target-arch runtime stage below.
+FROM --platform=$BUILDPLATFORM node:23-alpine AS frontend-builder
 
 WORKDIR /app-src
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -55,11 +55,117 @@ function Configure-Value([string]$Key, [string]$Label, [string]$Default, [string
     Set-EnvValue $Key (Ask-Value $Label $Default)
 }
 
+# Docker's platform vocabulary ('amd64'/'arm64'), not .NET's. Returns an
+# empty string for anything unrecognised, which disables the preflight
+# rather than guessing a platform string and rejecting a valid install.
+function Get-HostArch {
+    $a = ''
+    # RuntimeInformation is the portable source; PROCESSOR_ARCHITECTURE is
+    # the Windows PowerShell 5.1 fallback, where that type is unavailable.
+    try { $a = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString() }
+    catch { $a = $env:PROCESSOR_ARCHITECTURE }
+    switch -Regex ($a) {
+        '^(X64|AMD64)$'   { return 'amd64' }
+        '^(Arm64|ARM64)$' { return 'arm64' }
+        '^(Arm|ARM)$'     { return 'arm' }
+        default           { return '' }
+    }
+}
+
 function Detect-Platform {
     if ($IsLinux) { $script:Platform = 'Linux'; $script:DefaultRecordings = '/var/lib/opennvr/recordings' }
     elseif ($IsMacOS) { $script:Platform = 'macOS'; $script:DefaultRecordings = '/Users/Shared/opennvr-recordings' }
     else { $script:Platform = 'Windows'; $script:DefaultRecordings = 'C:/opennvr/recordings' }
-    Ok "Detected $script:Platform (Docker bridge mode)"
+    $script:HostArch = Get-HostArch
+    $shown = if ($script:HostArch) { $script:HostArch } else { 'unknown-arch' }
+    Ok "Detected $script:Platform/$shown (Docker bridge mode)"
+}
+
+# Does this image's manifest list carry an entry for the host architecture?
+#   0 - yes
+#   1 - the image resolves, but has no build for this architecture
+#   2 - undeterminable (no buildx, private image, registry hiccup, or a
+#       single-arch manifest with no platform metadata). Never a reason to
+#       block an install: a false 'unsupported' is worse than the raw daemon
+#       error this preflight exists to replace.
+function Test-ImageArch([string]$Image) {
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    $raw = (docker buildx imagetools inspect --raw $Image 2>$null | Out-String)
+    $code = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
+    if ($code -ne 0 -or -not $raw) { return 2 }
+    # A bare image manifest (schema 2, single platform) has no 'manifests'
+    # key and therefore no platform metadata to check.
+    if ($raw -notmatch '"manifests"') { return 2 }
+    # Buildx attestation entries sit alongside the real ones with
+    # "architecture":"unknown", so matching the host arch specifically is
+    # what distinguishes a usable build from provenance metadata.
+    $flat = $raw -replace '\s', ''
+    if ($flat -match ('"architecture":"' + [regex]::Escape($script:HostArch) + '"')) { return 0 }
+    return 1
+}
+
+# Preflight: name the images that cannot run here, before the pull starts.
+# `docker compose pull` resolves every image's manifest list against
+# linux/$HostArch, and when one has no matching entry the daemon aborts the
+# whole pull with a bare 'no matching manifest for linux/arm64/v8' - no image
+# name, no explanation, several services in. Only meaningful off amd64; every
+# image in the stack publishes amd64.
+function Check-ImageArchitectures {
+    if (-not $script:HostArch -or $script:HostArch -eq 'amd64') { return }
+
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    docker buildx version 2>$null | Out-Null
+    $buildxOk = ($LASTEXITCODE -eq 0)
+    $images = @()
+    if ($buildxOk) { $images = @(docker compose -f $BaseCompose config --images 2>$null) }
+    $ErrorActionPreference = $prevEAP
+    if (-not $buildxOk -or $images.Count -eq 0) { return }
+
+    Info "Checking that the pinned images publish a linux/$script:HostArch build..."
+    $unsupported = @()
+    foreach ($image in $images) {
+        if (-not $image) { continue }
+        if ((Test-ImageArch $image) -eq 1) { $unsupported += $image }
+    }
+    if ($unsupported.Count -eq 0) {
+        Ok "Every core image has a linux/$script:HostArch build"
+        return
+    }
+
+    Write-Host ''
+    Warn "This machine is $script:Platform/$script:HostArch. These images publish no linux/$script:HostArch build:"
+    foreach ($image in $unsupported) { Write-Host "      $image" }
+    Write-Host ''
+
+    if ($env:OPENNVR_ALLOW_EMULATION -eq '1') {
+        # Set on the process environment, not a local: the installer hands off
+        # to start.ps1 / start.sh, and every later `docker compose` call has to
+        # resolve the same way or the stack comes up half-emulated.
+        $env:DOCKER_DEFAULT_PLATFORM = 'linux/amd64'
+        Warn 'OPENNVR_ALLOW_EMULATION=1 - pulling the linux/amd64 builds and running'
+        Warn 'them under emulation. Detection latency will be several times worse.'
+        Warn 'In Docker Desktop, enable Settings -> General -> "Use Rosetta for'
+        Warn 'x86_64/amd64 emulation" first, or containers may fail to start at all.'
+        Write-Host ''
+        return
+    }
+
+    Write-Host '  Nothing has been downloaded. Left alone, the pull fails partway through'
+    Write-Host "  with `"no matching manifest for linux/$script:HostArch/v8`" and no indication"
+    Write-Host '  of which image caused it.'
+    Write-Host ''
+    Write-Host '  Options:'
+    Write-Host '    1. Install on an amd64 host.'
+    Write-Host '    2. Run the amd64 builds under emulation - slower, but functional.'
+    Write-Host '       In Docker Desktop enable Settings -> General -> "Use Rosetta for'
+    Write-Host '       x86_64/amd64 emulation", then re-run:'
+    Write-Host '         $env:OPENNVR_ALLOW_EMULATION = "1"; .\scripts\install.ps1'
+    Write-Host '    3. Build the images above from source for this architecture.'
+    Write-Host ''
+    Fail "Aborting: $($unsupported.Count) image(s) have no linux/$script:HostArch build."
 }
 
 # CLDR windowsZones primary (territory 001) mapping. Windows PowerShell 5.1
@@ -352,6 +458,7 @@ function Pull-AndBuild {
     Info 'Camera Agent, a local LLM model of ~1 GB). Depending on your network'
     Info 'this can take 8-15 minutes. Later starts are much faster - everything'
     Info 'is cached, so you only pay this cost once.'
+    Check-ImageArchitectures
     Write-Host ''
     Info 'Pulling the OpenNVR core stack...'
     docker compose -f $BaseCompose pull --ignore-buildable

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,7 +86,109 @@ detect_platform() {
         Darwin*) PLATFORM="macOS"; DEFAULT_RECORDINGS="/Users/Shared/opennvr-recordings" ;;
         *) die "Unsupported platform. On Windows run .\\scripts\\install.ps1" ;;
     esac
-    ok "Detected $PLATFORM (Docker bridge mode)"
+    # HOST_ARCH is Docker's platform vocabulary, not uname's. `docker compose
+    # pull` resolves every image's manifest list against linux/$HOST_ARCH, and
+    # when an image has no entry for it the daemon aborts the whole pull with a
+    # bare "no matching manifest for linux/arm64/v8" — no image name, no
+    # explanation, several services in. check_image_architectures() below turns
+    # that into a named list before anything is downloaded.
+    case "$(uname -m)" in
+        x86_64|amd64)  HOST_ARCH="amd64" ;;
+        arm64|aarch64) HOST_ARCH="arm64" ;;
+        armv7l)        HOST_ARCH="arm" ;;
+        # Unknown machine type: leave HOST_ARCH empty and skip the preflight
+        # rather than guess a platform string and reject a valid install.
+        *)             HOST_ARCH="" ;;
+    esac
+    ok "Detected $PLATFORM/${HOST_ARCH:-$(uname -m)} (Docker bridge mode)"
+}
+
+# Does this image's manifest list carry an entry for the host architecture?
+#   0 — yes
+#   1 — the image resolves, but has no build for this architecture
+#   2 — undeterminable (no buildx, private image, registry hiccup, or a
+#       single-arch manifest with no platform metadata). Never a reason to
+#       block an install: a false "unsupported" is worse than the raw
+#       daemon error we are replacing.
+image_supports_host_arch() {
+    local image="$1" raw
+    raw=$(docker buildx imagetools inspect --raw "$image" 2>/dev/null) || return 2
+    # A bare image manifest (schema 2, single platform) has no "manifests"
+    # key and therefore no platform metadata to check.
+    case "$raw" in
+        *'"manifests"'*) ;;
+        *) return 2 ;;
+    esac
+    # Buildx attestation entries appear alongside the real ones with
+    # "architecture":"unknown", so matching the host arch specifically is
+    # what distinguishes a usable build from provenance metadata.
+    if printf '%s' "$raw" | tr -d ' \t\r\n' | grep -q "\"architecture\":\"${HOST_ARCH}\""; then
+        return 0
+    fi
+    return 1
+}
+
+# Preflight: name the images that cannot run here, before the pull starts.
+# Only meaningful off amd64 — every image in the stack publishes amd64.
+check_image_architectures() {
+    [[ -n "$HOST_ARCH" && "$HOST_ARCH" != "amd64" ]] || return 0
+    docker buildx version >/dev/null 2>&1 || return 0
+
+    # A newline-delimited string plus an explicit counter, NOT an array:
+    # macOS still ships bash 3.2, where `${#arr[@]}` on an empty array under
+    # `set -u` is an "unbound variable" error — and an empty list is the
+    # normal, successful outcome of this function.
+    local images image rc unsupported="" count=0
+    images=$(docker compose -f "$BASE_COMPOSE" config --images 2>/dev/null) || return 0
+    [[ -n "$images" ]] || return 0
+
+    info "Checking that the pinned images publish a linux/${HOST_ARCH} build..."
+    while IFS= read -r image; do
+        [[ -n "$image" ]] || continue
+        rc=0
+        image_supports_host_arch "$image" || rc=$?
+        if [[ $rc -eq 1 ]]; then
+            unsupported+="${image}"$'\n'
+            count=$((count + 1))
+        fi
+    done <<< "$images"
+
+    if [[ $count -eq 0 ]]; then
+        ok "Every core image has a linux/${HOST_ARCH} build"
+        return 0
+    fi
+
+    printf '\n'
+    warn "This machine is ${PLATFORM}/${HOST_ARCH}. These images publish no linux/${HOST_ARCH} build:"
+    printf '%s' "$unsupported" | while IFS= read -r image; do
+        printf '      %s\n' "$image"
+    done
+    printf '\n'
+
+    if [[ "${OPENNVR_ALLOW_EMULATION:-0}" == "1" ]]; then
+        # Exported, not just set: the installer ends with `exec start.sh up`,
+        # and every later `docker compose` call has to resolve the same way
+        # or the stack comes up half-emulated and half-broken.
+        export DOCKER_DEFAULT_PLATFORM=linux/amd64
+        warn "OPENNVR_ALLOW_EMULATION=1 — pulling the linux/amd64 builds and running"
+        warn "them under emulation. Detection latency will be several times worse."
+        warn "On Docker Desktop, enable Settings -> General -> 'Use Rosetta for"
+        warn "x86_64/amd64 emulation' first, or containers may fail to start at all."
+        printf '\n'
+        return 0
+    fi
+
+    printf '  Nothing has been downloaded. Left alone, the pull fails partway through\n'
+    printf '  with "no matching manifest for linux/%s/v8" and no indication of which\n' "$HOST_ARCH"
+    printf '  image caused it.\n\n'
+    printf '  Options:\n'
+    printf '    1. Install on an amd64 host.\n'
+    printf '    2. Run the amd64 builds under emulation — slower, but functional.\n'
+    printf '       On Docker Desktop enable Settings -> General -> "Use Rosetta for\n'
+    printf '       x86_64/amd64 emulation", then re-run:\n'
+    printf '         OPENNVR_ALLOW_EMULATION=1 ./scripts/install.sh\n'
+    printf '    3. Build the images above from source for this architecture.\n\n'
+    die "Aborting: ${count} image(s) have no linux/${HOST_ARCH} build."
 }
 
 # Best-effort IANA timezone of this host, used as the default for the TZ
@@ -322,6 +424,7 @@ pull_and_build() {
     info "Camera Agent, a local LLM model of ~1 GB). Depending on your network"
     info "this can take 8-15 minutes. Later starts are much faster — everything"
     info "is cached, so you only pay this cost once."
+    check_image_architectures
     printf '\n'
     info "Pulling the OpenNVR core stack..."
     docker compose -f "$BASE_COMPOSE" pull --ignore-buildable


### PR DESCRIPTION
…=0.1.3

A fresh install on Apple Silicon / Pi 5 died in 'docker compose pull' with a bare 'no matching manifest for linux/arm64/v8' — every published image was amd64-only and neither installer checked the host arch.

- publish-images.yml, publish-detect-pipeline.yml: build+push linux/amd64 + linux/arm64 manifest lists (QEMU on the amd64 runner). PR builds stay amd64-only because the smoke steps need 'load:'.
- Dockerfile: pin the Node/Vite stage to $BUILDPLATFORM — its output is arch-independent, and emulating npm is what would make the arm64 leg impractical.
- install.sh / install.ps1: preflight every pinned image's manifest list against the host arch and name the unsupported images before anything downloads; OPENNVR_ALLOW_EMULATION=1 opts into running the amd64 images under emulation (exports DOCKER_DEFAULT_PLATFORM).
- ADAPTER_TAG pin 0.1.1 -> 0.1.3, the first ai-adapter release with ARM64 images. llamacpp/smolvlm adapters stay amd64-only pending upstream ggml-org/llama.cpp#19177.
- DOCKER_QUICKSTART: arch prerequisites + a troubleshooting entry keyed to the exact daemon error string. CHANGELOG entry under Unreleased.

NOTE: release-pins CI resolves .env.example pins against GHCR, so this must land AFTER ai-adapter v0.1.3 images are published.


Claude-Session: https://claude.ai/code/session_01Q9zaseSNDvn1g4FiVG2wCN