### PR TITLE
fix(camera-agent): cancellable voice turns, mic release, honest TTS f…

### DIFF
--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -608,6 +608,18 @@ def looks_like_noise(transcript: str) -> bool:
     words = norm.split()
     if len(words) <= 2 and all(w in _STT_NOISE_PHRASES for w in words):
         return True
+    # Repetition hallucination: Whisper on sustained background noise loops a
+    # phrase ("I will go to sleep. I will go to sleep. I will go to sleep.").
+    # Real questions almost never repeat the same 3-word run three times or
+    # collapse to a handful of unique words — such a transcript is noise, and
+    # answering it costs a full LLM+VLM turn (the observed failure: phantom
+    # turns keeping the vision model busy while nobody was speaking).
+    if len(words) >= 6:
+        if len(set(words)) / len(words) < 0.4:
+            return True
+        trigrams = [" ".join(words[i:i + 3]) for i in range(len(words) - 2)]
+        if trigrams and max(trigrams.count(t) for t in set(trigrams)) >= 3:
+            return True
     return False
 
 
@@ -4689,6 +4701,12 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
     # Demo-local conversation memory (single user). Kept tiny and turn-text
     # only; reset via POST /reset. A multi-user UI would key this per session.
     demo_history: list[dict[str, str]] = []
+    # The in-flight voice turn, cancellable from /converse/cancel. One slot on
+    # purpose: the demo UI serialises turns (``busy`` gate), so at most one
+    # LLM turn is ever running; Stop must be able to kill it — a 25 s
+    # LLM+VLM turn that can't be abandoned is the "Stop doesn't stop"
+    # complaint in code form.
+    _inflight: dict[str, asyncio.Task | None] = {"turn": None}
     _MAX_HISTORY_TURNS = 8  # 4 user + 4 assistant
 
     @app.post("/reset")
@@ -4886,15 +4904,38 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             # the current moment, not a frame cached seconds ago (a cause of the
             # same answer repeating when the scene has actually changed).
             runtime.context.invalidate_frame_cache()
+            turn = asyncio.create_task(_run_conversation_turn(
+                runtime, demo_history, question, preferred_camera=camera_hint,
+                tool_definitions=runtime.tools_for_tier(
+                    getattr(request.state, "agent_tier", "admin")),
+            ), name="converse-turn")
+            _inflight["turn"] = turn
             try:
-                reply = await _run_conversation_turn(
-                    runtime, demo_history, question, preferred_camera=camera_hint,
-                    tool_definitions=runtime.tools_for_tier(
-                        getattr(request.state, "agent_tier", "admin")),
-                )
+                reply = await turn
+            except asyncio.CancelledError:
+                # Two ways to get here, and they need different handling:
+                #  a) /converse/cancel cancelled THE TURN (user tapped Stop) —
+                #     answer the still-open request with {cancelled: true}.
+                #  b) THIS ENDPOINT was cancelled (client aborted the request /
+                #     disconnected) while the turn task is still running. The
+                #     turn is a separate task, so it would survive as an
+                #     orphan and keep burning the LLM — cancel it here, then
+                #     re-raise so the teardown proceeds. Without this, Stop's
+                #     fetch-abort raced /converse/cancel and could leave the
+                #     turn running to completion.
+                if not turn.done():
+                    turn.cancel()
+                    raise
+                logger.info("converse: turn cancelled by user")
+                timings["total"] = int((_t.perf_counter() - t0) * 1000)
+                return JSONResponse({"transcript": transcript, "reply": "",
+                                     "audio_b64": None, "timings_ms": timings,
+                                     "cancelled": True})
             except Exception:
                 logger.exception("converse: LLM turn failed")
                 return JSONResponse({"error": "assistant failed"}, status_code=502)
+            finally:
+                _inflight["turn"] = None
         t3 = _mark("llm", t2)
         logger.info("converse: reply=%r", reply[:160])
 
@@ -4904,14 +4945,27 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             demo_history.append({"role": "assistant", "content": reply})
             del demo_history[:-_MAX_HISTORY_TURNS]
 
-        # 4) Synthesise the reply.
+        # 4) Synthesise the reply. One retry (a transient 503 from a
+        #    just-restarted / briefly starved Piper adapter shouldn't mute a
+        #    whole turn); a persistent failure is REPORTED to the UI via
+        #    ``tts_error`` instead of silently degrading to text-only.
         audio_b64 = None
