### PR TITLE
feat(installer): default CAPTION_ADAPTER=ollamavlm when the LLM runs …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,7 +239,15 @@ OLLAMA_MODEL=qwen2.5:1.5b
 # Whisper STT model size: tiny.en | base.en (default) | small.en (most accurate)
 WHISPER_MODEL_SIZE=base.en
 
-# Caption adapter for describe_camera: moondream (VQA + captions) | blip (captions only)
+# Caption adapter for describe_camera:
+#   moondream  (VQA + captions, runs inside Docker — the safe default)
+#   blip       (captions only, runs inside Docker)
+#   ollamavlm  (proxies to the OLLAMA_EXTERNAL_URL Ollama — GPU-fast on
+#              macOS; ~1-2 s per caption vs ~25 s of VM CPU. The installer
+#              defaults to this whenever the LLM runs on the host, since
+#              the same Ollama then serves both. Same adapter contract and
+#              audited KAI-C path either way. Needs a host Ollama running,
+#              so don't set it on a headless Linux server without one.)
 CAPTION_ADAPTER=moondream
 
 # llama.cpp GGUF model repo (only if using llm_provider=llamacpp instead of Ollama).

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -553,8 +553,16 @@ function Choose-Example {
                 'Transcribes your spoken questions (voice mode only).' 'yes' `
                 'tiny.en (fastest) | base.en (default) | small.en (most accurate).'
         }
-        Configure-Value CAPTION_ADAPTER 'Scene-description model' 'moondream' `
-            'Describes what a camera sees. moondream answers questions (VQA); blip writes plain captions; ollamavlm proxies to your Ollama (GPU-fast when the LLM runs on this machine - needs an adapter tag newer than 0.1.3).' 'yes' `
+        # When the LLM already runs on the host Ollama, the VLM belongs there
+        # too: the ollamavlm adapter proxies scene questions to the same
+        # GPU-fast Ollama (a caption costs ~1-2 s vs ~25 s of VM CPU with
+        # the in-container weights). Same adapter contract, same audited
+        # KAI-C path - only where the weights execute changes. On the
+        # bundled-container path the in-VM moondream stays the default.
+        $captionDefault = 'moondream'
+        if ($llmWhere -eq 'host') { $captionDefault = 'ollamavlm' }
+        Configure-Value CAPTION_ADAPTER 'Scene-description model' $captionDefault `
+            'Describes what a camera sees. ollamavlm proxies to your Ollama (GPU-fast when the LLM runs on this machine - the default in that case; needs an adapter tag newer than 0.1.3); moondream/blip run inside Docker (moondream answers questions, blip writes plain captions).' 'yes' `
             'moondream | blip | ollamavlm - all local.'
         if ((Get-EnvValue CAPTION_ADAPTER) -eq 'ollamavlm') {
             Explain 'Multimodal Ollama model the ollamavlm adapter uses for scene questions; the adapter auto-pulls it. moondream is the tested default.' 'yes' $vlmSuggest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -607,8 +607,19 @@ choose_example() {
                 "Transcribes your spoken questions (voice mode only)." "yes" \
                 "tiny.en (fastest) | base.en (default) | small.en (most accurate)."
         fi
-        configure_value CAPTION_ADAPTER "Scene-description model" "moondream" \
-            "Describes what a camera sees. moondream answers questions (VQA); blip writes plain captions; ollamavlm proxies to your Ollama (GPU-fast on macOS when the LLM runs on this machine — needs an adapter tag newer than 0.1.3)." "yes" \
+        # When the LLM already runs on the host Ollama, the VLM belongs there
+        # too: the ollamavlm adapter proxies scene questions to the same
+        # GPU-fast Ollama (a caption costs ~1-2 s on Metal vs ~25 s of VM
+        # CPU with the in-container weights). Same adapter contract, same
+        # audited KAI-C path — only where the weights execute changes. On
+        # the bundled-container path the in-VM moondream stays the default
+        # (there may be no host Ollama at all on a Linux server).
+        local caption_default="moondream"
+        if [[ "$llm_where" == "host" ]]; then
+            caption_default="ollamavlm"
+        fi
+        configure_value CAPTION_ADAPTER "Scene-description model" "$caption_default" \
+            "Describes what a camera sees. ollamavlm proxies to your Ollama (GPU-fast when the LLM runs on this machine — the default in that case; needs an adapter tag newer than 0.1.3); moondream/blip run inside Docker (moondream answers questions, blip writes plain captions)." "yes" \
             "moondream | blip | ollamavlm — all local."
         # ollamavlm chosen → suggest a VLM sized like the LLM was.
         if [[ "$(env_get CAPTION_ADAPTER)" == "ollamavlm" ]]; then


### PR DESCRIPTION
…on host Ollama

When the installer's LLM-runtime question lands on 'Ollama on this machine' the same choice is right for the VLM: the ollamavlm adapter proxies scene questions to that Ollama, so a caption costs ~1-2 s on Metal instead of ~25 s of Docker-VM CPU (the load pattern behind the 620% caption-adapter incident). Same adapter contract, same audited KAI-C path — only where the weights execute changes.

The global default stays moondream-in-VM: a headless Linux server may have no host Ollama at all, and a silent 503-ing caption slot is worse than a slow one. Conditional default only, still confirmable at the prompt. Both installers (install.sh, install.ps1 — CRLF preserved) and the .env.example doc updated.