### PR TITLE
fix(agent): alarm time windows tick in the site's timezone — and spea…

### DIFF
--- a/docker-compose.camera-agent.yml
+++ b/docker-compose.camera-agent.yml
@@ -393,6 +393,13 @@ services:
       # LAN edge (https) — bind host follows nginx; auth: OpenNVR login +
       # device firewall (auth_mode: opennvr in config.docker.yml).
       - "${NGINX_BIND_HOST:-0.0.0.0}:9100:9100"
+    environment:
+      # Alarm / watch / report time windows are times of DAY ("after
+      # 12:10 pm") compared against THIS container's clock. Without TZ the
+      # container runs UTC and every spoken window fires hours off — an
+      # "after 12:10 pm" alarm on an IST site stayed dormant until
+      # 12:10 UTC (= 5:40 pm local). Must match the mediamtx/core TZ.
+      - TZ=${TZ:-UTC}
     volumes:
       - opennvr_camera_agent_config:/app/config:ro
       - ./agent-certs/camera-agent:/certs:ro
@@ -482,6 +489,9 @@ services:
     ports:
       # LAN edge (https) — see the voice variant's comment.
       - "${NGINX_BIND_HOST:-0.0.0.0}:9100:9100"
+    environment:
+      # Same rule as the voice agent: time windows tick in the site's zone.
+      - TZ=${TZ:-UTC}
     volumes:
       - opennvr_camera_agent_config_chat:/app/config:ro
       - ./agent-certs/camera-agent:/certs:ro

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1089,6 +1089,31 @@ class MonitorManager:
             default_interval_s=default_interval,
         )
 
+    def find_duplicate(self, *, kind: str, camera_ids: list[str],
+                       target: str, line: list[float] | None = None,
+                       ) -> "Monitor | None":
+        """An ACTIVE watch with the same kind, target, camera set (and
+        line, for crossings). Same rationale as AlarmManager: slow
+        feedback invites a second click, and a duplicated watch is not
+        just a list entry — for converged kinds it is a SECOND hosted
+        rule instance doing double inference and double notifications."""
+        want = (kind, target.strip().lower(), frozenset(camera_ids),
+                tuple(line) if line else None)
+        for m in self._monitors.values():
+            if m.active and (m.kind, m.target, frozenset(m.camera_ids),
+                             tuple(m.line) if m.line else None) == want:
+                return m
+        return None
+
+    def remove(self, monitor_id: int) -> bool:
+        """Stop AND forget — the UI's ✕ and a spoken 'stop the watch'
+        both mean gone, not parked inactive until restart."""
+        ok = self.stop(monitor_id)
+        self._monitors.pop(monitor_id, None)
+        if monitor_id in self._order:
+            self._order.remove(monitor_id)
+        return ok
+
     def create(self, *, kind: str, camera_ids: list[str], target: str,
                description: str = "", interval_s: float | None = None,
                line: list[float] | None = None) -> Monitor:
@@ -1994,6 +2019,26 @@ class ReportScheduler:
             self._schedules.pop(old, None)
         logger.info("report #%d %r scheduled (%s)", sched.id, sched.name, sched.schedule_label())
         return sched
+
+    def find_duplicate(self, *, query: str, at_min: int | None,
+                       every_minutes: int | None) -> "ReportSchedule | None":
+        """An ACTIVE schedule with the same query and cadence — a
+        duplicated report fires twice per slot into the feed and every
+        alert channel."""
+        want = (query.strip().lower(), at_min, every_minutes)
+        for r in self._schedules.values():
+            if r.active and (r.query.strip().lower(), r.at_min,
+                             r.every_minutes) == want:
+                return r
+        return None
+
+    def remove(self, report_id: int) -> bool:
+        """Stop AND forget (the UI's ✕ / a spoken cancel)."""
+        ok = self.stop(report_id)
+        self._schedules.pop(report_id, None)
+        if report_id in self._order:
+            self._order.remove(report_id)
+        return ok
 
     def stop(self, report_id: int) -> bool:
         sched = self._schedules.get(report_id)
@@ -3355,6 +3400,13 @@ class CameraAgentRuntime:
             every = int(every) if every else None
         except (TypeError, ValueError):
             every = None
