### PR TITLE
fix(tier0): bound worst-case load — label allowlist, conf floor, regi…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,33 @@ DETECT_FPS=5
 # This is what keeps a parked car or a person sitting still from pinning
 # the detector at full rate forever. 0 disables (every track, every frame).
 DETECT_STATIONARY_INTERVAL=10
+
+# ── Bounded-load guards ─────────────────────────────────────────────
+# Together these keep Tier-0's worst-case CPU flat no matter what the
+# camera sees. Field case: a desk full of wires/boards made yolov8n (at
+# conf 0.25, all 80 COCO classes) hallucinate "kite"/"banana" phantoms;
+# 181 of them confirmed into standing tracks and re-verifying them pushed
+# the detector to ~30s/frame. The defaults below make that impossible.
+#
+# Classes worth TRACKING (comma-separated; "all" = every COCO class).
+# An NVR rarely cares about bananas — Frigate ships person-only.
+DETECT_LABELS=person,car,truck,bus,motorcycle,bicycle,cat,dog
+# Detector confidence floor (default 0.4). Real people/vehicles usually
+# score >0.6; wire-phantoms live in the 0.25-0.4 band.
+DETECT_CONF=0.4
+# Hard cap on detector crops per frame (default 8; 0 = unbounded).
+# Motion regions get slots first; track re-verifies round-robin the rest.
+DETECT_MAX_REGIONS=8
+# Hard cap on live tracks per camera (default 50). At the cap new tracks
+# are refused (tier0_track_spawns_dropped) until the TTL drains old ones.
+DETECT_MAX_TRACKS=50
+# Wall-clock seconds a track may live without a positive re-detection
+# (default 300; 0 = never expire). Real objects are simply re-detected.
+DETECT_TRACK_TTL=300
+# Minimum detection score to CREATE a track (default 0.5). Weaker hits
+# still match existing tracks — hysteresis, like Frigate min_score.
+DETECT_MIN_SPAWN_SCORE=0.5
+
 DETECT_DETECTOR=onnx       # onnx (YOLOv8, default) | hog | blob | stub
 DETECT_ONNX_BACKEND=cvdnn  # cvdnn (zero-dep CPU, default) | ort (ONNX Runtime)
 DETECT_ONNX_PROVIDERS=     # ort EPs, e.g. OpenVINOExecutionProvider (Intel N100)

--- a/detect-pipeline/README.md
+++ b/detect-pipeline/README.md
@@ -101,6 +101,30 @@ scene, look for perpetual motion sources: a camera-OSD timestamp burned
 into the substream ticks every second and defeats motion gating — turn
 the overlay off in the camera, or crop/mask it.
 
