### PR TITLE
fix(apps): occupancy-counting and footage-search see nothing on a sto…

### DIFF
--- a/detect-pipeline/detect_pipeline/bus.py
+++ b/detect-pipeline/detect_pipeline/bus.py
@@ -13,6 +13,7 @@ entrypoint, keeping this pure and testable.
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Callable
 
 from .pipeline import FrameResult
@@ -34,7 +35,14 @@ def build_payload(camera_id: str, result: FrameResult, frame) -> dict:
         "adapter": ADAPTER,
         "camera_id": camera_id,
         "seq": getattr(frame, "seq", None),
+        # ``ts`` is the frame's time.monotonic() reading — fine for measuring
+        # intervals, USELESS as a date: it counts from an arbitrary origin
+        # (typically boot), so a consumer storing it as a timestamp would file
+        # every event near 1970. ``wall_ts`` is the epoch-seconds stamp
+        # consumers need to answer "what happened at 3am"; both ship so
+        # nothing that already reads ``ts`` changes meaning.
         "ts": getattr(frame, "ts", None),
+        "wall_ts": time.time(),
         # Frame size lets consumers normalize the pixel-space track boxes into
         # the contract's NormalizedBBox (x/y/w/h in 0-1) — see the App SDK's
         # tier0_to_detections bridge.
@@ -96,7 +104,14 @@ def build_gate_payload(camera_id: str, result, frame) -> dict:
         "adapter": ADAPTER,
         "camera_id": camera_id,
         "seq": getattr(frame, "seq", None),
+        # ``ts`` is the frame's time.monotonic() reading — fine for measuring
+        # intervals, USELESS as a date: it counts from an arbitrary origin
+        # (typically boot), so a consumer storing it as a timestamp would file
+        # every event near 1970. ``wall_ts`` is the epoch-seconds stamp
+        # consumers need to answer "what happened at 3am"; both ship so
+        # nothing that already reads ``ts`` changes meaning.
         "ts": getattr(frame, "ts", None),
+        "wall_ts": time.time(),
         # Frame size lets consumers normalize the pixel-space track boxes into
         # the contract's NormalizedBBox (x/y/w/h in 0-1) — see the App SDK's
         # tier0_to_detections bridge.

