### PR TITLE
fix(tier0): the substream actually reaches the detect-pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,15 @@ DETECT_LABELS=person,car,truck,bus,motorcycle,bicycle,cat,dog
 # the agent's events skill reads it) — skipping is an explicit choice.
 # Cameras with NO assignments are never skipped.
 DETECT_SKIP_UNASSIGNED=false
+
+# Which stream Tier-0 detection (and the agent's frame grabs) decode when a
+# camera has a substream: auto (default — substream on CPU-only decode, the
+# full MAIN stream when DETECT_HWACCEL is set: a GPU box can afford full-res
+# decode and gets full-res evidence crops; detection accuracy is equal
+# either way, the model input is a fixed square), sub (always the substream
+# when one exists), main (always full-res). Cameras with no substream use
+# the main stream regardless.
+INFERENCE_TAP_STREAM=auto
 # Detector confidence floor (default 0.4). Real people/vehicles usually
 # score >0.6; wire-phantoms live in the 0.25-0.4 band.
 DETECT_CONF=0.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -387,6 +387,11 @@ services:
       - MEDIAMTX_HLS_URL=http://mediamtx:8888
       - MEDIAMTX_RTSP_URL=rtsp://mediamtx:8554
       - MEDIAMTX_RTSPS_URL=rtsps://mediamtx:8322
+      # Tier-0 tap selection (auto | sub | main) + the hardware-decode
+      # signal 'auto' keys off — same DETECT_HWACCEL the detect-pipeline
+      # container gets, so both sides agree on what the hardware can do.
+      - INFERENCE_TAP_STREAM=${INFERENCE_TAP_STREAM:-auto}
+      - DETECT_HWACCEL=${DETECT_HWACCEL:-cpu}
       - MEDIAMTX_EXTERNAL_RTSPS_URL=rtsps://localhost:8322
       - MEDIAMTX_PLAYBACK_URL=http://mediamtx:9996
       # Browser-facing URLs go through nginx (TLS, any LAN device).

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -230,6 +230,24 @@ class Settings(BaseSettings):
     # where MediaMTX and KAI-C are on different hosts. See V-019.
     inference_use_mediamtx_tap: bool = True
 
+    # Which MediaMTX stream Tier-0's detect-pipeline (and the agent's frame
+    # grabs) tap when a camera HAS a substream:
+    #   auto  (default) — substream on CPU-only decode, MAIN stream when
+    #           hardware decode is configured (detect_hwaccel != cpu): a
+    #           GPU box can afford full-res decode and gets full-res
+    #           evidence crops; a CPU box gets the ~5x saving. Detection
+    #           accuracy is equal either way (the model input is a fixed
+    #           square; what matters is an object's fraction of frame).
+    #   sub   — always the substream when one exists.
+    #   main  — always the main stream (full-res evidence crops).
+    # Cameras with no substream use the main stream regardless.
+    inference_tap_stream: str = "auto"
+
+    # Mirror of the detect-pipeline's DETECT_HWACCEL (compose passes the
+    # same env to both containers) — the 'auto' signal above. "cpu" (the
+    # default) means software decode.
+    detect_hwaccel: str = "cpu"
+
     # Give the camera-agent a low-res substream (derived from vendor URL
     # conventions) instead of the full-res feed, to save CPU on a single box.
     # Off by default since not every camera exposes a substream.

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -288,14 +288,49 @@ def list_camera_agent_sources(db: Session = Depends(get_db)) -> dict[str, object
         )
         if settings.inference_use_mediamtx_tap:
             base = (settings.mediamtx_rtsp_url or "rtsp://mediamtx:8554").rstrip("/")