+**Worst case is bounded by design.** A cluttered scene (a desk of wires
+and boards) once drove the field failure this section exists for: at
+confidence 0.25 across all 80 COCO classes, yolov8n hallucinated
+"kite"/"banana" phantoms that confirmed into 181 standing tracks, and
+re-verifying that population cost ~30 s of detector per frame. Four
+guards now keep the worst case flat regardless of scene content, each
+with an env dial and a metric (never a silent cap):
+
+* `DETECT_LABELS` (default `person,car,truck,bus,motorcycle,bicycle,cat,dog`)
+  — only these classes are tracked; `all` restores every COCO class.
+* `DETECT_CONF` (default `0.4`) — detector confidence floor, plus
+  `DETECT_MIN_SPAWN_SCORE` (default `0.5`): it takes solid evidence to
+  *create* a track, weaker evidence still *matches* one (Frigate-style
+  hysteresis).
+* `DETECT_MAX_REGIONS` (default `8`) — hard per-frame budget of detector
+  crops. Motion regions win slots first; track re-verifies round-robin
+  the remainder across frames (skipped tracks coast, they don't age).
+  Capped frames count on `tier0_regions_capped_total`.
+* `DETECT_MAX_TRACKS` (default `50`) + `DETECT_TRACK_TTL` (default
+  `300` s) — a hard ceiling on live tracks, and a wall-clock TTL so a
+  track that is never positively re-detected always drains (frame-based
+  miss counting stalls exactly when the pipeline is overloaded). Refused
+  spawns show on `tier0_track_spawns_dropped`.
+
 **Second dial: lower `DETECT_FPS`.**
 Detection runs on every analyzed frame (the gate skips alarms, not
 inference), so pipeline CPU scales almost linearly with the per-camera

--- a/detect-pipeline/detect_pipeline/metrics.py
+++ b/detect-pipeline/detect_pipeline/metrics.py
@@ -169,6 +169,12 @@ def record_frame(
     else:
         metrics.inc("tier0_detector_skipped_total", {"camera": camera_id, "reason": "no_motion"})
     metrics.gauge("tier0_tracks_active", float(len(result.tracks)), cam)
+    # Bounded-load guards (#track-explosion) — never cap silently:
+    if getattr(result, "regions_capped", False):
+        metrics.inc("tier0_regions_capped_total", cam)
+    skipped = int(getattr(result, "skipped_stationary", 0) or 0)
+    if skipped:
+        metrics.inc("tier0_stationary_skipped_total", cam, value=float(skipped))
     for det in getattr(result, "detections", None) or []:
         metrics.inc("tier0_detections_total", {"camera": camera_id, "label": det.label})
     if latency_s is not None:

--- a/detect-pipeline/detect_pipeline/pipeline.py
+++ b/detect-pipeline/detect_pipeline/pipeline.py
@@ -68,6 +68,9 @@ class FrameResult:
     # Stationary tracks whose region was NOT scanned this frame (the PR B
     # saving, made visible for metrics/tests).
     skipped_stationary: int = 0
+    # True when the per-frame region budget dropped at least one candidate
+    # this frame (exported as tier0_regions_capped_total — no silent caps).
+    regions_capped: bool = False
     # Per-stage wall time for the frame (decode/motion/region/detect/track) — lets
     # the test-bed see *where* time goes, not just the end-to-end total.
     stage_latency_s: dict[str, float] = field(default_factory=dict)
@@ -92,17 +95,31 @@ def select_regions(
     min_region: int,
     multiplier: float = 1.35,
     dedup_iou: float = 0.7,
-) -> list[Box]:
+    max_regions: int | None = None,
+) -> tuple[list[Box], bool]:
     """One square region per motion box and per active track, de-duplicated.
 
-    Bounds how much is ever sent to the detector each frame.
+    Bounds how much is ever sent to the detector each frame. ``max_regions``
+    is the hard per-frame budget (#track-explosion): motion boxes are listed
+    first so live activity always wins a slot over track re-verification;
+    candidates beyond the budget are simply not scanned this frame — the
+    tracker's ``scanned_regions`` contract makes their tracks coast, and the
+    caller rotates ``track_boxes`` so the budget round-robins across frames.
+
+    Returns ``(regions, capped)`` — ``capped`` is True when at least one
+    candidate was dropped by the budget (never silently: the service exports
+    it as ``tier0_regions_capped_total``).
     """
     kept: list[Box] = []
+    capped = False
     for b in list(motion_boxes) + list(track_boxes):
+        if max_regions is not None and len(kept) >= max_regions:
+            capped = True
+            break
         r = calculate_region(frame_shape, b[0], b[1], b[2], b[3], min_region, multiplier)
         if all(intersection_over_union(r, k) < dedup_iou for k in kept):
             kept.append(r)
-    return kept
+    return kept, capped
 
 
 class DetectPipeline:
@@ -118,6 +135,8 @@ class DetectPipeline:
         model_size: tuple[int, int] = (320, 320),
         region_multiplier: float = 1.35,
         stationary_interval: int = 10,
+        max_regions: int = 8,
+        allowed_labels: frozenset[str] | set[str] | None = None,
     ) -> None:
         self.frame_source = frame_source
         self.motion = motion
@@ -131,6 +150,14 @@ class DetectPipeline:
         # the pre-PR-B behavior. Kept well below the tracker's disappearance
         # budget so a skipped track can never age out between verifications.
         self.stationary_interval = max(0, int(stationary_interval))