--- a/docs/tier0-consumption.md
+++ b/docs/tier0-consumption.md
@@ -1,0 +1,110 @@
+# Consuming Tier-0 from an app
+
+A default OpenNVR install runs the **detect-pipeline** (Tier-0) and no
+per-frame adapter loop. That makes Tier-0 the *only* detection stream on
+the bus out of the box — so an app that ignores it sees nothing, forever,
+on a stock system. This page is how an app consumes it.
+
+## The two event shapes
+
+Adapter events (what apps were originally written for) and Tier-0 events
+are deliberately different, and the difference is why an app can look
+"installed and healthy" while doing nothing:
+
+```jsonc
+// adapter, e.g. opennvr.inference.yolov8.cam1.completed
+{ "camera_id": "cam1", "completed_at": "2026-08-21T05:16:08Z",
+  "result": { "detections": [ { "label": "person",
+                                "bbox": {"x":0.4,"y":0.4,"w":0.1,"h":0.1} } ] } }
+
+// Tier-0, opennvr.inference.tier0.cam1.completed
+{ "schema": "opennvr.tier0.v1", "adapter": "tier0", "camera_id": "cam1",
+  "seq": 41, "ts": 1234.5, "wall_ts": 1755700000.0,
+  "frame": { "w": 1920, "h": 1080 }, "calibrating": false,
+  "tracks": [ { "id": 3, "label": "person", "score": 0.91,
+                "box": [768, 432, 960, 540],     // PIXELS, not normalised
+                "stationary": false, "best": true } ] }
+```
+
+Three traps live in that payload:
+
+* **`tracks`, not `result.detections`.** There is no `result` block at all.
+* **Pixel boxes.** `box` is `[x1, y1, x2, y2]` in frame pixels; the
+  contract's `bbox` is normalised 0–1. `frame.w/h` is there to convert.
+* **`ts` is `time.monotonic()`, not a date.** It counts from an arbitrary
+  origin (typically boot). Store it as a timestamp and every record lands
+  near 1970. Use **`wall_ts`** (epoch seconds) for anything time-related.
+
+## Detector apps: one flag
+
+For apps built on the SDK's `Detector`, the bridge is built in — turn it
+on and `on_detections` receives normal contract-shaped detections
+(`label`, `score`, `bbox`, plus `track_id`, `stationary`, `best`):
+
+```yaml
+# config.yml
+subject_pattern: "opennvr.inference.tier0.>"   # Tier-0 only
+consume_tier0: true
+```
+
+Add the field to the app's config dataclass and parse it (the SDK reads
+`getattr(config, "consume_tier0", False)`, so a flag the config object
+doesn't carry is silently ignored):
+
+```python
+@dataclass
+class AppConfig:
+    ...
+    consume_tier0: bool = True
+
+# in load_config(...)
+consume_tier0=bool(raw.get("consume_tier0", True)),
+```
+
+**Why the narrow subject.** With `opennvr.inference.>` *and* the flag on,
+an app that later gains a heavy adapter processes the same object twice —
+once from Tier-0, once from the adapter — and fires double alerts.
+Subscribing to `opennvr.inference.tier0.>` makes that impossible by
+construction. Widen it (and accept the dedup problem) only when you
+actually want adapter events too.
+
+## Whole-event apps
+
+An app that overrides `handle_event` (an indexer, a relay) bypasses the
+flag entirely and receives Tier-0 events whether or not it understands
+them — so it must parse `tracks` itself:
+
+```python
+labels = [d["label"] for d in (event.get("result") or {}).get("detections", [])]
+if not labels:                                  # Tier-0 shape
+    labels = list(dict.fromkeys(
+        str(t["label"]) for t in event.get("tracks") or [] if t.get("label")))
+```
+
+Use `opennvr_app_sdk.tier0.tier0_to_detections(event)` instead of
+hand-rolling the bbox maths — it does the pixel→normalised conversion and
+skips malformed tracks.
+
+## What Tier-0 gives you for free
+
+Beyond costing nothing (one detector, N subscribers — versus every app
+driving its own inference stream):
+
+* **`track_id`** — stable across frames, so "the same person" is free.
+* **`stationary`** — the object hasn't moved for ~10 s. Dwell and
+  abandoned-object rules can read it instead of re-deriving it.
+* **`best: true`** — Tier-0 retained the sharpest crop for that track and
+  serves it at `<pipeline>/best_frame?camera=&track=`. Run an expensive
+  model on *that*, never an arbitrary live grab.
+
+## Checklist when an app indexes/alerts nothing
+
+1. Is `consume_tier0` on the config **object**, not just the YAML?
+2. Does `subject_pattern` match `opennvr.inference.tier0.>`?
+3. Do the configured `camera_id`s match what Tier-0 publishes? The
+   classic failure is `cam-1` in config vs `cam1` on the bus — apps
+   should log once per unknown camera id rather than counting nothing in
+   silence.
+4. Is anything being published at all? Tier-0 skips empty frames by
+   default, so a still scene is legitimately quiet:
+   `docker compose logs detect-pipeline | grep published`.

--- a/examples/footage-search/store.py
+++ b/examples/footage-search/store.py
@@ -221,6 +221,23 @@ def keyframe_from_event(event: dict) -> Keyframe | None:
                 if lab:
                     labels.append(str(lab))
 
