### PR TITLE
fix(agent): refresh camera frame_url on reconcile — previews died aft…

### DIFF
--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -3911,11 +3911,18 @@ class CameraAgentRuntime:
 
     def _register_opennvr_cameras(self, specs: list[CameraSpec]) -> list[CameraSpec]:
         """Register OpenNVR-sourced camera specs that aren't known yet, wiring
-        each one's frame source. ADD-ONLY on purpose: a transient empty or
-        failed fetch must never tear down cameras that are already working."""
+        each one's frame source. ADD-ONLY for camera *identity*: a transient
+        empty or failed fetch must never tear down cameras that are already
+        working. But a known camera's ``frame_url`` IS refreshed when OpenNVR
+        serves a new one — the URL embeds a short-lived MediaMTX JWT
+        (~60 min), so keeping the boot-time URL means every frame fetch
+        starts 401ing within the hour and the camera tile shows "no frame"
+        forever (describe still works — KAI-C mints its own token — which
+        made this bug look like a UI problem instead of an expired URL)."""
         added: list[CameraSpec] = []
         for spec in specs:
             if self.context.known_camera(spec.camera_id):
+                self._refresh_frame_url(spec)
                 continue
             self.context.add_camera(spec)
             self.context.register_frame_source(
@@ -3925,6 +3932,34 @@ class CameraAgentRuntime:
             self.cfg.cameras.append(spec)
             added.append(spec)
         return added
+
+    def _refresh_frame_url(self, spec: CameraSpec) -> None:
+        """Swap a known camera's frame source when its URL changed.
+
+        OpenNVR re-mints the MediaMTX JWT baked into ``frame_url`` on every
+        reconcile fetch, so the URL differs each cycle by design; rebuilding
+        the frame source is just replacing a URL-holder object (no worker or
+        connection to bounce), so replace-on-change is cheap and keeps the
+        agent's tap token perpetually fresh. Cameras with a static URL
+        (config-file sources, local devices) compare equal and are left
+        untouched."""
+        if not spec.frame_url:
+            return
+        known = next(
+            (c for c in self.cfg.cameras if c.camera_id == spec.camera_id), None
+        )
+        if known is None or known.frame_url == spec.frame_url:
+            return
+        known.frame_url = spec.frame_url
+        # The context may hold a distinct spec object for boot-time cameras;
+        # keep it in step so UI listings show the live URL too.
+        ctx_spec = self.context.get_camera(spec.camera_id)
+        if ctx_spec is not None:
+            ctx_spec.frame_url = spec.frame_url
+        self.context.register_frame_source(
+            spec.camera_id,
+            build_frame_source(camera_id=spec.camera_id, url=spec.frame_url),
+        )
 
     def interactive_busy(self) -> bool:
         """True while a voice/chat turn is being served. Background detection

--- a/examples/camera-agent/tests/test_opennvr_camera_reconcile.py
+++ b/examples/camera-agent/tests/test_opennvr_camera_reconcile.py
@@ -140,3 +140,53 @@ async def test_reconcile_survives_a_fetch_exception(monkeypatch):
     rt._stop_event.set()
     await asyncio.wait_for(task, timeout=2.0)
     assert rt.context.known_camera("cam1")               # recovered after the error
+
+
+# ── frame_url refresh (the "no frame after an hour" bug) ───────────────
+
+
+def test_register_refreshes_frame_url_of_known_camera():
+    """OpenNVR bakes a ~60-min MediaMTX JWT into frame_url, so the reconcile
+    must swap a known camera's frame source when the served URL changes —
+    otherwise previews die within the hour and never recover ("no frame"
+    even after a browser refresh, until someone restarts the agent)."""
+    rt = _runtime()
+    old = CameraSpec(camera_id="cam1",
+                     frame_url="http://mtx/cam1/frame.jpg?jwt=OLD", role="front")
+    rt._register_opennvr_cameras([old])
+    src_before = rt.context._frame_sources["cam1"]
+
+    fresh = CameraSpec(camera_id="cam1",
+                       frame_url="http://mtx/cam1/frame.jpg?jwt=FRESH", role="front")
+    # still add-only for identity: nothing NEW is reported…
+    assert rt._register_opennvr_cameras([fresh]) == []
+    assert len(rt.cfg.cameras) == 1
+    # …but the URL and the frame source now carry the fresh token
+    assert rt.cfg.cameras[0].frame_url.endswith("jwt=FRESH")
+    assert rt.context.get_camera("cam1").frame_url.endswith("jwt=FRESH")
+    assert rt.context._frame_sources["cam1"] is not src_before
+
+
+def test_register_leaves_static_url_source_untouched():
+    """A camera whose URL didn't change (config-file/static sources) keeps its
+    existing frame source object — no needless churn."""
+    rt = _runtime()
+    spec = CameraSpec(camera_id="cam1", frame_url="rtsp://mtx/cam1", role="front")
+    rt._register_opennvr_cameras([spec])
+    src_before = rt.context._frame_sources["cam1"]
+    same = CameraSpec(camera_id="cam1", frame_url="rtsp://mtx/cam1", role="front")
+    assert rt._register_opennvr_cameras([same]) == []
+    assert rt.context._frame_sources["cam1"] is src_before
+
+
+def test_refresh_updates_boot_time_camera_specs_too():
+    """Boot-time cameras enter via AppConfig, not the reconcile — their spec
+    objects in the context must still pick up the fresh URL."""
+    boot = CameraSpec(camera_id="cam1",
+                      frame_url="http://mtx/cam1/frame.jpg?jwt=BOOT", role="front")
+    rt = _runtime(cameras=[boot])
+    fresh = CameraSpec(camera_id="cam1",
+                       frame_url="http://mtx/cam1/frame.jpg?jwt=NEW", role="front")
+    assert rt._register_opennvr_cameras([fresh]) == []
+    assert rt.context.get_camera("cam1").frame_url.endswith("jwt=NEW")
+    assert rt.cfg.cameras[0].frame_url.endswith("jwt=NEW")


### PR DESCRIPTION
…er the JWT expired

OpenNVR mints a ~60-minute MediaMTX JWT into every frame_url it serves, but the reconcile was add-only: a known camera kept its boot-time URL, so within the hour every preview fetch 401'd and the tile showed 'no frame' until the container was restarted (a browser refresh can't help — the stale token lives in the agent). describe_camera kept working because KAI-C mints its own token per call, which disguised this as a UI bug.

The reconcile now swaps a known camera's frame source whenever the served URL changes (a cheap URL-holder replacement — nothing to bounce), keeping the tap token perpetually fresh; static-URL cameras compare equal and are untouched. Identity stays add-only: transient empty fetches still never tear down working cameras.