-        try:
-            audio = await runtime.piper.synthesize(reply)
-            if audio:
-                audio_b64 = base64.b64encode(audio).decode("ascii")
-        except Exception:
-            logger.exception("converse: TTS failed")  # text still returned
+        tts_error = False
+        for attempt in (1, 2):
+            try:
+                audio = await runtime.piper.synthesize(reply)
+                if audio:
+                    audio_b64 = base64.b64encode(audio).decode("ascii")
+                break
+            except Exception:
+                if attempt == 1:
+                    logger.warning("converse: TTS failed; retrying once")
+                    await asyncio.sleep(0.4)
+                else:
+                    tts_error = True
+                    logger.exception(
+                        "converse: TTS failed after retry — check the piper "
+                        "adapter (docker logs, /health); text-only reply")
         _mark("tts", t3)
         timings["total"] = int((_t.perf_counter() - t0) * 1000)
         # Log the per-stage breakdown so a slow turn can be diagnosed straight
@@ -4924,7 +4978,18 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             "cameras_used": list(runtime.tools.last_cameras_used),
             "frames": _frames_for(runtime),
             "timings_ms": timings, "invoked": True, "armed": armed,
+            "tts_error": tts_error,
         })
+
+    @app.post("/converse/cancel")
+    async def _converse_cancel() -> JSONResponse:
+        """Abandon the in-flight voice turn (the demo's Stop while thinking).
+        Idempotent: cancelling when nothing is running is a no-op."""
+        turn = _inflight.get("turn")
+        if turn is not None and not turn.done():
+            turn.cancel()
+            return JSONResponse({"cancelled": True})
+        return JSONResponse({"cancelled": False})
 
     @app.websocket("/updates")
     async def _updates_ws(websocket: WebSocket) -> None:

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -113,6 +113,9 @@
     @keyframes orbpulse{0%,100%{box-shadow:0 0 0 1px rgba(94,179,246,0.55),0 0 46px rgba(94,179,246,0.4)}50%{box-shadow:0 0 0 1px rgba(94,179,246,0.7),0 0 72px rgba(94,179,246,0.6)}}
     .ram .mouth{fill:var(--accent); opacity:0; transition:opacity 0.15s;}
     .ram.speaking .mouth{opacity:0.92;} .ram.speaking .iris{opacity:0.85;}
+    .wakeopt{display:inline-flex; align-items:center; gap:0.35rem; font-size:0.74rem; color:var(--muted);
+      margin-top:0.3rem; cursor:pointer; user-select:none;}
+    .wakeopt input{accent-color:var(--accent);}
     .micdot{display:inline-flex; align-items:center; gap:0.3rem; font-size:0.72rem; color:var(--danger); margin-top:0.25rem;}
     .micdot::before{content:""; width:0.5rem; height:0.5rem; border-radius:50%; background:var(--danger); animation:blink 1.2s steps(2,start) infinite;}
 
@@ -446,7 +449,7 @@
        show. The body class is set once in loadAgent(). */
     body.mode-voice .askrow, body.mode-voice #camAsk{display:none !important;}
     body.mode-text #talk, body.mode-text .voicebar, body.mode-text #micdot,
-    body.mode-text #camTalk{display:none !important;}
+    body.mode-text #wakeOpt, body.mode-text #camTalk{display:none !important;}
     body.mode-voice .log:empty::after{content:"Ask your cameras anything — tap Talk and speak.";}
     body.mode-text .log:empty::after{content:"Ask your cameras anything — type your question below.";}
   </style>
@@ -475,6 +478,8 @@
             <div>
               <div class="titlerow"><h1 id="title"><span class="wm-open">Open</span><span class="wm-nvr">NVR</span> Agent</h1></div>
               <p class="lede" id="lede">Tap <strong>Talk</strong> and speak — it listens and answers aloud, tap Stop when done.</p>
+              <label class="wakeopt" id="wakeOpt" title="When on, the agent only answers utterances that start with its name — side conversations are ignored. OFF by default: name matching depends on STT hearing the name right, and a missed match means a real question gets ignored.">
+                <input type="checkbox" id="wakeReq"> only answer “Hey <span id="wakeName">agent</span>…”</label>
               <div class="micdot" id="micdot" hidden>mic live</div>
             </div>
           </div>
