### PR TITLE
feat(cameras): per-camera capability assignments — slice 1 (schema + …

### DIFF
--- a/app/src/views/Cameras.tsx
+++ b/app/src/views/Cameras.tsx
@@ -32,6 +32,11 @@ import { parseCameraQr } from '../lib/cameraQr'
 import { formatDuration } from '../lib/time'
 import { Modal } from '../components/Modal'
 
+// Per-camera capability assignment ("camera 1 does LPR") — slice 1 of
+// docs/design/per-camera-assignment.md. Written only here (the camera
+// settings surface); consumers read it from the internal endpoint.
+type CameraAssignment = { skill: string; labels?: string[] | null }
+
 type Camera = {
   id: number
   name: string
@@ -62,7 +67,11 @@ type Camera = {
   firmware_version?: string | null
   serial_number?: string | null
   hardware_id?: string | null
+  assignments?: CameraAssignment[] | null
 }
+
+// Form-side assignment row: labels edited as a comma-separated string.
+type AssignmentRow = { skill: string; labels: string }
 
 type CameraForm = {
   name: string
@@ -77,6 +86,7 @@ type CameraForm = {
   vlan?: string
   status?: string
   is_active?: boolean
+  assignments: AssignmentRow[]
 }
 
 export function Cameras() {
@@ -128,6 +138,7 @@ export function Cameras() {
     location: '',
     vlan: '',
     status: 'unknown',
+    assignments: [],
   })
 
   const resetForm = () => setForm({
@@ -142,6 +153,7 @@ export function Cameras() {
     location: '',
     vlan: '',
     status: 'unknown',
+    assignments: [],
   })
 
   // Fetch streaming status for cameras
@@ -306,6 +318,15 @@ export function Cameras() {
         vlan: form.vlan || null,
         status: form.status || undefined,
         is_active: form.is_active,
+        // Full replace ([] clears): rows with an empty skill are dropped;
+        // labels split on commas, blanks removed.
+        assignments: form.assignments
+          .map(r => ({
+            skill: r.skill.trim().toLowerCase(),
+            labels: r.labels.split(',').map(x => x.trim().toLowerCase()).filter(Boolean),
+          }))
+          .filter(r => r.skill)
+          .map(r => (r.labels.length ? r : { skill: r.skill })),
       }
       Object.keys(payload).forEach((k) => payload[k] === undefined && delete payload[k])
       await apiService.updateCamera(editing.id, payload)
@@ -400,6 +421,10 @@ export function Cameras() {
       vlan: c.vlan || '',
       status: c.status || 'unknown',
       is_active: c.is_active,
+      assignments: (c.assignments || []).map(a => ({
+        skill: a.skill,
+        labels: (a.labels || []).join(', '),
+      })),
     })
     setShowEditDialog(true)
   }
@@ -706,6 +731,56 @@ export function Cameras() {
             </Field>
             <Field label="Substream URL">
               <input className={EDIT_INPUT} value={form.substream_url || ''} onChange={(e) => setForm({ ...form, substream_url: e.target.value })} placeholder="Optional low-res feed for the camera agent's live view" />
+            </Field>
+
+            <Field label="Assignments">
+              <div className="space-y-2">
+                <p className="text-xs text-[var(--muted)]">
+                  What this camera is <em>for</em> — e.g. skill{' '}
+                  <code>license_plate_recognition</code>, or{' '}
+                  <code>object_detection</code> narrowed to labels{' '}
+                  <code>person, truck</code>. Nothing assigned = no
+                  restriction declared. Consumers (Tier-0, apps) adopt these
+                  incrementally.
+                </p>
+                {form.assignments.map((row, i) => (
+                  <div key={i} className="flex gap-2 items-center">
+                    <input
+                      className={`flex-1 ${EDIT_INPUT}`}
+                      value={row.skill}
+                      onChange={(e) => setForm({
+                        ...form,
+                        assignments: form.assignments.map((r, j) => j === i ? { ...r, skill: e.target.value } : r),
+                      })}
+                      placeholder="skill, e.g. object_detection"
+                      aria-label={`Assignment ${i + 1} skill`}
+                    />
+                    <input
+                      className={`flex-1 ${EDIT_INPUT}`}
+                      value={row.labels}
+                      onChange={(e) => setForm({
+                        ...form,
+                        assignments: form.assignments.map((r, j) => j === i ? { ...r, labels: e.target.value } : r),
+                      })}
+                      placeholder="labels (optional), e.g. person, truck"
+                      aria-label={`Assignment ${i + 1} labels`}
+                    />
+                    <button
+                      type="button"
+                      className="px-2 py-2 border border-[var(--border)] bg-[var(--panel-2)] rounded text-xs"
+                      onClick={() => setForm({ ...form, assignments: form.assignments.filter((_, j) => j !== i) })}
+                      title="Remove assignment"
+                      aria-label={`Remove assignment ${i + 1}`}
+                    >✕</button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  className="px-3 py-1.5 border border-[var(--border)] bg-[var(--panel-2)] rounded text-xs"
+                  onClick={() => setForm({ ...form, assignments: [...form.assignments, { skill: '', labels: '' }] })}
+                  disabled={form.assignments.length >= 8}
+                >+ Add assignment</button>
+              </div>
             </Field>
 
             <label className="flex items-center gap-2 text-sm">

--- a/server/migrations/versions/aa11bb22cc33_add_camera_assignments.py
+++ b/server/migrations/versions/aa11bb22cc33_add_camera_assignments.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""add camera assignments
+
+Per-camera capability assignment (docs/design/per-camera-assignment.md,
+slice 1): ONE place that answers "what is camera 4 for". A JSON list of
+``{"skill": "<capability>", "labels": [...]?}`` entries on the camera
+record, written by the camera settings surface, served additively on the
+internal camera-agent endpoint. Nothing consumes it yet — Tier-0
+per-camera labels, the SDK's ``cameras_for_skill()``, and the catalog UI
+opt in in later slices.
+
+Nullable, no default: existing rows keep NULL, which every consumer must
+read as "no restriction declared" (back-compat), never as "do nothing".
+
+Revision ID: aa11bb22cc33
+Revises: ff66aa77bb88
+Create Date: 2026-08-22 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "aa11bb22cc33"
+down_revision: str | None = "ff66aa77bb88"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cameras",
+        sa.Column(
+            "assignments",
+            sa.JSON(),
+            nullable=True,
+            comment=(
+                "Per-camera capability assignment: list of "
+                '{"skill": ..., "labels": [...]?} entries. NULL/[] = '
+                "nothing assigned (no restriction declared)."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("cameras", "assignments")

--- a/server/models.py
+++ b/server/models.py
@@ -238,6 +238,19 @@ class Camera(Base):
     location = Column(String(200), nullable=True)
     vlan = Column(String(50), nullable=True)
     status = Column(String(20), nullable=False, default="unknown")
+    # Per-camera capability assignment — the ONE source of truth for
+    # "what is this camera for" (docs/design/per-camera-assignment.md).
+    # A list of {"skill": "<capability>", "labels": [..]?} entries, e.g.
+    # [{"skill": "license_plate_recognition"},
+    #  {"skill": "object_detection", "labels": ["person", "truck"]}].
+    # Written ONLY by the camera settings surface; served additively on the
+    # internal camera-agent endpoint so consumers (Tier-0 reconcile, the
+    # App SDK's cameras_for_skill, the catalog UI) can opt in one by one.
+    # NULL/[] = nothing assigned — every consumer must treat that as
+    # "no restriction declared", never as "do nothing" (back-compat).
+    # Nullable so the additive column self-heal can add it to old
+    # create_all databases.
+    assignments = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -279,7 +279,7 @@ def list_camera_agent_sources(db: Session = Depends(get_db)) -> dict[str, object
         .order_by(Camera.id.asc())
         .all()
     )
-    out: list[dict[str, str]] = []
+    out: list[dict[str, object]] = []
     for cam in cameras:
         stream_name = _build_stream_name(
             settings.mediamtx_stream_prefix,
@@ -318,6 +318,11 @@ def list_camera_agent_sources(db: Session = Depends(get_db)) -> dict[str, object
                 "frame_url": frame_url,
                 "role": role,
                 "source": source,
+                # Per-camera capability assignment (slice 1 of
+                # docs/design/per-camera-assignment.md). Additive: existing
+                # consumers ignore it. [] = nothing assigned — consumers must
+                # read that as "no restriction declared", never "do nothing".
+                "assignments": list(cam.assignments or []),
             }
         )
 

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -355,6 +355,59 @@ class UserUpdate(BaseModel):
     role_id: int | None = None
 
 
+class CameraAssignment(BaseModel):
+    """One per-camera capability assignment — "this camera does <skill>".
+
+    ``skill`` names a capability (``license_plate_recognition``,
+    ``object_detection``, ``occupancy_counting``, …). Deliberately an open
+    vocabulary in slice 1: the catalog UI's requires_tasks validation
+    (consumer 3 in docs/design/per-camera-assignment.md) is where "is this
+    capability actually installed?" gets enforced, so an assignment can be
+    declared before its adapter/app exists. ``labels`` optionally NARROWS
+    a detection-shaped skill to specific classes ("camera 4 also wants
+    trucks") — it may narrow configuration, never replace it.
+    """
+
+    skill: str = Field(..., min_length=2, max_length=64, pattern=r"^[a-z][a-z0-9_]*$")
+    labels: list[str] | None = None
+
+    @field_validator("labels")
+    @classmethod
+    def validate_labels(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return v
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for raw in v:
+            s = str(raw).strip().lower()
+            if not s:
+                raise ValueError("labels must not contain empty strings")
+            if len(s) > 64:
+                raise ValueError("label too long (max 64 chars)")
+            if s not in seen:
+                seen.add(s)
+                cleaned.append(s)
+        if len(cleaned) > 32:
+            raise ValueError("too many labels (max 32)")
+        return cleaned
+
+
+def _validate_assignments(
+    v: list[CameraAssignment] | None,
+) -> list[CameraAssignment] | None:
+    """Shared assignments rules: bounded count, one entry per skill."""
+    if v is None:
+        return v
+    if len(v) > 8:
+        raise ValueError("too many assignments (max 8 per camera)")
+    seen: set[str] = set()
+    for a in v:
+        if a.skill in seen:
+            raise ValueError(f"duplicate assignment for skill {a.skill!r}")
+        seen.add(a.skill)
+    return v
+
+
 class CameraUpdate(BaseModel):
     """Schema for updating a camera."""
 
@@ -370,6 +423,16 @@ class CameraUpdate(BaseModel):
     vlan: str | None = Field(None, max_length=50)
     status: str | None = Field(None, max_length=20)
     is_active: bool | None = None
+    # Per-camera capability assignment (see CameraAssignment). Send the FULL
+    # list each time — this replaces, it does not merge. [] clears.
+    assignments: list[CameraAssignment] | None = None
+
+    @field_validator("assignments")
+    @classmethod
+    def validate_assignments(
+        cls, v: list[CameraAssignment] | None
+    ) -> list[CameraAssignment] | None:
+        return _validate_assignments(v)
 
     @field_validator("ip_address")
     @classmethod
@@ -556,6 +619,9 @@ class CameraResponse(CameraBase):
     id: int
     owner_id: int
     is_active: bool
+    # Per-camera capability assignment; None and [] both mean "nothing
+    # assigned" (read as: no restriction declared).
+    assignments: list[CameraAssignment] | None = None
     deleted_at: datetime | None = None
     created_at: datetime
     updated_at: datetime | None = None

--- a/server/tests/test_camera_assignments.py
+++ b/server/tests/test_camera_assignments.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""
+Per-camera capability assignment — slice 1 of
+docs/design/per-camera-assignment.md.
+
+Run with:
+
+    cd server && pytest tests/test_camera_assignments.py -v
+
+Coverage:
+
+* ``CameraAssignment`` / ``CameraUpdate`` validation — the write-path
+  rules: skill vocabulary shape, label normalization + bounds, the
+  8-assignments cap, one entry per skill, ``[]`` clears.
+* The internal camera-agent endpoint serves ``assignments`` additively:
+  a camera with assignments returns them verbatim; one without returns
+  ``[]``; every pre-existing key is still present (back-compat).
+"""
+from __future__ import annotations
+
+# Python 3.10 sandbox polyfill — pyproject requires 3.11+ where
+# datetime.UTC exists. No-op on 3.11+.
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017 — only runs where UTC is absent
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+for _name in (
+    "main_logger", "auth_logger", "camera_logger",
+    "recording_logger", "cloud_logger", "ai_logger",
+):
+    setattr(_lm, _name, _L())
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+from core.database import Base, get_db  # noqa: E402
+from models import Camera, Role, User  # noqa: E402
+from routers import internal_camera_agent as internal_router  # noqa: E402
+from schemas import CameraAssignment, CameraUpdate  # noqa: E402
+
+
+# ─── Write-path validation (the schema IS the rulebook) ─────────────────
+
+
+def test_assignment_accepts_skill_and_optional_labels():
+    a = CameraAssignment(skill="license_plate_recognition")
+    assert a.skill == "license_plate_recognition" and a.labels is None
+    b = CameraAssignment(skill="object_detection", labels=["Person", "TRUCK", "person"])
+    # normalized: lowercased, deduped, order kept
+    assert b.labels == ["person", "truck"]
+
+
+def test_assignment_rejects_bad_skill_shapes():
+    for bad in ("", "X", "Object Detection", "lpr!", "9skill", "a"):
+        with pytest.raises(ValidationError):
+            CameraAssignment(skill=bad)
+
+
+def test_assignment_label_bounds():
+    with pytest.raises(ValidationError):
+        CameraAssignment(skill="object_detection", labels=[""])
+    with pytest.raises(ValidationError):
+        CameraAssignment(skill="object_detection", labels=["x" * 65])
+    with pytest.raises(ValidationError):
+        CameraAssignment(
+            skill="object_detection", labels=[f"label{i}" for i in range(33)]
+        )
+
+
+def test_update_caps_assignments_and_forbids_duplicate_skills():
+    ok = CameraUpdate(assignments=[
+        {"skill": "object_detection", "labels": ["truck"]},
+        {"skill": "license_plate_recognition"},
+    ])
+    dumped = ok.model_dump(exclude_unset=True)["assignments"]
+    # model_dump produces plain JSON-ready dicts — what setattr stores.
+    assert dumped[0] == {"skill": "object_detection", "labels": ["truck"]}
+    with pytest.raises(ValidationError):
+        CameraUpdate(assignments=[{"skill": f"skill_{i}"} for i in range(9)])
+    with pytest.raises(ValidationError):
+        CameraUpdate(assignments=[
+            {"skill": "object_detection"}, {"skill": "object_detection"},
+        ])
+
+
+def test_update_empty_list_clears_and_none_means_untouched():
+    cleared = CameraUpdate(assignments=[])
+    assert cleared.model_dump(exclude_unset=True) == {"assignments": []}
+    untouched = CameraUpdate(name="Gate")
+    assert "assignments" not in untouched.model_dump(exclude_unset=True)
+
+
+# ─── Read path: the internal camera-agent endpoint ──────────────────────
+
+
+def _make_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(
+        engine, tables=[Camera.__table__, User.__table__, Role.__table__]
+    )
+    session_factory = sessionmaker(bind=engine)
+
+    app = FastAPI()
+    app.include_router(internal_router.router)
+
+    def _override_db():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[internal_router._require_internal_key] = lambda: None
+    return app, session_factory
+
+
+@pytest.fixture
+def seeded_client(monkeypatch):
+    """Two cameras — one assigned, one not — behind the internal router.
+
+    MediaMTX tap is disabled so ``frame_url`` falls back to the stored
+    rtsp_url and the test needs no JWT keys.
+    """
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "inference_use_mediamtx_tap", False)
+    app, session_factory = _make_app()
+    session = session_factory()
+    session.add(Role(id=1, name="admin"))
+    session.add(User(id=1, username="op", email="op@x",
+                     hashed_password="x", role_id=1))
+    session.add(Camera(
+        id=1, name="Gate", ip_address="10.0.0.1", owner_id=1, is_active=True,
+        rtsp_url="rtsp://cam1/stream",
+        assignments=[{"skill": "license_plate_recognition"},
+                     {"skill": "object_detection", "labels": ["person", "truck"]}],
+    ))
+    session.add(Camera(
+        id=2, name="Yard", ip_address="10.0.0.2", owner_id=1, is_active=True,
+        rtsp_url="rtsp://cam2/stream",
+    ))
+    session.commit()
+    session.close()
+    with TestClient(app) as client:
+        yield client
+
+
+def test_internal_endpoint_serves_assignments_additively(seeded_client):
+    body = seeded_client.get("/internal/camera-agent/cameras").json()
+    cams = {c["camera_id"]: c for c in body["cameras"]}
+    assert cams["cam1"]["assignments"] == [
+        {"skill": "license_plate_recognition"},
+        {"skill": "object_detection", "labels": ["person", "truck"]},
+    ]
+    # NULL in the DB serves as [] — "nothing assigned", never absent.
+    assert cams["cam2"]["assignments"] == []
+    # Back-compat: every pre-existing key is still there for old consumers.
+    for key in ("camera_id", "open_nvr_camera_id", "name",
+                "frame_url", "role", "source"):
+        assert key in cams["cam1"], key
+
+
+def test_update_dump_round_trips_through_the_model(seeded_client):
+    """What CameraUpdate dumps is exactly what the JSON column stores and
+    the internal endpoint serves — no serialization drift between the
+    write path's setattr loop and the read path."""
+    upd = CameraUpdate(assignments=[{"skill": "occupancy_counting"}])
+    dumped = upd.model_dump(exclude_unset=True)["assignments"]
+    assert dumped == [{"skill": "occupancy_counting"}]


### PR DESCRIPTION
…endpoint)

Slice 1 of docs/design/per-camera-assignment.md: ONE place that answers 'what is camera 4 for'.

- Camera gains a nullable JSON 'assignments' column: a list of {skill, labels?} entries ({skill: license_plate_recognition}, {skill: object_detection, labels: [person, truck]}). Alembic migration aa11bb22cc33 (additive; self-heal covers create_all DBs).
- Write path: CameraUpdate accepts 'assignments' (full replace, [] clears). CameraAssignment validates the vocabulary shape (^[a-z][a-z0-9_]*$, 2-64 chars), normalizes labels (lowercase, deduped, <=32, each <=64 chars), caps at 8 assignments per camera, one entry per skill. Skill names stay an OPEN vocabulary on purpose: 'is this capability actually installed' is consumer 3's job (catalog-UI requires_tasks validation), so an assignment can be declared before its adapter exists.
- Read path: the internal camera-agent endpoint serves 'assignments' additively on every camera (NULL -> [], meaning 'nothing assigned / no restriction declared' — never 'do nothing'). Existing consumers ignore it; Tier-0 per-camera labels and the SDK's cameras_for_skill() opt in over the next slices.
- UI: the camera edit dialog gains an Assignments editor (skill + optional comma-separated labels, add/remove, 8-row cap) — the ONE surface that writes assignments, per the design's invariants.
- CameraResponse exposes assignments so the settings page can render what is stored.

Tests: tests/test_camera_assignments.py — schema rules, [] -vs- unset semantics, model_dump/JSON-column/endpoint round-trip, additive back-compat of the internal payload. Full server suite green (the one failing reconciler-identity test fails identically on main).