### PR TITLE
fix(agent): alarm UX — dedup, true removal, honest feedback, daily wi…

### DIFF
--- a/examples/camera-agent/ALARMS.md
+++ b/examples/camera-agent/ALARMS.md
@@ -18,9 +18,17 @@ By voice (the agent routes these to `create_alarm`):
 - "Alert me loudly if a car enters between 10pm and 6am on all cameras" →
   `target=car, after=22:00, before=06:00, camera_id=all`
 
-Time windows are 24h `HH:MM`. A window where `after > before` (e.g.
-`22:00`–`06:00`) wraps across midnight. The agent silences with `stop_alarm`
-(`action: silence`) or removes with `stop_alarm` (`action: disarm`).
+Time windows are 24h `HH:MM`, and a window **repeats daily** by nature
+(`after`/`before` are times of day). No window at all means **all day,
+every day** — the default; nothing about time is required. A window
+where `after > before` (e.g. `22:00`–`06:00`) wraps across midnight.
+The UI offers the same choices as quick picks: All day (default), Night
+(22:00–06:00), After hours (18:00–08:00), or a custom from/until pair.
+The agent silences with `stop_alarm` (`action: silence`) or removes with
+`stop_alarm` (`action: disarm`) — disarming deletes the alarm from the
+list. Arming the exact same alarm twice (same target, cameras, window,
+level) is refused with a pointer at the existing one, so a double-click
+can never stack duplicates.
 
 The UI also offers one-tap **preset** alarms and an "add alarm" path via
 `POST /alarms`. Presets come from `GET /alarm-presets` with **honest,

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1465,6 +1465,23 @@ class AlarmManager:
         self._rearm = rearm_cooldown
         self._max = max_alarms
 
