### PR TITLE
fix(footage,agent): voice footage search works on a stock install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,6 +197,13 @@ OPENNVR_EXAMPLE=
 OPENNVR_EXAMPLE_COMPOSE=
 OPENNVR_EXAMPLE_PROFILE=
 
+# Apps that run BY DEFAULT on every install: occupancy-counting and
+# footage-search. Both ride the always-on Tier-0 detection stream — no extra
+# adapter, model, or GPU — so a stock install gets zone occupancy alerts and
+# natural-language footage search ("red truck yesterday") out of the box.
+# Set to "off" to run the core stack only.
+OPENNVR_DEFAULT_APPS=
+
 KAI_C_URL=http://127.0.0.1:8100
 KAI_C_IP=127.0.0.1
 

--- a/DOCKER_QUICKSTART.md
+++ b/DOCKER_QUICKSTART.md
@@ -135,7 +135,7 @@ overlay using repeated `-f` flags and the overlay's `--profile`.
 | File | What it is | How to use |
 |---|---|---|
 | `docker-compose.yml` | **Core stack** — Postgres, MediaMTX, NATS, the YOLOv8 adapter, `opennvr-core` (backend + frontend + KAI-C), and nginx. | `docker compose -f docker-compose.yml up -d` |
-| `docker-compose.apps.yml` | **Detector apps overlay** — the example SDK apps (intrusion, loitering, LPR, …). | add `-f docker-compose.apps.yml --profile apps` |
+| `docker-compose.apps.yml` | **Detector apps overlay** — the example SDK apps (intrusion, loitering, LPR, …). Two of them — occupancy-counting and footage-search — are ON BY DEFAULT via `start.sh`/`start.ps1` (profile `default-apps`; they ride the always-on Tier-0 stream, no extra adapter/model/GPU; opt out with `OPENNVR_DEFAULT_APPS=off` in `.env`). | everything else: add `-f docker-compose.apps.yml --profile apps` |
 | `docker-compose.camera-agent.yml` | **Camera-agent overlay** — the voice/chat agent plus its Whisper/Piper/caption/Ollama adapters. | add `-f docker-compose.camera-agent.yml --profile camera-agent` (or `camera-agent-chat`) |
 | `docker-compose.installer.yml` | **App-installer** — the single privileged reconciler for one-click installs (holds the Docker socket). Opt-in only. | add `-f docker-compose.installer.yml --profile app-installer` |
 

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -106,7 +106,12 @@ services:
   # zone. Contract surface on :9201.
   # ──────────────────────────────────────────────────────────────
   occupancy-counting-config-init:
-    profiles: [apps]
+    # In BOTH profiles: ``apps`` (the everything-on profile / the
+    # reconciler's) and ``default-apps`` — the profile start.sh/start.ps1
+    # enable on every stock install, because these apps ride the Tier-0
+    # stream that is always on and need no extra adapter, model, or GPU.
+    # Opt out with OPENNVR_DEFAULT_APPS=off in .env.
+    profiles: [apps, default-apps]
     image: alpine:3.20
     container_name: opennvr_occupancy_config_init
     restart: "no"
@@ -127,7 +132,12 @@ services:
       - opennvr_occupancy_config:/generated
 
   occupancy-counting:
-    profiles: [apps]
+    # In BOTH profiles: ``apps`` (the everything-on profile / the
+    # reconciler's) and ``default-apps`` — the profile start.sh/start.ps1
+    # enable on every stock install, because these apps ride the Tier-0
+    # stream that is always on and need no extra adapter, model, or GPU.
+    # Opt out with OPENNVR_DEFAULT_APPS=off in .env.
+    profiles: [apps, default-apps]
     build:
       context: .
       dockerfile: examples/occupancy-counting/Dockerfile
@@ -533,7 +543,12 @@ services:
   # Contract surface on :9208 (health/state/actions + registration).
   # ──────────────────────────────────────────────────────────────
   footage-search-config-init:
-    profiles: [apps]
+    # In BOTH profiles: ``apps`` (the everything-on profile / the
+    # reconciler's) and ``default-apps`` — the profile start.sh/start.ps1
+    # enable on every stock install, because these apps ride the Tier-0
+    # stream that is always on and need no extra adapter, model, or GPU.
+    # Opt out with OPENNVR_DEFAULT_APPS=off in .env.
+    profiles: [apps, default-apps]
     image: alpine:3.20
     container_name: opennvr_footage_search_config_init
     restart: "no"
@@ -554,7 +569,12 @@ services:
       - opennvr_footage_search_config:/generated
 
   footage-search:
-    profiles: [apps]
+    # In BOTH profiles: ``apps`` (the everything-on profile / the
+    # reconciler's) and ``default-apps`` — the profile start.sh/start.ps1
+    # enable on every stock install, because these apps ride the Tier-0
+    # stream that is always on and need no extra adapter, model, or GPU.
+    # Opt out with OPENNVR_DEFAULT_APPS=off in .env.
+    profiles: [apps, default-apps]
     build:
       context: .
       dockerfile: examples/footage-search/Dockerfile

--- a/docker-compose.camera-agent.yml
+++ b/docker-compose.camera-agent.yml
@@ -396,6 +396,13 @@ services:
     volumes:
       - opennvr_camera_agent_config:/app/config:ro
       - ./agent-certs/camera-agent:/certs:ro
+      # Read-only view of the footage-search index → enables the
+      # search_footage voice tool ("did a red truck come by earlier?").
+      # Same named volume the apps overlay's footage-search service
+      # writes (compose runs from the same project, so the names meet).
+      # Without the apps overlay it's just an empty dir and the tool
+      # reports cleanly that the index hasn't been built.
+      - opennvr_footage_search_data:/footage:ro
     command:
       - --config
       - /app/config/config.yml
@@ -478,6 +485,8 @@ services:
     volumes:
       - opennvr_camera_agent_config_chat:/app/config:ro
       - ./agent-certs/camera-agent:/certs:ro
+      # Same read-only footage-search index view as the voice agent.
+      - opennvr_footage_search_data:/footage:ro
     command:
       - --config
       - /app/config/config.yml
@@ -485,6 +494,12 @@ services:
       - opennvr_internal
 
 volumes:
+  # footage-search's SQLite index. Declared here as well as in
+  # docker-compose.apps.yml so this overlay works standalone: same name +
+  # same compose project → the SAME volume, so when the apps overlay runs
+  # the footage-search indexer, the agent's search_footage tool reads what
+  # it writes. Without the apps overlay it stays an empty dir (harmless).
+  opennvr_footage_search_data:
   # Ollama model store — persisted so the LLM survives ``compose down``.
   opennvr_ollama_models:
   # Faster-whisper model cache for the GHCR whisper adapter.

--- a/examples/camera-agent/ALARMS.md
+++ b/examples/camera-agent/ALARMS.md
@@ -22,8 +22,14 @@ Time windows are 24h `HH:MM`. A window where `after > before` (e.g.
 `22:00`–`06:00`) wraps across midnight. The agent silences with `stop_alarm`
 (`action: silence`) or removes with `stop_alarm` (`action: disarm`).
 