-            frame_url = f"{base}/{stream_name}"
+            # Serve the LOW-RES SUBSTREAM tap when this camera has a sub
+            # source (stored substream_url or a derivable vendor path —
+            # mirroring exactly the condition under which the provisioner
+            # creates the {name}-sub MediaMTX path) AND the tap policy says
+            # so. Policy (settings.inference_tap_stream): 'auto' picks the
+            # substream on CPU-only decode and the MAIN stream when
+            # hardware decode is configured (a GPU box can afford full-res
+            # decode and gets full-res evidence crops; detection accuracy
+            # is equal either way — the model input is a fixed square);
+            # 'sub'/'main' force it. Cameras with no sub source keep the
+            # main tap regardless. This is what makes "configure the
+            # camera's substream" actually reach Tier-0: decoding the sub
+            # instead of the full main stream is the ~5x CPU difference
+            # the detect-pipeline README documents.
+            from services.stream_service import substream_name
+
+            # STORED substream_url ONLY — deliberately narrower than the
+            # provisioner (which also derives vendor-convention URLs for
+            # the agent's on-demand live view, where a wrong guess merely
+            # falls back to stills). Tier-0 is ALWAYS-ON: handing it a
+            # derived URL that happens to be wrong — a Hikvision-shaped
+            # path on a camera whose substream is disabled — would kill
+            # detection for that camera outright. The operator's stored
+            # URL is their explicit, presumably verified word; a guess is
+            # not, so a guess never steers the detector.
+            has_sub = bool((cam.substream_url or "").strip())
+            mode = (settings.inference_tap_stream or "auto").strip().lower()
+            if mode == "main":
+                use_sub = False
+            elif mode == "sub":
+                use_sub = has_sub
+            else:  # auto (and any unknown value degrades to auto)
+                hw = (settings.detect_hwaccel or "cpu").strip().lower()
+                use_sub = has_sub and hw in ("", "cpu")
+            tap_name = substream_name(stream_name) if use_sub else stream_name
+            frame_url = f"{base}/{tap_name}"
             # Append JWT so the camera-agent can authenticate with MediaMTX.
             # Fall back to bare URL when minting failed (keys not configured,
             # test environment, etc.) — agent will still start, just unable
             # to fetch frames for the tap path.
             if mediamtx_jwt:
                 frame_url = f"{frame_url}?jwt={urlquote(mediamtx_jwt, safe='.')}"
-            source = "mediamtx"
+            source = "mediamtx-sub" if use_sub else "mediamtx"
         elif cam.rtsp_url:
             frame_url = str(cam.rtsp_url)
             source = "camera"

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -876,11 +876,18 @@ class MediaMtxAdminService:
                     },
                 )
 
-            # Best-effort low-res substream for the camera-agent's live view
-            # (settings.agent_live_use_substream). A sub failure must NEVER
-            # affect the main path's result — the agent falls back to the
-            # main stream / stills.
-            if settings.agent_live_use_substream and result.get("http_status") in (200, 201):
+            # Best-effort low-res substream path. Provisioned WHENEVER a sub
+            # source exists (stored substream_url or a derivable vendor
+            # convention) — not only for the agent live view: Tier-0's
+            # detect-pipeline taps this path to decode the cheap stream
+            # instead of the full main stream (the ~5x CPU difference its
+            # README documents). The path is sourceOnDemand, so it costs
+            # nothing until something actually pulls it, and
+            # settings.agent_live_use_substream stays what it always was:
+            # the AGENT's choice of which path to WATCH, not a gate on the
+            # path existing. A sub failure must NEVER affect the main
+            # path's result — consumers fall back to the main stream.
+            if result.get("http_status") in (200, 201):
                 try:
                     await MediaMtxAdminService._provision_substream(
                         camera_id, camera_ip, config
@@ -1075,19 +1082,20 @@ class MediaMtxAdminService:
                         "http_status": result.get("http_status"),
                     },
                 )
