### PR TITLE
feat(sdk,occupancy): cameras_for_skill — apps follow per-camera assig…

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Eight reference adapters and a one-command scaffold to start your own live in th
 
 ## Applications ship on top of it
 
-Adapters are *capabilities*; applications are *solutions*. Each example below is a working application — adapter(s) + a pipeline + alert rules — that you install, point at a camera, and adapt. Replace the predicate (the zone check, the dwell timer, the plate watchlist) with your domain logic and you have a purpose-built NVR. This is the platform's direction: a catalog of installable applications, not a fixed feature set.
+Adapters are *capabilities*; applications are *solutions*. And every camera can be given a *job*: assign camera 1 to LPR and cameras 2–3 to people counting on the camera's settings page, and the capabilities point themselves at the right cameras — while streaming, recording, and default detection continue on all of them ([how assignments work](docs/CAMERA_ASSIGNMENTS.md)). Each example below is a working application — adapter(s) + a pipeline + alert rules — that you install, point at a camera, and adapt. Replace the predicate (the zone check, the dwell timer, the plate watchlist) with your domain logic and you have a purpose-built NVR. This is the platform's direction: a catalog of installable applications, not a fixed feature set.
 
 | Application | What you'll build | Difficulty |
 |---|---|---|
@@ -325,7 +325,7 @@ Commercial deployments — deployment assistance, NDA adapter authoring, complia
 
 ## Documentation
 
-**Getting started** — [Docker quickstart](DOCKER_QUICKSTART.md) · [User manual](USER_MANUAL.md) · [Local dev setup](docs/LOCAL_SETUP.md) · [Use cases by industry](docs/USE_CASES.md) · [Comparisons](docs/COMPARISONS.md)
+**Getting started** — [Docker quickstart](DOCKER_QUICKSTART.md) · [User manual](USER_MANUAL.md) · [Camera assignments — give each camera a job](docs/CAMERA_ASSIGNMENTS.md) · [Local dev setup](docs/LOCAL_SETUP.md) · [Use cases by industry](docs/USE_CASES.md) · [Comparisons](docs/COMPARISONS.md)
 
 **Architecture & security** — [Security architecture](docs/SECURITY_ARCHITECTURE.md) · [Compliance mapping](docs/COMPLIANCE.md) · [Government deployment brief](docs/GOVERNMENT_DEPLOYMENT.md) · [AI Adapter Contract](docs/AI_ADAPTER_CONTRACT.md) · [Edge autonomy & robotics](docs/EDGE_AUTONOMY.md)
 