+    def find_duplicate(self, *, target: str, camera_ids: list[str],
+                       after_min: int | None, before_min: int | None,
+                       ring: str) -> "Alarm | None":
+        """An ACTIVE alarm with the same target, camera set, window and
+        level. Create-time dedup: the arm button gives slow feedback on a
+        busy box, the natural reaction is clicking again, and without this
+        every extra click armed an identical alarm — each its own polling
+        loop, and a list where ✕ visibly 'didn't work' because killing one
+        left its twins."""
+        want = (target.strip().lower(), frozenset(camera_ids),
+                after_min, before_min, ring)
+        for a in self._alarms.values():
+            if a.active and (a.target, frozenset(a.camera_ids),
+                             a.after_min, a.before_min, a.ring) == want:
+                return a
+        return None
+
     def create(self, *, name: str, target: str, camera_ids: list[str],
                after_min: int | None = None, before_min: int | None = None,
                emergency_contact: str | None = None,
@@ -1501,6 +1518,16 @@ class AlarmManager:
         if t:
             t.cancel()
         return True
+
+    def remove(self, alarm_id: int) -> bool:
+        """Stop AND forget the alarm. What the UI's ✕ and a spoken
+        'stop alarm N' mean: the alarm is gone from the list, not parked
+        as an inactive row that lingers until restart."""
+        ok = self.stop(alarm_id)
+        self._alarms.pop(alarm_id, None)
+        if alarm_id in self._order:
+            self._order.remove(alarm_id)
+        return ok
 
     def acknowledge(self, alarm_id: int | None = None) -> int:
         """Silence one alarm (or all when id is None). Returns how many."""
@@ -3251,13 +3278,26 @@ class CameraAgentRuntime:
             # Site-configurable default (built-ins: fire-grade → siren);
             # everything unmapped is a doorbell-style chime.
             ring = self.ring_defaults().get(target, "chime")
+        existing = self.alarms.find_duplicate(
+            target=target, camera_ids=cams,
+            after_min=after_min, before_min=before_min, ring=ring,
+        )
+        if existing is not None:
+            return (f"Alarm #{existing.id} '{existing.name}' already covers "
+                    f"that — same target, cameras and window. It stays armed; "
+                    f"nothing new was added.")
         alarm = self.alarms.create(
             name=name, target=target, camera_ids=cams,
             after_min=after_min, before_min=before_min, emergency_contact=contact,
             ring=ring,
         )
         self.persist()
-        where = "all cameras" if set(cams) == {c.camera_id for c in self.cfg.cameras} else ", ".join(cams)
+        # "all cameras" reads wrong on a single-camera install (the one
+        # camera IS the fleet, but the operator armed it on THAT camera
+        # and expects to hear its name back).
+        _fleet = {c.camera_id for c in self.cfg.cameras}
+        where = ("all cameras" if len(_fleet) > 1 and set(cams) == _fleet
+                 else ", ".join(cams))
         window = alarm.window_label()
         when = "" if window == "any time" else f" ({window})"
         extra = f" If it fires I'll flag the emergency contact ({contact})." if contact else ""
@@ -3277,9 +3317,10 @@ class CameraAgentRuntime:
         if action == "silence":
             return ("Silenced." if self.alarms.acknowledge(aid)
                     else f"Alarm #{aid} isn't currently ringing.")
-        ok = self.alarms.stop(aid)
+        ok = self.alarms.remove(aid)
         self.persist()
-        return (f"Disarmed alarm #{aid}." if ok else f"I don't have an alarm #{aid}.")
+        return (f"Disarmed and removed alarm #{aid}." if ok
+                else f"I don't have an alarm #{aid}.")
 
     async def _handle_create_report(self, args: dict[str, Any]) -> str:
         name = str(args.get("name") or "").strip() or "Report"
@@ -3465,7 +3506,12 @@ class CameraAgentRuntime:
             return (f"ERROR: I couldn't set that watch up — this build "
                     f"doesn't include the '{rule}' rule library.")
         self.persist()
-        where = "all cameras" if set(cams) == {c.camera_id for c in self.cfg.cameras} else ", ".join(cams)
+        # "all cameras" reads wrong on a single-camera install (the one
+        # camera IS the fleet, but the operator armed it on THAT camera
+        # and expects to hear its name back).
+        _fleet = {c.camera_id for c in self.cfg.cameras}
+        where = ("all cameras" if len(_fleet) > 1 and set(cams) == _fleet
+                 else ", ".join(cams))
         if kind == "notify":
             return (f"Done — watch #{mon.id} is live. I'll let you know whenever "
                     f"I see a {target} on {where}.")
@@ -4763,7 +4809,8 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
 
     @app.delete("/alarms/{alarm_id}")
     async def _delete_alarm(alarm_id: int) -> JSONResponse:
-        ok = runtime.alarms.stop(alarm_id)
+        """The UI's ✕: stop AND forget (see AlarmManager.remove)."""
+        ok = runtime.alarms.remove(alarm_id)
         runtime.persist()
         return JSONResponse({"stopped": ok}, status_code=200 if ok else 404)
 

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -553,7 +553,18 @@
                   <option value="siren">🚨 Critical — siren until silenced</option>
                   <option value="silent">🤫 Silent — notifications only</option>
                 </select>
-                <label class="addform-lbl">Only after <input id="paAfter" type="time"></label>
+                <label class="addform-lbl">When
+              <select id="paWhen" aria-label="Alarm time window">
+                <option value="">All day, every day</option>
+                <option value="night">Night (22:00–06:00, daily)</option>
+                <option value="afterhours">After hours (18:00–08:00, daily)</option>
+                <option value="custom">Custom window…</option>
+              </select>
+            </label>
+            <span id="paCustomWin" hidden>
+              <label class="addform-lbl">From <input id="paAfter" type="time"></label>
+              <label class="addform-lbl">Until <input id="paBefore" type="time"></label>
+            </span>
                 <button class="go" id="paGo" type="button">Arm alarm</button>
               </div>
             </div>
@@ -620,7 +631,18 @@
               <option value="siren">🚨 Critical — siren until silenced (fire, break-in)</option>
               <option value="silent">🤫 Silent — notifications only</option>
             </select>
-            <label class="addform-lbl">Only after <input id="alarmAfter" type="time"></label>
+            <label class="addform-lbl">When
+              <select id="alarmWhen" aria-label="Alarm time window">
+                <option value="">All day, every day</option>
+                <option value="night">Night (22:00–06:00, daily)</option>
+                <option value="afterhours">After hours (18:00–08:00, daily)</option>
+                <option value="custom">Custom window…</option>
+              </select>
+            </label>
+            <span id="alarmCustomWin" hidden>
+              <label class="addform-lbl">From <input id="alarmAfter" type="time"></label>
+              <label class="addform-lbl">Until <input id="alarmBefore" type="time"></label>
+            </span>
             <button class="ghost primary" id="alarmArm" type="button">Arm alarm</button>
           </div>
           <div class="notifyrow" id="notifyRow" hidden>
@@ -1475,8 +1497,7 @@
         const cam=window._camScreenCam, target=($("paTarget").value||"").trim();
         if(!cam||!target){ $("paTarget").focus(); return; }
         const body={name:"Alarm: "+target+" on "+cam,target,camera_ids:[cam],
-                    ring:$("paRing").value};
-        const after=$("paAfter").value; if(after) body.after=after;
+                    ring:$("paRing").value, ...alarmWindow("pa")};
         try{ const r=await fetch("/alarms",{method:"POST",headers:{"Content-Type":"application/json"},
             body:JSON.stringify(body)});
           const d=await r.json().catch(()=>({}));
@@ -1706,9 +1727,22 @@
         s.addEventListener("click",()=>disarmAlarm(a.id)); d.appendChild(s); alarmListEl.appendChild(d); } }
     async function ackAlarms(){ ensureOutputAudio(); try{ await fetch("/alarms/ack",{method:"POST",headers:{"Content-Type":"application/json"},body:"{}"});}catch{}
       alarmRinging=false; alarmbarEl.hidden=true; stopSiren(); pollAlarms(); }