+    # Tier-0 events carry their objects as top-level ``tracks`` and have no
+    # ``result`` block at all — the always-on detector is the ONLY stream a
+    # default install produces, so without this branch the index stays
+    # permanently empty on a stock system. Labels are de-duplicated: one
+    # frame with four people is searchable as "person", not "person" x4.
+    if not labels:
+        tracks = event.get("tracks")
+        if isinstance(tracks, list):
+            seen: set[str] = set()
+            for tr in tracks:
+                if not isinstance(tr, dict):
+                    continue
+                lab = tr.get("label")
+                if lab and str(lab) not in seen:
+                    seen.add(str(lab))
+                    labels.append(str(lab))
+
     caption = result.get("caption")
     caption = str(caption).strip() if isinstance(caption, str) else ""
 
@@ -229,7 +246,11 @@ def keyframe_from_event(event: dict) -> Keyframe | None:
 
     return Keyframe(
         camera_id=str(camera_id),
-        ts=_event_ts(event.get("completed_at")),
+        # Tier-0 stamps the FRAME's epoch seconds in ``ts``; adapter events
+        # carry an ISO ``completed_at``. Prefer whichever the event has so a
+        # search for "around 3am" lands on when it was SEEN, not when it was
+        # indexed.
+        ts=_event_ts(event.get("completed_at"), event.get("wall_ts")),
         correlation_id=str(event.get("correlation_id") or ""),
         adapter=str(event.get("adapter") or "unknown"),
         labels=labels,
@@ -237,7 +258,16 @@ def keyframe_from_event(event: dict) -> Keyframe | None:
     )
 
 
-def _event_ts(raw: object) -> float:
+def _event_ts(raw: object, wall_ts: object = None) -> float:
+    """Best available WALL-CLOCK stamp for an event.
+
+    ``raw`` is an adapter event's ISO ``completed_at``; ``wall_ts`` is
+    Tier-0's epoch-seconds stamp. Tier-0's other time field (``ts``) is a
+    ``time.monotonic()`` reading and is deliberately NOT accepted here —
+    storing it would date every keyframe from the machine's boot origin,
+    breaking every time-window search. Falls back to now: indexing happens
+    within milliseconds of the event.
+    """
     import datetime as _dt
     if isinstance(raw, str):
         try:
@@ -247,4 +277,8 @@ def _event_ts(raw: object) -> float:
             return ts.timestamp()
         except ValueError:
             pass
+    # Epoch seconds (Tier-0's wall_ts). Bounded below by 2001-01-01: a
+    # smaller number is a monotonic reading that leaked in, not a date.
+    if isinstance(wall_ts, (int, float)) and wall_ts > 978_307_200:
+        return float(wall_ts)
     return time.time()

--- a/examples/footage-search/tests/test_footage_search.py
+++ b/examples/footage-search/tests/test_footage_search.py
@@ -169,3 +169,54 @@ def test_search_action_validates_params():
         indexer.on_action("search", {"query": "x", "limit": 0})
     with _pytest.raises(KeyError):
         indexer.on_action("enroll-face", {})
