### PR TITLE
fix(installer): camera-agent selection exited silently at the mode pr…

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,15 @@ ask_secret() {
 explain() {
     printf '  %s\n' "$1"
     printf '    required: %-4s  default: %s\n' "$2" "$3"
-    [[ -n "${4:-}" ]] && printf '    note: %s\n' "$4"
+    # An if, NOT ``[[ -n ... ]] && printf``: with no note argument the
+    # && list makes the function's exit status 1, and under ``set -e``
+    # the bare ``explain ...`` call kills the installer SILENTLY — the
+    # camera-agent selection died exactly here (the only call site
+    # without a note). Same failure family as the ``read || true``
+    # rule documented above; keep explain() unconditionally returning 0.
+    if [[ -n "${4:-}" ]]; then
+        printf '    note: %s\n' "$4"
+    fi
 }
 # Curated, ALWAYS-prompted value with an explanation. Enter keeps the current
 # .env value (or the given default on a fresh install); typing overrides it.


### PR DESCRIPTION
…ompt

explain() ended with '[[ -n ${4:-} ]] && printf' — with no note argument (the camera-agent voice/chat call, the only 3-arg call site) the && list leaves the function's exit status at 1, and under 'set -Eeuo pipefail' the bare 'explain ...' call terminates the installer with no error, right after printing the explanation and before the mode prompt. Replaced with an explicit if so explain() always returns 0. Same failure family as the documented 'read || true' EOF rule.