-    async function disarmAlarm(id){ try{ await fetch("/alarms/"+id,{method:"DELETE"});}catch{} pollAlarms(); }
+    async function disarmAlarm(id){
+      try{
+        const r=await fetch("/alarms/"+id,{method:"DELETE"});
+        if(!r.ok) addMsg(`Couldn't remove alarm #${id} (HTTP ${r.status}${r.status===403?" — operator login required":""}).`,"sys");
+      }catch(err){ addMsg(`Couldn't remove alarm #${id}: ${err.message}`,"sys"); }
+      pollAlarms(); }
     async function addAlarm(body){ ensureOutputAudio();
-      try{ await fetch("/alarms",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)}); addMsg(`Armed alarm: ${body.name}.`,"sys"); }catch{}
+      // Truthful feedback: relay the SERVER's message (it may report a
+      // duplicate was skipped) and never claim success on an error —
+      // the old unconditional "Armed alarm" + silence on failure is what
+      // made people click again and stack duplicates.
+      try{
+        const r=await fetch("/alarms",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+        const d=await r.json().catch(()=>({}));
+        addMsg(r.ok?(d.message||`Armed alarm: ${body.name}.`):`Couldn't arm the alarm: ${d.error||("HTTP "+r.status)}`,"sys");
+      }catch(err){ addMsg(`Couldn't arm the alarm: ${err.message}`,"sys"); }
       if(!alarmTimer) alarmTimer=setInterval(pollAlarmsHttp,2500); pollAlarms(); }
 
     // ── live updates (WebSocket push; HTTP polling is the fallback) ──
@@ -1977,15 +2011,38 @@
     wireRingPreselect("alarmTarget","alarmRing");
     wireRingPreselect("paTarget","paRing");
 
+    // Alarm time windows: the window repeats DAILY by nature (after/before
+    // are times of day; overnight ranges wrap midnight server-side). "All
+    // day" = no window at all — the common case, so it is the default and
+    // nothing is required. Speaking works too: "alarm if a person shows up
+    // after 10pm", "…between 10pm and 6am".
+    function alarmWindow(prefix){
+      const mode=($(prefix+"When")||{}).value||"";
+      if(mode==="night") return {after:"22:00", before:"06:00"};
+      if(mode==="afterhours") return {after:"18:00", before:"08:00"};
+      if(mode==="custom"){
+        const w={}, a=$(prefix+"After"), b=$(prefix+"Before");
+        if(a&&a.value) w.after=a.value;
+        if(b&&b.value) w.before=b.value;
+        return w;
+      }
+      return {};
+    }
+    function wireWindowSelect(prefix){
+      const sel=$(prefix+"When"), custom=$(prefix+"CustomWin");
+      if(sel&&custom) sel.addEventListener("change",()=>{ custom.hidden=sel.value!=="custom"; });
+    }
+    wireWindowSelect("alarm"); wireWindowSelect("pa");
+
     // Alarms: + reveals a small custom-alarm form (POST /alarms via addAlarm).
     (function(){ const add=$("alarmAdd"), f=$("alarmForm"), arm=$("alarmArm");
       if(add&&f) add.addEventListener("click",()=>{ f.hidden=!f.hidden; add.classList.toggle("open",!f.hidden); if(!f.hidden) $("alarmName").focus(); });
       if(arm) arm.addEventListener("click",()=>{ const target=$("alarmTarget").value.trim();
         if(!target){ $("alarmTarget").focus(); return; }
         const body={name:$("alarmName").value.trim()||("Alarm: "+target),target,camera_id:cameraParam(),
-                    ring:$("alarmRing").value};
-        const after=$("alarmAfter").value; if(after) body.after=after; addAlarm(body);
-        $("alarmName").value=""; $("alarmTarget").value=""; $("alarmAfter").value=""; f.hidden=true; add.classList.remove("open"); }); })();
+                    ring:$("alarmRing").value, ...alarmWindow("alarm")};
+        addAlarm(body);
+        $("alarmName").value=""; $("alarmTarget").value=""; f.hidden=true; add.classList.remove("open"); }); })();
 
     // ── hardware: what the ENABLED skills run on vs. what makes them fast.
     // Advisory (fallbacks always work); recomputed whenever skills change.

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -353,3 +353,67 @@ def test_presets_endpoint_serves_the_list():
     assert "fire" in ids and "person" in ids
     fire = next(p for p in d["presets"] if p["id"] == "fire")
     assert fire["available"] is False and fire["requires"]
