### PR TITLE
fix(occupancy): refresh credentials, loop-thread mutation, honest cei…

### DIFF
--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -205,6 +205,11 @@ class AppConfig:
     default_max: int = 0
     default_min: int | None = None
     opennvr_url_for_discovery: str = ""
+    # The key used for BOOT discovery, kept so the refresh loop presents
+    # the same credentials. Boot honouring a YAML ``internal_api_key``
+    # while refresh silently fell back to the env var was a real (if
+    # docker-invisible) way to discover cameras once and never again.
+    internal_api_key: str | None = None
 
     # App contract (spec §03) — all optional; see the SDK's contract
     # module. ``contract_port`` serves /health /manifest /state;
@@ -305,6 +310,18 @@ def load_config(path: str) -> AppConfig:
             for c in discovered
         ]
         if cameras_raw:
+            if default_max is None:
+                # Auto-derived cameras have no per-camera value to fall back
+                # on, so the app-level default is mandatory. Raise HERE with
+                # a message naming the actual situation — letting the
+                # per-camera loop below catch it produces "camera entry 0
+                # malformed", pointing the operator at a YAML entry that
+                # does not exist.
+                raise ValueError(
+                    "config: 'max_occupancy' is required when cameras are "
+                    "discovered from OpenNVR — set it as an app-level "
+                    "default (auto-derived cameras have no per-camera value)"
+                )
             logger.info(
                 "no cameras configured — watching all %d camera(s) OpenNVR "
                 "knows about with a whole-frame zone: %s",
@@ -429,6 +446,7 @@ def load_config(path: str) -> AppConfig:
         default_max=int(default_max or 0),
         default_min=int(default_min) if default_min is not None else None,
         opennvr_url_for_discovery=str(raw.get("opennvr_url") or ""),
+        internal_api_key=raw.get("internal_api_key") or None,
         opennvr_url=raw.get("opennvr_url"),
         opennvr_token=raw.get("opennvr_token"),
     )
@@ -481,17 +499,28 @@ class OccupancyCounter(Detector):
 
     # ── Camera-set refresh ────────────────────────────────────────
 