@@ -800,7 +805,7 @@
     const alarmbarEl=$("alarmbar"), alarmTextEl=$("alarmText"), silenceBtn=$("silence");
     const alarmListEl=$("alarmList"), monitorListEl=$("monitorList"), taskListEl=$("taskList"), reportListEl=$("reportList");
     const ledeEl=$("lede");
-    const mouthEl=$("mouth"), micdotEl=$("micdot");
+    const mouthEl=$("mouth"), micdotEl=$("micdot"), wakeReqEl=$("wakeReq");
     // Inline SVG icons (no webfont, no external assets — works fully offline).
     const IC={
       mic:'<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="11" rx="3"/><path d="M5 10a7 7 0 0 0 14 0"/><line x1="12" y1="17" x2="12" y2="21"/></svg>',
@@ -821,6 +826,9 @@
     let mediaStream=null, audioCtx=null, analyser=null, floatBuf=null;
     let recorder=null, chunks=[];
     let sessionActive=false, capturing=false, speaking=false, busy=false, alarmRinging=false;
+    // Turn lifecycle: a generation counter + AbortController let Stop abandon
+    // an in-flight /converse — the reply that eventually lands is discarded.
+    let inflightCtl=null, turnGen=0, armedUntil=0, ttsWarned=false;
     let loudFrames=0, captureStart=0, lastVoice=0, lastActivity=0;
     let vadTimer=null, pollTimer=null, alarmTimer=null, workingTimer=null, introPlayed=false;
     const knownTasks={}, seenNotes={}, seenAlarmEvents={}, seenReports={};
@@ -989,6 +997,8 @@
       window._ringDefaults=a.ring_defaults||{};
       // The card greets with the AGENT'S configured name (/agent is an
       // open endpoint precisely so the gate can be personal pre-login).
+      window._agentName=a.name||"agent";
+      { const wn=$("wakeName"); if(wn) wn.textContent=window._agentName; }
       if(a.name){ const ln=$("loginAgentLine");
         if(ln){ ln.innerHTML="Sign in with your OpenNVR account to talk to <b></b>";
           ln.querySelector("b").textContent=a.name; } }
@@ -1533,19 +1543,35 @@
 
     async function onUtterance(){ const blob=new Blob(chunks,{type:recorder.mimeType||"audio/webm"});
       if(blob.size<1200){ if(sessionActive){setAvatar("listening");setStatus("Listening… speak your question.","active");} return; }
-      busy=true;
-      try{ // wake=0 → the session is the addressing; every utterance is answered.
-        const url="/converse?camera="+encodeURIComponent(cameraParam())+"&wake=0";
-        const resp=await fetch(url,{method:"POST",headers:{"Content-Type":"application/octet-stream"},body:blob});
+      busy=true; const gen=++turnGen; inflightCtl=new AbortController();
+      setAvatar("thinking"); setStatus("Thinking… tap Stop to cancel.","active");
+      try{
+        // Addressing: with "require my name" ON the server's wake-word gate
+        // decides whether this utterance was for the agent (side chatter and
+        // TV audio are ignored). A bare "Hey <name>" ARMS it: the next
+        // utterance within 20 s is answered without the name.
+        const wantWake = wakeReqEl && wakeReqEl.checked && Date.now()>armedUntil;
+        const url="/converse?camera="+encodeURIComponent(cameraParam())+"&wake="+(wantWake?"1":"0");
+        const resp=await fetch(url,{method:"POST",headers:{"Content-Type":"application/octet-stream"},body:blob,signal:inflightCtl.signal});
+        if(gen!==turnGen) return;                       // stopped while waiting — discard
         if(!resp.ok){const e=await resp.json().catch(()=>({}));throw new Error(e.error||("HTTP "+resp.status));}
         const data=await resp.json();
+        if(gen!==turnGen || data.cancelled) return;     // stopped mid-turn — discard
+        if(data.invoked===false){                       // heard, but not addressed to the agent
+          if(sessionActive){ setAvatar("listening");
+            setStatus(`Heard you, but you didn't say my name — start with “Hey ${window._agentName||"agent"}…”`,"active"); }
+          return; }
         if(!data.transcript){ if(sessionActive){setAvatar("listening");setStatus("Didn't catch that — go ahead.","active");} return; }
         addMsg(data.transcript,"user"); lastActivity=performance.now(); showWorking(data.cameras_used); showLatency(data.timings_ms);
+        if(data.armed) armedUntil=Date.now()+20000;     // "Yes?" — next utterance needs no name
         if(data.reply) addMsg(data.reply,"agent",data.frames);
-        if(data.audio_b64){ speaking=true; setAvatar("speaking"); await speak(data.audio_b64); speaking=false; }
+        if(data.reply && !data.audio_b64 && data.tts_error && !ttsWarned){ ttsWarned=true;
+          addMsg("🔇 Voice replies are unavailable — the speech (Piper) adapter isn't responding, so replies are text-only until it recovers. Check: docker logs opennvr_piper_adapter","sys"); }
+        if(data.audio_b64 && gen===turnGen){ speaking=true; setAvatar("speaking"); await speak(data.audio_b64); speaking=false; }
         if(sessionActive){ setAvatar("listening"); setStatus("Listening… ask a follow-up, or tap Stop.","active"); }
-      }catch(err){ addMsg("Request failed: "+err.message,"sys"); if(sessionActive){setAvatar("listening");setStatus("Error: "+err.message,"error");} }
-      finally{ busy=false; lastActivity=performance.now(); }
+      }catch(err){ if(gen!==turnGen || err.name==="AbortError") return;  // user cancelled — not an error
+        addMsg("Request failed: "+err.message,"sys"); if(sessionActive){setAvatar("listening");setStatus("Error: "+err.message,"error");} }
+      finally{ if(gen===turnGen){ busy=false; inflightCtl=null; } lastActivity=performance.now(); }
     }
 
     // ── listening session ──
@@ -1568,7 +1594,24 @@
     }
     function endSession(){ sessionActive=false; if(vadTimer){clearInterval(vadTimer);vadTimer=null;} if(capturing)stopCapture();
       if(levelRAF){cancelAnimationFrame(levelRAF);levelRAF=null;} talkBtn.style.boxShadow="";
-      stopSpeaking(); micdotEl.hidden=true; talkBtn.classList.remove("listening"); setAvatar("idle"); }
+      stopSpeaking(); micdotEl.hidden=true; talkBtn.classList.remove("listening"); setAvatar("idle");
+      // Abandon any in-flight turn: drop its eventual reply client-side
+      // (generation bump), abort the request, and tell the server to stop
+      // burning the LLM/VLM on an answer nobody is waiting for.
+      cancelTurn();
+      // RELEASE the microphone. Keeping the stream open after Stop leaves the
+      // browser/OS mic indicator on and the room audible to the page — "it
+      // keeps listening" — even though VAD stopped. ensureMic() reopens it on
+      // the next session.
+      if(mediaStream){ try{ mediaStream.getTracks().forEach(t=>t.stop()); }catch{}
+        mediaStream=null; analyser=null; } }
+    function cancelTurn(){ turnGen++;
+      // Server cancel FIRST, then abort: aborting first tears the endpoint
+      // down, which clears its in-flight slot — the cancel that follows
+      // would find nothing and the LLM turn could run on as an orphan (the
+      // server also guards this, but don't rely on the race going our way).
+      if(busy){ fetch("/converse/cancel",{method:"POST"}).catch(()=>{}); busy=false; }
+      if(inflightCtl){ try{ inflightCtl.abort(); }catch{} inflightCtl=null; } }
     function stopSession(){ endSession(); talkBtn.innerHTML=IC.mic+" Talk"; setStatus("Stopped. Tap Talk to start again."); }
     function pauseForIdle(){ endSession(); talkBtn.innerHTML=IC.mic+" Talk";
       setStatus("Stopped listening after a quiet spell. Tap Talk to resume.");
@@ -1703,9 +1746,13 @@
       if(btn.dataset.ring) body.ring=btn.dataset.ring; addAlarm(body); }));
     $("askBtn").addEventListener("click", ask);
     $("askInput").addEventListener("keydown",(e)=>{ if(e.key==="Enter") ask(); });