+
+
+# ── Alarm UX fixes: dedup, true removal, honest single-camera wording ──
+
+
+def test_duplicate_create_is_refused_with_the_existing_id():
+    """Slow feedback invites double-clicks; each used to arm an identical
+    alarm (its own polling loop), and ✕ visibly 'didn't work' because
+    killing one left its twins."""
+    rt = _runtime()
+    first = asyncio.run(rt._handle_create_alarm(
+        {"name": "Porch", "target": "person", "camera_id": "cam1"}))
+    assert "Armed alarm #1" in first
+    second = asyncio.run(rt._handle_create_alarm(
+        {"name": "Porch", "target": "person", "camera_id": "cam1"}))
+    assert "already covers" in second and "#1" in second
+    assert len(rt.alarms.list()) == 1
+    # A DIFFERENT window is a different alarm — allowed.
+    third = asyncio.run(rt._handle_create_alarm(
+        {"name": "Night porch", "target": "person", "camera_id": "cam1",
+         "after": "22:00", "before": "06:00"}))
+    assert "Armed alarm #2" in third
+
+
+def test_delete_removes_the_alarm_from_the_list():
+    """✕ means GONE — not parked as an inactive row until restart."""
+    rt = _runtime()
+    asyncio.run(rt._handle_create_alarm(
+        {"name": "Porch", "target": "person", "camera_id": "cam1"}))
+    assert len(rt.alarms.list()) == 1
+    assert rt.alarms.remove(1) is True
+    assert rt.alarms.list() == []
+    # ...and re-arming after removal works (no stale dedup hit).
+    again = asyncio.run(rt._handle_create_alarm(
+        {"name": "Porch", "target": "person", "camera_id": "cam1"}))
+    assert "Armed alarm" in again
+
+
+def test_voice_disarm_also_removes():
+    rt = _runtime()
+    asyncio.run(rt._handle_create_alarm(
+        {"name": "Porch", "target": "person", "camera_id": "cam1"}))
+    msg = asyncio.run(rt._handle_stop_alarm({"alarm_id": 1}))
+    assert "removed" in msg.lower()
+    assert rt.alarms.list() == []
+
+
+def test_delete_endpoint_removes(client_factory=None):
+    rt = _runtime()
+    client = TestClient(build_app(rt))
+    asyncio.run(rt._handle_create_alarm(
+        {"name": "Porch", "target": "person", "camera_id": "cam1"}))
+    r = client.delete("/alarms/1")
+    assert r.status_code == 200
+    assert client.get("/alarms").json()["alarms"] == []
+
+
+def test_single_camera_message_names_the_camera():
+    """One camera IS the whole fleet, but the operator armed THAT camera
+    and expects its name back — 'all cameras' reads like a scoping bug."""
+    rt = _runtime()
+    msg = asyncio.run(rt._handle_create_alarm(
+        {"name": "Porch", "target": "person", "camera_id": "cam1"}))
+    assert "cam1" in msg and "all cameras" not in msg


### PR DESCRIPTION
…ndows

Field report from a single-camera install, four symptoms, one story:

- Arming felt slow and said 'on all cameras' though one camera was open and selected. The scoping was actually correct — but on a single-camera install the confirmation compared the camera set to the fleet and the one camera IS the fleet, so it SAID 'all cameras'. Both the alarm and monitor confirmations now name the camera unless the fleet is >1 and genuinely all of it is covered.
- ✕ 'did not remove' alarms. Two real causes: DELETE only disarmed (the record lingered inactive), and — the bigger one — slow feedback invited double-clicks while create had NO duplicate guard, so each click armed an identical alarm with its own polling loop; killing one left its twins. Now: AlarmManager.remove() stops AND forgets (DELETE and the spoken disarm both use it), and create refuses an exact duplicate (same target, cameras, window, level) with a pointer at the existing alarm.
- The UI claimed 'Armed alarm' unconditionally and swallowed every failure silently — the exact recipe for click-again. addAlarm and disarmAlarm now relay the server's verdict (including the duplicate message) and name the failure (with the operator-tier hint on 403).
- The 'Only after' time field read as required and undersold what windows can do. Both alarm forms now offer: All day (default) / Night 22:00-06:00 / After hours 18:00-08:00 / Custom from-until — windows repeat daily by nature, overnight ranges wrap, and speaking works as before ('between 10pm and 6am'). ALARMS.md updated.

Tests: duplicate-create refused (different window still allowed), delete-removes (+re-arm works after), voice disarm removes, DELETE endpoint removes, single-camera wording. Camera-agent suite: 601.