+        # Per-frame detector budget (#track-explosion): the worst-case number
+        # of region crops YOLO ever runs on one frame, no matter how many
+        # tracks accumulate. 0 disables (unbounded, the pre-guard behavior).
+        self.max_regions = max(0, int(max_regions))
+        # Labels worth TRACKING. An NVR watching a cluttered desk has no
+        # business confirming tracks for "kite"/"banana" wire false
+        # positives — every phantom is a standing re-verify cost. None = all.
+        self.allowed_labels = frozenset(allowed_labels) if allowed_labels else None
         self._frame_idx = 0
 
     def process_frame(self, frame) -> FrameResult:
@@ -168,9 +195,15 @@ class DetectPipeline:
                 skipped += 1
                 continue
             track_boxes.append(t.box)
+        # Rotate the track-region candidates by frame index so the per-frame
+        # budget round-robins across tracks instead of starving the tail.
+        if self.max_regions > 0 and len(track_boxes) > 1:
+            off = self._frame_idx % len(track_boxes)
+            track_boxes = track_boxes[off:] + track_boxes[:off]
         _t = time.monotonic()
-        regions = select_regions(
-            motion_boxes, track_boxes, frame_shape, self.min_region, self.region_multiplier
+        regions, regions_capped = select_regions(
+            motion_boxes, track_boxes, frame_shape, self.min_region, self.region_multiplier,
+            max_regions=self.max_regions or None,
         )
         stages["region"] = time.monotonic() - _t
 
@@ -186,6 +219,8 @@ class DetectPipeline:
                 crop = crop_and_resize(bgr, region, self.model_size[0], self.model_size[1])
                 raws = self.detector.detect(crop)
                 dets.extend(detections_to_frame(raws, region))
+            if self.allowed_labels is not None:
+                dets = [d for d in dets if d.label in self.allowed_labels]
             dets = nms(dets)
             detect_latency_s = time.monotonic() - _t   # pure detector time (this model)
             stages["detect"] = detect_latency_s
@@ -198,7 +233,7 @@ class DetectPipeline:
         return FrameResult(
             tracks, motion_boxes, regions, False,
             detections=dets, detect_latency_s=detect_latency_s, stage_latency_s=stages,
-            skipped_stationary=skipped,
+            skipped_stationary=skipped, regions_capped=regions_capped,
         )
 
     def run(self, on_tracks: OnTracks | None = None) -> None:

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -69,6 +69,11 @@ class ServiceConfig:
     # #10 Tier-1 dispatch — off unless a KAI-C URL is set; only fires in enforce.
     dispatch_kaic_url: str
     dispatch_task: str
+    # Bounded-load guards (#track-explosion): detector confidence floor.
+    # yolov8n at 0.25 on a cluttered scene (wires, boards) hallucinates
+    # kites/bananas endlessly; each becomes a standing track. 0.4 keeps real
+    # people/vehicles (typically >0.6) while starving the phantom supply.
+    detect_conf: float = 0.4
     visits_enabled: bool = True
 
 
@@ -120,7 +125,19 @@ def config_from_env(env: dict) -> ServiceConfig:
         metrics_port=int(env.get("DETECT_METRICS_PORT", "9109")),
         dispatch_kaic_url=env.get("DETECT_DISPATCH_KAIC_URL", ""),
         dispatch_task=env.get("DETECT_DISPATCH_TASK", "caption"),
+        detect_conf=_env_float(env, "DETECT_CONF", 0.4),
     )