-    // Click Talk to start/stop the listening session.
+    // Click Talk to start/stop the listening session. Stop must ALWAYS work —
+    // especially while the agent is thinking (stopSession → endSession →
+    // cancelTurn aborts the in-flight request and tells the server to stop).
+    // The old `if(busy&&sessionActive)return;` made Stop a no-op during the
+    // longest, most cancel-worthy moment of a turn.
     talkBtn.addEventListener("click",()=>{ ensureOutputAudio();
-      if(busy&&sessionActive)return; if(sessionActive)stopSession(); else startSession(); });
+      if(sessionActive)stopSession(); else startSession(); });
     resetBtn.addEventListener("click",async()=>{ stopSpeaking(); clearPin(); try{ await fetch("/reset",{method:"POST"}); logEl.innerHTML=""; addMsg("Conversation reset.","sys"); }catch{} });
 
     async function loadNotify(){

--- a/examples/camera-agent/tests/test_noise_filter.py
+++ b/examples/camera-agent/tests/test_noise_filter.py
@@ -25,11 +25,28 @@ def test_noise_is_filtered(text):
 
 
 @pytest.mark.parametrize("text", [
+    # Repetition hallucinations: Whisper looping a phrase over sustained
+    # background noise (observed live: each one cost a full LLM+VLM turn).
+    "Yes, I will do it. Okay. So, you have to do this. Yes, I will do it. "
+    "You come here. I will do it. You come here. I will do it. I will do it. "
+    "I will not go to bed. I will go to sleep. I will go to sleep. "
+    "I will go to sleep.",
+    "I will go to sleep. I will go to sleep. I will go to sleep.",
+    "okay okay okay okay okay okay okay okay",
+])
+def test_repetition_hallucinations_are_filtered(text):
+    assert looks_like_noise(text) is True
+
+
+@pytest.mark.parametrize("text", [
     "how many people are at the door",
     "is anyone in the kitchen?",
     "sound a fire alarm if you see smoke",
     "what's happening on the driveway",
     "count the cars",
+    # Long real sentences with some repeated words must NOT be dropped.
+    "check the front door camera and the back door camera and tell me if "
+    "there is a person at either door right now",
 ])
 def test_real_questions_pass(text):
     assert looks_like_noise(text) is False

--- a/examples/camera-agent/tests/test_voice_turn_ux.py
+++ b/examples/camera-agent/tests/test_voice_turn_ux.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Voice turn lifecycle UX: cancellable turns and honest TTS failure.
+
+The demo's Stop button must be able to abandon a 25 s LLM+VLM turn
+(``/converse/cancel``), and a dead Piper adapter must be REPORTED
+(``tts_error``) instead of silently degrading every reply to text-only —
+the field complaint was "the text comes back but no speech, and nothing
+says why"."""
+from __future__ import annotations
+
+import pytest
+
+from camera_agent import AppConfig, CameraAgentRuntime, build_app
+from context import CameraSpec
+from fastapi.testclient import TestClient
+
+
+def _runtime():
+    cfg = AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+                    wake_word_required=False,
+                    cameras=[CameraSpec(camera_id="cam1", frame_url="http://x/1.jpg", role="r")])
+    return CameraAgentRuntime(cfg)
+
+
+def _stub_stt(monkeypatch, rt, text="what do you see"):
+    import camera_agent as ca
+
+    async def fake_transcribe(_wav):
+        return text
+    monkeypatch.setattr(rt.whisper, "transcribe", fake_transcribe)
+    monkeypatch.setattr(ca, "_transcode_to_wav16k", lambda b: b"RIFFwav")
+
+
+def test_cancel_with_nothing_in_flight_is_a_noop():
+    client = TestClient(build_app(_runtime()))
+    assert client.post("/converse/cancel").json() == {"cancelled": False}
+
+
+def test_tts_failure_is_reported_not_silent(monkeypatch):
+    """Piper down on every attempt → reply text intact + tts_error=True."""
+    rt = _runtime()
+    _stub_stt(monkeypatch, rt)
+    import camera_agent as ca
+
+    async def fake_turn(*a, **k):
+        return "a person at the door"
+    monkeypatch.setattr(ca, "_run_conversation_turn", fake_turn)
+
+    calls = {"n": 0}
+
+    async def broken_synth(_t):
+        calls["n"] += 1
+        raise RuntimeError("503 from piper")
+    monkeypatch.setattr(rt.piper, "synthesize", broken_synth)
+
+    data = TestClient(build_app(rt)).post(
+        "/converse?camera=all&wake=0", content=b"fakeaudio",
+        headers={"Content-Type": "application/octet-stream"}).json()
+    assert data["reply"] == "a person at the door"   # text still delivered
+    assert data["audio_b64"] is None
+    assert data["tts_error"] is True                 # ...and the UI is told why
+    assert calls["n"] == 2                           # one retry before giving up
+
+
+def test_tts_transient_failure_recovers_on_retry(monkeypatch):
+    rt = _runtime()
+    _stub_stt(monkeypatch, rt)
+    import camera_agent as ca
+
+    async def fake_turn(*a, **k):
+        return "all quiet"
+    monkeypatch.setattr(ca, "_run_conversation_turn", fake_turn)
+
+    calls = {"n": 0}
+
+    async def flaky_synth(_t):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient 503")
+        return b"RIFFfakewav"
+    monkeypatch.setattr(rt.piper, "synthesize", flaky_synth)
+
+    data = TestClient(build_app(rt)).post(
+        "/converse?camera=all&wake=0", content=b"fakeaudio",
+        headers={"Content-Type": "application/octet-stream"}).json()
+    assert data["audio_b64"]                          # second attempt delivered audio
+    assert data["tts_error"] is False
+
+
+def test_cancelled_turn_returns_cancelled_payload(monkeypatch):
+    """A turn cancelled mid-LLM returns {cancelled: true}, no reply, no TTS."""
+    rt = _runtime()
+    _stub_stt(monkeypatch, rt)
+    import asyncio
+
+    import camera_agent as ca
+
+    async def slow_turn(*a, **k):
+        # Cancel ourselves the way /converse/cancel would: cancel the current
+        # task while it is the registered in-flight turn.
+        asyncio.current_task().cancel()
+        await asyncio.sleep(30)
+        return "never"
+    monkeypatch.setattr(ca, "_run_conversation_turn", slow_turn)
+
+    synth = {"called": False}
+
+    async def fake_synth(_t):
+        synth["called"] = True
+        return b"wav"
+    monkeypatch.setattr(rt.piper, "synthesize", fake_synth)
+
+    data = TestClient(build_app(rt)).post(
+        "/converse?camera=all&wake=0", content=b"fakeaudio",
+        headers={"Content-Type": "application/octet-stream"}).json()
+    assert data.get("cancelled") is True
+    assert data["reply"] == ""
+    assert synth["called"] is False                   # no TTS for a dead turn