+
+
+# ── Tier-0 events (the always-on detector) ─────────────────────────
+#
+# A stock OpenNVR install runs detect-pipeline and no per-frame adapter
+# loop, so Tier-0 events are the ONLY thing on the bus. They carry
+# top-level ``tracks`` and NO ``result`` block — the shape the indexer
+# used to walk straight past, leaving the index permanently empty.
+
+def _tier0_event(labels, *, camera_id="cam-1", wall_ts=1_755_700_000.0):
+    return {
+        "schema": "opennvr.tier0.v1",
+        "adapter": "tier0",
+        "camera_id": camera_id,
+        "seq": 7,
+        "ts": 1234.5,            # time.monotonic() — NOT a date
+        "wall_ts": wall_ts,
+        "frame": {"w": 1920, "h": 1080},
+        "tracks": [
+            {"id": i + 1, "label": lab, "score": 0.9,
+             "box": [10, 10, 50, 50], "stationary": False, "best": True}
+            for i, lab in enumerate(labels)
+        ],
+    }
+
+
+def test_tier0_tracks_are_indexed_with_deduped_labels():
+    kf = keyframe_from_event(_tier0_event(["person", "person", "car"]))
+    assert kf is not None, "Tier-0 events must produce a keyframe"
+    assert kf.labels == ["person", "car"]      # one frame, four people → "person" once
+    assert kf.adapter == "tier0"
+    assert kf.camera_id == "cam-1"
+
+
+def test_tier0_keyframe_uses_wall_clock_not_monotonic():
+    """``ts`` is a monotonic reading; storing it would date every keyframe
+    from the machine's boot origin and break every time-window search."""
+    kf = keyframe_from_event(_tier0_event(["person"]))
+    assert kf.ts == 1_755_700_000.0
+
+
+def test_monotonic_leak_is_rejected_in_favour_of_now():
+    import time as _t
+    ev = _tier0_event(["person"], wall_ts=1234.5)   # a monotonic value leaked in
+    kf = keyframe_from_event(ev)
+    assert kf.ts > 1_700_000_000, "a pre-2001 stamp must fall back to now"
+    assert abs(kf.ts - _t.time()) < 5
+
+
+def test_tier0_event_with_no_tracks_is_not_indexed():
+    assert keyframe_from_event(_tier0_event([])) is None

--- a/examples/occupancy-counting/config.docker.yml
+++ b/examples/occupancy-counting/config.docker.yml
@@ -18,7 +18,14 @@ nats_url: "nats://nats:4222"
 # The standard stack runs NATS with ``--auth INTERNAL_API_KEY``.
 nats_token: "${INTERNAL_API_KEY}"
 
-subject_pattern: "opennvr.inference.>"
+# Tier-0 ONLY by default: the always-on detect-pipeline is the
+# detection stream a standard install actually produces. Narrowing
+# the subject (rather than the wildcard) means an adapter you add
+# later cannot double-count the same object through both streams.
+# Widen to "opennvr.inference.>" if you want adapter events too.
+subject_pattern: "opennvr.inference.tier0.>"
+# Bridge Tier-0 tracks into contract-shaped detections.
+consume_tier0: true
 
 # ── What to count / thresholds — EDIT for your scene ───────────────
 watch_labels:

--- a/examples/occupancy-counting/config.example.yml
+++ b/examples/occupancy-counting/config.example.yml
@@ -23,7 +23,14 @@ nats_token: null
 
 # Subject pattern. ``opennvr.inference.>`` catches every adapter;
 # narrow to ``opennvr.inference.yolov8.>`` for object detection only.
-subject_pattern: "opennvr.inference.>"
+# Tier-0 ONLY by default: the always-on detect-pipeline is the
+# detection stream a standard install actually produces. Narrowing
+# the subject (rather than the wildcard) means an adapter you add
+# later cannot double-count the same object through both streams.
+# Widen to "opennvr.inference.>" if you want adapter events too.
+subject_pattern: "opennvr.inference.tier0.>"
+# Bridge Tier-0 tracks into contract-shaped detections.
+consume_tier0: true
 
 # ── What to count ─────────────────────────────────────────────────
 #

--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -176,6 +176,15 @@ class AppConfig:
     nats_alerts_url: str | None = None
     nats_alerts_token: str | None = None
     nats_alerts_subject_prefix: str = "opennvr.alerts"
+    # Consume the always-on Tier-0 detector (docs/tier0-consumption.md).
+    # ON by default: Tier-0 ships enabled in the standard stack and is the
+    # only detection stream a default install produces, so an app that
+    # ignored it would sit silent forever. The SDK's own default is off
+    # (contract compatibility); an app that also subscribes to a heavy
+    # adapter should narrow ``subject_pattern`` to
+    # ``opennvr.inference.tier0.>`` — as the shipped config does — or turn
+    # this off, otherwise the same object is counted from both streams.
+    consume_tier0: bool = True
 
     # App contract (spec §03) — all optional; see the SDK's contract
     # module. ``contract_port`` serves /health /manifest /state;