+        # Mirror create's own default so dedup compares what will be stored.
+        _at = at_min if (at_min is not None or every) else 8 * 60
+        dup = self.reports.find_duplicate(query=query, at_min=_at,
+                                          every_minutes=every)
+        if dup is not None:
+            return (f"Report #{dup.id} '{dup.name}' already runs that exact "
+                    f"query on that schedule; nothing new was added.")
         sched = self.reports.create(name=name, query=query, at_min=at_min, every_minutes=every)
         self.persist()
         return (f"Scheduled report #{sched.id} '{name}' — {sched.schedule_label()}. "
@@ -3365,9 +3417,10 @@ class CameraAgentRuntime:
             rid = int(args.get("report_id"))
         except (TypeError, ValueError):
             return "Which report? Tell me its number."
-        ok = self.reports.stop(rid)
+        ok = self.reports.remove(rid)
         self.persist()
-        return (f"Cancelled report #{rid}." if ok else f"I don't have a report #{rid}.")
+        return (f"Cancelled and removed report #{rid}." if ok
+                else f"I don't have a report #{rid}.")
 
     async def _handle_enroll_face(self, args: dict[str, Any]) -> str:
         if not self.faces:
@@ -3506,6 +3559,14 @@ class CameraAgentRuntime:
                 return ("For crossing counts I need a line as [x1,y1,x2,y2] in "
                         "0-1 frame coordinates — where should the line go?")
             line = [float(v) for v in line]
+        dup = self.monitors.find_duplicate(
+            kind=kind, camera_ids=cams, target=target,
+            line=line if kind == "crossing" else None,
+        )
+        if dup is not None:
+            return (f"Watch #{dup.id} already covers that — same kind, "
+                    f"target and cameras. It keeps running; nothing new "
+                    f"was added.")
         try:
             mon = self.monitors.create(
                 kind=kind, camera_ids=cams, target=target,
@@ -3548,9 +3609,10 @@ class CameraAgentRuntime:
             mid = int(args.get("monitor_id"))
         except (TypeError, ValueError):
             return "Which watch should I stop? Tell me its number."
-        ok = self.monitors.stop(mid)
+        ok = self.monitors.remove(mid)
         self.persist()
-        return (f"Stopped watch #{mid}." if ok else f"I don't have a watch #{mid} running.")
+        return (f"Stopped and removed watch #{mid}." if ok
+                else f"I don't have a watch #{mid} running.")
 
     # ── App door handlers (read-only) ─────────────────────────────
     # Relay installed catalog apps + their state. NO enable/disable/config
@@ -3719,6 +3781,15 @@ class CameraAgentRuntime:
         query = str(args.get("query") or args.get("description") or "").strip()
         if not query:
             return "I need a bit more detail about what to look for."
+        running = next(
+            (t for t in self.tasks._tasks.values()
+             if t.status == "running"
+             and t.query.strip().lower() == query.lower()),
+            None,
+        )
+        if running is not None:
+            return (f"Task #{running.id} is already running that exact "
+                    f"search — I'll report when it finishes.")
         task = self.tasks.create(query)
         return (
             f"That one needs a closer look, so I've started it as background "
@@ -4773,7 +4844,8 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
 
     @app.delete("/monitors/{monitor_id}")
     async def _stop_monitor(monitor_id: int) -> JSONResponse:
-        ok = runtime.monitors.stop(monitor_id)
+        """The UI's ✕: stop AND forget (see MonitorManager.remove)."""
+        ok = runtime.monitors.remove(monitor_id)
         runtime.persist()
         return JSONResponse({"stopped": ok}, status_code=200 if ok else 404)
 
@@ -4861,7 +4933,9 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
 
     @app.delete("/reports/{report_id}")
     async def _delete_report(report_id: int) -> JSONResponse:
-        ok = runtime.reports.stop(report_id)
+        """The UI's ✕: stop AND forget (see ReportScheduler.remove)."""
+        ok = runtime.reports.remove(report_id)
+        runtime.persist()
         return JSONResponse({"stopped": ok}, status_code=200 if ok else 404)
 
     @app.get("/people")

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1377,16 +1377,34 @@ def _stop_monitor_tool() -> dict[str, Any]:
 
 
 def _parse_hhmm(value: Any) -> int | None:
-    """Parse 'HH:MM' (24h) to minutes-since-midnight, else None."""
+    """Parse a time of day to minutes-since-midnight, else None.
+
+    Accepts 24h 'HH:MM' plus the forms people actually SPEAK — '12:10 pm',
+    '7pm', '07:00 PM'. am/pm follows clock convention: 12am -> 00:xx,
+    12pm -> 12:xx. Silent tolerance was a real bug: an unparseable
+    'after 12:10 pm' quietly became NO window (all day) — the opposite of
+    what was asked."""
     if not value:
         return None
+    raw = str(value).strip().lower()
+    meridian = None
+    if raw.endswith(("am", "pm")):
+        meridian = raw[-2:]
+        raw = raw[:-2].strip().rstrip(".")
     try:
-        h, m = str(value).strip().split(":")
-        h, m = int(h), int(m)
-        if 0 <= h < 24 and 0 <= m < 60:
-            return h * 60 + m
+        if ":" in raw:
+            h_s, m_s = raw.split(":")
+            h, m = int(h_s), int(m_s)
+        else:
+            h, m = int(raw), 0          # '7pm' -> 7, 0
     except (ValueError, AttributeError):
-        pass
+        return None
+    if meridian == "am" and h == 12:
+        h = 0
+    elif meridian == "pm" and 1 <= h <= 11:
+        h += 12
+    if 0 <= h < 24 and 0 <= m < 60:
+        return h * 60 + m
     return None
 
 
@@ -1693,8 +1711,8 @@ def _create_alarm_tool(camera_enum_all: list[str]) -> dict[str, Any]:
                     "target": {"type": "string", "description": "What triggers it, e.g. 'fire', 'person', 'smoke'."},
                     "camera_id": {"type": "string", "enum": camera_enum_all, "description": "A camera id, or 'all'."},
                     "camera_ids": {"type": "array", "items": {"type": "string", "enum": camera_enum_all}},
-                    "after": {"type": "string", "description": "Only active after this 24h time 'HH:MM' (e.g. '18:00' for after 6pm)."},
-                    "before": {"type": "string", "description": "Only active before this 24h time 'HH:MM'."},
+                    "after": {"type": "string", "description": "Only active after this time of day, in the SITE's local time. 24h 'HH:MM' preferred (e.g. '18:00' for after 6pm; '12:10' for after 12:10 pm); '12:10 pm' style also accepted. The window repeats daily."},
+                    "before": {"type": "string", "description": "Only active before this time of day (site-local; 24h 'HH:MM' preferred). With 'after' later than 'before' the window wraps midnight."},
                     "ring": {"type": "string",
                              "enum": ["siren", "pulse", "chime", "silent"],
                              "description": "How it announces. 'siren' rings until "
@@ -1703,7 +1721,11 @@ def _create_alarm_tool(camera_enum_all: list[str]) -> dict[str, Any]:
                                             "minute then stands down — urgent, not "
                                             "evacuation. 'chime' dings once — visitors, "
                                             "deliveries, vehicles. 'silent' = notifications "
-                                            "only. Omit to pick by the site's defaults."},
+                                            "only. If the user explicitly asks it to RING, "
+                                            "sound loudly, or wake them, choose 'siren' (or "
+                                            "'pulse') — do not let a quiet default swallow "
+                                            "an explicit request to be alerted out loud. "
+                                            "Omit only when the user expressed no loudness."},
                 },
                 "required": ["name", "target", "camera_id"],
             },

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -209,6 +209,8 @@
     .log:empty{align-items:center; justify-content:center;}
     .log:empty::after{content:"Ask your cameras anything — tap Talk or type below."; color:var(--faint); font-size:0.85rem;}
     .msg{max-width:82%;} .msg .who{font-weight:600; font-size:0.68rem; text-transform:uppercase; letter-spacing:0.05em; display:block; margin-bottom:3px;}
