### PR TITLE
feat(detect): ship onnxruntime in the service image; name the loaded …

### DIFF
--- a/detect-pipeline/README.md
+++ b/detect-pipeline/README.md
@@ -346,7 +346,7 @@ so the backend is interchangeable):
 | Intel N100 / iGPU / NPU | `pip install onnxruntime-openvino` | `DETECT_ONNX_PROVIDERS=OpenVINOExecutionProvider` |
 | Nvidia / Jetson | `pip install onnxruntime-gpu` | `DETECT_ONNX_PROVIDERS=TensorrtExecutionProvider,CUDAExecutionProvider` |
 | Apple Silicon | `pip install onnxruntime` | `DETECT_ONNX_PROVIDERS=CoreMLExecutionProvider` |
-| Any CPU | `pip install 'detect-pipeline[onnxruntime]'` | `DETECT_ONNX_BACKEND=ort` |
+| Any CPU | already in the container image (`[service]` extra); bare pip installs: `pip install 'detect-pipeline[onnxruntime]'` | `DETECT_ONNX_BACKEND=ort` |
 
 ```bash
 # .env — Intel N100 example

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -275,15 +275,24 @@ def _detector_factory(cfg: ServiceConfig):
 
         def make_onnx():
             try:
-                return OnnxYoloDetector(
+                det = OnnxYoloDetector(
                     model_path=cfg.onnx_model, input_size=cfg.onnx_input,
                     backend=backend, providers=providers,
                     conf_threshold=cfg.detect_conf,
                 )
+                log.info(
+                    "tier0 detector loaded: family=yolo model=%s backend=%s input=%d",
+                    os.path.basename(cfg.onnx_model), det.backend_name, cfg.onnx_input,
+                )
+                return det
             except Exception:
                 log.warning(
-                    "failed to load ONNX model %s (backend=%s); using stub",
+                    "failed to load ONNX model %s (backend=%s)",
                     cfg.onnx_model, cfg.onnx_backend, exc_info=True,
+                )
+                log.error(
+                    "DETECTION IS OFF for this worker: running the STUB detector "
+                    "(motion/tracking only, no objects). Fix the model/backend."
                 )
                 from .detector import StubDetector
                 return StubDetector()
@@ -312,17 +321,27 @@ def _detector_factory(cfg: ServiceConfig):
         def make_rfdetr():
             for attempt in ([backend, "ort"] if backend == "cvdnn" else [backend]):
                 try:
-                    return OnnxDetrDetector(
+                    det = OnnxDetrDetector(
                         model_path=cfg.onnx_model, input_size=cfg.onnx_input,
                         backend=attempt, providers=providers,
                         conf_threshold=cfg.detect_conf,
                     )
+                    log.info(
+                        "tier0 detector loaded: family=detr model=%s backend=%s input=%d",
+                        os.path.basename(cfg.onnx_model), det.backend_name, cfg.onnx_input,
+                    )
+                    return det
                 except Exception:
                     log.warning(
                         "failed to load RF-DETR model %s (backend=%s)",
                         cfg.onnx_model, attempt, exc_info=True,
                     )
-            log.warning("RF-DETR unavailable on any backend; using stub detector")
+            log.error(
+                "DETECTION IS OFF for this worker: RF-DETR could not load on any "
+                "backend — running the STUB detector (motion/tracking only, no "
+                "objects). Fix the model path/backend; do not mistake this for a "
+                "working detector."
+            )
             from .detector import StubDetector
             return StubDetector()
 

--- a/detect-pipeline/pyproject.toml
+++ b/detect-pipeline/pyproject.toml
@@ -19,9 +19,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# The container service also needs a NATS client to publish detections.
+# The container service also needs a NATS client to publish detections —
+# and ships plain (CPU) onnxruntime so both detector families work out of
+# the box: rfdetr REQUIRES ort (transformer ops exceed cv2.dnn), and the
+# YOLO family can opt into the faster ort CPU engine. Accelerator wheels
+# (onnxruntime-openvino / onnxruntime-gpu) CONFLICT with plain onnxruntime:
+# a derived accelerator image must `pip uninstall onnxruntime` first.
 service = [
     "nats-py>=2.6",
+    "onnxruntime>=1.17",
 ]
 # Optional ONNX Runtime backend (DETECT_ONNX_BACKEND=ort / --backend ort). The
 # default detector runs on cv2.dnn with no extra install; install this for the


### PR DESCRIPTION
…detector loudly

The stock container installed only the zero-dep stack, so DETECT_DETECTOR=rfdetr hit an ImportError on its ort backend and silently degraded to the stub — 'running' while detecting nothing. Plain (CPU) onnxruntime now ships in the [service] extra the Dockerfile installs: rfdetr works out of the box, and the YOLO family gains the faster ort CPU engine as an option. Accelerator wheels still conflict with plain ort — derived images must uninstall it first (documented in pyproject).

Both factories now log exactly what loaded (family/model/backend/input), and every stub fallback logs an ERROR that says DETECTION IS OFF — a stub can no longer masquerade as a working detector in the logs.