--- a/docs/CAMERA_ASSIGNMENTS.md
+++ b/docs/CAMERA_ASSIGNMENTS.md
@@ -1,0 +1,91 @@
+# Per-camera skill assignment — give each camera a job
+
+> Camera 1 reads license plates. Cameras 2 and 3 count people. Camera 4
+> watches for trucks. Declared once, on the camera's settings page, and
+> honoured by everything that cares.
+
+This is the operator guide to camera assignments. The engineering design
+behind it is [`docs/design/per-camera-assignment.md`](design/per-camera-assignment.md).
+
+## What an assignment is — and is not
+
+Every camera in OpenNVR always does the **default work**: live
+streaming, recording, and the always-on Tier-0 detection that feeds the
+event timeline. None of that ever depends on assignments.
+
+An **assignment** is *additional, specialized attention* layered on top:
+it declares what a camera is *for*, so the capabilities ("skills") that
+can serve that purpose point themselves at the right cameras. Assigning
+camera 1 to `license_plate_recognition` doesn't change what camera 1
+records — it tells the LPR capability *this is your camera*. Assigning
+cameras 2–3 to `occupancy_counting` tells the counting app to watch
+exactly those two and ignore the rest.
+
+Think of skills as what the system **can do** (detect objects, read
+plates, count occupancy, recognise faces) and an assignment as **where
+each of those abilities should look**.
+
+## The one rule that keeps old setups working
+
+**Nothing assigned means nothing restricted.** A skill with no camera
+assigned to it behaves exactly as before assignments existed: the
+occupancy app watches every camera, the indexer indexes everything.
+Restriction begins only when the *first* camera is assigned a given
+skill — from that moment, the assignment list for that skill is the
+whole truth. Un-assign the last camera and the restriction lifts again.
+
+This is why upgrading changes nothing until you choose to use the
+feature, and why an app never goes silently blind: "no assignment" can
+never be misread as "watch nothing".
+
+## How to assign
+
+Open the camera's **edit dialog** (Cameras → ✎) and use the
+**Assignments** section: each row is a skill name, plus optional labels
+that narrow it.
+
+| You type | It means |
+|---|---|
+| `license_plate_recognition` | this camera is for LPR |
+| `occupancy_counting` | this camera is counted by the occupancy app |
+| `object_detection` + labels `person, truck` | this camera cares specifically about people and trucks |
+
+Rules enforced by the server: skill names are lowercase snake_case, at
+most 8 assignments per camera, one row per skill, labels normalized and
+capped. The vocabulary is deliberately open — you can declare an
+assignment before its adapter or app is installed; validation against
+what's actually installed arrives with the catalog-UI integration.
+
+## What honours assignments today
+
+* **occupancy-counting** (on by default): when at least one camera is
+  assigned `occupancy_counting`, the app scopes to exactly those
+  cameras — picked up at boot *and* on its 5-minute discovery refresh,
+  so assigning or un-assigning on the settings page takes effect within
+  minutes, no restart. An explicit `cameras:` list in the app's own
+  config always wins over assignments (the operator's written word is
+  never second-guessed).
+* **Any app built on the App SDK** can adopt the same behaviour with
+  one call — `filter_cameras_for_skill(discovered, "my_skill")` /
+  `cameras_for_skill(url, "my_skill")` — following the same
+  `None` = "no restriction declared" contract.
+
+## What's coming (the remaining slices)
+
+* **Tier-0 per-camera classes**: `object_detection` + labels on a
+  camera will narrow the always-on detector's classes for that camera
+  ("camera 4 also wants trucks"), and a camera assigned nothing
+  detection-shaped will be skippable entirely — a CPU saving, opt-in.
+* **Catalog-UI validation**: the camera settings page will grey out a
+  skill whose capability isn't installed, with a pointer to what to
+  install ("LPR needs the plate adapter — not installed").
+* **Retiring the per-model polling loop** in favour of assignments +
+  the publish/subscribe path.
+
+## For app developers
+
+Read the design doc for the invariants, then copy the occupancy
+pattern: fetch `discover_cameras()` once, pass the payload through
+`filter_cameras_for_skill(...)`, and re-run the same scoping on your
+refresh tick. Honour the contract: `None` from the filter means watch
+everything you'd otherwise watch — never treat it as an empty list.

--- a/docs/design/per-camera-assignment.md
+++ b/docs/design/per-camera-assignment.md
@@ -146,10 +146,12 @@ Each slice is independently shippable and useful on its own:
 
 1. **Schema + endpoint.** `assignments` on the camera record, written by the
    camera settings page, served by the internal endpoint. Nothing consumes
