### PR TITLE
fix(live-view): stream playback broke on any origin except the pinned…

### DIFF
--- a/app/src/lib/streamUrl.ts
+++ b/app/src/lib/streamUrl.ts
@@ -21,8 +21,14 @@
  * every origin nginx serves equally valid. Non-proxied URLs (direct
  * MediaMTX ports, absolute URLs to other services) pass through
  * untouched, as does anything that fails to parse.
+ *
+ * /playback/get and /playback/list are the recording-playback
+ * endpoints nginx proxies the same way (exact-match locations). The
+ * backend returns absolute playback_url values built from the same
+ * pinned base; today the SPA only truthiness-checks them, but any
+ * consumer that starts playing them must go through here too.
  */
-const PROXIED_STREAM_PREFIXES = ['/webrtc/', '/hls/']
+const PROXIED_STREAM_PREFIXES = ['/webrtc/', '/hls/', '/playback/get', '/playback/list']
 
 export function rebaseToCurrentOrigin(url: string | undefined): string | undefined {
   if (!url || typeof window === 'undefined') return url

--- a/app/src/lib/streamUrl.ts
+++ b/app/src/lib/streamUrl.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 OpenNVR
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Rebase a backend-provided stream URL onto the origin the UI is
+ * currently being served from.
+ *
+ * The backend builds WHEP/HLS URLs from MEDIAMTX_EXTERNAL_BASE_URL,
+ * which start.sh pins to ONE origin — the detected LAN IP (e.g.
+ * https://192.168.1.4/webrtc/cam-1/whep). nginx, however, proxies
+ * /webrtc/ and /hls/ identically on EVERY origin it serves: localhost,
+ * the LAN IP, a hostname, a VPN address. A browser on
+ * https://localhost that receives the absolute LAN-IP URL makes a
+ * cross-origin request to a host whose self-signed cert it has never
+ * accepted, and the fetch fails silently — live view shows NO LINK on
+ * https://localhost while working on the LAN URL.
+ *
+ * Fix: if the URL's path is one nginx proxies for streaming, ignore
+ * the backend's choice of host and use window.location.origin. This is
+ * a no-op when the user is already on the pinned origin, and it makes
+ * every origin nginx serves equally valid. Non-proxied URLs (direct
+ * MediaMTX ports, absolute URLs to other services) pass through
+ * untouched, as does anything that fails to parse.
+ */
+const PROXIED_STREAM_PREFIXES = ['/webrtc/', '/hls/']
+
+export function rebaseToCurrentOrigin(url: string | undefined): string | undefined {
+  if (!url || typeof window === 'undefined') return url
+  try {
+    const parsed = new URL(url, window.location.origin)
+    if (!PROXIED_STREAM_PREFIXES.some((p) => parsed.pathname.startsWith(p))) {
+      return url
+    }
+    return new URL(parsed.pathname + parsed.search + parsed.hash, window.location.origin).toString()
+  } catch {
+    return url
+  }
+}

--- a/app/src/views/LiveView.tsx
+++ b/app/src/views/LiveView.tsx
@@ -18,6 +18,7 @@
 
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
 import { apiService } from '../lib/apiService'
+import { rebaseToCurrentOrigin } from '../lib/streamUrl'
 import { duplicateCameraNames, isDuplicateCameraError } from '../services/cameraService'
 import { VideoPlayer, type VideoPlayerHandle } from '../components/VideoPlayer'
 import { QrScanner } from '../components/QrScanner'
@@ -681,8 +682,11 @@ function Tile({
           const { data } = await apiService.getStreamUrls(camera.id)
           if (!alive) return
           setUrls({
-            whep: data.urls?.webrtc,
-            hls: data.urls?.hls,
+            // Rebase onto the origin the UI is being served from — the
+            // backend pins these to the LAN IP, which breaks playback
+            // when browsing via https://localhost (see lib/streamUrl.ts).
+            whep: rebaseToCurrentOrigin(data.urls?.webrtc),
+            hls: rebaseToCurrentOrigin(data.urls?.hls),
             token: data.token
           })
         } catch {

--- a/start.sh
+++ b/start.sh
@@ -682,6 +682,38 @@ print_security_posture() {
 # We try to detect the LAN-facing IP best-effort so the operator
 # sees a clickable URL. Failure paths fall back to a generic
 # "https://<server-ip>/" string so the message is never misleading.
+# True if this source-IP / egress-interface pair looks like a VPN
+# tunnel rather than the operator's LAN. Route-aware detection has one
+# failure mode the heuristics it replaced did not: on a host running a
+# full-tunnel VPN (Tailscale, WireGuard, ...) the default route IS the
+# tunnel, so `ip route get` deterministically returns the tunnel IP —
+# and MEDIAMTX_PUBLIC_URL, the WebRTC ICE hosts, and the cert SAN get
+# pinned to an address LAN browsers can't reach. Two independent
+# signals, either one disqualifies:
+#   * egress device named like a tunnel (wg*, tun*, tap*, utun*,
+#     tailscale*, zt* (ZeroTier), nebula*)
+#   * source address in 100.64.0.0/10 — the CGNAT range Tailscale
+#     allocates from; never a home/office LAN address in practice
+# Operators who genuinely WANT the tunnel address (remote-only access)
+# set OPENNVR_HOST_IP in .env, which wins before detection runs.
+is_vpn_tunnel_source() {
+    local src="$1" dev="$2"
+    case "$dev" in
+        wg*|tun*|tap*|utun*|tailscale*|zt*|nebula*) return 0 ;;
+    esac
+    case "$src" in
+        100.*)
+            local second
+            second="${src#100.}"
+            second="${second%%.*}"
+            case "$second" in
+                6[4-9]|7[0-9]|8[0-9]|9[0-9]|1[0-1][0-9]|12[0-7]) return 0 ;;
+            esac
+            ;;
+    esac
+    return 1
+}
+
 detect_lan_ip() {
     # Self-review M-1: on dual-NIC hosts, NGINX_BIND_HOST is the
     # *authoritative* answer for "which IP does the operator browse
@@ -711,10 +743,17 @@ detect_lan_ip() {
     # WebRTC ICE hosts, wrong cert SAN). No packet is sent: `ip
     # route get` is a pure routing-table lookup.
     if command -v ip >/dev/null 2>&1; then
-        local route_src
-        route_src=$(ip -4 route get 1.1.1.1 2>/dev/null \
+        local route_out route_src route_dev
+        route_out=$(ip -4 route get 1.1.1.1 2>/dev/null | head -n 1)
+        route_src=$(printf '%s\n' "$route_out" \
             | awk '{for (i=1; i<=NF; i++) if ($i == "src") {print $(i+1); exit}}')
-        if [ -n "$route_src" ]; then
+        route_dev=$(printf '%s\n' "$route_out" \
+            | awk '{for (i=1; i<=NF; i++) if ($i == "dev") {print $(i+1); exit}}')
+        # A tunnel egress means "the default route is the VPN", not
+        # "this is the operator-facing NIC" — skip to the LAN
+        # heuristics below instead of pinning URLs/certs to an
+        # address LAN browsers can't reach (see is_vpn_tunnel_source).
+        if [ -n "$route_src" ] && ! is_vpn_tunnel_source "$route_src" "${route_dev:-}"; then
             echo "$route_src"
             return
         fi

--- a/start.sh
+++ b/start.sh
@@ -365,6 +365,21 @@ configure_nginx_bind_host() {
 
     mode="multi-undeclared"
     export NGINX_BIND_HOST="0.0.0.0"
+    # Best-effort browser-facing URLs even without a declared topology:
+    # this branch previously exported no MEDIAMTX_PUBLIC_URL at all, so
+    # compose fell back to https://localhost and live view broke for
+    # every LAN client. detect_lan_ip is now route-aware (default-route
+    # source IP), so its guess is the operator-facing NIC, not
+    # enumeration luck.
+    local fallback_host
+    fallback_host=$(detect_lan_ip 2>/dev/null || echo "")
+    if [ -n "$fallback_host" ]; then
+        export MEDIAMTX_PUBLIC_URL="https://${fallback_host}"
+        export MEDIAMTX_WEBRTC_HOSTS="${fallback_host}"
+        if [ -z "$(get_env_var OPENNVR_HOST_IP 2>/dev/null)" ]; then
+            export OPENNVR_HOST_IP="${fallback_host}"
+        fi
+    fi
     echo -e "  ${YELLOW}NIC topology: multi-NIC, undeclared (non-interactive)${NC}" >&2
     echo -e "  ${GRAY}  Detected ${nic_count} routable interfaces:${NC}" >&2
     echo "$nics" | while IFS=: read -r iface ip; do
@@ -523,6 +538,19 @@ prompt_nic_topology() {
             write_env_var CAMERA_NETWORK_INTERFACE "$cam_iface"
             write_env_var MGMT_NETWORK_INTERFACE "$mgmt_iface"
             export NGINX_BIND_HOST="$mgmt_ip"
+            # First-run parity with the dual-declared branch of
+            # configure_nginx_bind_host: that branch only runs on the
+            # NEXT ./start.sh up (it reads the interface names we just
+            # wrote to .env). Without these exports, the compose up
+            # that follows THIS walkthrough falls back to
+            # https://localhost for the browser-facing stream URLs and
+            # advertises no reachable WebRTC ICE host — live view
+            # broken until a restart nobody knows they need.
+            export MEDIAMTX_PUBLIC_URL="https://${mgmt_ip}"
+            export MEDIAMTX_WEBRTC_HOSTS="${mgmt_ip}"
+            if [ -z "$(get_env_var OPENNVR_HOST_IP 2>/dev/null)" ]; then
+                export OPENNVR_HOST_IP="${mgmt_ip}"
+            fi
             echo "" >&2
             echo -e "  ${GREEN}✓ Dual-NIC mode saved.${NC}" >&2
             echo -e "  ${GRAY}  camera network : ${WHITE}${cam_iface}${GRAY}  (UI not exposed here)${NC}" >&2
@@ -673,6 +701,23 @@ detect_lan_ip() {
     if [ -n "$override" ]; then
         echo "$override"
         return
+    fi
+    # Route-aware detection: the source IP the kernel would use to
+    # reach the internet. On multi-NIC hosts this lands on the
+    # operator-facing NIC by construction — a directly-attached
+    # camera NIC has no default route — unlike the `hostname -I`
+    # fallback below, whose ordering is interface-enumeration luck
+    # and can pick the camera NIC (wrong MEDIAMTX_PUBLIC_URL, wrong
+    # WebRTC ICE hosts, wrong cert SAN). No packet is sent: `ip
+    # route get` is a pure routing-table lookup.
+    if command -v ip >/dev/null 2>&1; then
+        local route_src
+        route_src=$(ip -4 route get 1.1.1.1 2>/dev/null \
+            | awk '{for (i=1; i<=NF; i++) if ($i == "src") {print $(i+1); exit}}')
+        if [ -n "$route_src" ]; then
+            echo "$route_src"
+            return
+        fi
     fi
     # Linux: hostname -I returns space-separated v4/v6 addresses on
     # configured interfaces. Take the first non-loopback v4.


### PR DESCRIPTION
… LAN IP

The backend builds WHEP/HLS URLs from MEDIAMTX_EXTERNAL_BASE_URL, which start.sh pins to the detected LAN IP. Browsing the UI on any other origin nginx serves — https://localhost being the one the installer banner itself advertises — made the player fetch cross-origin against a self-signed cert the browser never accepted, so the request failed silently and live view showed NO LINK.

Frontend now rebases proxied stream URLs (/webrtc/, /hls/) onto window.location.origin before use: a no-op on the pinned origin, and playback works from every origin nginx serves (localhost, LAN IP, hostname, VPN). Non-proxied absolute URLs pass through untouched.