### PR TITLE
feat(cameras,ui): assignable-skills — the Assignments editor suggests…

### DIFF
--- a/app/src/services/cameraService.ts
+++ b/app/src/services/cameraService.ts
@@ -47,6 +47,8 @@ export const cameraService = {
   createCamera: (payload: any, opts: { force?: boolean } = {}) =>
     api.post('/api/v1/cameras/', payload, opts.force ? { params: { force: true } } : undefined),
   updateCamera: (cameraId: number, payload: any) => api.put(`/api/v1/cameras/${cameraId}`, payload),
+  // Suggestions + live availability for the camera Assignments editor.
+  getAssignableSkills: () => api.get('/api/v1/cameras/assignable-skills'),
   deleteCamera: (cameraId: number) => api.delete(`/api/v1/cameras/${cameraId}`),
   // Bin (irreversibly soft-deleted cameras)
   getDeletedCameras: () => api.get('/api/v1/cameras/deleted'),

--- a/app/src/views/Cameras.tsx
+++ b/app/src/views/Cameras.tsx
@@ -37,6 +37,17 @@ import { Modal } from '../components/Modal'
 // settings surface); consumers read it from the internal endpoint.
 type CameraAssignment = { skill: string; labels?: string[] | null }
 
+// One row of GET /cameras/assignable-skills: a known skill with live
+// availability. available === null means "couldn't tell" (KAI-C
+// unreachable) and must never grey anything out.
+type AssignableSkill = {
+  skill: string
+  label: string
+  source: string
+  available: boolean | null
+  hint: string
+}
+
 type Camera = {
   id: number
   name: string
@@ -125,6 +136,24 @@ export function Cameras() {
   // in flight left the button disabled and looking broken.
   const [saving, setSaving] = useState(false)
   const [scanQr, setScanQr] = useState(false)
+
+  // Known skills for the Assignments editor — fetched once per dialog
+  // open; [] until loaded (the editor stays free-text either way).
+  const [assignableSkills, setAssignableSkills] = useState<AssignableSkill[]>([])
+
+  const loadAssignableSkills = async () => {
+    try {
+      const { data } = await apiService.getAssignableSkills()
+      setAssignableSkills(data?.skills || [])
+    } catch {
+      setAssignableSkills([])
+    }
+  }
+
+  const skillInfo = (raw: string): AssignableSkill | undefined => {
+    const s = raw.trim().toLowerCase()
+    return s ? assignableSkills.find(k => k.skill === s) : undefined
+  }
 
   const [form, setForm] = useState<CameraForm>({
     name: '',
@@ -427,6 +456,7 @@ export function Cameras() {
       })),
     })
     setShowEditDialog(true)
+    loadAssignableSkills()
   }
 
   const closeEditDialog = () => {
@@ -743,6 +773,13 @@ export function Cameras() {
                   restriction declared. Consumers (Tier-0, apps) adopt these
                   incrementally.
                 </p>
+                <datalist id="assignable-skills">
+                  {assignableSkills.map(k => (
+                    <option key={k.skill} value={k.skill}>
+                      {`${k.label}${k.available === false ? ' (not installed)' : ''}`}
+                    </option>
+                  ))}
+                </datalist>
                 {form.assignments.map((row, i) => (
                   <div key={i} className="flex gap-2 items-center">
                     <input
@@ -753,6 +790,7 @@ export function Cameras() {
                         assignments: form.assignments.map((r, j) => j === i ? { ...r, skill: e.target.value } : r),
                       })}
                       placeholder="skill, e.g. object_detection"
+                      list="assignable-skills"
                       aria-label={`Assignment ${i + 1} skill`}
                     />
                     <input
@@ -774,6 +812,29 @@ export function Cameras() {
                     >✕</button>
                   </div>
                 ))}
+                {form.assignments.map((row, i) => {
+                  const info = skillInfo(row.skill)
+                  if (!row.skill.trim()) return null
+                  // Only ANNOTATE — never block: available === false gets an
+                  // amber "what to install" note; null (unknown) and true
+                  // stay quiet; an unknown spelling gets a gentle nudge.
+                  if (info && info.available === false) {
+                    return (
+                      <p key={`hint-${i}`} className="text-xs text-amber-500">
+                        {info.label}: {info.hint}
+                      </p>
+                    )
+                  }
+                  if (!info && assignableSkills.length > 0) {
+                    return (
+                      <p key={`hint-${i}`} className="text-xs text-[var(--muted)]">
+                        “{row.skill.trim()}” isn’t a known skill on this install —
+                        it will be stored, but nothing consumes it yet.
+                      </p>
+                    )
+                  }
+                  return null
+                })}
                 <button
                   type="button"
                   className="px-3 py-1.5 border border-[var(--border)] bg-[var(--panel-2)] rounded text-xs"

--- a/docs/CAMERA_ASSIGNMENTS.md
+++ b/docs/CAMERA_ASSIGNMENTS.md
@@ -79,11 +79,14 @@ what's actually installed arrives with the catalog-UI integration.
   skips Tier-0 analysis entirely, a straight CPU saving. Cameras with no
   assignments are never skipped.
 
-## What's coming (the remaining slices)
-
-* **Catalog-UI validation**: the camera settings page will grey out a
-  skill whose capability isn't installed, with a pointer to what to
-  install ("LPR needs the plate adapter — not installed").
+The Assignments editor also **suggests and annotates**: typing in a
+skill row offers every skill the install knows (canonical adapter tasks
+plus installed catalog apps), and a skill whose capability isn't
+actually served shows an amber note naming what to install ("no
+registered adapter advertises license_plate_recognition — register one
+on the AI Adapters page"). It annotates, it never blocks — the
+vocabulary stays open, and when adapter status can't be determined
+(KAI-C unreachable) nothing is flagged.
 
 (The old per-model polling loop — a Start button that drove live
 inference on a timer per camera — has been retired: live detection now

--- a/docs/design/per-camera-assignment.md
+++ b/docs/design/per-camera-assignment.md
@@ -115,6 +115,12 @@ explicit override, never as the thing an operator must fill in.
 manifest declares `requires_tasks`, can refuse an assignment whose
 capability isn't installed ("people counting needs object detection —
 Tier-0 provides it ✓" / "LPR needs the plate adapter — not installed").
+*(shipped — GET /cameras/assignable-skills composes the canonical task
+registry, live adapter tasks via KAI-C, and installed apps into a
+tri-state availability list; the editor suggests via datalist and
+annotates unavailable skills with a what-to-install note. Annotate,
+never refuse: the vocabulary stays open, and unknown availability —
+KAI-C unreachable — flags nothing.)*
 
 ## Rules that keep the concerns separate
 

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -687,6 +687,112 @@ def get_deleted_cameras(
     return DeletedCameraList(cameras=items, total=len(items))
 
 
+# ── Assignable skills (per-camera assignment, consumer 3) ───────────
+#
+# The camera edit dialog's Assignments editor asks this endpoint what
+# skills EXIST and whether each is actually served right now, so it can
+# offer suggestions and flag "LPR needs the plate adapter — not
+# installed" instead of leaving the operator to guess spellings.
+# Composed from three sources, none authoritative over the others:
+#   * the canonical task registry (server/config/tasks.yml) — every
+#     adapter-shaped capability, available when a registered adapter
+#     advertises the task (or an alias). object_detection is special:
+#     the always-on Tier-0 detector provides it on every install.
+#   * the installed-apps registry — every registered catalog app is a
+#     skill (id with '-' -> '_'), available when enabled.
+# ``available`` is a TRI-STATE: true / false / null, where null means
+# "couldn't tell" (KAI-C unreachable) — the UI must never grey a skill
+# on null, the same advisory rule the agent's skills panel follows.
+# The vocabulary stays OPEN: this endpoint suggests and annotates; it
+# never becomes a validation gate (an assignment may be declared before
+# its capability is installed).
+
+
+def _assignable_task_entries(tasks_advertised: set[str] | None) -> list[dict]:
+    import yaml as _yaml
+
+    registry_path = Path(__file__).resolve().parents[1] / "config" / "tasks.yml"
+    try:
+        registry = _yaml.safe_load(registry_path.read_text()) or []
+    except Exception:
+        camera_logger.warning("assignable-skills: tasks.yml unreadable", exc_info=True)
+        registry = []
+    out: list[dict] = []
+    for entry in registry:
+        if not isinstance(entry, dict) or not entry.get("task"):
+            continue
+        task = str(entry["task"])
+        names = {task, *(str(a) for a in entry.get("aliases") or [])}
+        if task == "object_detection":
+            available: bool | None = True
+            hint = "Provided by the built-in Tier-0 detector on every install."
+        elif tasks_advertised is None:
+            available = None
+            hint = "Adapter status unknown (KAI-C unreachable) — not greyed out."
+        elif names & tasks_advertised:
+            available = True
+            hint = "An installed adapter advertises this task."
+        else:
+            available = False
+            suggested = ", ".join(entry.get("suggested_adapters") or []) or "an adapter"
+            hint = (
+                f"No registered adapter advertises {task!r} — register one "
+                f"(suggested: {suggested}) on the AI Adapters page."
+            )
+        out.append({
+            "skill": task,
+            "label": str(entry.get("label") or task),
+            "source": "tier0" if task == "object_detection" else "adapter",
+            "available": available,
+            "hint": hint,
+        })
+    return out
+
+
+@router.get("/assignable-skills")
+async def assignable_skills(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Suggestions + live availability for the Assignments editor."""
+    # Adapter tasks via KAI-C — advisory: unreachable = unknown, not empty.
+    tasks_advertised: set[str] | None = None
+    try:
+        from services.kai_c_service import get_kai_c_service
+
+        capabilities = await get_kai_c_service().get_capabilities()
+        tasks_advertised = set()
+        for entry in (capabilities.get("adapters") or {}).values():
+            caps = (entry or {}).get("capabilities") or {}
+            tasks_advertised.update(str(t) for t in caps.get("tasks_advertised") or [])
+    except Exception:
+        camera_logger.info("assignable-skills: KAI-C unreachable; availability unknown")
+
+    skills = _assignable_task_entries(tasks_advertised)
+
+    # Installed catalog apps — each is a skill; available when enabled.
+    from models import InstalledApp
+
+    for app_row in db.query(InstalledApp).all():
+        skill = str(app_row.id).replace("-", "_")
+        skills.append({
+            "skill": skill,
+            "label": str(app_row.name or skill),
+            "source": "app",
+            "available": bool(app_row.enabled),
+            "hint": (
+                "App installed and enabled." if app_row.enabled
+                else "App installed but disabled — enable it in the App Catalog."
+            ),
+        })
+
+    # One entry per skill; a later (app) entry wins over a task twin.
+    merged: dict[str, dict] = {}
+    for entry in skills:
+        merged[entry["skill"]] = entry
+    return {"skills": sorted(merged.values(), key=lambda e: e["skill"])}
+
+
 @router.get("/{camera_id}", response_model=CameraResponse)
 def get_camera(
     camera_id: int,

--- a/server/tests/test_assignable_skills.py
+++ b/server/tests/test_assignable_skills.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""
+GET /cameras/assignable-skills — suggestions + live availability for the
+camera Assignments editor (per-camera assignment, consumer 3).
+
+Run with:
+
+    cd server && pytest tests/test_assignable_skills.py -v
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017 — only runs where UTC is absent
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+# Force-assign (not setdefault): an earlier-collected test may have installed
+# a narrower stub without a __getattr__ fallback, which breaks
+# `from core.logging_config import mediamtx_logger` at import time.
+sys.modules["core.logging_config"] = _lm
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+from core.auth import get_current_active_user  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import InstalledApp, Role, User  # noqa: E402
+from routers import cameras as cameras_router  # noqa: E402
+
+
+class _StubUser:
+    id = 1
+    username = "tester"
+    is_superuser = True
+
+
+class _FakeKaiC:
+    def __init__(self, adapters=None, fail=False):
+        self._adapters = adapters or {}
+        self._fail = fail
+
+    async def get_capabilities(self):
+        if self._fail:
+            raise RuntimeError("KAI-C unreachable")
+        return {"adapters": self._adapters}
+
+
+def _client(monkeypatch, *, kaic: _FakeKaiC, apps=()):
+    import services.kai_c_service as kaic_mod
+
+    monkeypatch.setattr(kaic_mod, "get_kai_c_service", lambda: kaic)
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(
+        engine, tables=[InstalledApp.__table__, User.__table__, Role.__table__]
+    )
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    for app_id, enabled in apps:
+        session.add(InstalledApp(
+            id=app_id, name=app_id.replace("-", " ").title(), version="1.0.0",
+            url=f"http://{app_id}:9200", manifest_json={"id": app_id},
+            config_json={}, enabled=enabled,
+        ))
+    session.commit()
+    session.close()
+
+    app = FastAPI()
+    app.include_router(cameras_router.router)
+
+    def _override_db():
+        s = session_factory()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_active_user] = lambda: _StubUser()
+    return TestClient(app)
+
+
+def _skills(client) -> dict[str, dict]:
+    r = client.get("/cameras/assignable-skills")
+    assert r.status_code == 200, r.text
+    return {s["skill"]: s for s in r.json()["skills"]}
+
+
+def test_tier0_always_provides_object_detection(monkeypatch):
+    sk = _skills(_client(monkeypatch, kaic=_FakeKaiC()))
+    assert sk["object_detection"]["available"] is True
+    assert "Tier-0" in sk["object_detection"]["hint"]
+
+
+def test_adapter_tasks_and_aliases_mark_availability(monkeypatch):
+    kaic = _FakeKaiC(adapters={
+        # canonical spelling on one adapter, an ALIAS on another
+        "plates": {"capabilities": {"tasks_advertised": ["lpr"]}},
+        "faces": {"capabilities": {"tasks_advertised": ["face_recognition"]}},
+    })
+    sk = _skills(_client(monkeypatch, kaic=kaic))
+    assert sk["license_plate_recognition"]["available"] is True   # via alias
+    assert sk["face_recognition"]["available"] is True
+    assert sk["image_captioning"]["available"] is False
+    assert "AI Adapters" in sk["image_captioning"]["hint"]
+
+
+def test_kaic_unreachable_means_unknown_not_unavailable(monkeypatch):
+    sk = _skills(_client(monkeypatch, kaic=_FakeKaiC(fail=True)))
+    # Tri-state: null, never false — the UI must not grey on unknown.
+    assert sk["license_plate_recognition"]["available"] is None
+    assert sk["object_detection"]["available"] is True            # Tier-0 regardless
+
+
+def test_installed_apps_are_skills_available_when_enabled(monkeypatch):
+    client = _client(monkeypatch, kaic=_FakeKaiC(), apps=[
+        ("occupancy-counting", True), ("loitering-detection", False),
+    ])
+    sk = _skills(client)
+    assert sk["occupancy_counting"]["available"] is True
+    assert sk["occupancy_counting"]["source"] == "app"
+    assert sk["loitering_detection"]["available"] is False
+    assert "disabled" in sk["loitering_detection"]["hint"]


### PR DESCRIPTION
… and annotates

Consumer 3 of docs/design/per-camera-assignment.md, completing the design: the camera edit dialog's Assignments editor now knows what skills EXIST on this install and whether each is actually served.

- GET /cameras/assignable-skills composes three sources into one list: the canonical task registry (server/config/tasks.yml — every adapter-shaped capability, matched against live tasks_advertised incl. aliases, with object_detection always available via Tier-0), and the installed-apps registry (each app id is a skill, available when enabled). Availability is a TRI-STATE: true / false / null, null meaning 'could not tell' (KAI-C unreachable) — the same advisory rule the agent's skills panel follows, so nothing is ever greyed out on a transient outage.
- The editor's skill input gains a datalist of known skills (labels, with '(not installed)' markers), and each row an annotation: amber what-to-install note for a known-but-unserved skill ('no registered adapter advertises license_plate_recognition — register one on the AI Adapters page'), a gentle nudge for an unknown spelling. It ANNOTATES, never blocks — the vocabulary stays open by design (an assignment may be declared before its capability is installed).

Tests: Tier-0 always-available, alias matching, unreachable-KAI-C tri-state, installed/disabled app availability. Full server suite: 769 passing (the one reconciler-identity failure pre-exists on main). UI type-checks clean.