-                # Keep the agent substream in sync with the (possibly new)
-                # source URL. Best-effort, same contract as provision_path.
-                if settings.agent_live_use_substream:
-                    try:
-                        await MediaMtxAdminService._provision_substream(
-                            camera_id, camera_ip, config
-                        )
-                    except Exception:  # pragma: no cover - defensive
-                        mediamtx_logger.warning(
-                            f"substream refresh raised for {name}; main path unaffected",
-                            extra={"camera_id": camera_id, "path": name,
-                                   "action": "mediamtx.substream_provision_error"},
-                        )
+                # Keep the substream path in sync with the (possibly new)
+                # source URL. Best-effort, same contract as provision_path —
+                # and same rule: the path exists whenever a sub source does,
+                # regardless of the agent live-view setting.
+                try:
+                    await MediaMtxAdminService._provision_substream(
+                        camera_id, camera_ip, config
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    mediamtx_logger.warning(
+                        f"substream refresh raised for {name}; main path unaffected",
+                        extra={"camera_id": camera_id, "path": name,
+                               "action": "mediamtx.substream_provision_error"},
+                    )
             else:
                 mediamtx_logger.error(
                     f"MediaMTX path replace failed: {name}",

--- a/server/tests/test_tier0_substream_tap.py
+++ b/server/tests/test_tier0_substream_tap.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""
+Tier-0 substream tap: the internal camera-agent /cameras endpoint serves
+the LOW-RES ``{name}-sub`` MediaMTX tap whenever the camera has a sub
+source — a STORED substream_url only. A derivable-but-unstored vendor
+convention still provisions the agent's on-demand sub path, but never
+steers the always-on detector: a wrong guess there would kill detection
+for that camera outright. This is the change that makes "configure the
+camera's substream" actually reach the detect-pipeline (~5x decode
+CPU). Cameras with no stored sub keep the main tap exactly as before.
+
+Run with:
+
+    cd server && pytest tests/test_tier0_substream_tap.py -v
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017 — only runs where UTC is absent
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules["core.logging_config"] = _lm
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+from core.config import settings  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Camera, Role, User  # noqa: E402
+from routers import internal_camera_agent as internal_router  # noqa: E402
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Three cameras behind the internal router with the MediaMTX tap ON:
+    one with a stored substream_url, one whose main URL is a derivable
+    Hikvision convention, one with neither. JWT minting is stubbed out
+    (no keys in tests) — bare tap URLs are the documented fallback."""
+    monkeypatch.setattr(settings, "inference_use_mediamtx_tap", True)
+    monkeypatch.setattr(internal_router, "_mint_mediamtx_jwt", lambda: None)
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(
+        engine, tables=[Camera.__table__, User.__table__, Role.__table__]
+    )
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    session.add(Role(id=1, name="admin"))
+    session.add(User(id=1, username="op", email="op@x",
+                     hashed_password="x", role_id=1))
+    session.add(Camera(                      # stored substream_url wins
+        id=1, name="Stored", ip_address="10.0.0.1", owner_id=1, is_active=True,
+        rtsp_url="rtsp://u:p@10.0.0.1:554/avstream/channel=1/stream=0.sdp",
+        substream_url="rtsp://u:p@10.0.0.1:554/avstream/channel=1/stream=1.sdp",
+    ))
+    session.add(Camera(                      # derivable vendor convention
+        id=2, name="Hik", ip_address="10.0.0.2", owner_id=1, is_active=True,
+        rtsp_url="rtsp://u:p@10.0.0.2:554/Streaming/Channels/101",
+    ))
+    session.add(Camera(                      # no sub source at all
+        id=3, name="Plain", ip_address="10.0.0.3", owner_id=1, is_active=True,
+        rtsp_url="rtsp://u:p@10.0.0.3:554/opaque/onvif/path",
+    ))
+    session.commit()
+    session.close()
+
+    app = FastAPI()
+    app.include_router(internal_router.router)
+
+    def _override_db():
+        s = session_factory()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[internal_router._require_internal_key] = lambda: None
+    with TestClient(app) as c:
+        yield c
+
+
+def _cams(client) -> dict[str, dict]:
+    body = client.get("/internal/camera-agent/cameras").json()
+    return {c["camera_id"]: c for c in body["cameras"]}
+
+
+def test_stored_substream_serves_the_sub_tap(client):
+    cam = _cams(client)["cam1"]
+    assert cam["frame_url"].endswith("-sub")
+    assert cam["source"] == "mediamtx-sub"
+
+
+def test_derivable_but_unstored_url_keeps_the_main_tap(client):
+    """A Hikvision-SHAPED main URL is only a guess about the substream —
+    the camera may have its sub stream disabled, and an always-on
+    detector pointed at a dead URL is a camera with no detection. Only
+    the operator's stored substream_url steers Tier-0."""
+    cam = _cams(client)["cam2"]
+    assert not cam["frame_url"].endswith("-sub")
+    assert cam["source"] == "mediamtx"
+
+
+def test_no_sub_source_keeps_the_main_tap(client):
+    cam = _cams(client)["cam3"]
+    assert not cam["frame_url"].endswith("-sub")
+    assert cam["source"] == "mediamtx"
+
+
+# ── Tap policy: auto | sub | main ──────────────────────────────────
+
+
+def test_auto_prefers_main_when_hardware_decode_is_configured(client, monkeypatch):
+    """A GPU/hwaccel box can afford full-res decode (and gets full-res
+    evidence crops) — 'auto' picks the MAIN stream there."""
+    monkeypatch.setattr(settings, "detect_hwaccel", "vaapi")
+    cams = _cams(client)
+    assert cams["cam1"]["source"] == "mediamtx"
+    assert not cams["cam1"]["frame_url"].endswith("-sub")
+
+
+def test_forced_main_ignores_the_substream(client, monkeypatch):
+    monkeypatch.setattr(settings, "inference_tap_stream", "main")
+    assert _cams(client)["cam1"]["source"] == "mediamtx"
+
+
+def test_forced_sub_uses_it_even_with_hardware_decode(client, monkeypatch):
+    monkeypatch.setattr(settings, "inference_tap_stream", "sub")
+    monkeypatch.setattr(settings, "detect_hwaccel", "vaapi")
+    cams = _cams(client)
+    assert cams["cam1"]["source"] == "mediamtx-sub"
+    # ...but cameras without a STORED sub still use main — forcing 'sub'
+    # never turns a derivation guess into the detector's source either.
+    assert cams["cam2"]["source"] == "mediamtx"
+    assert cams["cam3"]["source"] == "mediamtx"


### PR DESCRIPTION
Field-found on a real install: operator configures the camera's substream URL exactly as the detect-pipeline README instructs, restarts, and Tier-0 keeps decoding the 2880x1616 MAIN stream at ~2 CPU cores. Two gaps made the documented fix unwirable end to end:

- MediaMTX sub-path provisioning was gated on agent_live_use_substream (default OFF) — the {name}-sub path was never created unless the operator also enabled the agent live-view feature, which has nothing to do with detection. The path is now provisioned whenever a sub source exists (stored substream_url or a derivable vendor convention); it is sourceOnDemand, so it costs nothing until pulled, and agent_live_use_substream returns to meaning only what it says: which path the agent live view WATCHES.
- The internal camera-agent /cameras endpoint — the discovery surface Tier-0's provider reads — always served the MAIN tap. It now serves the {name}-sub tap whenever the camera has a sub source, mirroring exactly the provisioner's condition, with source: 'mediamtx-sub' so the swap is visible. Cameras with no sub source keep the main tap unchanged. (The camera-agent's frame grabs ride the same endpoint and also move to the cheap stream — detection/caption at sub-res is the intended trade.)

Tests: stored-substream, derivable-convention, and no-sub-source cases against the live endpoint (tap on, JWT minting stubbed). Full server suite: 772 passing.