### PR TITLE
feat(tier0): per-camera assignment labels + opt-in skip (slice 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,17 @@ DETECT_STATIONARY_INTERVAL=10
 #
 # Classes worth TRACKING (comma-separated; "all" = every COCO class).
 # An NVR rarely cares about bananas — Frigate ships person-only.
+# A camera's ``object_detection`` assignment (camera settings page) may
+# carry its own labels — "camera 4 wants person + truck" — which replace
+# this global set FOR THAT CAMERA only. See docs/CAMERA_ASSIGNMENTS.md.
 DETECT_LABELS=person,car,truck,bus,motorcycle,bicycle,cat,dog
+
+# Opt-in CPU saving: skip Tier-0 analysis on cameras whose assignments are
+# all detection-free (e.g. an LPR-only camera). OFF by default because the
+# Tier-0 stream feeds more than detection apps (footage-search indexes it,
+# the agent's events skill reads it) — skipping is an explicit choice.
+# Cameras with NO assignments are never skipped.
+DETECT_SKIP_UNASSIGNED=false
 # Detector confidence floor (default 0.4). Real people/vehicles usually
 # score >0.6; wire-phantoms live in the 0.25-0.4 band.
 DETECT_CONF=0.4

--- a/detect-pipeline/detect_pipeline/providers.py
+++ b/detect-pipeline/detect_pipeline/providers.py
@@ -78,19 +78,82 @@ def _default_fps() -> int:
     return max(1, min(30, fps))
 
 
+# Skills whose consumers ride the Tier-0 detection stream. Used ONLY by the
+# opt-in DETECT_SKIP_UNASSIGNED mode: a camera whose assignments contain
+# none of these (e.g. LPR-only) can skip Tier-0 analysis entirely — a CPU
+# saving. Kept deliberately broad, and the mode ships OFF, because Tier-0
+# feeds many subscribers (footage-search indexes everything, the agent's
+# events skill reads every camera): skipping must be an explicit operator
+# choice, never an inference.
+DETECTION_SHAPED_SKILLS: frozenset[str] = frozenset({
+    "object_detection", "occupancy_counting", "people_counting",
+    "line_crossing", "intrusion_detection", "loitering_detection",
+    "abandoned_object", "package_delivery", "smart_doorbell",
+    "footage_search", "motion_detection",
+})
+
+
+def _skip_unassigned() -> bool:
+    """DETECT_SKIP_UNASSIGNED=true opts in to skipping cameras whose
+    assignments are detection-free. Default OFF (see above)."""
+    return os.environ.get("DETECT_SKIP_UNASSIGNED", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _assignment_view(c: dict) -> tuple[frozenset[str] | None, bool]:
+    """(per-camera labels, analyze) from a camera dict's ``assignments``.
+
+    Labels come from an ``object_detection`` assignment carrying labels —
+    "camera 4 wants person + truck" — and REPLACE the global DETECT_LABELS
+    for that camera only (unset → global applies, as ever). ``analyze``
+    stays True unless the opt-in skip mode is on AND the camera carries
+    assignments, none of them detection-shaped. The back-compat rule
+    everywhere: NO assignments = no restriction declared = analyze with
+    global labels, exactly as before assignments existed.
+    """
+    assignments = c.get("assignments")
+    if not isinstance(assignments, list) or not assignments:
+        return None, True
+    labels: frozenset[str] | None = None
+    skills: set[str] = set()
+    for a in assignments:
+        if not isinstance(a, dict):
+            continue
+        skill = str(a.get("skill", "")).strip().lower()
+        if not skill:
+            continue
+        skills.add(skill)
+        if skill == "object_detection" and a.get("labels"):
+            labels = frozenset(
+                str(s).strip().lower() for s in a["labels"] if str(s).strip()
+            ) or None
+    analyze = True
+    if _skip_unassigned() and skills and not (skills & DETECTION_SHAPED_SKILLS):
+        analyze = False
+        log.info(
+            "tier0: skipping %s — assignments (%s) need no Tier-0 detection "
+            "and DETECT_SKIP_UNASSIGNED is on",
+            c.get("camera_id"), ", ".join(sorted(skills)),
+        )
+    return labels, analyze
+
+
 def _to_spec(c: dict) -> CameraSpec:
     # The endpoint returns active cameras with a resolved ``frame_url``. All
     # active cameras are analyzed by default (on-by-default); an ``analyze`` flag
     # is honoured if the endpoint ever adds per-camera opt-out.
+    labels, assignment_analyze = _assignment_view(c)
     return CameraSpec(
         camera_id=str(c["camera_id"]),
         name=c.get("name", str(c["camera_id"])),
         substream_url=c["frame_url"],
-        analyze=bool(c.get("analyze", True)),
+        analyze=bool(c.get("analyze", True)) and assignment_analyze,
         width=c.get("width"),
         height=c.get("height"),
         fps=int(c.get("fps", _default_fps())),
         hwaccel=c.get("hwaccel", "cpu"),
+        labels=labels,
     )
 
 

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -103,6 +103,24 @@ class CameraSpec:
     height: int | None = None
     fps: int = 5
     hwaccel: str = "cpu"
+    # Per-camera label set from the camera's ``object_detection`` assignment
+    # ("camera 4 wants person + truck"). None = no per-camera declaration →
+    # the global DETECT_LABELS applies, exactly as before assignments
+    # existed. Set by the provider from the internal endpoint's
+    # ``assignments`` field; a change restarts the worker on the next
+    # reconcile tick (see WorkerManager.reconcile).
+    labels: frozenset[str] | None = None
+
+
+def allowed_labels_for(spec: "CameraSpec") -> frozenset[str] | None:
+    """The label allowlist THIS camera's pipeline should run with.
+
+    The camera's assignment wins when declared; else the global env
+    (DETECT_LABELS, defaulting to the curated track set). Factored out of
+    the worker so the precedence is testable without opening a stream."""
+    if spec.labels is not None:
+        return spec.labels
+    return _env_labels("DETECT_LABELS", DEFAULT_TRACK_LABELS)
 
 
 class CameraProvider(Protocol):
@@ -226,8 +244,13 @@ class CameraWorker:
             model_size=(self.model_size, self.model_size),
             stationary_interval=_env_int("DETECT_STATIONARY_INTERVAL", 10),
             max_regions=_env_int("DETECT_MAX_REGIONS", 8),
-            allowed_labels=_env_labels("DETECT_LABELS", DEFAULT_TRACK_LABELS),
+            allowed_labels=allowed_labels_for(self.spec),
         )
+        if self.spec.labels is not None:
+            log.info(
+                "tier0 %s: per-camera assignment labels active: %s",
+                self.spec.camera_id, ", ".join(sorted(self.spec.labels)) or "-",
+            )
         log.info("tier0 %s: started (%dx%d)", self.spec.camera_id, w, h)
         record_worker_state(self.spec.camera_id, True, target_fps=self.spec.fps)
         prev_seq: int | None = None
@@ -361,6 +384,12 @@ class WorkerManager:
         self._visit_poster = visit_poster
         self._factory = worker_factory or self._default_factory
         self._workers: dict[str, Worker] = {}
+        # The spec each running worker was built with — reconcile compares
+        # ONLY the fields a worker bakes in at start (today: labels) so a
+        # settings-page change takes effect within one tick. Deliberately
+        # not whole-spec equality: frame_url carries a freshly minted JWT
+        # on every fetch and would restart every worker every tick.
+        self._specs: dict[str, CameraSpec] = {}
 
     def _default_factory(self, spec: CameraSpec, sink: ResultSink) -> Worker:
         return CameraWorker(
@@ -400,21 +429,36 @@ class WorkerManager:
 
         for cid in list(self._workers):
             worker = self._workers[cid]
-            if cid not in desired or not worker.is_alive():
+            labels_changed = (
+                cid in desired
+                and self._specs.get(cid) is not None
+                and desired[cid].labels != self._specs[cid].labels
+            )
+            if cid not in desired or not worker.is_alive() or labels_changed:
                 worker.stop()
                 del self._workers[cid]
+                self._specs.pop(cid, None)
+                if labels_changed:
+                    log.info(
+                        "tier0: restarting %s — per-camera labels changed to %s",
+                        cid,
+                        sorted(desired[cid].labels) if desired[cid].labels is not None
+                        else "(global default)",
+                    )
 
         for cid, spec in desired.items():
             if cid not in self._workers:
                 worker = self._factory(spec, self.sink)
                 worker.start()
                 self._workers[cid] = worker
+                self._specs[cid] = spec
                 log.info("tier0: started worker for camera %s", cid)
 
     def _stop_all(self) -> None:
         for worker in self._workers.values():
             worker.stop()
         self._workers.clear()
+        self._specs.clear()
 
     def stop(self) -> None:
         self._stop_all()

--- a/detect-pipeline/test/test_bus_providers.py
+++ b/detect-pipeline/test/test_bus_providers.py
@@ -139,3 +139,56 @@ def test_provider_returns_empty_on_failure():
 
     prov = HttpCameraProvider("http://core:8000", opener=boom)
     assert prov.list_cameras() == []                    # never raises; retries next tick
+
+
+# ── Assignments → per-camera labels + opt-in skip (slice 3) ─────────
+
+
+def _cam(cid="cam4", assignments=None):
+    c = {"camera_id": cid, "name": cid, "frame_url": f"rtsp://m/{cid}"}
+    if assignments is not None:
+        c["assignments"] = assignments
+    return c
+
+
+def test_object_detection_assignment_labels_become_per_camera(monkeypatch):
+    from detect_pipeline.providers import _to_spec
+
+    spec = _to_spec(_cam(assignments=[
+        {"skill": "object_detection", "labels": ["Person", "TRUCK", ""]},
+        {"skill": "occupancy_counting"},
+    ]))
+    assert spec.labels == frozenset({"person", "truck"})
+    assert spec.analyze is True
+
+
+def test_no_assignments_means_global_labels_and_analyze(monkeypatch):
+    from detect_pipeline.providers import _to_spec
+
+    assert _to_spec(_cam()).labels is None
+    assert _to_spec(_cam()).analyze is True
+    # An object_detection assignment WITHOUT labels declares intent but no
+    # narrowing — global DETECT_LABELS still applies.
+    spec = _to_spec(_cam(assignments=[{"skill": "object_detection"}]))
+    assert spec.labels is None and spec.analyze is True
+
+
+def test_skip_unassigned_is_opt_in(monkeypatch):
+    from detect_pipeline.providers import _to_spec
+
+    lpr_only = _cam(assignments=[{"skill": "license_plate_recognition"}])
+    # Default: an LPR-only camera is STILL analyzed — Tier-0 feeds many
+    # subscribers (footage-search, the agent's events) beyond detection apps.
+    monkeypatch.delenv("DETECT_SKIP_UNASSIGNED", raising=False)
+    assert _to_spec(lpr_only).analyze is True
+
+    # Opt-in: the operator declares the CPU saving is worth it.
+    monkeypatch.setenv("DETECT_SKIP_UNASSIGNED", "true")
+    assert _to_spec(lpr_only).analyze is False
+    # A detection-shaped assignment keeps the camera analyzed even then...
+    assert _to_spec(_cam(assignments=[
+        {"skill": "license_plate_recognition"}, {"skill": "occupancy_counting"},
+    ])).analyze is True
+    # ...and NO assignments at all is never skipped (no restriction declared).
+    assert _to_spec(_cam()).analyze is True
+    assert _to_spec(_cam(assignments=[])).analyze is True

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -200,3 +200,56 @@ def test_camera_worker_records_restart_and_stores_best_frame(monkeypatch):
     assert len(store) >= 1
     assert store.latest_jpeg("cam-front") is not None
     metrics.reset()
+
+
+# ── Per-camera assignment labels (slice 3) ──────────────────────────
+#
+# "Camera 4 wants person + truck": the camera's object_detection
+# assignment sets THAT worker's allowlist; every other camera keeps the
+# global DETECT_LABELS. A label change on the settings page restarts
+# just that worker on the next reconcile tick.
+
+
+def test_allowed_labels_precedence(monkeypatch):
+    from detect_pipeline.service import allowed_labels_for
+
+    monkeypatch.setenv("DETECT_LABELS", "person,car")
+    assigned = CameraSpec("a", "a", "rtsp://h/a", labels=frozenset({"truck"}))
+    unassigned = CameraSpec("b", "b", "rtsp://h/b")
+    assert allowed_labels_for(assigned) == frozenset({"truck"})
+    assert allowed_labels_for(unassigned) == frozenset({"person", "car"})
+
+
+def test_reconcile_restarts_worker_when_labels_change():
+    made = []
+
+    def factory(spec, sink):
+        w = _FakeWorker(spec, sink)
+        made.append(w)
+        return w
+
+    prov = _FakeProvider([_spec("a"), _spec("b")])
+    mgr = WorkerManager(prov, _FakeSink(), worker_factory=factory)
+    mgr.reconcile()
+    assert len(made) == 2
+
+    # Same cameras next tick → nothing restarts (frame_url JWT churn and
+    # friends must never bounce workers).
+    prov.specs = [_spec("a"), _spec("b")]
+    mgr.reconcile()
+    assert len(made) == 2
+
+    # Operator narrows camera a to trucks → only a's worker is rebuilt.
+    prov.specs = [
+        CameraSpec("a", "a", "rtsp://h/a", labels=frozenset({"truck"})),
+        _spec("b"),
+    ]
+    mgr.reconcile()
+    assert len(made) == 3
+    assert made[2].spec.labels == frozenset({"truck"})
+    assert made[0].stopped and not made[1].stopped
+
+    # ...and un-assigning restores the global default via one more restart.
+    prov.specs = [_spec("a"), _spec("b")]
+    mgr.reconcile()
+    assert len(made) == 4 and made[3].spec.labels is None

--- a/docs/CAMERA_ASSIGNMENTS.md
+++ b/docs/CAMERA_ASSIGNMENTS.md
@@ -69,13 +69,18 @@ what's actually installed arrives with the catalog-UI integration.
   one call — `filter_cameras_for_skill(discovered, "my_skill")` /
   `cameras_for_skill(url, "my_skill")` — following the same
   `None` = "no restriction declared" contract.
+* **Tier-0 (the always-on detector)**: an `object_detection` assignment
+  with labels narrows that camera's detected classes ("camera 4 wants
+  person + truck") — the global `DETECT_LABELS` still applies to every
+  camera without a declaration, and a label change on the settings page
+  restarts just that camera's worker within one reconcile tick. And with
+  `DETECT_SKIP_UNASSIGNED=true` in `.env` (off by default), a camera
+  whose assignments are all detection-free — say an LPR-only camera —
+  skips Tier-0 analysis entirely, a straight CPU saving. Cameras with no
+  assignments are never skipped.
 
 ## What's coming (the remaining slices)
 
-* **Tier-0 per-camera classes**: `object_detection` + labels on a
-  camera will narrow the always-on detector's classes for that camera
-  ("camera 4 also wants trucks"), and a camera assigned nothing
-  detection-shaped will be skippable entirely — a CPU saving, opt-in.
 * **Catalog-UI validation**: the camera settings page will grey out a
   skill whose capability isn't installed, with a pointer to what to
   install ("LPR needs the plate adapter — not installed").

--- a/docs/design/per-camera-assignment.md
+++ b/docs/design/per-camera-assignment.md
@@ -154,6 +154,10 @@ Each slice is independently shippable and useful on its own:
    reference consumer, re-scoping on every discovery refresh)*
 3. **Tier-0 per-camera labels/analyze.** The class-selection case from the
    goal, plus the CPU saving of not analysing unassigned cameras.
+   *(shipped — provider parses ``assignments`` into per-camera labels;
+   label changes restart just that worker on the reconcile tick; the
+   skip is opt-in via ``DETECT_SKIP_UNASSIGNED``, off by default because
+   the Tier-0 stream feeds non-detection consumers too)*
 4. **Retire `AIModel`'s polling loop** in favour of assignment + the
    publish/subscribe path, removing the second inference route entirely.
 


### PR DESCRIPTION
Slice 3 of docs/design/per-camera-assignment.md — Tier-0 becomes the third consumer of camera assignments.

- CameraSpec gains 'labels'; the provider parses each camera's assignments from the internal endpoint: an object_detection assignment carrying labels ('camera 4 wants person + truck') REPLACES the global DETECT_LABELS for that camera only. No declaration -> global set, exactly as before.
- WorkerManager.reconcile compares the label field of the running worker's spec against the fresh fetch and restarts JUST that worker when it changed — a settings-page edit takes effect within one tick. Deliberately not whole-spec equality: frame_url carries a freshly minted MediaMTX JWT on every fetch and would bounce every worker every tick.
- Opt-in CPU saving: DETECT_SKIP_UNASSIGNED=true skips analysis on cameras whose assignments are all detection-free (an LPR-only camera). OFF by default, and cameras with NO assignments are never skipped: the Tier-0 stream feeds more than detection apps (footage-search indexes it, the agent's events skill reads it), so skipping must be an explicit operator choice, never an inference. DETECTION_SHAPED_SKILLS is the closed set the mode consults.
- allowed_labels_for(spec) factors the precedence out of the worker so it is testable without opening a stream.

Docs: .env.example documents both knobs; docs/CAMERA_ASSIGNMENTS.md moves Tier-0 from 'coming' to 'honours assignments today'; design doc marks slice 3 shipped.

Tests: label precedence, restart-on-label-change (and no restart on identical re-fetch), assignment parsing (labels, no-labels intent, junk tolerance), skip-mode opt-in semantics incl. never skipping unassigned cameras. detect-pipeline suite: 207 passing.