### PR TITLE
docs: name the CPU-detector candidates and the eval harness; VLM sizi…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,7 +205,11 @@ OLLAMA_EXTERNAL_URL=
 # Ollama-proxy VLM adapter (adapter releases after 0.1.3). It follows
 # OLLAMA_EXTERNAL_URL, so scene descriptions run on the same host
 # Ollama (GPU on macOS) as the LLM; the adapter auto-pulls a missing
-# model. Any Ollama multimodal model works: moondream | llava | qwen2.5vl.
+# model. Any Ollama multimodal model works. moondream (~1.8B) is the
+# lightest and the safe pick for CPU-only bundled Ollama — but it's also
+# the weakest describer (bad viewpoints/lighting can read as "empty").
+# When Ollama runs on a host GPU, qwen3-vl:4b (~3.5 GB at Q4) is a big
+# accuracy jump for scene questions, and qwen3-vl:8b bigger still.
 OLLAMA_VLM_MODEL=moondream
 
 # Image tag for all GHCR adapter images (whisper, piper, yolov8, blip,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -122,13 +122,37 @@ The headline themes are *new AI capabilities* and *operator polish*.
   bark detection. The audio-input shape isn't represented in v0.1's
   shipped adapters.
 - **Lightweight CPU-first Tier-0 detector** — an alternative to YOLOv8
-  for low-power boxes with no hardware accelerator (NanoDet-Plus /
-  MobileNet-SSD-class, selectable via the existing `DETECT_DETECTOR`
-  switch). Trades some accuracy for a pipeline that stays in
-  single-digit CPU per camera; complements — doesn't replace — the
-  substream tap and `DETECT_HWACCEL` paths, and pairs with the
+  for low-power boxes with no hardware accelerator, selectable via the
+  existing `DETECT_DETECTOR` switch. Every candidate exports to ONNX and
+  rides the pipeline's existing cv2.dnn/ort path — the per-model work is
+  an output-decoding head next to the YOLOv8 one. Candidates, in rough
+  preference order:
+  - *RF-DETR nano* (Apache-2.0) — the friendliest license; the RF-DETR
+    family is the first real-time line past 60 mAP on COCO, with strong
+    domain transfer.
+  - *YOLO26n* (AGPL-3.0) — the strongest pure-CPU story: up to ~43%
+    faster CPU inference than YOLO11-N, NMS-free end-to-end output
+    (simpler decode head, stable fp16/fp32).
+  - *RTMDet-tiny* (MIT) — throughput specialist.
+  - *NanoDet-Plus / PP-PicoDet* — the ultra-light legacy tier for very
+    weak boxes.
+  Licensing note: "we only use the model" is not an exemption — AGPL
+  weights/code carry copyleft on distribution and network use. That is
+  compatible with OpenNVR's AGPL core, but weights must stay
+  runtime-downloaded (as yolov8n is today), never vendored into
+  Apache-licensed components. Trades some accuracy for a pipeline that
+  stays in single-digit CPU per camera; complements — doesn't replace —
+  the substream tap and `DETECT_HWACCEL` paths, and pairs with the
   accelerator detector adapters (Coral / Hailo / RKNN) tracked in
   `detect-pipeline/FOLLOWUPS.md`.
+- **Detector / VLM eval harness** — a scripted benchmark that replays
+  recorded site footage (or a labeled clip set) through candidate
+  detectors and caption VLMs and reports recall / precision per label,
+  CPU cost per frame, and describe-quality spot checks side by side —
+  so a `DETECT_DETECTOR` or `OLLAMA_VLM_MODEL` swap is a measured
+  decision, not vibes. Motivating case: moondream answering "appears to
+  be empty" on a frame with a person directly in front of the lens,
+  where qwen3-vl:4b answers correctly.
 
 ### Operator polish
 - **Active Directory / SAML SSO** for staff authentication. v0.1 uses


### PR DESCRIPTION
…ng guidance

ROADMAP's lightweight-detector entry now names concrete candidates with licenses (RF-DETR nano Apache-2.0, YOLO26n AGPL, RTMDet-tiny MIT, NanoDet/PicoDet legacy tier) and states the licensing reality: AGPL weights carry copyleft on distribution/network use — compatible with the AGPL core, but weights stay runtime-downloaded, never vendored. Adds a detector/VLM eval-harness item so model swaps are measured. .env.example now explains when to move OLLAMA_VLM_MODEL beyond moondream (qwen3-vl:4b on host-GPU Ollama).