-The UI also offers one-tap **preset** alarms (Fire; After-hours person) and an
-"add alarm" path via `POST /alarms`.
+The UI also offers one-tap **preset** alarms and an "add alarm" path via
+`POST /alarms`. Presets come from `GET /alarm-presets` with **honest,
+capability-aware availability**: each preset's target is checked against what
+the detection path can actually see (the standard YOLOv8/COCO-80 vocabulary
+plus the config's `detector_extra_labels`). Detectable presets — After-hours
+person, Person, Car, Truck, Dog — arm in one click; the safety presets (Fire,
+Smoke, Gas leak) are greyed out on a stock stack because COCO has no such
+classes, and clicking one explains what to register to enable it.
 
 ## How it works
 

--- a/examples/camera-agent/GUIDE.md
+++ b/examples/camera-agent/GUIDE.md
@@ -1,0 +1,243 @@
+# OpenNVR Agent — user guide
+
+Everything the agent can do, how each capability is enabled, and how to
+use it. This is the operator-facing companion to
+[AGENT_DESIGN.md](AGENT_DESIGN.md) (architecture) and the deep-dives it
+links. If a term appears in the demo UI, it is explained here.
+
+The agent runs in two flavours from the same code — **voice**
+(`--profile camera-agent`: speak, hear the answer) and **chat**
+(`--profile camera-agent-chat`: type, read). Both expose the demo at
+`https://localhost:9100/demo`. Everything below applies to both unless
+stated otherwise.
+
+---
+
+## Skills
+
+A **skill** is a user-facing capability the agent carries — "see what's
+happening", "count people", "search recorded footage". Each skill maps
+to one or more **tools** (the functions the LLM can call). Switching a
+skill off drops its tools from the advertised set, so the model can no
+longer call them — the agent genuinely reconfigures, it doesn't just
+refuse politely.
+
+| Skill | Ask it… | Voice default | Chat default | Needs |
+|---|---|---|---|---|
+| **see** | "What's happening at the front door?" | ✅ on | ✅ on | nothing (falls back to the object detector until a caption/VQA adapter registers) |
+| **count** | "How many people are in the back yard?" | ✅ on | ✅ on | nothing (standard YOLOv8) |
+| **footage** | "Did a red truck come by earlier today?" | ✅ on | ✅ on | the footage-search app (on by default) |
+| **apps** | "Is the occupancy counter healthy?" | ✅ on | ✅ on | nothing (reads the app registry) |
+| **events** | "Did anyone come to the door in the last 30 minutes?" | ✅ on | ✅ on | nothing (the NATS event bus) |
+| **alarm** | "Alarm me if someone is at the door after 10pm." | ✅ on | ✅ on | nothing |
+| **watch** | "Watch the driveway and tell me if more than 3 cars show up." | ✅ on | ✅ on | nothing |
+| **faces** | "Who's at the front door?" | ⬜ off | ⬜ off | the InsightFace recognition adapter |
+| **report** | "Every morning at 7, summarise overnight activity." | ⬜ off | ⬜ off | nothing — enable in config (below) |
+| **task** | "Check every camera for anyone in a red shirt." | ⬜ off | ⬜ off | nothing — enable in config (below) |
+
+**How enablement works — two layers.**
+
+1. **The config allowlist** (`enabled_tools` in the agent's config)
+   decides which tools are *ever* advertised. The docker demos ship a
+   deliberate list (the ✅ column above) to keep the LLM prompt short —
+   on CPU, every extra tool definition slows the first token. A
+   bare-metal config with `enabled_tools` unset advertises everything.
+   To turn a ⬜ skill on, add its tool names to the list, e.g. for
+   background tasks and reports:
+
+   ```yaml
+   enabled_tools:
+     # …existing entries…
+     - create_background_task        # the "task" skill
+     - create_report                 # the "report" skill
+     - stop_report
+   ```
+
+2. **The runtime toggle** (the demo's **Skills** card, admin tier)
+   switches a skill on/off live without a restart. A skill whose
+   backend isn't wired is greyed out **with a reason and a deep link**
+   — e.g. faces shows "needs a face-recognition adapter" and links to
+   the AI Adapters page to register one. The greyed state is honest:
+   it reflects what is actually registered in KAI-C right now.
+
+## Alarms
+
+Alarms are the **urgent** tier: when their target appears on a watched
+camera (optionally only within a time window), they **ring in the UI
+until a human acknowledges them**. Full mechanics: [ALARMS.md](ALARMS.md).
+
+**Creating one — three ways:**
+
+* **By voice/chat**: "Sound a fire alarm if you see fire", "Alarm if a
+  person is detected after 6pm", "Alert me loudly if a car enters
+  between 10pm and 6am on all cameras". Overnight windows
+  (`22:00`–`06:00`) wrap correctly.
+* **One-click presets** on the Alarms card. Presets are
+  **capability-aware**: the server checks each preset's target against
+  what the detection path can actually see. Presets the stock stack
+  can serve — *After-hours person, Person, Car, Truck, Dog* — are
+  armable immediately. The safety presets — *Fire, Smoke, Gas leak* —
+  are **greyed out on a stock install**, because the standard
+  YOLOv8/COCO detector has no fire, smoke, or gas class; clicking one
+  explains exactly what to do (register a detection adapter trained
+  for it, then list its label under `detector_extra_labels` in the
+  agent config, which lights the preset up). A Fire button that armed
+  an alarm which could never ring would be worse than none.
+* **The + form** on the Alarms card: free-form name, target, alert
+  level, time window.
+
+**Alert levels** (per alarm, preselected by target):
+
+| Level | Behaviour |
+|---|---|
+| **siren** (critical) | latches — rings until a human silences it |
+| **pulse** (urgent) | loud for a minute, then stands down on its own |
+| **chime** | a single ding, no latch |
+| **silent** | notifications only |
+
+Fire-grade targets (fire, smoke, flame, gas) default to **siren**;
+everything else to **chime**. The ⚙ button on the Alarms card edits
+this **site policy** (admin tier) — a farm can make "snake" critical, a
+bank "person". Nothing is pre-armed out of the box: arming is always a
+one-click or one-utterance human decision, and only **operator-tier**
+users can arm or disarm anything (see Access tiers).
+
+If an `emergency_contacts` entry matches the alarm, the triggered event
+is tagged with the contact so your notification channel can escalate —
+the agent itself never dials anyone.
+
+## Watches (monitors)
+
+The **informational** tier — same detection engine as alarms, calmer
+output: "watch the driveway and tell me if more than 3 cars show up"
+creates a monitor that counts over time and posts a notification when
+the condition is met, without ringing anything. Use an alarm when a
+human must react *now*; a watch when you want to *know*. Watches live
+in the right-rail "Watches" card; stop one by voice ("stop watching the
+driveway") or with its ✕.
+
+## Background tasks
+
+A **task** is a one-shot, longer-running job that would block the
+conversation if run inline: "check every camera for anyone in a red
+shirt" fans out over every camera, runs detection and description on
+each, and reports back when done — while you keep talking.
+
+* **How it works**: the agent queues the job and answers immediately;
+  a background worker runs a full tool-calling turn for the query and
+  stores the result. The Tasks card polls progress, and the completion
+  is surfaced back into the chat. Guardrail: a background task runs
+  with the agent-control tools removed — a task can't spawn more
+  tasks, arm alarms, or create watches.
+* **How to enable**: off in both docker demos (it's the most
+  token-hungry skill on CPU). Add `create_background_task` to
+  `enabled_tools` and restart, or run a bare-metal config with
+  `enabled_tools` unset.
+* **Task vs watch**: a task runs once and finishes; a watch runs
+  forever until stopped.
+
+## Events
+
+The agent remembers what the detection stream saw. With the **events**
+skill on (default), ask about the recent past — "did anyone come to the
+door in the last 30 minutes?" — and the agent answers from the NATS
+event ring (`recent_events`). This is short-term memory (the in-process
+ring, `event_ring_size`); for days-back questions use **footage**
+search, which reads the persistent index. The skill's deeper tools —
+`search_history`, `describe_event`, `describe_window` — are not in the
+docker allowlists (prompt size); add them to `enabled_tools` to let the
+agent narrate a specific event or time window.
+
+## Alerts & notifications
+
+Three streams end up in front of you:
+
+* **The notification feed** the demo polls: alarm rings, watch hits,
+  task completions — and **app alerts**. The agent subscribes to
+  `opennvr.alerts.app.>` on the bus, so any catalog app's alert (on a
+  stock install: the default-on occupancy counter's *over-occupancy*)
+  lands in the feed proactively, throttled per app+camera so a
+  misbehaving app can't spam. Ask "any occupancy alerts this morning?"
+  (`recent_app_alerts`) for the full, unthrottled history.
+* **The events card**: the same items, in the right rail.
+* **External delivery**: webhooks / Apprise push (ntfy, Telegram,
+  email, …) via `notify_webhooks` / `notify_apprise` — see
+  [NOTIFICATIONS.md](NOTIFICATIONS.md). Off until configured; the
+  "Test" button verifies a channel end-to-end.
+
+## Footage search
+
+"Did a red truck come by earlier today?" — the **footage** skill
+searches the index that the footage-search app (on by default) builds
+from the inference stream: object labels from the detector, scene
+captions when a captioner runs. The agent decomposes your question into
+keywords, time window, and camera; results come back newest-first as
+distinct sightings. The index lives on the footage-search volume
+(mounted read-only into the agent); if the indexer hasn't created it
+yet the tool says so and lights up by itself once it exists — no
+restart needed.
+
+## Apps door
+
+With the **apps** skill (default on), the agent reads the OpenNVR app
+registry: "what apps are running?", "is the occupancy counter
+healthy?", "any alerts from the loitering detector?". Strictly
+**read-only** — the agent reports on apps; enabling, disabling, or
+configuring one stays in the OpenNVR App Catalog UI.
+
+## Faces
+
+Off by default — it needs the InsightFace recognition adapter, which
+the standard stack doesn't register. Once the adapter is up (AI
+Adapters page), the faces skill un-greys and the agent can recognise
+("who's at the door?"), enroll ("remember this person as Sam"), list,
+and forget people. Details: [FACES.md](FACES.md).
+
+## Reports
+
+"Every morning at 7, summarise overnight activity" — a scheduled query
+whose answer lands in the Reports card and the notification feed. Off
+in both docker demos; enable by adding `create_report` / `stop_report`
+to `enabled_tools`.
+
+## Access tiers
+
+When the agent delegates auth to OpenNVR (`auth_mode: opennvr`, the
+docker default), your OpenNVR role maps to a tier:
+
+| Tier | Can |
+|---|---|
+| **viewer** | look and chat — every read tool, plus the read-only app door and face listing |
+| **operator** | everything viewers can, **plus** arm/disarm alarms, create/stop watches, tasks, reports |
+| **admin** | everything, **plus** toggle skills and edit the site alert-level defaults |
+
+The tiers are enforced at the toolset, not just the UI — a viewer's
+chat physically lacks the mutating tools, so it can't be talked into
+arming anything.
+
+## Wake word
+
+**Off by default, on purpose.** In voice mode the agent listens only
+while a session is open (click **Talk**); **Stop** always works — even
+mid-thought, it cancels the in-flight turn server-side. The optional
+wake word can be enabled per-session in the demo, but with CPU
+transcription accuracy a mis-heard wake word eats real questions, so
+the default stays off.
+
+---
+
+## Quick reference — what a stock install gives you
+
+Say it and it works, no configuration:
+
+* "What's happening at the front door?" · "How many people are in the
+  back yard?" (see / count)
+* "Did a red truck come by earlier today?" (footage)
+* "Did anyone come to the door in the last 30 minutes?" (events)
+* "Alarm me if someone is at the door after 10pm." · "Stop alarm 2." (alarm)
+* "Watch the driveway and tell me if more than 3 cars show up." (watch)
+* "Is the occupancy counter healthy?" · "Any occupancy alerts this
+  morning?" (apps)
+
+One config line away: background tasks, reports. One adapter away:
+faces, and the Fire / Smoke / Gas-leak alarm presets.

--- a/examples/camera-agent/GUIDE.md
+++ b/examples/camera-agent/GUIDE.md
@@ -13,14 +13,40 @@ stated otherwise.
 
 ---
 
+## Skills and tasks — the two words that matter
+
+Everything the agent does is built from two ideas. Get these two and
+the rest of this guide is detail.
+
+A **skill** is a capability the agent *has* — something it knows how to
+do. Seeing and analysing a live stream is a skill. Counting objects is
+a skill. Searching recorded footage is a skill. Recognising faces is a
+skill. Skills are the agent's verbs, and the set is designed to grow:
+if a *calling* skill were added tomorrow (dial a VoIP/SIP number),
+nothing else about the agent would change — there would simply be one
+more thing it knows how to do, and every assignment built on it would
+light up.
+
+A **task** is an assignment *you* give, built out of those skills.
+"Send me a report at 8 AM every day of how many trucks entered" is a
+task: the agent takes it and keeps doing it — the counting skill plus a
+schedule. "If someone comes to the office gate after 6 pm, call me on
+my SIP URI" would be a task too: the detection skill composed with that
+future calling skill, standing until you cancel it.
+
+So: **skills are what the agent can do; tasks are what you've asked it
+to keep doing with them.** Adding a skill upgrades what every future
+task can be made of; adding a task never requires new code — it's just
+you talking.
+
+---
+
 ## Skills
 
-A **skill** is a user-facing capability the agent carries — "see what's
-happening", "count people", "search recorded footage". Each skill maps
-to one or more **tools** (the functions the LLM can call). Switching a
-skill off drops its tools from the advertised set, so the model can no
-longer call them — the agent genuinely reconfigures, it doesn't just
-refuse politely.
+A skill maps to one or more **tools** (the functions the LLM can
+call). Switching a skill off drops its tools from the advertised set,
+so the model can no longer call them — the agent genuinely
+reconfigures, it doesn't just refuse politely.
 
 | Skill | Ask it… | Voice default | Chat default | Needs |
 |---|---|---|---|---|
@@ -59,6 +85,31 @@ refuse politely.
    — e.g. faces shows "needs a face-recognition adapter" and links to
    the AI Adapters page to register one. The greyed state is honest:
    it reflects what is actually registered in KAI-C right now.
+
+## Tasks — the assignments you can give
+
+Every assignment the agent accepts is one of four shapes. They differ
+on just two axes: **when it runs** (once, continuously, or on a clock)
+and **how loudly the outcome arrives** (an answer, a notification, or a
+latching ring):
+
+| Shape | Runs | Outcome | Example | Tool |
+|---|---|---|---|---|
+| **Background run** | once, then done | answer back in chat | "Check every camera for anyone in a red shirt." | `create_background_task` |
+| **Watch** | continuously until stopped | notification when the condition is met | "Watch the driveway and tell me if more than 3 cars show up." | `create_monitor` |
+| **Alarm** | continuously until stopped | **rings until a human acknowledges** | "Alarm me if someone is at the door after 10 pm." | `create_alarm` |
+| **Report** | on a schedule, forever | a delivered summary, each time | "Every day at 8 AM, tell me how many trucks entered." | `create_report` |
+
+Why is a watch not just a task? Because "once" and "forever" are
+different promises: a background run finishes and is gone; a watch is a
+*standing* assignment that keeps consuming the stream until you cancel
+it. And why does the alarm get its own name when it's shaped like a
+watch? **Urgency.** A watch informs — read it when you like. An alarm
+interrupts — it latches and rings until a person deals with it. Same
+engine, opposite contract with your attention. The four shapes are one
+family; the names just tell you which promise you're getting.
+
+Each shape is detailed in its own section below.
 
 ## Alarms
 
@@ -148,7 +199,32 @@ search, which reads the persistent index. The skill's deeper tools —
 docker allowlists (prompt size); add them to `enabled_tools` to let the
 agent narrate a specific event or time window.
 
-## Alerts & notifications
+## Events, alerts, and alarms — the attention ladder
+
+Three words that sound alike but mean three different demands on your
+attention. From quietest to loudest:
+
+* An **event** is a recorded fact: *"person seen on cam2 at 14:02."*
+  The detection stream produces them continuously. Nobody is notified —
+  events are the raw material the agent (and every app) reasons over.
+  You query them ("did anyone come to the door in the last 30
+  minutes?"); they never come to you.
+* An **alert** is an event that matched something someone *said they
+  care about* — a watch's condition, an app's rule (the occupancy
+  counter crossing its limit), a report arriving. It's delivered as a
+  notification: informational, read it when you like, nothing latches.
+* A **critical alert** is an alert that demands a human *now* — and
+  **alarms are how you ask for one**. An alarm's siren latches and
+  rings until acknowledged; that's the whole difference. (An alarm
+  created at the *chime* or *silent* level is really asking for an
+  ordinary alert on an alarm's engine — the level, not the word, sets
+  the urgency. **siren** and **pulse** are the critical grades.)
+
+So: events happen, alerts inform, alarms interrupt. A fact climbs the
+ladder only because a rule you created (watch, app, alarm) said it
+should.
+
+## Where alerts reach you
 
 Three streams end up in front of you:
 
@@ -195,10 +271,13 @@ and forget people. Details: [FACES.md](FACES.md).
 
 ## Reports
 
-"Every morning at 7, summarise overnight activity" — a scheduled query
-whose answer lands in the Reports card and the notification feed. Off
-in both docker demos; enable by adding `create_report` / `stop_report`
-to `enabled_tools`.
+The scheduled task shape: "every morning at 7, summarise overnight
+activity", or "every day at 8 AM, tell me how many trucks entered" — a
+standing query the agent re-runs on its clock, with each answer landing
+in the Reports card and the notification feed (and any configured
+external channel). Create by voice/chat, stop the same way ("stop the
+morning report"). Off in both docker demos; enable by adding
+`create_report` / `stop_report` to `enabled_tools`.
 
 ## Access tiers
 

--- a/examples/camera-agent/README.md
+++ b/examples/camera-agent/README.md
@@ -45,6 +45,10 @@ On a low-RAM box: `OLLAMA_MODEL=qwen2.5:0.5b examples/camera-agent/quickstart.sh
 
 ### Read in detail
 
+- [**User guide**](GUIDE.md) — skills, alarms & alert levels, watches,
+  background tasks, events, alerts & notifications, footage search, the
+  apps door, access tiers — what each is, what's on by default, and how
+  to enable the rest.
 - [**Models & latency**](MODELS_AND_LATENCY.md) — how model choices were weighed
   for CPU latency and good UX, plus the efficient model picks.
 - [**Alarms**](ALARMS.md) — ringing alarms, time windows, presets, and the

--- a/examples/camera-agent/README.md
+++ b/examples/camera-agent/README.md
@@ -45,10 +45,12 @@ On a low-RAM box: `OLLAMA_MODEL=qwen2.5:0.5b examples/camera-agent/quickstart.sh
 
 ### Read in detail
 
-- [**User guide**](GUIDE.md) — skills, alarms & alert levels, watches,
-  background tasks, events, alerts & notifications, footage search, the
-  apps door, access tiers — what each is, what's on by default, and how
-  to enable the rest.
+- [**User guide**](GUIDE.md) — starts with the two words that matter
+  (**skills** = capabilities the agent has, like seeing live streams or
+  searching footage; **tasks** = assignments you give it, like "report
+  truck counts at 8 AM daily"), then covers the four task shapes,
+  alarms & alert levels, the events → alerts → alarms attention ladder,
+  what's on by default, and how to enable the rest.
 - [**Models & latency**](MODELS_AND_LATENCY.md) — how model choices were weighed
   for CPU latency and good UX, plus the efficient model picks.
 - [**Alarms**](ALARMS.md) — ringing alarms, time windows, presets, and the

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -185,6 +185,14 @@ class AppConfig:
     # example's ``index`` subcommand.
     footage_index_path: str | None = None
 
+    # Labels the deployment's detection adapter can see BEYOND the standard
+    # YOLOv8/COCO-80 set. Alarm presets (GET /alarm-presets) are greyed out
+    # when their target isn't detectable — a "Fire" preset that could never
+    # fire is worse than none. An operator who registers a fire/smoke-capable
+    # detector lists its extra labels here (e.g. ["fire", "smoke"]) and the
+    # matching presets light up.
+    detector_extra_labels: list[str] = field(default_factory=list)
+
     # Optional OpenNVR camera discovery. Docker uses this so camera-agent can
     # reuse cameras configured in OpenNVR instead of duplicating RTSP URLs.
     opennvr_cameras_url: str | None = None
@@ -340,6 +348,27 @@ _DEFAULT_SYSTEM_PROMPT = (
 # metadata and the OPTIONAL wake word — it keeps the legacy "Camera Agent"
 # value for infra/wake-word compat. The voice is a separate choice.
 DEFAULT_AGENT_NAME = "Camera Agent"
+
+# The COCO-80 vocabulary of the standard ``default`` YOLOv8 detection
+# adapter — the labels alarm polling can actually match. Alarm-preset
+# availability is checked against this set (plus the config's
+# ``detector_extra_labels``) so the UI never offers an alarm that could
+# never ring: note there is NO fire, smoke, or gas in here.
+_COCO80_LABELS: frozenset[str] = frozenset({
+    "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train",
+    "truck", "boat", "traffic light", "fire hydrant", "stop sign",
+    "parking meter", "bench", "bird", "cat", "dog", "horse", "sheep",
+    "cow", "elephant", "bear", "zebra", "giraffe", "backpack", "umbrella",
+    "handbag", "tie", "suitcase", "frisbee", "skis", "snowboard",
+    "sports ball", "kite", "baseball bat", "baseball glove", "skateboard",
+    "surfboard", "tennis racket", "bottle", "wine glass", "cup", "fork",
+    "knife", "spoon", "bowl", "banana", "apple", "sandwich", "orange",
+    "broccoli", "carrot", "hot dog", "pizza", "donut", "cake", "chair",
+    "couch", "potted plant", "bed", "dining table", "toilet", "tv",
+    "laptop", "mouse", "remote", "keyboard", "cell phone", "microwave",
+    "oven", "toaster", "sink", "refrigerator", "book", "clock", "vase",
+    "scissors", "teddy bear", "hair drier", "toothbrush",
+})
 DEFAULT_VOICE_GENDER = "neutral"
 
 # ── Skills ──────────────────────────────────────────────────────────
@@ -2437,6 +2466,11 @@ def load_config(path: str | Path) -> AppConfig:
         nats_inference_url=raw.get("nats_inference_url"),
         nats_inference_token=raw.get("nats_inference_token"),
         footage_index_path=raw.get("footage_index_path"),
+        detector_extra_labels=[
+            str(s).strip().lower()
+            for s in (raw.get("detector_extra_labels") or [])
+            if str(s).strip()
+        ],
         opennvr_cameras_url=raw.get("opennvr_cameras_url"),
         opennvr_api_key=raw.get("opennvr_api_key"),
         opennvr_api_url=_opennvr_api_url,
@@ -2813,6 +2847,75 @@ class CameraAgentRuntime:
 
     _RING_BUILTIN_DEFAULTS = {"fire": "siren", "smoke": "siren",
                               "flame": "siren", "gas": "siren"}
+
+    # ── Alarm presets ─────────────────────────────────────────────
+    # Curated one-click alarms for the demo's Alarms card. Availability is
+    # HONEST: a preset is offered only when the detection path that alarm
+    # polling actually uses (the ``default`` adapter, COCO-80 labels unless
+    # ``detector_extra_labels`` widens it) can see the target. The safety
+    # presets (fire/smoke/gas) are therefore GREYED OUT on a stock stack —
+    # a Fire alarm that could never ring is worse than none — and the
+    # payload says exactly what to run to light them up.
+    _ALARM_PRESETS: list[dict[str, Any]] = [
+        {"id": "fire", "name": "Fire", "target": "fire",
+         "ring": "siren", "safety": True},
+        {"id": "smoke", "name": "Smoke", "target": "smoke",
+         "ring": "siren", "safety": True},
+        {"id": "gas", "name": "Gas leak", "target": "gas",
+         "ring": "siren", "safety": True},
+        {"id": "after-hours", "name": "After-hours person", "target": "person",
+         "ring": "siren", "after": "18:00", "safety": False},
+        {"id": "person", "name": "Person", "target": "person",
+         "ring": "chime", "safety": False},
+        {"id": "vehicle", "name": "Car", "target": "car",
+         "ring": "chime", "safety": False},
+        {"id": "truck", "name": "Truck", "target": "truck",
+         "ring": "chime", "safety": False},
+        {"id": "dog", "name": "Dog", "target": "dog",
+         "ring": "chime", "safety": False},
+    ]
+
+    def _detectable_labels(self) -> set[str]:
+        """What the alarm-polling detector can actually see: the standard
+        YOLOv8/COCO-80 vocabulary plus any ``detector_extra_labels`` the
+        operator declared for a custom detector."""
+        return set(_COCO80_LABELS) | set(
+            getattr(self.cfg, "detector_extra_labels", []) or [])
+
+    def alarm_presets(self) -> list[dict[str, Any]]:
+        """The Alarms card's preset list, with honest availability.
+
+        A preset is ``available`` when an object-detection adapter is live
+        (per the KAI-C capabilities view; unknown = assume live, the same
+        advisory fallback the skills panel uses) AND its target is in the
+        detectable label set. Unavailable presets carry a ``requires``
+        sentence naming exactly what to run/register."""
+        labels = self._detectable_labels()
+        live_tasks = self.kaic_capabilities.tasks_advertised
+        det_live = live_tasks is None or bool(
+            {"object_detection", "detect_objects", "object-detection"} & live_tasks)
+        out: list[dict[str, Any]] = []
+        for p in self._ALARM_PRESETS:
+            entry = dict(p)
+            if not det_live:
+                entry["available"] = False
+                entry["requires"] = (
+                    "Needs an object-detection adapter registered in KAI-C — "
+                    "the standard stack's YOLOv8 adapter provides it."
+                )
+            elif p["target"] not in labels:
+                entry["available"] = False
+                entry["requires"] = (
+                    f"The standard YOLOv8 detector can't see {p['target']!r}. "
+                    "Register a detection adapter trained for it (AI Adapters "
+                    "page), then list its label under 'detector_extra_labels' "
+                    "in the agent config to enable this preset."
+                )
+            else:
+                entry["available"] = True
+                entry["requires"] = None
+            out.append(entry)
+        return out
 
     def ring_defaults(self) -> dict[str, str]:
         """Target→annunciation defaults: built-ins overlaid with the
@@ -4625,6 +4728,15 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 for a in alarms) else ("pulse" if any(
                     a["triggered"] and a["active"] for a in alarms) else None)),
         }
+
+    @app.get("/alarm-presets")
+    async def _alarm_presets() -> dict[str, Any]:
+        """Curated one-click alarms with HONEST availability: presets whose
+        target the live detection path can't see come back with
+        ``available: false`` and a ``requires`` sentence naming what to
+        run — the UI greys them out instead of arming an alarm that could
+        never ring. Read-only, viewer tier."""
+        return {"presets": runtime.alarm_presets()}
 
     @app.post("/alarms")
     async def _create_alarm(request: Request) -> JSONResponse:

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -2649,8 +2649,9 @@ class CameraAgentRuntime:
             else:
                 logger.info(
                     "camera-agent: footage_index_path set (%s) but the index "
-                    "isn't readable yet; search_footage will report it's "
-                    "unavailable until the footage-search indexer has run",
+                    "isn't readable yet — search_footage lights up "
+                    "automatically once the footage-search indexer has "
+                    "created it (the reader re-tries on every call)",
                     cfg.footage_index_path,
                 )
 
@@ -2776,6 +2777,12 @@ class CameraAgentRuntime:
         # handlers degrade gracefully if the registry is momentarily down.
         if not self.skill_requirement_met("apps"):
             excluded.update(SKILL_TOOLS["apps"])
+        # Same principle for footage: with no footage_index_path configured
+        # there is nothing the tool could ever read, so the LLM shouldn't
+        # see it. When the path IS set, the tool stays advertised and
+        # degrades cleanly until the indexer has built the file.
+        if not self.skill_requirement_met("footage"):
+            excluded.update(SKILL_TOOLS["footage"])
         allow = None if self.cfg.enabled_tools is None else set(self.cfg.enabled_tools)
 
         def keep(defn: dict[str, Any]) -> bool:
@@ -2869,8 +2876,12 @@ class CameraAgentRuntime:
         if req == "events":
             return bool(self.cfg.nats_inference_url)
         if req == "footage":
-            return bool(getattr(self, "footage_index", None)
-                        and self.footage_index.available)
+            # Configuration presence is the gate (same principle as the app
+            # door): the reader re-tries opening on every call, so an index
+            # the footage-search container creates AFTER the agent booted
+            # lights the tool up without an agent restart. When the index
+            # isn't readable yet the tool itself says so, cleanly.
+            return getattr(self, "footage_index", None) is not None
         if req == "apps":
             # The app door is wired iff the OpenNVR server base URL is set —
             # then the AppRegistryClient exists. Configuration presence is the

--- a/examples/camera-agent/config.docker.chat.yml
+++ b/examples/camera-agent/config.docker.chat.yml
@@ -38,6 +38,12 @@ enabled_tools:
   - recent_events
   - create_monitor
   - create_alarm
+  # Reads the footage-search app's index (mounted read-only at /footage);
+  # reports cleanly until the apps overlay has built it.
+  - search_footage
+
+# See config.docker.yml — same read-only mount, same self-healing reader.
+footage_index_path: /footage/footage_index.sqlite3
 
 frame_cache_ttl_seconds: 2.0
 event_ring_size: 256

--- a/examples/camera-agent/config.docker.chat.yml
+++ b/examples/camera-agent/config.docker.chat.yml
@@ -41,6 +41,10 @@ enabled_tools:
   # Reads the footage-search app's index (mounted read-only at /footage);
   # reports cleanly until the apps overlay has built it.
   - search_footage
+  # The app door (read-only): answers about the default-on catalog apps.
+  - list_apps
+  - app_status
+  - recent_app_alerts
 
 # See config.docker.yml — same read-only mount, same self-healing reader.
 footage_index_path: /footage/footage_index.sqlite3

--- a/examples/camera-agent/config.docker.chat.yml
+++ b/examples/camera-agent/config.docker.chat.yml
@@ -37,7 +37,9 @@ enabled_tools:
   - describe_camera
   - recent_events
   - create_monitor
+  - stop_monitor
   - create_alarm
+  - stop_alarm
   # Reads the footage-search app's index (mounted read-only at /footage);
   # reports cleanly until the apps overlay has built it.
   - search_footage

--- a/examples/camera-agent/config.docker.yml
+++ b/examples/camera-agent/config.docker.yml
@@ -75,6 +75,12 @@ enabled_tools:
   - detect_objects
   - describe_camera
   - search_footage
+  # The app door (read-only, backed by opennvr_api_url below): lets the
+  # agent answer about the default-on catalog apps — "is the occupancy
+  # counter healthy?", "any occupancy alerts this morning?".
+  - list_apps
+  - app_status
+  - recent_app_alerts
 
 # LLM tuning. qwen2.5:1.5b is the docker-compose.camera-agent.yml default —
 # ~1 GB of RAM, snappy on CPU, Apache-2.0, and NON-thinking (the right choice on

--- a/examples/camera-agent/config.docker.yml
+++ b/examples/camera-agent/config.docker.yml
@@ -81,6 +81,15 @@ enabled_tools:
   - list_apps
   - app_status
   - recent_app_alerts
+  # Voice parity with the chat demo: look back at recent events, watch a
+  # camera over time, and arm/disarm alarms by voice ("alarm me if someone
+  # is at the door after 10pm"). All ride the streams the standard stack
+  # already runs — no extra adapter or model.
+  - recent_events
+  - create_monitor
+  - stop_monitor
+  - create_alarm
+  - stop_alarm
 
 # LLM tuning. qwen2.5:1.5b is the docker-compose.camera-agent.yml default —
 # ~1 GB of RAM, snappy on CPU, Apache-2.0, and NON-thinking (the right choice on

--- a/examples/camera-agent/config.docker.yml
+++ b/examples/camera-agent/config.docker.yml
@@ -64,15 +64,17 @@ recognition_adapter: insightface
 caption_adapter: ${CAPTION_ADAPTER}   # moondream (default) — auto-registered by caption-adapter-register
 
 # Tools advertised to the LLM. standard stack only registers the YOLOv8 object
-# detector, so the demo exposes just the two tools that actually work:
-# detect_objects (counts people/cars/…) and describe_camera (which falls
-# back to the detector when no caption adapter is present). This keeps the
-# prompt short (faster CPU prefill) and stops the model calling face
-# recognition / footage search whose adapters aren't deployed. Add names
-# here once you register BLIP / InsightFace / the footage index.
+# detector, so the demo exposes the tools that actually work: detect_objects
+# (counts people/cars/…), describe_camera (which falls back to the detector
+# when no caption adapter is present), and search_footage (reads the
+# footage-search app's index — mounted read-only at /footage; reports
+# cleanly until the apps overlay has built it). This keeps the prompt short
+# (faster CPU prefill) and stops the model calling face recognition whose
+# adapter isn't deployed. Add names here once you register BLIP / InsightFace.
 enabled_tools:
   - detect_objects
   - describe_camera
+  - search_footage
 
 # LLM tuning. qwen2.5:1.5b is the docker-compose.camera-agent.yml default —
 # ~1 GB of RAM, snappy on CPU, Apache-2.0, and NON-thinking (the right choice on
@@ -100,6 +102,14 @@ event_ring_size: 256
 # last 30 minutes?". The token matches the NATS --auth value in the
 # standard stack compose (which uses INTERNAL_API_KEY).
 nats_inference_url: nats://nats:4222
+
+# The footage-search app's SQLite index, mounted read-only by the compose
+# overlay (volume opennvr_footage_search_data → /footage). Enables the
+# search_footage tool — "did a red truck come by earlier today?". The
+# reader re-tries on every call, so the tool lights up automatically once
+# the apps overlay's indexer has created the file; until then it reports
+# the index hasn't been built yet.
+footage_index_path: /footage/footage_index.sqlite3
 nats_inference_token: ${INTERNAL_API_KEY}
 
 # Load cameras from OpenNVR. OpenNVR returns internal MediaMTX frame-source

--- a/examples/camera-agent/config.example.yml
+++ b/examples/camera-agent/config.example.yml
@@ -113,6 +113,13 @@ event_ring_size: 256
 # indexer writes to.
 # footage_index_path: /data/footage_index.sqlite3
 
+# Labels your detection adapter can see BEYOND the standard YOLOv8/COCO-80
+# set. Alarm presets (the demo's one-click Fire / Smoke / Gas leak buttons)
+# stay greyed out until their target is detectable — a Fire alarm that could
+# never ring is worse than none. Registered a fire/smoke-capable detector?
+# List its labels here and the matching presets light up.
+# detector_extra_labels: ["fire", "smoke"]
+
 # Optional: auto-discover cameras from a running OpenNVR instance.
 # When set and the `cameras` list below is empty, the agent calls
 # GET <opennvr_cameras_url> (auth: X-Internal-Api-Key) and builds

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -256,6 +256,9 @@
     #alarmCard .item .badge{color:var(--danger);}
     .presets{display:flex; flex-wrap:wrap; gap:0.4rem; margin-top:0.4rem;}
     .presets .ghost{font-size:0.78rem;}
+    .presets .preset.unavail{opacity:0.45; cursor:help; filter:grayscale(1);}
+    .preset-hint{font-size:0.74rem; color:var(--muted); margin-top:0.35rem; line-height:1.35;
+      border-left:2px solid var(--danger); padding-left:0.5rem;}
 
     /* skills */
     .skillhint{color:var(--faint); font-size:0.72rem; margin:-0.15rem 0 0.5rem;}
@@ -602,10 +605,12 @@
             <button class="ghost" id="ringAddRow" type="button">+ add target</button>
             <button class="ghost primary" id="ringSave" type="button">Save defaults</button>
           </div>
-          <div class="presets">
-            <button class="ghost preset" data-name="Fire" data-target="fire" data-ring="siren" type="button"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true"><path d="M12 2c1 3 4 4 4 8a4 4 0 0 1-8 0c0-2 1-3 2-4 0 2 2 2 2 0 0-2-2-2-2-4z"/></svg> Fire</button>
-            <button class="ghost preset" data-name="After-hours person" data-target="person" data-after="18:00" data-ring="siren" type="button"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A8 8 0 1 1 11.2 3 6 6 0 0 0 21 12.8z"/></svg> After-hours</button>
-          </div>
+          <!-- One-click presets, rendered from GET /alarm-presets with HONEST
+               availability: a preset whose target the live detector can't see
+               (fire/smoke/gas on the stock COCO YOLOv8) is greyed out, and
+               clicking it explains exactly what to run to enable it. -->
+          <div class="presets" id="alarmPresets"></div>
+          <div class="preset-hint" id="presetHint" hidden></div>
           <div class="addform" id="alarmForm" hidden>
             <input id="alarmName" type="text" placeholder="Name, e.g. Porch person" autocomplete="off">
             <input id="alarmTarget" type="text" placeholder="Watch for, e.g. person / car / package" autocomplete="off">
@@ -1740,10 +1745,37 @@
 
     // ── wiring ──
     silenceBtn.addEventListener("click", ackAlarms);
-    document.querySelectorAll(".preset").forEach(btn=>btn.addEventListener("click",()=>{
-      const body={name:btn.dataset.name,target:btn.dataset.target,camera_id:cameraParam()};
-      if(btn.dataset.after) body.after=btn.dataset.after;
-      if(btn.dataset.ring) body.ring=btn.dataset.ring; addAlarm(body); }));
+    // Alarm presets come from the server so availability is honest: the
+    // backend checks each target against what the live detection path can
+    // actually see. Unavailable ones render greyed; clicking one shows the
+    // "what to run" hint instead of arming an alarm that could never ring.
+    async function loadAlarmPresets(){
+      try{
+        const d=await (await fetch("/alarm-presets")).json();
+        const wrap=$("alarmPresets"); if(!wrap) return; wrap.innerHTML="";
+        (d.presets||[]).forEach(p=>{
+          const b=document.createElement("button");
+          b.type="button"; b.className="ghost preset"+(p.available?"":" unavail");
+          b.textContent=p.name;
+          b.title=p.available?("Arm: watch for "+p.target+(p.after?(" after "+p.after):"")):(p.requires||"Not available yet");
+          b.addEventListener("click",()=>{
+            if(!p.available){ showPresetHint(p); return; }
+            const body={name:p.name,target:p.target,camera_id:cameraParam()};
+            if(p.after) body.after=p.after;
+            if(p.ring) body.ring=p.ring;
+            addAlarm(body);
+          });
+          wrap.appendChild(b);
+        });
+      }catch{}
+    }
+    function showPresetHint(p){
+      const h=$("presetHint"); if(!h) return;
+      h.textContent=p.name+": "+(p.requires||"not available yet.");
+      h.hidden=false;
+      clearTimeout(showPresetHint._t);
+      showPresetHint._t=setTimeout(()=>{ h.hidden=true; }, 15000);
+    }
     $("askBtn").addEventListener("click", ask);
     $("askInput").addEventListener("keydown",(e)=>{ if(e.key==="Enter") ask(); });
     // Click Talk to start/stop the listening session. Stop must ALWAYS work —
@@ -2031,7 +2063,7 @@
     // Resolve auth state (open /agent) BEFORE loading any gated data, so a
     // signed-out visitor doesn't fire a burst of 401s behind the login. After
     // sign-in the page reloads with a token and these run normally.
-    loadAgent().then(()=>{ if(authReady()){ loadCameras().then(openDeepLinkedCamera); loadNotify(); loadSkills(); loadHardware(); loadEvents(); } connectUpdates(); });
+    loadAgent().then(()=>{ if(authReady()){ loadCameras().then(openDeepLinkedCamera); loadNotify(); loadAlarmPresets(); loadSkills(); loadHardware(); loadEvents(); } connectUpdates(); });
     setAvatar("idle");
     renderTasks([]); renderMonitors([]); renderAlarms([]); renderReports([]);
     alarmTimer = setInterval(pollAlarmsHttp, 2500);   // alarms ring even before Talk

--- a/examples/camera-agent/footage_index.py
+++ b/examples/camera-agent/footage_index.py
@@ -40,22 +40,41 @@ class FootageIndex:
     def __init__(self, db_path: str) -> None:
         self._path = db_path
         self._conn: sqlite3.Connection | None = None
-        if Path(db_path).exists():
-            try:
-                # Open read-only via URI so we never create or mutate the
-                # indexer's database from the agent process.
-                self._conn = sqlite3.connect(
-                    f"file:{db_path}?mode=ro", uri=True, check_same_thread=False
-                )
-                self._conn.row_factory = sqlite3.Row
-                # Probe the expected table; if absent, treat as unavailable.
-                self._conn.execute("SELECT 1 FROM keyframes LIMIT 1")
-            except sqlite3.Error:
-                self._conn = None
+        self._ensure_open()
+
+    def _ensure_open(self) -> bool:
+        """Open (or re-try opening) the index. Lazy on purpose: on a stock
+        install the agent and the footage-search indexer start together, and
+        the agent usually probes BEFORE the indexer has created its schema.
+        A one-shot probe at boot would leave ``search_footage`` reporting
+        "unavailable" forever until an agent restart — so every call re-tries
+        until the index exists. Cheap when it doesn't: a Path.exists check."""
+        if self._conn is not None:
+            return True
+        if not Path(self._path).exists():
+            return False
+        try:
+            # Open read-only via URI so we never create or mutate the
+            # indexer's database from the agent process.
+            conn = sqlite3.connect(
+                f"file:{self._path}?mode=ro", uri=True, check_same_thread=False
+            )
+        except sqlite3.Error:
+            return False
+        conn.row_factory = sqlite3.Row
+        try:
+            # Probe the expected table; the file can exist before the
+            # indexer has created its schema — treat that as not-yet.
+            conn.execute("SELECT 1 FROM keyframes LIMIT 1")
+        except sqlite3.Error:
+            conn.close()
+            return False
+        self._conn = conn
+        return True
 
     @property
     def available(self) -> bool:
-        return self._conn is not None
+        return self._ensure_open()
 
     def search(
         self,
@@ -68,7 +87,7 @@ class FootageIndex:
         """Find keyframes where every keyword appears in the labels or
         the caption, optionally within a recent time window and on one
         camera. Newest-first."""
-        if self._conn is None:
+        if not self._ensure_open():
             return []
         clauses: list[str] = []
         params: list[object] = []
@@ -94,6 +113,9 @@ class FootageIndex:
         try:
             rows = self._conn.execute(sql, params).fetchall()
         except sqlite3.Error:
+            # A failing query (index file replaced or truncated mid-read)
+            # drops the handle so the next call re-opens fresh.
+            self.close()
             return []
         return [
             IndexHit(

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -305,3 +305,51 @@ def test_alarm_defaults_endpoints_and_admin_gate():
     assert ok.status_code == 200 and ok.json()["defaults"]["snake"] == "siren"
     assert c.put("/alarm-defaults", json={"overrides": "nope"},
                  headers=h("tok-admin")).status_code == 400
+
+
+# ── Alarm presets (GET /alarm-presets) ─────────────────────────────
+#
+# Availability must be HONEST: the stock detection path is YOLOv8/COCO-80,
+# which cannot see fire/smoke/gas — those presets must come back greyed
+# with a "what to run" sentence, not armable. Detectable targets (person,
+# car, …) are available out of the box.
+
+
+def test_presets_stock_availability():
+    rt = _runtime()
+    by_id = {p["id"]: p for p in rt.alarm_presets()}
+    for sid in ("fire", "smoke", "gas"):
+        assert by_id[sid]["available"] is False, sid
+        assert "detector" in by_id[sid]["requires"].lower(), sid
+    for sid in ("person", "after-hours", "vehicle", "truck", "dog"):
+        assert by_id[sid]["available"] is True, sid
+        assert by_id[sid]["requires"] is None, sid
+    # The after-hours preset carries its window so one click arms 18:00+.
+    assert by_id["after-hours"]["after"] == "18:00"
+
+
+def test_presets_extra_labels_light_up_safety_alarms():
+    rt = _runtime()
+    rt.cfg.detector_extra_labels = ["fire", "smoke"]
+    by_id = {p["id"]: p for p in rt.alarm_presets()}
+    assert by_id["fire"]["available"] is True
+    assert by_id["smoke"]["available"] is True
+    assert by_id["gas"]["available"] is False, "gas still needs a detector"
+
+
+def test_presets_grey_out_when_no_detection_adapter():
+    rt = _runtime()
+    rt.kaic_capabilities._tasks = {"image_captioning"}   # live view, no detector
+    assert all(p["available"] is False for p in rt.alarm_presets())
+    rt.kaic_capabilities._tasks = None                   # unknown → assume live
+    assert any(p["available"] for p in rt.alarm_presets())
+
+
+def test_presets_endpoint_serves_the_list():
+    rt = _runtime()
+    client = TestClient(build_app(rt))
+    d = client.get("/alarm-presets").json()
+    ids = [p["id"] for p in d["presets"]]
+    assert "fire" in ids and "person" in ids
+    fire = next(p for p in d["presets"] if p["id"] == "fire")
+    assert fire["available"] is False and fire["requires"]

--- a/examples/camera-agent/tests/test_demo_skills_ui.py
+++ b/examples/camera-agent/tests/test_demo_skills_ui.py
@@ -260,7 +260,12 @@ def test_alarm_ring_levels_wired(script: str, html: str) -> None:
     assert "function wireRingPreselect" in script
     assert "flashChime" in script and 'playChime("bell")' in script
     assert ".alarmbar.chime" in html, "chime banner style missing"
-    assert 'data-ring="siren"' in html, "presets lost their siren grade"
+    # Presets are server-rendered now (GET /alarm-presets, honest
+    # availability); the siren grade rides in each preset's payload and
+    # the click handler forwards it into the arm body.
+    assert "/alarm-presets" in script, "presets no longer server-driven"
+    assert "body.ring=p.ring" in script.replace(" ", ""), (
+        "preset click no longer forwards the ring grade")
 
 
 def test_ring_defaults_editor_wired(script: str, html: str) -> None:

--- a/examples/camera-agent/tests/test_footage_search_tool.py
+++ b/examples/camera-agent/tests/test_footage_search_tool.py
@@ -133,3 +133,39 @@ async def test_tool_requires_keywords(tmp_path):
     tools = _tools(FootageIndex(db))
     out = await tools.search_footage({"keywords": []})
     assert "ERROR" in out
+
+
+# ── Lazy (re-)open ─────────────────────────────────────────────────
+#
+# On a stock install the agent and the footage-search indexer start
+# together, and the agent probes BEFORE the indexer has created its
+# schema. A one-shot probe at boot left search_footage "unavailable"
+# forever until an agent restart; the reader now re-tries on every call.
+
+
+def test_index_created_after_boot_lights_up_without_restart(tmp_path):
+    db = str(tmp_path / "late.sqlite3")
+    idx = FootageIndex(db)                    # agent boots first
+    assert idx.available is False
+    _build_index(db, [                         # indexer catches up later
+        ("cam-dock", time.time() - 60, "A", "tier0", "truck", ""),
+    ])
+    assert idx.available is True, "reader must re-try, not remember failure"
+    hits = idx.search(keywords=["truck"])
+    assert len(hits) == 1 and hits[0].camera_id == "cam-dock"
+
+
+def test_file_present_but_schema_not_yet_is_not_yet(tmp_path):
+    """The DB file can exist before the indexer has created its table
+    (sqlite creates the file on connect). Treat that as not-yet, then
+    succeed once the schema lands."""
+    db = str(tmp_path / "empty.sqlite3")
+    sqlite3.connect(db).close()               # zero-byte file, no schema
+    idx = FootageIndex(db)
+    assert idx.available is False
+    assert idx.search(keywords=["truck"]) == []
+    _build_index(db, [
+        ("cam-gate", time.time() - 30, "B", "tier0", "person", ""),
+    ])
+    assert idx.available is True
+    assert len(idx.search(keywords=["person"])) == 1

--- a/examples/footage-search/config.docker.yml
+++ b/examples/footage-search/config.docker.yml
@@ -49,6 +49,15 @@ result_limit: 25
 # 6h. Set 0 to keep everything forever (you own the disk).
 retention_days: 30
 
+# One row per EPISODE, not per frame: Tier-0 publishes an event per
+# analyzed frame, so without this a person sitting in view at 2 fps is
+# 7,200 identical "person" rows an hour — and a search returns 25
+# consecutive frames instead of 25 distinct sightings. Caption-less
+# repeats of the same label set on a camera within this many seconds
+# merge into one row (its timestamp advances). Set 0 to index every
+# frame separately.
+coalesce_seconds: 60
+
 # ── Optional LLM query parsing (Ollama) ────────────────────────────
 # When enabled, queries are parsed by a local Ollama model (e.g. the
 # camera-agent overlay's ``ollama`` service) instead of the built-in

--- a/examples/footage-search/config.example.yml
+++ b/examples/footage-search/config.example.yml
@@ -52,6 +52,15 @@ result_limit: 25
 # 6h. Set 0 to keep everything forever (you own the disk).
 retention_days: 30
 
+# One row per EPISODE, not per frame: Tier-0 publishes an event per
+# analyzed frame, so without this a person sitting in view at 2 fps is
+# 7,200 identical "person" rows an hour — and a search returns 25
+# consecutive frames instead of 25 distinct sightings. Caption-less
+# repeats of the same label set on a camera within this many seconds
+# merge into one row (its timestamp advances). Set 0 to index every
+# frame separately.
+coalesce_seconds: 60
+
 # ── Optional LLM query parsing (Ollama) ───────────────────────────
 #
 # When enabled, the natural-language query is parsed by a local Ollama

--- a/examples/footage-search/footage_search.py
+++ b/examples/footage-search/footage_search.py
@@ -109,6 +109,10 @@ MANIFEST = AppManifest(
         Param("result_limit", int, default=25),
         Param("retention_days", int, default=30,
               description="Delete indexed keyframes older than this. 0 keeps everything."),
+        Param("coalesce_seconds", int, default=60,
+              description="Merge caption-less repeats of the same label set on "
+                          "a camera within this window into one row (Tier-0 "
+                          "publishes per frame). 0 disables."),
     ],
     emits=[],  # writes an index; fires no alerts
     # Declarative live-state views — rendered generically by the catalog.
@@ -163,6 +167,12 @@ class AppConfig:
     # unbounded index is a slow disk leak on an active camera. 0
     # disables pruning (an operator who wants a permanent archive).
     retention_days: int = 30
+    # Tier-0 publishes an event per analyzed frame with no correlation_id;
+    # without coalescing a person sitting in frame is thousands of identical
+    # rows and a search returns 25 consecutive frames instead of 25 distinct
+    # episodes. Repeats of the same label set within this window advance the
+    # existing row's timestamp instead of inserting. 0 disables.
+    coalesce_seconds: int = 60
 
     # App contract (spec §03) — all optional; see the SDK's contract
     # module. ``contract_port`` serves /health /manifest /state AND the
@@ -219,6 +229,7 @@ def load_config(path: str) -> AppConfig:
         ollama=ollama,
         result_limit=result_limit,
         retention_days=max(0, int(raw.get("retention_days", 30) or 0)),
+        coalesce_seconds=max(0, int(raw.get("coalesce_seconds", 60) or 0)),
         contract_port=(
             int(contract_port_raw) if contract_port_raw is not None else None
         ),
@@ -458,7 +469,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"config error: {exc}", file=sys.stderr)
         return 2
 
-    store = FootageStore(config.db_path)
+    store = FootageStore(
+        config.db_path, coalesce_seconds=float(config.coalesce_seconds)
+    )
     try:
         if args.command == "search":
             results = run_search(config, store, args.query)

--- a/examples/footage-search/store.py
+++ b/examples/footage-search/store.py
@@ -57,7 +57,14 @@ class FootageStore:
     process doesn't trip over it.
     """
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, *, coalesce_seconds: float = 60.0) -> None:
+        # Tier-0 publishes an event per analyzed frame and its events carry
+        # no correlation_id, so nothing merges: a person sitting in frame at
+        # 2 fps would insert 7,200 identical "person" rows per hour. Rows
+        # that repeat the previous row's label set within this window are
+        # coalesced into it (its timestamp advances) — one row per
+        # *episode*, not per frame. 0 disables.
+        self._coalesce_seconds = max(0.0, float(coalesce_seconds))
         self._conn = sqlite3.connect(path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._init_schema()
@@ -89,8 +96,11 @@ class FootageStore:
         correlation_id. Merging them onto one row is what lets a query
         like "red truck" match — ``truck`` from the detector's labels and
         ``red`` from the captioner's text end up on the same row. A
-        keyframe with no correlation_id can't be merged, so it's always
-        inserted fresh.
+        keyframe with no correlation_id can't be merged that way; instead,
+        a caption-less one that repeats the previous row's label set on the
+        same camera within ``coalesce_seconds`` is treated as the same
+        episode continuing (the row's timestamp advances) — anything else
+        is inserted fresh.
         """
         labels = " ".join(sorted({s.lower() for s in kf.labels}))
         caption = kf.caption.lower()
@@ -119,6 +129,32 @@ class FootageStore:
                     "UPDATE keyframes SET labels = ?, caption = ?, adapter = ? "
                     "WHERE id = ?",
                     (merged_labels, merged_caption, adapters, existing["id"]),
+                )
+                self._conn.commit()
+                return
+
+        elif self._coalesce_seconds > 0 and not caption:
+            # No correlation_id (Tier-0's continuous per-frame stream) and
+            # nothing to merge: if the SAME camera already has a row with the
+            # SAME label set inside the window, this event is the previous
+            # one continuing, not a new episode — advance that row's
+            # timestamp instead of inserting. Search results then read as
+            # distinct episodes, and a person sitting in frame is one row
+            # per window instead of one per analyzed frame. Comparing
+            # against the newest row *with these labels* (not the newest row
+            # overall) keeps alternating scenes — person / person+car —
+            # from defeating the window. Caption-carrying rows are exempt:
+            # captions differ frame to frame and deserve their own rows.
+            existing = self._conn.execute(
+                "SELECT id, ts FROM keyframes "
+                "WHERE camera_id = ? AND correlation_id = '' AND labels = ? "
+                "AND caption = '' ORDER BY ts DESC LIMIT 1",
+                (kf.camera_id, labels),
+            ).fetchone()
+            if existing is not None and 0 <= kf.ts - existing["ts"] <= self._coalesce_seconds:
+                self._conn.execute(
+                    "UPDATE keyframes SET ts = ? WHERE id = ?",
+                    (kf.ts, existing["id"]),
                 )
                 self._conn.commit()
                 return

--- a/examples/footage-search/tests/test_footage_search.py
+++ b/examples/footage-search/tests/test_footage_search.py
@@ -281,3 +281,68 @@ def test_retention_window_prunes_ancient_rows(tmp_path):
     assert indexer.prune_now() == 1
     assert store.count() == 1
     store.close()
+
+
+# ── Episode coalescing ─────────────────────────────────────────────
+#
+# Tier-0 publishes an event per analyzed frame and its events carry no
+# correlation_id, so nothing merges by correlation: without coalescing a
+# person sitting in frame at 2 fps is 7,200 identical rows an hour, and a
+# search returns 25 consecutive frames instead of 25 distinct sightings.
+
+
+def test_repeated_tier0_frames_coalesce_into_one_episode(tmp_path):
+    store = FootageStore(str(tmp_path / "idx.sqlite3"), coalesce_seconds=60)
+    base = 1_755_700_000.0
+    for i in range(10):                      # 10 frames over 45 seconds
+        _kf(store, ts=base + i * 5)
+    assert store.count() == 1, "one episode, not one row per frame"
+    hit = store.search(labels=["person"])[0]
+    assert hit.ts == base + 45, "the episode's timestamp advances to the latest frame"
+    store.close()
+
+
+def test_a_gap_beyond_the_window_starts_a_new_episode(tmp_path):
+    store = FootageStore(str(tmp_path / "idx.sqlite3"), coalesce_seconds=60)
+    base = 1_755_700_000.0
+    _kf(store, ts=base)
+    _kf(store, ts=base + 61)                 # outside the window
+    assert store.count() == 2
+    store.close()
+
+
+def test_different_label_sets_do_not_coalesce_and_alternation_survives(tmp_path):
+    """person / person+car alternating each frame must not defeat the
+    window: each set coalesces against ITS OWN newest row."""
+    store = FootageStore(str(tmp_path / "idx.sqlite3"), coalesce_seconds=60)
+    base = 1_755_700_000.0
+    for i in range(6):
+        labels = ("person",) if i % 2 == 0 else ("car", "person")
+        _kf(store, ts=base + i * 5, labels=labels)
+    assert store.count() == 2, "one episode per distinct label set"
+    store.close()
+
+
+def test_caption_and_correlation_rows_are_exempt_from_coalescing(tmp_path):
+    store = FootageStore(str(tmp_path / "idx.sqlite3"), coalesce_seconds=60)
+    base = 1_755_700_000.0
+    # Caption-carrying keyframes (no correlation_id) each keep their row —
+    # captions differ frame to frame and are the searchable payload.
+    store.add(Keyframe(camera_id="cam-1", ts=base, correlation_id="",
+                       adapter="blip", labels=["person"], caption="a red coat"))
+    store.add(Keyframe(camera_id="cam-1", ts=base + 5, correlation_id="",
+                       adapter="blip", labels=["person"], caption="a blue coat"))
+    # Correlation-id keyframes keep the merge-by-correlation behavior.
+    _kf(store, ts=base + 10, corr="A")
+    _kf(store, ts=base + 15, corr="B")
+    assert store.count() == 4
+    store.close()
+
+
+def test_coalescing_can_be_disabled(tmp_path):
+    store = FootageStore(str(tmp_path / "idx.sqlite3"), coalesce_seconds=0)
+    base = 1_755_700_000.0
+    _kf(store, ts=base)
+    _kf(store, ts=base + 1)
+    assert store.count() == 2
+    store.close()

--- a/start.ps1
+++ b/start.ps1
@@ -66,6 +66,18 @@ function Get-ComposeArgs {
         }
     }
     if ($exampleProfile) { $args += @("--profile", $exampleProfile) }
+    # Default-on apps: occupancy-counting + footage-search ride the always-on
+    # Tier-0 stream and need no extra adapter, model, or GPU, so a stock
+    # install runs them (profile default-apps in docker-compose.apps.yml).
+    # Opt out with OPENNVR_DEFAULT_APPS=off in .env. Mirrors compose_args
+    # in start.sh.
+    $defaultApps = Get-EnvVar "OPENNVR_DEFAULT_APPS"
+    if (@("off", "false", "0", "no") -notcontains "$defaultApps".ToLower()) {
+        if (-not ($exampleCompose -like "*docker-compose.apps.yml")) {
+            $args += @("-f", "docker-compose.apps.yml")
+        }
+        $args += @("--profile", "default-apps")
+    }
     return $args
 }
 

--- a/start.sh
+++ b/start.sh
@@ -102,6 +102,20 @@ compose_args() {
         fi
     fi
     [[ -n "$example_profile" ]] && args="$args --profile $example_profile"
+    # Default-on apps: occupancy-counting + footage-search ride the always-on
+    # Tier-0 stream and need no extra adapter, model, or GPU, so a stock
+    # install runs them (profile ``default-apps`` in docker-compose.apps.yml).
+    # Opt out with OPENNVR_DEFAULT_APPS=off in .env. Lowercasing via ``tr``
+    # (not ${var,,}) so macOS bash 3.2 works.
+    local default_apps
+    default_apps=$(get_env_var "OPENNVR_DEFAULT_APPS" 2>/dev/null)
+    case "$(printf '%s' "$default_apps" | tr '[:upper:]' '[:lower:]')" in
+        off|false|0|no) ;;
+        *)
+            [[ "$example_compose" != *docker-compose.apps.yml ]] &&                 args="$args -f docker-compose.apps.yml"
+            args="$args --profile default-apps"
+            ;;
+    esac
     echo "$args"
 }
 


### PR DESCRIPTION
Three fixes from a review of footage-search + its camera-agent tie-in:

- Wire the two together in docker: mount footage-search's index volume read-only into both agent services (/footage), set footage_index_path in both docker configs, and advertise search_footage. The tool, the read-only reader, and the skill gate all existed — but no stock compose path ever connected them, so voice footage search was dead out of the box, silently.
- FootageIndex re-tries opening on every call instead of probing once at boot. The agent and the indexer start together and the agent probes first, so the one-shot probe left search_footage reporting "unavailable" forever until an agent restart. The skill gate becomes configuration-presence (the app-door precedent) and _configure_tools hides the tool only when no path is configured.
- Coalesce Tier-0's per-frame stream into episodes: a caption-less keyframe with no correlation_id that repeats the previous row's label set on the same camera within coalesce_seconds (default 60, 0 disables) advances that row's timestamp instead of inserting. A person sitting in frame at 2 fps was 7,200 identical rows an hour, and a search returned 25 consecutive frames instead of 25 distinct sightings. Caption rows and correlation-merged rows are exempt.