+    .msg .when{font-weight:400; font-size:0.64rem; color:var(--faint); text-transform:none; letter-spacing:0; margin-left:0.45rem;}
+    .msg.sys .when{margin-left:0.35rem; font-style:normal;}
     .msg.user{align-self:flex-end; background:linear-gradient(180deg,rgba(94,179,246,0.18),rgba(61,157,243,0.12));
       border:1px solid rgba(94,179,246,0.22); border-radius:14px 14px 4px 14px; padding:0.55rem 0.75rem;}
     .msg.user .who{color:var(--user);}
@@ -985,9 +987,19 @@
     function setAvatar(s){ ramEl.className="ram "+(avatarVideoOk?"has-video ":"")+s;
       if(avatarVideoOk) setAvatarClip(s==="speaking"?"speaking":(s==="thinking"?"thinking":"idle")); }
     function setStatus(t,k=""){ statusEl.textContent=t; statusEl.className="status"+(k?(" "+k):""); }
+    function msgTime(){
+      // HH:MM next to every message; the full date rides the tooltip.
+      const now=new Date();
+      const t=document.createElement("span"); t.className="when";
+      t.textContent=now.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"});
+      t.title=now.toLocaleString();
+      return t; }
     function addMsg(text,who,frames){ const d=document.createElement("div"); d.className="msg "+who;
-      if(who==="sys"){d.textContent=text;} else { const label=who==="user"?"you":"agent";
-        d.innerHTML=`<span class="who">${label}</span>`; d.appendChild(document.createTextNode(text));
+      if(who==="sys"){ d.textContent=text; d.appendChild(msgTime()); }
+      else { const label=who==="user"?"you":"agent";
+        d.innerHTML=`<span class="who">${label}</span>`;
+        d.querySelector(".who").appendChild(msgTime());
+        d.appendChild(document.createTextNode(text));
         // Show the frame(s) the agent actually looked at, inline in the bubble.
         if(frames&&frames.length){ const fr=document.createElement("div"); fr.className="frames";
           frames.forEach(f=>{ const wrap=document.createElement("div");

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1676,7 +1676,12 @@
         else { q.textContent=`${cams} for ${m.target}`; }
         d.appendChild(q); const s=document.createElement("button"); s.className="stop"; s.title="Stop"; s.textContent="✕";
         s.addEventListener("click",()=>stopMonitor(m.id)); d.appendChild(s); monitorListEl.appendChild(d); } }
-    async function stopMonitor(id){ try{ await fetch("/monitors/"+id,{method:"DELETE"}); }catch{} pollMonitors(); }
+    async function stopMonitor(id){
+      try{
+        const r=await fetch("/monitors/"+id,{method:"DELETE"});
+        if(!r.ok) addMsg(`Couldn't remove watch #${id} (HTTP ${r.status}${r.status===403?" — operator login required":""}).`,"sys");
+      }catch(err){ addMsg(`Couldn't remove watch #${id}: ${err.message}`,"sys"); }
+      pollMonitors(); }
 
     // ── scheduled reports ──
     async function pollReports(data){ if(!authReady())return; if(!data) try{ data=await (await fetch("/reports")).json(); }catch{ return; }

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -472,3 +472,44 @@ def test_spoken_pm_window_gates_polling():
         assert rt.alarms._in_window(a) is True
     finally:
         datetime.datetime = real_dt
+
+
+# ── Parity: watches, reports, tasks get the same anti-double-wiring ──
+#
+# A duplicated WATCH is worse than a duplicated alarm: for converged
+# kinds it is a second hosted rule instance doing double inference and
+# double notifications. Reports fire twice per slot into every channel.
+
+
+def test_duplicate_watch_is_refused_and_delete_removes():
+    rt = _runtime()
+    first = asyncio.run(rt._handle_create_monitor(
+        {"kind": "notify", "target": "person", "camera_id": "cam1"}))
+    assert "#1" in first
+    second = asyncio.run(rt._handle_create_monitor(
+        {"kind": "notify", "target": "person", "camera_id": "cam1"}))
+    assert "already covers" in second
+    assert len([m for m in rt.monitors.list() if m["active"]]) == 1
+    assert rt.monitors.remove(1) is True
+    assert all(not m["active"] for m in rt.monitors.list())
+    # Removed means forgotten — re-creating works, no stale dedup hit.
+    again = asyncio.run(rt._handle_create_monitor(
+        {"kind": "notify", "target": "person", "camera_id": "cam1"}))
+    assert "already covers" not in again
+
+
+def test_duplicate_report_is_refused_and_remove_forgets():
+    rt = _runtime()
+    first = asyncio.run(rt._handle_create_report(
+        {"name": "Morning", "query": "summarise overnight activity"}))
+    assert "#1" in first
+    dup = asyncio.run(rt._handle_create_report(
+        {"name": "Different name", "query": "summarise overnight activity"}))
+    assert "already runs" in dup
+    # A DIFFERENT cadence is a different report.
+    other = asyncio.run(rt._handle_create_report(
+        {"name": "Hourly", "query": "summarise overnight activity",
+         "every_minutes": 60}))
+    assert "already runs" not in other
+    assert rt.reports.remove(1) is True
+    assert all(r["id"] != 1 for r in rt.reports.list())

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -417,3 +417,58 @@ def test_single_camera_message_names_the_camera():
     msg = asyncio.run(rt._handle_create_alarm(
         {"name": "Porch", "target": "person", "camera_id": "cam1"}))
     assert "cam1" in msg and "all cameras" not in msg
+# ── Spoken time forms + the silent-window bug ──────────────────────
+#
+# "Ring an alarm when you see a person after 12:10 pm" — three ways that
+# sentence used to fail quietly: the container clock ran UTC (fixed in
+# compose: TZ now follows the site), '12:10 pm' didn't parse (silently
+# became NO window — all day, the opposite of what was asked), and the
+# quiet 'chime' default could swallow an explicit request to RING (tool
+# schema now steers the LLM to siren/pulse for explicit loudness).
+
+
+def test_parse_hhmm_accepts_spoken_am_pm_forms():
+    assert _parse_hhmm("12:10 pm") == 12 * 60 + 10   # noon-ten stays 12:10
+    assert _parse_hhmm("12:10 am") == 10             # midnight-ten -> 00:10
+    assert _parse_hhmm("7pm") == 19 * 60
+    assert _parse_hhmm("07:00 PM") == 19 * 60
+    assert _parse_hhmm("7 am") == 7 * 60
+    assert _parse_hhmm("11:59pm") == 23 * 60 + 59
+    # 24h forms unchanged; junk still None (never a phantom window).
+    assert _parse_hhmm("18:00") == 18 * 60
+    assert _parse_hhmm("25:00") is None
+    assert _parse_hhmm("noonish") is None
+
+
+def test_spoken_pm_window_gates_polling():
+    """An 'after 12:10 pm' alarm armed from speech must be OUT of window
+    at 11:00 and IN at 13:00 (site-local — the compose TZ fix makes the
+    container clock the site clock)."""
+    rt = _runtime()
+    asyncio.run(rt._handle_create_alarm(
+        {"name": "Afternoon person", "target": "person",
+         "camera_id": "cam1", "after": "12:10 pm"}))
+    [a] = [x for x in rt.alarms._alarms.values()]
+    assert a.after_min == 12 * 60 + 10
+    import datetime
+
+    class _At:
+        def __init__(self, h, m): self._t = datetime.time(h, m)
+        def time(self): return self._t
+
+    real_dt = datetime.datetime
+    try:
+        class _FakeDT(datetime.datetime):
+            _now = None
+
+            @classmethod
+            def now(cls, tz=None):
+                return cls._now
+
+        datetime.datetime = _FakeDT
+        _FakeDT._now = real_dt(2026, 8, 22, 11, 0)
+        assert rt.alarms._in_window(a) is False
+        _FakeDT._now = real_dt(2026, 8, 22, 13, 0)
+        assert rt.alarms._in_window(a) is True
+    finally:
+        datetime.datetime = real_dt

--- a/examples/camera-agent/tests/test_reports.py
+++ b/examples/camera-agent/tests/test_reports.py
@@ -114,7 +114,10 @@ def test_stop_report_handler():
     async def go():
         s = rt.reports.create(name="r", query="q", every_minutes=10)
         assert f"#{s.id}" in await rt._handle_stop_report({"report_id": s.id})
-        assert rt.reports.get(s.id).active is False
+        # Cancel now REMOVES the schedule (stop-and-forget parity with
+        # alarms/watches) — it must be gone, not parked inactive.
+        assert rt.reports.get(s.id) is None
+        assert all(r["id"] != s.id for r in rt.reports.list())
 
     asyncio.run(go())
 


### PR DESCRIPTION
…k am/pm

Field report: 'ring an alarm when you see a person after 12:10 pm' — armed fine, never rang. Three quiet failures stacked:

- The agent containers had NO TZ and ran UTC. Windows are times of DAY compared against the CONTAINER clock, so on an IST site 'after 12:10 pm' stayed dormant until 12:10 UTC = 5:40 pm local. Both agent services now get TZ=${TZ:-UTC}, matching mediamtx/core — the window ticks in the site's zone.
- _parse_hhmm only accepted 24h 'HH:MM'. A spoken '12:10 pm' passed through verbatim silently became NO window at all — all day, the opposite of what was asked. It now accepts the forms people speak ('12:10 pm', '7pm', '07:00 PM'; 12am->00, 12pm->12) and junk still parses to None, never a phantom window.
- The tool schema now tells the LLM: times are SITE-LOCAL; and when the user explicitly asks the alarm to RING or sound loudly, pick siren/pulse rather than letting the quiet per-target default (person -> chime) swallow an explicit request to be alerted out loud.

Based on fix/alarm-ux (PR #284) — merge that first; this then lands as one commit. Tests: spoken am/pm forms incl. the noon/midnight edges, and the pm window gating polling out at 11:00 / in at 13:00. Camera-agent alarm suite: 27.