### PR TITLE
fix(nginx): re-resolve upstream DNS at runtime so recreated container…

### DIFF
--- a/nginx/opennvr.conf
+++ b/nginx/opennvr.conf
@@ -22,6 +22,14 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+# Docker's embedded DNS. Upstream hostnames are kept in variables inside each
+# location so nginx re-resolves them at request time (cached for valid=10s)
+# instead of once at startup — a statically-resolved name goes stale the
+# moment Docker recreates a container with a new bridge IP, and every request
+# then 502s against the dead address until nginx itself is restarted.
+resolver 127.0.0.11 valid=10s ipv6=off;
+resolver_timeout 5s;
+
 # 80 → 443 redirect. Operators who hit http://server-ip get bounced
 # to https. We don't try to serve HTTP at all so misconfigured clients
 # fail loudly rather than silently downgrading.
@@ -96,7 +104,12 @@ server {
     # inside the bridge to forge a cert, which is a higher bar than
     # this verification protects against.
     location /webrtc/ {
-        proxy_pass https://mediamtx:8889/;
+        # Variable upstream → per-request DNS (see resolver above). Variable
+        # proxy_pass skips the automatic URI mapping a static one does, so
+        # the /webrtc/ → / prefix strip becomes an explicit rewrite.
+        set $mediamtx_webrtc https://mediamtx:8889;
+        rewrite ^/webrtc/(.*)$ /$1 break;
+        proxy_pass $mediamtx_webrtc;
         proxy_ssl_verify off;
         proxy_ssl_server_name on;
         proxy_http_version 1.1;
@@ -114,7 +127,9 @@ server {
     # mediamtx serves HTTPS here too (hlsEncryption=yes); same
     # self-signed-trust-by-design rationale as /webrtc/.
     location /hls/ {
-        proxy_pass https://mediamtx:8888/;
+        set $mediamtx_hls https://mediamtx:8888;
+        rewrite ^/hls/(.*)$ /$1 break;
+        proxy_pass $mediamtx_hls;
         proxy_ssl_verify off;
         proxy_ssl_server_name on;
         proxy_http_version 1.1;
@@ -133,7 +148,11 @@ server {
     # browser refresh or bookmark loads the UI instead of the media proxy
     # 404ing. Plaintext on the bridge; nginx is the TLS edge.
     location = /playback/get {
-        proxy_pass http://mediamtx:9996/get;
+        # rewrite (not a URI on proxy_pass) so the query string survives —
+        # a variable proxy_pass with an explicit URI would drop it.
+        set $mediamtx_playback http://mediamtx:9996;
+        rewrite ^ /get break;
+        proxy_pass $mediamtx_playback;
         proxy_http_version 1.1;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
@@ -146,7 +165,9 @@ server {
     }
 
     location = /playback/list {
-        proxy_pass http://mediamtx:9996/list;
+        set $mediamtx_playback_list http://mediamtx:9996;
+        rewrite ^ /list break;
+        proxy_pass $mediamtx_playback_list;
         proxy_http_version 1.1;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
@@ -158,7 +179,10 @@ server {
 
     # Everything else proxies to opennvr-core.
     location / {
-        proxy_pass http://opennvr-core:8000;
+        # No URI mapping here (no trailing slash before), so the variable
+        # form needs no rewrite — the original URI passes through as-is.
+        set $core_upstream http://opennvr-core:8000;
+        proxy_pass $core_upstream;
         proxy_http_version 1.1;
 
         # Standard reverse-proxy headers.


### PR DESCRIPTION
…s don't 502

All proxy_pass directives used static hostnames, which nginx resolves once at config load and caches forever. When Docker recreates opennvr-core or mediamtx and the container comes back on a different bridge IP, nginx kept proxying to the dead address — every request 502'd (connect() failed to the stale IP) until nginx itself was reloaded.

Fix: declare Docker's embedded DNS (127.0.0.11) as a resolver with a 10s cache, and move each upstream into a per-location variable, which defers resolution to request time. A recreated container is picked up within seconds, no nginx reload needed.

Variable proxy_pass skips the automatic URI mapping a static one performs, so the locations that remap URIs gain explicit rewrites:
- /webrtc/ and /hls/ strip their prefix via rewrite (was the trailing-slash proxy_pass form)
- /playback/get and /playback/list rewrite to /get and /list — rewrite rather than a URI on proxy_pass so the query string survives
- location / passes the URI through unchanged (no rewrite needed)

Verified live: force-recreated opennvr_core (new bridge IP), nginx followed within ~3s with no reload; /playback/list query args, WHEP, and HLS paths all still land on the right MediaMTX endpoints.

Fixes #256