-    def refresh_cameras(self) -> tuple[list[str], list[str]]:
+    def refresh_cameras(
+        self, discovered: list[dict[str, Any]] | None = None
+    ) -> tuple[list[str], list[str]]:
         """Re-derive the watched camera set from OpenNVR. Returns
         ``(added, removed)``. No-op (and no network call) when the set was
         pinned in config. Separated from the timer so it is testable
-        without a running loop."""
+        without a running loop.
+
+        ``discovered`` lets the caller supply an already-fetched camera
+        list so the dict mutation runs on the event loop while only the
+        blocking HTTP call runs in a worker thread (see
+        ``_discovery_loop``) — mutating ``_config.cameras`` / ``_states``
+        from another thread could race a concurrent ``/state`` snapshot.
+        Discovery presents the same credentials boot did (a YAML
+        ``internal_api_key`` wins, else the env var)."""
         if not self._auto_cameras:
             return [], []
-        discovered = discover_cameras(
-            self._config.opennvr_url_for_discovery,
-            api_key=None,
-        )
+        if discovered is None:
+            discovered = discover_cameras(
+                self._config.opennvr_url_for_discovery,
+                api_key=self._config.internal_api_key,
+            )
         ids = {c["camera_id"] for c in discovered}
         if not ids:
             # Treat "core answered with nothing" as no news rather than
@@ -521,7 +550,15 @@ class OccupancyCounter(Detector):
         while True:
             await asyncio.sleep(interval_s)
             try:
-                await asyncio.to_thread(self.refresh_cameras)
+                # Blocking HTTP in a worker thread; the dict mutation then
+                # happens here on the loop, serialized with on_detections
+                # and state_snapshot — no cross-thread writes.
+                discovered = await asyncio.to_thread(
+                    discover_cameras,
+                    self._config.opennvr_url_for_discovery,
+                    api_key=self._config.internal_api_key,
+                )
+                self.refresh_cameras(discovered=discovered)
             except Exception:
                 logger.warning("camera refresh failed", exc_info=True)
 

--- a/examples/occupancy-counting/tests/test_occupancy_counting.py
+++ b/examples/occupancy-counting/tests/test_occupancy_counting.py
@@ -335,3 +335,84 @@ def test_discovered_cameras_require_an_app_level_ceiling(tmp_path, monkeypatch):
     p.write_text('nats_url: "nats://x:4222"\nopennvr_url: "http://core:8000"\ncameras: []\n')
     with pytest.raises(ValueError, match="max_occupancy"):
         oc.load_config(str(p))
+
+
+# ── Review-nit fixes ───────────────────────────────────────────────
+#
+# Three small holes found on a post-merge review pass: refresh must
+# present the same credentials boot did; refresh's dict mutation must be
+# runnable on the event loop with a pre-fetched list (no cross-thread
+# writes); and a missing ceiling with DISCOVERED cameras must not blame
+# a YAML "camera entry 0" that does not exist.
+
+
+def test_refresh_uses_the_same_api_key_boot_did(tmp_path, monkeypatch):
+    """Boot honoured a YAML ``internal_api_key``; a refresh that falls
+    back to the env var would discover cameras once and never again."""
+    seen_keys = []
+
+    def _spy(url, api_key=None):
+        seen_keys.append(api_key)
+        return [{"camera_id": "cam1"}]
+
+    monkeypatch.setattr(oc, "discover_cameras", _spy)
+    cfg = oc.load_config(_write_config(
+        tmp_path,
+        'opennvr_url: "http://core:8000"\n'
+        'internal_api_key: "yaml-secret"\n'
+        "cameras: []\n",
+    ))
+    counter = oc.OccupancyCounter(cfg, _NullDispatcher())
+    counter.refresh_cameras()
+    assert seen_keys == ["yaml-secret", "yaml-secret"], (
+        "boot and refresh must present the same credentials"
+    )
+
+
+def test_refresh_accepts_a_prefetched_camera_list(tmp_path, monkeypatch):
+    """``refresh_cameras(discovered=...)`` must apply the set without a
+    network call — the discovery loop fetches in a worker thread and
+    mutates on the event loop, so the mutation path alone must never
+    touch the network."""
+    calls = {"n": 0}
+
+    def _boot_only(url, api_key=None):
+        calls["n"] += 1
+        return [{"camera_id": "cam1"}]
+
+    monkeypatch.setattr(oc, "discover_cameras", _boot_only)
+    cfg = oc.load_config(_write_config(
+        tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
+    counter = oc.OccupancyCounter(cfg, _NullDispatcher())
+    assert calls["n"] == 1                              # boot discovery only
+
+    added, removed = counter.refresh_cameras(
+        discovered=[{"camera_id": "cam1"}, {"camera_id": "cam2"}]
+    )
+    assert added == ["cam2"] and removed == []
+    assert calls["n"] == 1, "a supplied list must not trigger a fetch"
+    # Blip immunity holds on the pre-fetched path too.
+    assert counter.refresh_cameras(discovered=[]) == ([], [])
+    assert sorted(cfg.cameras) == ["cam1", "cam2"]
+
+
+def test_missing_ceiling_with_discovered_cameras_names_the_real_cause(
+    tmp_path, monkeypatch
+):
+    """With cameras FOUND by discovery and no app-level max_occupancy,
+    the error must describe the discovery case — not "camera entry 0
+    malformed", an entry that does not exist in the operator's YAML."""
+    import pytest
+
+    monkeypatch.setattr(
+        oc, "discover_cameras", lambda url, api_key=None: [{"camera_id": "cam1"}]
+    )
+    p = tmp_path / "config.yml"
+    p.write_text(
+        'nats_url: "nats://x:4222"\nopennvr_url: "http://core:8000"\ncameras: []\n'
+    )
+    with pytest.raises(ValueError, match="discovered from OpenNVR"):
+        oc.load_config(str(p))
+    with pytest.raises(ValueError) as excinfo:
+        oc.load_config(str(p))
+    assert "camera entry 0" not in str(excinfo.value)


### PR DESCRIPTION
…ling error

Three small holes from a post-merge review pass:

- refresh_cameras now presents the same credentials boot discovery did (a YAML internal_api_key wins, else the env var). Boot honouring the YAML key while refresh fell back to the env var meant a bare-metal config could discover cameras once and then silently never again.
- The discovery loop fetches in a worker thread but applies the camera set on the event loop (refresh_cameras gains a discovered= parameter), so _config.cameras / _states are never mutated from another thread while /state or on_detections iterates them.
- A missing max_occupancy with cameras FOUND by discovery now raises a message naming the discovery case instead of "camera entry 0 malformed" — an entry that does not exist in the operator's YAML.