+
+
+def _env_float(env: dict, name: str, default: float) -> float:
+    raw = (env.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning("%s=%r is not a number; using %s", name, raw, default)
+        return default
 
 
 def _gate_factory(cfg: ServiceConfig):
@@ -181,6 +198,7 @@ def _detector_factory(cfg: ServiceConfig):
                 return OnnxYoloDetector(
                     model_path=cfg.onnx_model, input_size=cfg.onnx_input,
                     backend=backend, providers=providers,
+                    conf_threshold=cfg.detect_conf,
                 )
             except Exception:
                 log.warning(

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -34,6 +34,7 @@ from .dispatch import dispatch_escalations
 from .gate import Gate
 from .ffmpeg_presets import HwAccel
 from .metrics import (
+    metrics as _metrics,
     record_frame,
     record_gate,
     record_processing_fps,
@@ -47,6 +48,47 @@ from .pipeline import DetectPipeline, FrameResult
 from .tracking import TrackConfig, Tracker
 
 log = logging.getLogger("detect_pipeline.service")
+
+# Labels Tier-0 TRACKS by default (#track-explosion). yolov8n predicts all 80
+# COCO classes, but an NVR only cares about a handful — and every tracked
+# phantom ("kite" on a wall of wires) is a standing per-frame re-verify cost.
+# Frigate ships `person`-only for the same reason; we default a little wider.
+# Override with DETECT_LABELS (comma-separated); "all" tracks everything.
+DEFAULT_TRACK_LABELS = "person,car,truck,bus,motorcycle,bicycle,cat,dog"
+
+
+def _env_int(name: str, default: int) -> int:
+    import os as _os
+    raw = (_os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning("%s=%r is not an integer; using %d", name, raw, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    import os as _os
+    raw = (_os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning("%s=%r is not a number; using %s", name, raw, default)
+        return default
+
+
+def _env_labels(name: str, default_csv: str) -> frozenset[str] | None:
+    """Parse a comma-separated label allowlist; "all"/"*" → None (no filter)."""
+    import os as _os
+    raw = (_os.environ.get(name) or "").strip() or default_csv
+    if raw.lower() in ("all", "*"):
+        return None
+    labels = frozenset(p.strip().lower() for p in raw.split(",") if p.strip())
+    return labels or None
 
 
 @dataclass(frozen=True)
@@ -173,18 +215,18 @@ class CameraWorker:
         from .events_poster import VisitLifecycle
         lifecycle = VisitLifecycle(self.spec.camera_id)
         motion = MotionDetector((h, w), MotionConfig())
-        tracker = Tracker((h, w), TrackConfig(fps=self.spec.fps))
-        import os as _os
-        try:
-            _stationary_interval = int(_os.environ.get("DETECT_STATIONARY_INTERVAL", "10"))
-        except ValueError:
-            log.warning("DETECT_STATIONARY_INTERVAL=%r is not an integer; using 10",
-                        _os.environ.get("DETECT_STATIONARY_INTERVAL"))
-            _stationary_interval = 10
+        tracker = Tracker((h, w), TrackConfig(
+            fps=self.spec.fps,
+            max_tracks=_env_int("DETECT_MAX_TRACKS", 50),
+            coast_ttl_seconds=float(_env_int("DETECT_TRACK_TTL", 300)),
+            min_spawn_score=_env_float("DETECT_MIN_SPAWN_SCORE", 0.5),
+        ))
         pipe = DetectPipeline(
             None, motion, self.detector, tracker,
             model_size=(self.model_size, self.model_size),
-            stationary_interval=_stationary_interval,
+            stationary_interval=_env_int("DETECT_STATIONARY_INTERVAL", 10),
+            max_regions=_env_int("DETECT_MAX_REGIONS", 8),
+            allowed_labels=_env_labels("DETECT_LABELS", DEFAULT_TRACK_LABELS),
         )
         log.info("tier0 %s: started (%dx%d)", self.spec.camera_id, w, h)
         record_worker_state(self.spec.camera_id, True, target_fps=self.spec.fps)
@@ -209,6 +251,12 @@ class CameraWorker:
                     detector_latency_s=getattr(result, "detect_latency_s", None),
                     stage_latency_s=getattr(result, "stage_latency_s", None),
                     model=self.model_id,
+                )
+                # Bounded-load observability: spawns refused by the track
+                # cap / spawn-score floor (monotonic; exported as a gauge).
+                _metrics.gauge(
+                    "tier0_track_spawns_dropped", float(tracker.spawns_dropped),
+                    {"camera": self.spec.camera_id},
                 )
                 # Retain each track's best crop for on-demand fetch (best-frame
                 # store) — cheap: a reference, encoded lazily only if requested.

--- a/detect-pipeline/detect_pipeline/tracking.py
+++ b/detect-pipeline/detect_pipeline/tracking.py
@@ -20,6 +20,7 @@ prevents ID churn. Kept dependency-light on purpose.
 from __future__ import annotations
 
 import math
+import time
 from dataclasses import dataclass, field
 from itertools import count
 
@@ -53,6 +54,26 @@ class TrackConfig:
     motionless_iou: float = 0.9
     # motionless frames before a track is considered stationary (Frigate: 50)
     stationary_threshold: int = 50
+    # ── Bounded-load guards (#track-explosion) ─────────────────────────
+    # Hard ceiling on live tracks per camera. A cluttered scene full of
+    # persistent false positives (wires → "kite"/"banana") must not grow the
+    # track list — and with it the per-frame re-verify region count — without
+    # bound. At the cap, new spawns are refused (counted on
+    # ``Tracker.spawns_dropped``); expiry below drains the population.
+    max_tracks: int = 50
+    # Wall-clock TTL: a track not positively MATCHED for this many seconds
+    # expires no matter what, coasting or not. Frame-based miss counting
+    # drains far too slowly when the pipeline is overloaded (the very moment
+    # an explosion needs draining) — wall time doesn't care how slow frames
+    # are. A real object that expires is simply re-detected on the next scan
+    # of its region; cheap churn, bounded state. 0 disables.
+    coast_ttl_seconds: float = 300.0
+    # Minimum detection score to SPAWN a new track (matching an existing
+    # track has no floor beyond the detector's own threshold). Frigate's
+    # min_score/threshold hysteresis: it takes solid evidence to create an
+    # object, weaker evidence to keep following it. 0 preserves the
+    # pre-guard behavior for existing callers/tests.
+    min_spawn_score: float = 0.0
 
     def initialized(self) -> int:
         return self.min_initialized if self.min_initialized is not None else max(1, self.fps // 2)
@@ -77,6 +98,9 @@ class Track:
     confirmed: bool = False
     best: ThumbCandidate | None = None
     stationary_threshold: int = 50
+    # Monotonic timestamp of the last positive match (set at spawn and on
+    # every match) — the coast-TTL expiry anchor.
+    last_matched: float = 0.0
     # BGR crop of the best frame, retained only when the tracker is fed pixels
     # (the Tier-1 gate dispatches THIS on escalation — see gate/dispatch, PR B #10).
     best_crop: object | None = field(default=None, repr=False, compare=False)
@@ -133,11 +157,19 @@ def _crop_bgr(bgr, box: Box):
 class Tracker:
     """Greedy, size-aware multi-object tracker."""
 
-    def __init__(self, frame_shape: tuple[int, int], config: TrackConfig | None = None) -> None:
+    def __init__(
+        self, frame_shape: tuple[int, int], config: TrackConfig | None = None,
+        clock=None,
+    ) -> None:
         self.frame_shape = frame_shape  # (h, w)
         self.config = config or TrackConfig()
         self._tracks: list[Track] = []
         self._ids = count(1)
+        # Injectable monotonic clock (tests); wall time drives coast-TTL expiry.
+        self._clock = clock or time.monotonic
+        # Spawns refused because the track cap or spawn-score floor was hit —
+        # observability for the bounded-load guards (service exports it).
+        self.spawns_dropped = 0
 
     @property
     def tracks(self) -> list[Track]:
@@ -159,6 +191,7 @@ class Tracker:
         # (the default, and every pre-PR-B caller) preserves the original
         # behavior: every unmatched track counts a miss.
         cfg = self.config
+        now = self._clock()
         unmatched_tracks = set(range(len(self._tracks)))
         unmatched_dets = set(range(len(detections)))
 
@@ -175,17 +208,31 @@ class Tracker:
 
         for _dist, ti, di in pairs:
             if ti in unmatched_tracks and di in unmatched_dets:
-                self._match(self._tracks[ti], detections[di], bgr)
+                self._match(self._tracks[ti], detections[di], bgr, now)
                 unmatched_tracks.discard(ti)
                 unmatched_dets.discard(di)
 
-        # unmatched detections -> new tentative tracks
+        # unmatched detections -> new tentative tracks (bounded: the track
+        # cap and the spawn-score floor refuse, never grow without limit)
         for di in unmatched_dets:
-            self._spawn(detections[di], bgr)
+            det = detections[di]
+            if det.score < cfg.min_spawn_score or len(self._tracks) >= cfg.max_tracks:
+                self.spawns_dropped += 1
+                continue
+            self._spawn(det, bgr, now)
 
         # unmatched tracks -> age out (or coast, if never scanned this frame)
         survivors: list[Track] = []
         for ti, tr in enumerate(self._tracks):
+            # Coast-TTL: however it got here — coasting unscanned, surviving
+            # on misses — a track that hasn't been positively matched in
+            # ``coast_ttl_seconds`` of WALL time is gone. This is the drain
+            # that frame-based miss counting can't provide under load.
+            if (
+                cfg.coast_ttl_seconds > 0
+                and (now - tr.last_matched) > cfg.coast_ttl_seconds
+            ):
+                continue
             if ti in unmatched_tracks:
                 tr.age += 1
                 if scanned_regions is not None and not any(
@@ -211,7 +258,7 @@ class Tracker:
         self._tracks = survivors
         return self.tracks
 
-    def _match(self, tr: Track, det: Detection, bgr=None) -> None:
+    def _match(self, tr: Track, det: Detection, bgr=None, now: float | None = None) -> None:
         iou = intersection_over_union(tr.box, det.box)
         if iou >= self.config.motionless_iou:
             tr.motionless_count += 1
@@ -222,17 +269,19 @@ class Tracker:
         tr.hits += 1
         tr.age += 1
         tr.misses = 0
+        tr.last_matched = now if now is not None else self._clock()
         if not tr.confirmed and tr.hits >= self.config.initialized():
             tr.confirmed = True
         self._update_best(tr, det, bgr)
 
-    def _spawn(self, det: Detection, bgr=None) -> None:
+    def _spawn(self, det: Detection, bgr=None, now: float | None = None) -> None:
         tr = Track(
             id=next(self._ids),
             label=det.label,
             box=det.box,
             score=det.score,
             stationary_threshold=self.config.stationary_threshold,
+            last_matched=now if now is not None else self._clock(),
         )
         tr.confirmed = self.config.initialized() <= 1
         self._update_best(tr, det, bgr)

--- a/detect-pipeline/test/test_bounded_load.py
+++ b/detect-pipeline/test/test_bounded_load.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Bounded-load guards (#track-explosion).
+
+Field failure these lock in: a camera on a cluttered desk (wires, boards)
+fed yolov8n-at-0.25 phantoms ("kite" x992, "banana" x168...) that confirmed
+into 181 standing tracks; per-frame re-verification of that population put
+the detector at ~30 s/frame and pinned two cores indefinitely. The pipeline
+must stay bounded no matter what it looks at:
+
+* track cap        — the track list never grows past ``max_tracks``
+* spawn-score floor— weak evidence never creates a track
+* coast TTL        — an unverified track always drains, in WALL time
+* region budget    — the detector never runs more than ``max_regions`` crops
+* label allowlist  — phantom classes are dropped before tracking
+"""
+from __future__ import annotations
+
+from detect_pipeline.detector import RawDetection
+from detect_pipeline.ffmpeg_presets import frame_size_bytes
+from detect_pipeline.frame_source import Frame
+from detect_pipeline.pipeline import DetectPipeline
+from detect_pipeline.tracking import Detection, TrackConfig, Tracker
+
+W, H = 1280, 720
+
+
+# ── tracker bounds ──────────────────────────────────────────────────
+
+def _dets(n: int, score: float = 0.9) -> list[Detection]:
+    """n same-label detections far enough apart to never match each other."""
+    out = []
+    for i in range(n):
+        x = (i % 16) * 80
+        y = (i // 16) * 90
+        out.append(Detection("person", (x, y, x + 40, y + 60), score))
+    return out
+
+
+def test_track_cap_bounds_population():
+    tr = Tracker((H, W), TrackConfig(fps=5, min_initialized=1, max_tracks=10))
+    tr.update(_dets(100))
+    assert len(tr.tracks) <= 10
+    assert tr.spawns_dropped >= 90
+    # and it stays bounded on repeat floods
+    tr.update(_dets(100))
+    assert len(tr.tracks) <= 10
+
+
+def test_min_spawn_score_refuses_weak_evidence():
+    tr = Tracker((H, W), TrackConfig(fps=5, min_initialized=1, min_spawn_score=0.5))
+    tr.update([Detection("person", (0, 0, 40, 60), 0.4)])
+    assert tr.tracks == [] and tr.spawns_dropped == 1
+    tr.update([Detection("person", (200, 0, 240, 60), 0.6)])
+    assert len(tr.tracks) == 1
+
+
+def test_weak_score_still_matches_existing_track():
+    """The floor gates SPAWNING only — hysteresis, not a match filter."""
+    tr = Tracker((H, W), TrackConfig(fps=5, min_initialized=1, min_spawn_score=0.5))
+    tr.update([Detection("person", (0, 0, 40, 60), 0.9)])
+    (t,) = tr.tracks
+    tr.update([Detection("person", (2, 0, 42, 60), 0.35)])   # weak, but same object
+    assert tr.tracks[0].id == t.id and tr.tracks[0].misses == 0
+
+
+def test_coast_ttl_expires_unverified_track_in_wall_time():
+    clk = {"t": 0.0}
+    tr = Tracker(
+        (H, W),
+        TrackConfig(fps=5, min_initialized=1, coast_ttl_seconds=100.0),
+        clock=lambda: clk["t"],
+    )
+    tr.update([Detection("person", (0, 0, 40, 60), 0.9)])
+    # Coasting (nothing scanned its region) keeps it alive within the TTL...
+    clk["t"] = 50.0
+    assert len(tr.update([], scanned_regions=[])) == 1
+    # ...but wall time, not frame count, is the ceiling: past the TTL it dies
+    # even though it never accumulated a single miss.
+    clk["t"] = 150.0
+    assert tr.update([], scanned_regions=[]) == []
+
+
+def test_coast_ttl_spares_recently_matched_tracks():
+    clk = {"t": 0.0}
+    tr = Tracker(
+        (H, W),
+        TrackConfig(fps=5, min_initialized=1, coast_ttl_seconds=100.0),
+        clock=lambda: clk["t"],
+    )
+    tr.update([Detection("person", (0, 0, 40, 60), 0.9)])
+    for t in (60.0, 120.0, 180.0):                 # re-matched before each deadline
+        clk["t"] = t
+        assert len(tr.update([Detection("person", (0, 0, 40, 60), 0.9)])) == 1
+
+
+def test_coast_ttl_zero_disables_expiry():
+    clk = {"t": 0.0}
+    tr = Tracker(
+        (H, W),
+        TrackConfig(fps=5, min_initialized=1, coast_ttl_seconds=0.0),
+        clock=lambda: clk["t"],
+    )
+    tr.update([Detection("person", (0, 0, 40, 60), 0.9)])
+    clk["t"] = 1e9
+    assert len(tr.update([], scanned_regions=[])) == 1
+
+
+# ── pipeline bounds ─────────────────────────────────────────────────
+
+def _frame(seq: int) -> Frame:
+    return Frame(bytes(frame_size_bytes(W, H)), W, H, seq, float(seq))
+
+
+class _ManyBoxMotion:
+    """Five well-separated motion boxes — five distinct region candidates."""
+
+    def detect(self, luma):
+        return [
+            (0, 0, 50, 50), (450, 0, 500, 50), (900, 0, 950, 50),
+            (0, 400, 50, 450), (450, 400, 500, 450),
+        ]
+
+    def is_calibrating(self):
+        return False
+
+
+class _CountingDetector:
+    def __init__(self, raws=None):
+        self.calls = 0
+        self.raws = raws or []
+
+    def detect(self, crop):
+        self.calls += 1
+        return list(self.raws)
+
+
+def test_region_budget_caps_detector_passes():
+    det = _CountingDetector()
+    pipe = DetectPipeline(
+        None, _ManyBoxMotion(), det, Tracker((H, W), TrackConfig(fps=5)),
+        max_regions=2,
+    )
+    result = pipe.process_frame(_frame(1))
+    assert len(result.regions) == 2
+    assert det.calls == 2
+    assert result.regions_capped is True
+
+
+def test_region_budget_zero_is_unbounded():
+    det = _CountingDetector()
+    pipe = DetectPipeline(
+        None, _ManyBoxMotion(), det, Tracker((H, W), TrackConfig(fps=5)),
+        max_regions=0,
+    )
+    result = pipe.process_frame(_frame(1))
+    assert len(result.regions) == 5
+    assert result.regions_capped is False
+
+
+def test_label_allowlist_drops_phantom_classes_before_tracking():
+    det = _CountingDetector(raws=[
+        RawDetection("kite", 0.9, (0.1, 0.1, 0.3, 0.3)),
+        RawDetection("banana", 0.8, (0.6, 0.6, 0.8, 0.8)),
+        RawDetection("person", 0.9, (0.3, 0.3, 0.7, 0.9)),
+    ])
+    tracker = Tracker((H, W), TrackConfig(fps=5, min_initialized=1))
+    pipe = DetectPipeline(
+        None, _ManyBoxMotion(), det, tracker,
+        allowed_labels={"person"},
+    )
+    result = pipe.process_frame(_frame(1))
+    assert {d.label for d in result.detections} == {"person"}
+    assert {t.label for t in tracker.tracks} == {"person"}

--- a/detect-pipeline/test/test_pipeline.py
+++ b/detect-pipeline/test/test_pipeline.py
@@ -56,8 +56,9 @@ def test_nms_suppresses_overlapping_same_label():
 
 def test_select_regions_dedups_overlapping():
     boxes = [(100, 100, 160, 200), (105, 100, 165, 205)]  # near-identical
-    regions = select_regions(boxes, [], (H, W), min_region=320)
+    regions, capped = select_regions(boxes, [], (H, W), min_region=320)
     assert len(regions) == 1                              # collapsed to one region
+    assert capped is False
 
 
 # ── integration ─────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,6 +309,20 @@ services:
       # (staggered per track; motion near the object re-checks immediately).
       # 0 = pre-gating behavior. See .env.example.
       - DETECT_STATIONARY_INTERVAL=${DETECT_STATIONARY_INTERVAL:-10}
+      # Bounded-load guards — keep Tier-0's worst case flat no matter how
+      # cluttered the scene is (see .env.example for the full story):
+      #   DETECT_LABELS       classes worth tracking ("all" = every COCO class)
+      #   DETECT_CONF         detector confidence floor
+      #   DETECT_MAX_REGIONS  detector crops per frame, hard cap (0 = off)
+      #   DETECT_MAX_TRACKS   live tracks per camera, hard cap
+      #   DETECT_TRACK_TTL    seconds an unverified track may live (0 = off)
+      #   DETECT_MIN_SPAWN_SCORE  score needed to CREATE a track
+      - DETECT_LABELS=${DETECT_LABELS:-}
+      - DETECT_CONF=${DETECT_CONF:-}
+      - DETECT_MAX_REGIONS=${DETECT_MAX_REGIONS:-}
+      - DETECT_MAX_TRACKS=${DETECT_MAX_TRACKS:-}
+      - DETECT_TRACK_TTL=${DETECT_TRACK_TTL:-}
+      - DETECT_MIN_SPAWN_SCORE=${DETECT_MIN_SPAWN_SCORE:-}
       - OMP_NUM_THREADS=${DETECT_CV_THREADS:-2}
       # #10 Tier-1 dispatch: empty = off. Set to the KAI-C URL (e.g. http://kai-c:8100)
       # to run the gated model on enforce escalations, governed + audited by KAI-C.


### PR DESCRIPTION
…on budget, track cap + TTL

Field failure: a cluttered desk scene (wires, boards) at conf 0.25 across all 80 COCO classes confirmed 181 phantom tracks (kite x992, banana x168); re-verifying that population cost ~30s of detector per frame and pinned two cores indefinitely. Tier-0 must stay bounded whatever it looks at:

* DETECT_LABELS (default person,car,truck,bus,motorcycle,bicycle,cat,dog) filters detections before tracking; 'all' restores every class.
* DETECT_CONF (default 0.4) detector confidence floor, and DETECT_MIN_SPAWN_SCORE (default 0.5) to create — not match — a track.
* DETECT_MAX_REGIONS (default 8): hard per-frame detector-crop budget; motion first, track re-verifies round-robin; tier0_regions_capped_total.
* DETECT_MAX_TRACKS (default 50) + DETECT_TRACK_TTL (default 300s): track ceiling and wall-clock expiry for never-re-verified tracks (frame-based miss counting stalls exactly when overloaded); tier0_track_spawns_dropped.

Also exports tier0_stationary_skipped_total (gating observability). Ten regression tests lock in the explosion scenario; suite 202 green.