@@ -316,6 +325,7 @@ def load_config(path: str) -> AppConfig:
         ),
         contract_bind_host=raw.get("contract_bind_host"),
         contract_host=raw.get("contract_host"),
+        consume_tier0=bool(raw.get("consume_tier0", True)),
         opennvr_url=raw.get("opennvr_url"),
         opennvr_token=raw.get("opennvr_token"),
     )
@@ -356,6 +366,10 @@ class OccupancyCounter(Detector):
 
     def setup(self) -> None:
         self._states: dict[str, _ZoneState] = {}
+        # Camera ids seen on the bus that this app has no config for —
+        # tracked so the "not my camera" warning fires once each, not per
+        # frame (Tier-0 publishes continuously).
+        self._unknown_cameras: set[str] = set()
 
     # ── Pure helpers (testable without NATS) ──────────────────────
 
@@ -397,6 +411,18 @@ class OccupancyCounter(Detector):
         camera = self._config.cameras.get(camera_id)
         if camera is None:
             # Another monitoring app may be watching this camera; we're not.
+            # But an id that matches NOTHING configured is the difference
+            # between "not my camera" and "this app counts nothing, forever"
+            # — and the two look identical from outside. Say it once per
+            # unknown id so a config/id mismatch (the classic ``cam-1`` vs
+            # ``cam1``) is one log line instead of a silent no-op.
+            if camera_id not in self._unknown_cameras:
+                self._unknown_cameras.add(camera_id)
+                logger.warning(
+                    "receiving events for camera %r, which is not in my config "
+                    "— nothing will be counted for it. Configured cameras: %s",
+                    camera_id, sorted(self._config.cameras) or "(none)",
+                )
             return []
 
         count = self.count_in_zone(camera, detections)

--- a/examples/occupancy-counting/tests/test_occupancy_counting.py
+++ b/examples/occupancy-counting/tests/test_occupancy_counting.py
@@ -113,3 +113,83 @@ def test_debounce_requires_persistence():
 def test_unknown_camera_ignored():
     c = _counter(_camera())
     assert c.handle_event(_event(9, camera_id="cam-unknown")) == []
