### PR TITLE
ci: publish the catalog app images to GHCR

### DIFF
--- a/.github/workflows/publish-app-images.yml
+++ b/.github/workflows/publish-app-images.yml
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build + publish the example APP container images to GHCR.
+#
+# Why this exists
+# ---------------
+# The App Catalog's curated index (server/config/apps_index.yml)
+# advertises ``ghcr.io/open-nvr/<app>:latest`` for every catalog app,
+# and the one-click installer's reconciler pulls exactly those refs —
+# but until this workflow, nothing ever PUSHED them: app-images-smoke.yml
+# builds with ``push: false`` (it exists to catch Dockerfile breakage on
+# PRs, and deliberately does not publish). So the index advertised
+# images that did not exist, and one-click install could only work on
+# the local-build path. This workflow closes that gap: every app image
+# the index names gets published, multi-arch, with the same tag policy
+# as the core image.
+#
+# Division of labour
+#   - app-images-smoke.yml  → PR-time build + in-image import smoke (no push)
+#   - THIS workflow         → post-merge publish (main), release publish (v*)
+#
+# Tag policy (mirrors publish-images.yml for ghcr.io/open-nvr/core):
+#   - push to main → :main, :sha-<short>, :latest
+#     (:latest tracks main for v0.x — the catalog index pins :latest, so
+#     the one-click promise depends on it existing; the reconciler's
+#     digest pinning is the reproducibility story, not the tag)
+#   - tag v*       → :<version>, :<major>.<minor>, :sha-<short>, :latest
+#
+# Architecture: linux/amd64 + linux/arm64, same rationale as the core
+# image (Apple Silicon and Raspberry Pi are first-class Tier 0 targets;
+# an amd64-only manifest makes ``docker pull`` fail there with a bare
+# daemon error). All ten images are python:3.11-slim + the in-repo SDK
+# with no heavy native deps, so the QEMU arm64 leg is cheap.
+#
+# To add a new catalog app: add it to apps_index.yml, to the smoke
+# matrix in app-images-smoke.yml, and to the matrix below.
+
+name: publish-app-images
+
+on:
+  # No ``paths`` filter on push — GitHub applies push path filters to
+  # both branches AND tags, so a release tag on a commit that didn't
+  # touch examples/ would silently skip publishing (same landmine
+  # publish-images.yml documents). Main-push builds are cheap with the
+  # GHA layer cache; correctness wins.
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-app-images-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: publish ${{ matrix.app }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { app: abandoned-object,           title: Abandoned Object }
+          - { app: footage-search,             title: Footage Search }
+          - { app: home-assistant-relay,       title: Home Assistant Relay }
+          - { app: intrusion-detection,        title: Intrusion Detection }
+          - { app: license-plate-recognition,  title: License Plate Recognition }
+          - { app: line-crossing,              title: Line Crossing }
+          - { app: loitering-detection,        title: Loitering Detection }
+          - { app: occupancy-counting,         title: Occupancy Counting }
+          - { app: package-delivery,           title: Package Delivery }
+          - { app: smart-doorbell,             title: Smart Doorbell }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (cross-arch emulation for the arm64 build)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/open-nvr/${{ matrix.app }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            # Same v0.x policy as the core image: :latest tracks main and
+            # release tags, because apps_index.yml advertises :latest and
+            # the one-click catalog install depends on it existing.
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=OpenNVR ${{ matrix.title }}
+            org.opencontainers.image.description=OpenNVR catalog app — ${{ matrix.title }} (App SDK example).
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+            org.opencontainers.image.vendor=OpenNVR
+            org.opencontainers.image.documentation=https://github.com/open-nvr/open-nvr/blob/main/examples/${{ matrix.app }}/README.md
+
+      - name: Build + push ${{ matrix.app }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: examples/${{ matrix.app }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Same cache scope the PR smoke workflow warms — a merge
+          # usually finds every layer already built.
+          cache-from: type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,scope=${{ matrix.app }},mode=max

--- a/docs/APPS_INSTALL.md
+++ b/docs/APPS_INSTALL.md
@@ -193,12 +193,15 @@ warning above fires. Teardown (`desired="absent"`) passes no override —
 
 Pinning is fully **wired and takes effect** the moment the curated index
 carries an `image_digest` for an app *and* that image is published to a
-registry the host can pull from. **Today, the shipped apps ship as a
-local `build:` overlay with `:local-build` tags and NO published digest
-in `apps_index.yml`** — so installing one of them right now logs the
-UNPINNED warning and uses the local build. That is expected, not a bug:
-the missing piece is a published, digest-pinned registry (see *What is
-deferred*), not the pinning mechanism, which is complete and tested.
+registry the host can pull from. **The app images ARE now published**:
+`.github/workflows/publish-app-images.yml` pushes every catalog app to
+`ghcr.io/open-nvr/<id>` on each main push and release tag (multi-arch,
+same tag policy as core), so the index's `image` refs resolve. What the
+index still ships WITHOUT is a per-entry `image_digest` — so an install
+today logs the UNPINNED warning and pulls the tag. Recording digests in
+the index at release time is the remaining step to make pinning bite;
+the mechanism itself is complete and tested, and the local `build:`
+overlay with `:local-build` tags remains the dev / air-gapped path.
 
 ---
 

--- a/server/config/apps_index.yml
+++ b/server/config/apps_index.yml
@@ -33,12 +33,14 @@
 # path failed with "no such service"; all 8 have since been restored
 # WITH their service blocks). See docs/CONTRIBUTING_APPS.md.
 #
-# IMAGES ARE NOT PUBLISHED YET. Unlike the adapters and core (which pull
-# from ghcr.io/open-nvr/*), the detector apps ship only as a build
-# overlay today (docker-compose.apps.yml uses `build:` +
-# opennvr/<id>:local-build). The `image` field below records the
-# CANONICAL intended GHCR ref (ghcr.io/open-nvr/<id>:latest) for when
-# publishing lands; `build_context` names the source folder explicitly.
+# IMAGES ARE PUBLISHED by .github/workflows/publish-app-images.yml:
+# every push to main (and every v* release tag) pushes each app image
+# to its `image` ref below — ghcr.io/open-nvr/<id>:latest, multi-arch
+# (amd64 + arm64), same tag policy as the core image. The local
+# `build:` overlay (docker-compose.apps.yml, opennvr/<id>:local-build)
+# remains the dev / air-gapped path; `build_context` names the source
+# folder explicitly. For releases, record an `image_digest` per entry
+# so the reconciler's pinning takes effect.
 #
 # NO SECRETS in this file — the compose snippets reference
 # ${INTERNAL_API_KEY} from the operator's .env, never a literal.


### PR DESCRIPTION
The App Catalog's curated index advertises ghcr.io/open-nvr/<app>:latest for all ten catalog apps and the one-click installer's reconciler pulls exactly those refs — but nothing ever pushed them: app-images-smoke.yml deliberately builds with push:false (it exists to catch Dockerfile breakage on PRs). The index was advertising images that did not exist, so one-click install could only ever work on the local-build path.

publish-app-images.yml closes the gap: a 10-app matrix that builds and pushes each catalog image on every push to main and every v* release tag — multi-arch (amd64 + arm64: Apple Silicon and Raspberry Pi are first-class targets, and all ten images are slim Python + the in-repo SDK, so the QEMU leg is cheap), with the same tag policy as the core image (:main + :sha-<short> + :latest on main; :<version> + :<major>.<minor> + :latest on tags — :latest tracks main for v0.x because the index pins it). It reuses the GHA cache scopes the PR smoke workflow already warms, so a merge usually finds every layer built. No paths filter on push, for the documented tag-skip landmine.

Division of labour stays clean: smoke owns PR-time build+import checks, this workflow owns publishing. apps_index.yml's 'IMAGES ARE NOT PUBLISHED YET' header and APPS_INSTALL.md's current-state section updated to the new truth (the remaining release step is recording per-entry image_digest so the reconciler's pinning bites).