-   it yet.
+   it yet. *(shipped — PR #275)*
 2. **SDK `cameras_for_skill()`.** Apps opt in; occupancy switches from
    "watch every camera" to "watch my assigned cameras", explicit config
-   still winning.
+   still winning. *(shipped — `filter_cameras_for_skill` /
+   `cameras_for_skill` in `opennvr_app_sdk.cameras`; occupancy is the
+   reference consumer, re-scoping on every discovery refresh)*
 3. **Tier-0 per-camera labels/analyze.** The class-selection case from the
    goal, plus the CPU saving of not analysing unassigned cameras.
 4. **Retire `AIModel`'s polling loop** in favour of assignment + the

--- a/examples/occupancy-counting/README.md
+++ b/examples/occupancy-counting/README.md
@@ -33,6 +33,15 @@ Use it for room/venue capacity, queue and concourse crowding, loading-bay
 vehicle limits, or a guard post that must always be staffed
 (`min_occupancy: 1`).
 
+## Per-camera assignment
+
+Leave `cameras: []` and the app watches every camera OpenNVR knows
+about — unless the camera settings page assigns the
+`occupancy_counting` skill to specific cameras, in which case the app
+scopes to exactly those (re-checked every discovery refresh, no
+restart). No assignment anywhere = no restriction. See
+[docs/CAMERA_ASSIGNMENTS.md](../../docs/CAMERA_ASSIGNMENTS.md).
+
 ## Run it
 
 ```bash

--- a/examples/occupancy-counting/config.docker.yml
+++ b/examples/occupancy-counting/config.docker.yml
@@ -45,7 +45,10 @@ nats_alerts_token: "${INTERNAL_API_KEY}"
 
 # ── Cameras ───────────────────────────────────────────────────────
 # LEAVE EMPTY to watch every camera OpenNVR knows about, each with a
-# whole-frame zone — the app reads the live camera list from
+# whole-frame zone. If the camera settings page assigns the
+# ``occupancy_counting`` skill to specific cameras, the app scopes to
+# exactly those (re-checked every refresh); with no such assignment
+# anywhere, nothing is restricted and every camera is watched — the app reads the live camera list from
 # ``opennvr_url`` on boot, so the ids always match what Tier-0
 # publishes (OpenNVR names them cam1, cam2 — NOT cam-1).
 #

--- a/examples/occupancy-counting/config.example.yml
+++ b/examples/occupancy-counting/config.example.yml
@@ -80,7 +80,10 @@ nats_alerts_token: null
 
 # ── Cameras ───────────────────────────────────────────────────────
 # LEAVE EMPTY to watch every camera OpenNVR knows about, each with a
-# whole-frame zone — the app reads the live camera list from
+# whole-frame zone. If the camera settings page assigns the
+# ``occupancy_counting`` skill to specific cameras, the app scopes to
+# exactly those (re-checked every refresh); with no such assignment
+# anywhere, nothing is restricted and every camera is watched — the app reads the live camera list from
 # ``opennvr_url`` on boot, so the ids always match what Tier-0
 # publishes (OpenNVR names them cam1, cam2 — NOT cam-1).
 #

--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -85,6 +85,7 @@ from opennvr_app_sdk import (
 from opennvr_app_sdk.cameras import (
     UNIT_FRAME,
     discover_cameras,
+    filter_cameras_for_skill,
     full_frame_polygon,
 )
 from opennvr_app_sdk.config import load_yaml
@@ -96,6 +97,33 @@ logger = logging.getLogger("occupancy-counting")
 # Cameras get added and removed while the app runs; a set captured once
 # at boot would silently never watch camera 5 added tomorrow.
 DISCOVERY_REFRESH_S: int = 300
+
+# The capability name this app answers to in per-camera assignments
+# ("camera 2 and 3 do occupancy_counting" on the camera settings page).
+# When at least one camera is assigned this skill, auto-derivation scopes
+# to exactly those cameras; when none is, nothing is restricted and the
+# app watches every camera, exactly as before assignments existed.
+SKILL: str = "occupancy_counting"
+
+
+def _scope_to_assignment(discovered: list[dict]) -> list[dict]:
+    """Narrow a discover_cameras() payload to this app's assigned cameras.
+
+    No camera assigned SKILL -> no restriction declared -> unchanged.
+    Assignments are additive intent: they point THIS app's attention;
+    streaming/recording/Tier-0 on the other cameras are unaffected.
+    """
+    assigned = filter_cameras_for_skill(discovered, SKILL)
+    if assigned is None:
+        return discovered
+    keep = set(assigned)
+    scoped = [c for c in discovered if str(c.get("camera_id")) in keep]
+    logger.info(
+        "per-camera assignment active: %d of %d camera(s) assigned %r (%s)",
+        len(scoped), len(discovered), SKILL,
+        ", ".join(sorted(keep)) or "-",
+    )
+    return scoped
 
 
 MANIFEST = AppManifest(
@@ -295,10 +323,10 @@ def load_config(path: str) -> AppConfig:
         # space, which is exactly correct at any real resolution (see
         # opennvr_app_sdk.cameras). Draw a real zone in the catalog UI —
         # or list cameras explicitly here — to override.
-        discovered = discover_cameras(
+        discovered = _scope_to_assignment(discover_cameras(
             str(raw.get("opennvr_url") or ""),
             api_key=raw.get("internal_api_key"),
-        )
+        ))
         cameras_raw = [
             {
                 "camera_id": c["camera_id"],
@@ -521,6 +549,10 @@ class OccupancyCounter(Detector):
                 self._config.opennvr_url_for_discovery,
                 api_key=self._config.internal_api_key,
             )
+        # Assignment scoping runs on every refresh, so assigning or
+        # un-assigning a camera on the settings page takes effect within
+        # one refresh interval — no app restart.
+        discovered = _scope_to_assignment(discovered)
         ids = {c["camera_id"] for c in discovered}
         if not ids:
             # Treat "core answered with nothing" as no news rather than

--- a/examples/occupancy-counting/tests/test_occupancy_counting.py
+++ b/examples/occupancy-counting/tests/test_occupancy_counting.py
@@ -416,3 +416,94 @@ def test_missing_ceiling_with_discovered_cameras_names_the_real_cause(
     with pytest.raises(ValueError) as excinfo:
         oc.load_config(str(p))
     assert "camera entry 0" not in str(excinfo.value)
+
+
+# ── Per-camera assignment scoping (slice 2) ────────────────────────
+#
+# "Cameras 2-3 count people" on the settings page must scope this app to
+# exactly those cameras — additively: nothing assigned anywhere means
+# watch everything, exactly as before assignments existed.
+
+
+def _discovered(*specs):
+    out = []
+    for spec in specs:
+        cam_id, *skills = spec.split(":")
+        cam = {"camera_id": cam_id}
+        if skills and skills[0]:
+            cam["assignments"] = [{"skill": s} for s in skills[0].split("+")]
+        out.append(cam)
+    return out
+
+
+def test_boot_scopes_to_assigned_cameras(tmp_path, monkeypatch):
+    """cam1 is for LPR, cams 2-3 for occupancy → watch exactly 2 and 3."""
+    monkeypatch.setattr(oc, "discover_cameras", lambda url, api_key=None: _discovered(
+        "cam1:license_plate_recognition",
+        "cam2:occupancy_counting",
+        "cam3:occupancy_counting+object_detection",
+        "cam4:",
+    ))
+    cfg = oc.load_config(_write_config(
+        tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
+    assert sorted(cfg.cameras) == ["cam2", "cam3"]
+    counter = oc.OccupancyCounter(cfg, _NullDispatcher())
+    # The unassigned camera's events are "not my camera", not counted.
+    assert counter.handle_event(_tier0_event(6, camera_id="cam4")) == []
+    fired = counter.handle_event(_tier0_event(6, camera_id="cam2"))
+    assert len(fired) == 1
+
+
+def test_no_assignments_anywhere_means_watch_everything(tmp_path, monkeypatch):
+    """Back-compat: assignments that exist for OTHER skills only do not
+    restrict this app either way — restriction starts with OUR skill."""
+    monkeypatch.setattr(oc, "discover_cameras", lambda url, api_key=None: _discovered(
+        "cam1:", "cam2:",
+    ))
+    cfg = oc.load_config(_write_config(
+        tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
+    assert sorted(cfg.cameras) == ["cam1", "cam2"]
+
+
+def test_refresh_follows_assignment_changes(tmp_path, monkeypatch):
+    """Assigning / un-assigning on the settings page takes effect within
+    one refresh — including un-assigning the LAST camera, which lifts the
+    restriction entirely (back to watch-everything, by the rule)."""
+    live = _discovered("cam1:", "cam2:")
+    monkeypatch.setattr(oc, "discover_cameras", lambda url, api_key=None: [dict(c) for c in live])
+    cfg = oc.load_config(_write_config(
+        tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
+    counter = oc.OccupancyCounter(cfg, _NullDispatcher())
+    assert sorted(cfg.cameras) == ["cam1", "cam2"]
+
+    # Operator assigns occupancy to cam2 only → scope narrows.
+    live[:] = _discovered("cam1:", "cam2:occupancy_counting")
+    added, removed = counter.refresh_cameras()
+    assert removed == ["cam1"] and added == []
+    assert sorted(cfg.cameras) == ["cam2"]
+
+    # Operator removes the assignment again → restriction lifts.
+    live[:] = _discovered("cam1:", "cam2:")
+    added, removed = counter.refresh_cameras()
+    assert added == ["cam1"] and removed == []
+    assert sorted(cfg.cameras) == ["cam1", "cam2"]
+
+
+def test_explicit_camera_list_ignores_assignments(tmp_path, monkeypatch):
+    """A pinned YAML camera list is the operator's word — assignments
+    never second-guess it (and no discovery call is made at all)."""
+    called = {"n": 0}
+
+    def _count(*a, **k):
+        called["n"] += 1
+        return _discovered("cam9:occupancy_counting")
+
+    monkeypatch.setattr(oc, "discover_cameras", _count)
+    cfg = oc.load_config(_write_config(tmp_path, (
+        "cameras:\n"
+        '  - camera_id: "cam1"\n'
+        "    frame_width: 1920\n"
+        "    frame_height: 1080\n"
+        "    zone: [[0, 0], [1920, 0], [1920, 1080], [0, 1080]]\n"
+    )))
+    assert list(cfg.cameras) == ["cam1"] and called["n"] == 0

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -62,7 +62,7 @@ from .tier0 import (
     snapshot_from_event,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     # Archetype bases + runners

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/cameras.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/cameras.py
@@ -93,3 +93,66 @@ def discover_cameras(
 def full_frame_polygon(size: int = UNIT_FRAME) -> list[list[int]]:
     """The whole-frame zone, in the unit space auto-derived zones use."""
     return [[0, 0], [size, 0], [size, size], [0, size]]
+
+
+# ── Per-camera capability assignment (slice 2) ─────────────────────
+#
+# Operators can declare "camera 1 does LPR, cameras 2-3 count people" on
+# the camera settings page; the internal endpoint serves it as an
+# ``assignments`` list on each camera. An assignment is ADDITIVE intent:
+# the camera keeps streaming, recording, and Tier-0 detection regardless
+# — it only tells interested apps WHERE to point their attention.
+#
+# The back-compat rule every consumer must honour: restriction exists
+# only once at least one camera carries THIS skill. No camera assigned
+# the skill (or no assignments feature at all — an older core) means
+# "no restriction declared", and the app behaves exactly as before
+# assignments existed: watch everything.
+
+
+def filter_cameras_for_skill(
+    cameras: list[dict[str, Any]], skill: str
+) -> list[str] | None:
+    """Which of ``cameras`` (a :func:`discover_cameras` payload) are
+    assigned ``skill``.
+
+    Returns ``None`` when NO camera carries the skill — "no restriction
+    declared": the caller must fall back to watching everything, exactly
+    as before assignments existed. Returns the (possibly empty-labelled)
+    camera-id list once at least one camera is assigned the skill —
+    from then on the operator's declaration is the whole truth.
+
+    Pure — feed it the list you already fetched instead of fetching
+    twice (the occupancy example's refresh loop does exactly this).
+    """
+    want = str(skill).strip().lower()
+    if not want:
+        return None
+    out: list[str] = []
+    for cam in cameras:
+        if not isinstance(cam, dict):
+            continue
+        for a in cam.get("assignments") or []:
+            if isinstance(a, dict) and str(a.get("skill", "")).lower() == want:
+                out.append(str(cam["camera_id"]))
+                break
+    return out or None
+
+
+def cameras_for_skill(
+    opennvr_url: str,
+    skill: str,
+    *,
+    api_key: str | None = None,
+    timeout: float = 5.0,
+) -> list[str] | None:
+    """Fetch-and-filter convenience: the camera ids assigned ``skill``.
+
+    ``None`` means "no restriction declared" — either no camera carries
+    the skill, or discovery failed (both cases mean: keep current
+    behaviour, don't narrow). Use :func:`filter_cameras_for_skill` when
+    you already hold a :func:`discover_cameras` result.
+    """
+    return filter_cameras_for_skill(
+        discover_cameras(opennvr_url, api_key=api_key, timeout=timeout), skill
+    )

--- a/sdk/opennvr-app-sdk/pyproject.toml
+++ b/sdk/opennvr-app-sdk/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "opennvr-app-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared SDK for OpenNVR monitoring apps: §11.5 alert dispatch, zone geometry, keyed TTL state, app manifests, and the Detector / FrameApp base loops."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/sdk/opennvr-app-sdk/tests/test_cameras.py
+++ b/sdk/opennvr-app-sdk/tests/test_cameras.py
@@ -10,7 +10,9 @@ import pytest
 
 from opennvr_app_sdk.cameras import (
     UNIT_FRAME,
+    cameras_for_skill,
     discover_cameras,
+    filter_cameras_for_skill,
     full_frame_polygon,
     internal_api_key,
 )
@@ -72,3 +74,67 @@ def test_internal_api_key_prefers_explicit_then_env(monkeypatch):
 def test_full_frame_polygon_covers_the_unit_space():
     poly = full_frame_polygon()
     assert poly == [[0, 0], [UNIT_FRAME, 0], [UNIT_FRAME, UNIT_FRAME], [0, UNIT_FRAME]]
+
+
+# ── Per-camera assignment (slice 2) ────────────────────────────────
+#
+# "Camera 1 does LPR, cameras 2-3 count people." The back-compat rule:
+# restriction exists only once at least one camera carries the skill —
+# no camera assigned (or an older core with no assignments field) means
+# "no restriction declared", and the caller keeps watching everything.
+
+
+_ASSIGNED = [
+    {"camera_id": "cam1",
+     "assignments": [{"skill": "license_plate_recognition"}]},
+    {"camera_id": "cam2",
+     "assignments": [{"skill": "occupancy_counting"}]},
+    {"camera_id": "cam3",
+     "assignments": [{"skill": "occupancy_counting",
+                      "labels": ["person"]},
+                     {"skill": "object_detection"}]},
+    {"camera_id": "cam4", "assignments": []},
+]
+
+
+def test_filter_returns_only_cameras_assigned_the_skill():
+    assert filter_cameras_for_skill(_ASSIGNED, "occupancy_counting") == ["cam2", "cam3"]
+    assert filter_cameras_for_skill(_ASSIGNED, "license_plate_recognition") == ["cam1"]
+
+
+def test_filter_none_means_no_restriction_declared():
+    # Nobody carries the skill → None, NOT [] — the caller must fall back
+    # to watching everything, exactly as before assignments existed.
+    assert filter_cameras_for_skill(_ASSIGNED, "face_recognition") is None
+    # Older core: cameras with no assignments field at all.
+    legacy = [{"camera_id": "cam1"}, {"camera_id": "cam2"}]
+    assert filter_cameras_for_skill(legacy, "occupancy_counting") is None
+    assert filter_cameras_for_skill([], "occupancy_counting") is None
+    assert filter_cameras_for_skill(_ASSIGNED, "") is None
+
+
+def test_filter_matches_case_insensitively_and_ignores_junk():
+    messy = [
+        {"camera_id": "cam9",
+         "assignments": [{"skill": "Occupancy_Counting"}, "junk", 42]},
+        "not-a-dict",
+    ]
+    assert filter_cameras_for_skill(messy, "occupancy_counting") == ["cam9"]
+
+
+def test_cameras_for_skill_fetches_then_filters(monkeypatch):
+    def fake_get(url, headers=None, timeout=None):
+        return httpx.Response(200, json={"cameras": _ASSIGNED},
+                              request=httpx.Request("GET", url))
+
+    _patch_get(monkeypatch, fake_get)
+    assert cameras_for_skill("http://core:8000", "occupancy_counting") == ["cam2", "cam3"]
+
+
+def test_cameras_for_skill_discovery_failure_is_no_restriction(monkeypatch):
+    def boom(url, headers=None, timeout=None):
+        raise httpx.ConnectError("down")
+
+    _patch_get(monkeypatch, boom)
+    # Failure means "unknown", and unknown must never narrow the set.
+    assert cameras_for_skill("http://core:8000", "occupancy_counting") is None


### PR DESCRIPTION
…nments (slice 2)

Slice 2 of docs/design/per-camera-assignment.md. Assignment is ADDITIVE intent: a camera keeps streaming, recording, and Tier-0 detection no matter what — assigning it a skill points a capability's attention at it ('camera 1 does LPR, cameras 2-3 count people').

- App SDK 0.2.0: filter_cameras_for_skill(discovered, skill) (pure — reuse the discovery payload you already fetched) and cameras_for_skill(url, skill) (fetch-and-filter). The back-compat rule is in the return type: None = no restriction declared (no camera carries the skill, an older core without the field, or discovery failed — unknown must never narrow); a non-empty list = the operator's declaration is the whole truth.
- occupancy-counting is the reference consumer: auto-derivation scopes to cameras assigned 'occupancy_counting' at boot AND on every discovery refresh, so assigning/un-assigning on the settings page takes effect within one refresh interval, no restart. Un-assigning the LAST camera lifts the restriction (back to watch-everything, by the rule). An explicit YAML camera list still wins outright and makes no discovery call.

Tests: 5 SDK (skill filtering, None-vs-list semantics, legacy cores, case/junk tolerance, fetch failure = no restriction) + 4 occupancy (boot scoping, other-skills-don't-restrict, refresh follows assignment changes both directions, pinned list immunity).