### PR DESCRIPTION
…ailure, hallucination gate

Four field-reported voice UX failures, one root each:

* Whisper repetition hallucinations passed the noise filter and cost a full LLM+VLM turn each ('I will go to sleep. I will go to sleep. ...'). looks_like_noise now drops transcripts that repeat a trigram 3x or collapse below 40% unique words — the main guard against the agent answering speech that was never addressed to it.

* Stop didn't stop: the Talk handler was a no-op while busy (if(busy&&sessionActive)return), the in-flight /converse was never aborted, and the reply still spoke after Stop. Stop now always works: AbortController + turn-generation guard client-side, and a new POST /converse/cancel that cancels the in-flight LLM task server-side (Ollama aborts generation on teardown — the burn actually stops).

* 'It keeps listening': endSession never released the microphone stream, so the browser/OS mic indicator stayed live after Stop. The stream's tracks are now stopped and reacquired on the next session.

* Speech replies silently missing: a failing Piper adapter degraded every turn to text-only with no signal. TTS now retries once and the response carries tts_error; the demo surfaces a one-time 'voice replies unavailable' notice with the diagnostic command.

Also: an OFF-by-default 'only answer "Hey <name>"' toggle exposing the server's existing wake-word gate for noisy multi-person rooms — off because STT-dependent name matching can reject real questions; the repetition gate above is the default protection instead. A bare wake arms a 20 s follow-up window when the toggle is on.

Thinking state is now explicit in the UI (avatar + status + 'tap Stop to cancel'). 8 new tests; camera-agent suite 590 green.