+
+
+# ── Tier-0 consumption (the always-on detector) ────────────────────
+#
+# A default OpenNVR install runs detect-pipeline and NO per-frame adapter
+# loop, so Tier-0 events are the ONLY detections on the bus. These tests
+# drive the app with the real Tier-0 payload shape (detect_pipeline's
+# bus.build_payload) rather than adapter-shaped events.
+
+
+def _tier0_event(n_people: int, *, camera_id="cam-1", w=1920, h=1080) -> dict:
+    """A Tier-0 event as detect-pipeline publishes it: top-level ``tracks``
+    with PIXEL boxes and a ``frame`` size — no ``result`` block at all."""
+    return {
+        "schema": "opennvr.tier0.v1",
+        "adapter": "tier0",
+        "camera_id": camera_id,
+        "seq": 41,
+        "ts": 1234.5,                 # monotonic — never a date
+        "wall_ts": 1_755_700_000.0,   # epoch seconds
+        "frame": {"w": w, "h": h},
+        "calibrating": False,
+        "tracks": [
+            {"id": i + 1, "label": "person", "score": 0.9,
+             # centred box: 0.4-0.5 of the frame in both axes
+             "box": [int(w * 0.4), int(h * 0.4), int(w * 0.5), int(h * 0.5)],
+             "stationary": False, "best": True}
+            for i in range(n_people)
+        ],
+    }
+
+
+def test_tier0_events_are_counted_and_fire():
+    """The regression this whole slice exists for: on a stock install the
+    app saw Tier-0 events and silently dropped every one."""
+    counter = _counter(_camera(max_occ=2))
+    assert counter.consume_tier0 is True, "app default must consume Tier-0"
+    assert counter.handle_event(_tier0_event(2)) == []      # at the ceiling
+    alerts = counter.handle_event(_tier0_event(3))          # over it
+    assert len(alerts) == 1
+    assert alerts[0].evidence["level"] == "over"
+    assert alerts[0].evidence["count"] == 3
+
+
+def test_tier0_pixel_boxes_map_into_the_zone():
+    """Tracks carry PIXEL boxes; the SDK bridge normalises them and the app
+    scales back into zone space. A track outside the zone must not count."""
+    zone = Zone.from_config("left-half", [[0, 0], [960, 0], [960, 1080], [0, 1080]])
+    camera = oc.CameraZone(camera_id="cam-1", zone=zone, frame_width=1920,
+                           frame_height=1080, max_occupancy=0, min_occupancy=None)
+    counter = _counter(camera)
+    # One person centred at 45% width → inside the left half → over max(0).
+    fired = counter.handle_event(_tier0_event(1))
+    assert len(fired) == 1 and fired[0].evidence["count"] == 1
+    # Same person on the right half → not counted, so no alert and the
+    # state machine returns to normal.
+    right = _tier0_event(1)
+    right["tracks"][0]["box"] = [1500, 400, 1700, 600]
+    assert counter.handle_event(right) == []
+    assert counter._states["cam-1"].last_count == 0
+
+
+def test_tier0_can_be_turned_off():
+    """Operators who also drive a heavy adapter can opt out and keep the
+    single (adapter) stream — no double counting."""
+    camera = _camera(max_occ=0)
+    cfg = _config(camera)
+    cfg.consume_tier0 = False
+    counter = oc.OccupancyCounter(cfg, _NullDispatcher())
+    assert counter.handle_event(_tier0_event(3)) == []
+
+
+def test_unknown_camera_id_warns_once(caplog):
+    """``cam-1`` vs ``cam1`` used to be a silent no-op forever."""
+    counter = _counter(_camera())
+    with caplog.at_level("WARNING"):
+        counter.handle_event(_tier0_event(1, camera_id="cam1"))
+        counter.handle_event(_tier0_event(1, camera_id="cam1"))
+    warnings = [r for r in caplog.records if "not in my config" in r.message]
+    assert len(warnings) == 1, "warn once per unknown camera, not per frame"


### PR DESCRIPTION
…ck install

Both catalog apps run, report healthy, and do nothing on a default OpenNVR system. Tier-0 detect-pipeline ships enabled and is the ONLY detection stream a stock install produces — and neither app could consume it, for two different reasons:

* occupancy-counting (Detector): the SDK drops Tier-0 events unless consume_tier0 is set, and AppConfig had no such field — so the flag could not be set even by editing the YAML. Adds the field (default ON: Tier-0 is what actually runs), parses it, and narrows the shipped subject to opennvr.inference.tier0.> so a heavy adapter added later cannot double-count the same object through both streams.

* footage-search (overrides handle_event, so it always RECEIVED Tier-0 events): keyframe_from_event only walked result.detections, which a Tier-0 event does not have — every event produced no keyframe and the index stayed permanently empty. Now parses top-level tracks with de-duplicated labels (one frame with four people is searchable as 'person', not 'person' x4).

Also fixes a time bug that would have broken every window search: Tier-0's ts is a time.monotonic() reading, not a date — indexing it would file every keyframe from the machine's boot origin. detect-pipeline now publishes wall_ts (epoch seconds) alongside it on both the event and gate payloads, footage-search prefers completed_at -> wall_ts, and values before 2001 are rejected as leaked monotonic readings.

occupancy-counting now warns once per unknown camera id instead of counting nothing in silence — the classic 'cam-1' in config vs 'cam1' on the bus. Adds docs/tier0-consumption.md, which the SDK has referenced since the bridge landed but which never existed.

9 new tests driving the real Tier-0 payload shape end to end; occupancy 11, footage-search 12, detect-pipeline 202 green.