### PR TITLE
feat(agent): end-to-end system self-check + honest degradation

### DIFF
--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -3961,6 +3961,127 @@ class CameraAgentRuntime:
             build_frame_source(camera_id=spec.camera_id, url=spec.frame_url),
         )
 
+    async def run_system_check(self):
+        """Exercise every REAL capability path with a REAL payload and return
+        a SystemReport. Process healthchecks say "up"; this says "works" —
+        built after a field incident where the caption adapter was healthy,
+        registered, and had never received a single inference (KAI-C 403)."""
+        import httpx
+
+        from system_check import DEGRADED, DOWN, OK, run_checks
+
+        cam_ids = [c.camera_id for c in self.cfg.cameras]
+        frame_holder: dict[str, bytes] = {}
+
+        async def check_frame():
+            if not cam_ids:
+                return DEGRADED, "no cameras configured"
+            jpeg = await self.context.get_frame(cam_ids[0])
+            frame_holder["jpeg"] = jpeg
+            return OK, f"live frame from {cam_ids[0]} ({len(jpeg)} bytes)"
+
+        async def check_detection():
+            frame = frame_holder.get("jpeg")
+            if frame is None:
+                return DOWN, "skipped: no live frame to test with"
+            resp = await self.tools._detect.infer(frame_jpeg=frame)
+            dets = (resp.get("result") or {}).get("detections") or []
+            labels = ", ".join(sorted({str(d.get("label")) for d in dets})) or "none"
+            return OK, f"object detector answered (labels this frame: {labels})"
+
+        async def check_vision():
+            frame = frame_holder.get("jpeg")
+            if frame is None:
+                return DOWN, "skipped: no live frame to test with"
+            try:
+                resp = await self.tools._caption.infer(
+                    frame_jpeg=frame, extra={"task": "scene_caption"})
+            except Exception as exc:
+                reason = self.tools._vision_error_reason(exc)
+                return DOWN, (f"caption/VQA path failed: {reason} "
+                              f"({type(exc).__name__}: {str(exc)[:120]}) — "
+                              f"describe answers are detector-only until fixed")
+            result = resp.get("result") or {}
+            caption = (result.get("answer") or result.get("caption") or "").strip()
+            if not caption:
+                return DEGRADED, "caption adapter answered but returned no text"
+            return OK, f"VLM answered: \"{caption[:80]}\""
+
+        async def check_llm():
+            if self.cfg.llm_provider.strip().lower() == "openai":
+                return OK, "external OpenAI-compatible endpoint (not probed)"
+            url = f"{self.cfg.ollama_url.rstrip('/')}/api/tags"
+            async with httpx.AsyncClient(timeout=8.0) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+                models = [m.get("name") for m in (resp.json().get("models") or [])]
+            want = self.cfg.llm_model
+            if any(want == m or str(m).startswith(want) for m in models if m):
+                return OK, f"Ollama reachable; model {want} present"
+            return DEGRADED, (f"Ollama reachable but model {want!r} not pulled "
+                              f"(have: {', '.join(models[:5]) or 'none'})")
+
+        async def _http_ok(name, base_url):
+            async with httpx.AsyncClient(timeout=6.0) as client:
+                resp = await client.get(f"{base_url.rstrip('/')}/health")
+                resp.raise_for_status()
+            return OK, f"{name} reachable"
+
+        async def check_stt():
+            return await _http_ok("whisper (speech-to-text)", self.cfg.whisper_url)
+
+        async def check_tts():
+            return await _http_ok("piper (voice)", self.cfg.piper_url)
+
+        async def check_alarms():
+            armed = len(list(getattr(self.alarms, "_alarms", {}) or {}))
+            task = getattr(self.alarms, "_task", None)
+            running = bool(task is not None and not task.done())
+            if armed and not running:
+                return DOWN, f"{armed} alarm(s) armed but the poll engine is NOT running"
+            state = "engine running" if running else "engine idle (starts with the first alarm)"
+            return OK, f"{armed} alarm(s) armed; {state}"
+
+        async def check_events():
+            task = self._subscriber_task
+            if self.cfg.nats_inference_url and (task is None or task.done()):
+                return DOWN, "NATS subscriber is not running — no detection events reach the agent"
+            newest = None
+            for cid in cam_ids:
+                ev = self.context.latest_inference(cid, adapter="tier0")
+                if ev is not None:
+                    age = time.time() - ev.received_at
+                    newest = age if newest is None else min(newest, age)
+            if newest is None:
+                return DEGRADED, ("subscriber up, but no Tier-0 events received yet "
+                                  "(quiet scene, or detect-pipeline down)")
+            return OK, f"Tier-0 events flowing (newest {newest:.0f}s ago)"
+
+        return await run_checks({
+            "camera frame": check_frame,
+            "object detection": check_detection,
+            "vision (VLM describe)": check_vision,
+            "language model": check_llm,
+            "speech-to-text": check_stt,
+            "text-to-speech": check_tts,
+            "alarms": check_alarms,
+            "detection events": check_events,
+        })
+
+    async def _startup_system_check(self) -> None:
+        """One self-check shortly after boot, logged as a board — every
+        silent-degradation bug becomes a named startup line instead of a
+        confused user report days later."""
+        await asyncio.sleep(25)          # let adapters/models finish warming
+        try:
+            report = await self.run_system_check()
+        except Exception:
+            logger.exception("startup system check failed to run")
+            return
+        logger.info("system check: %s", report.summary)
+        for line in report.lines():
+            (logger.info if "✅" in line else logger.error)("system check: %s", line)
+
     def interactive_busy(self) -> bool:
         """True while a voice/chat turn is being served. Background detection
         loops check this and skip their (expensive) frame-fetch + inference for
@@ -4101,6 +4222,9 @@ class CameraAgentRuntime:
                 self._reconcile_opennvr_cameras(),
                 name="camera-agent-opennvr-camera-reconcile",
             )
+        # Boot-time capability board (see run_system_check).
+        asyncio.create_task(self._startup_system_check(),
+                            name="camera-agent-startup-system-check")
 
     async def _prewarm_llm(self) -> None:
         try:
@@ -4544,6 +4668,14 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
     @app.get("/demo", response_class=HTMLResponse)
     async def _demo() -> HTMLResponse:
         return HTMLResponse(_load_demo_html())
+
+    @app.get("/system-check")
+    async def _system_check() -> dict:
+        """Exercise every real capability path (frame → detector → VLM → LLM →
+        STT/TTS → alarms → events) and return the board. Slow by design (it
+        runs real inference); the demo UI calls it on demand."""
+        report = await runtime.run_system_check()
+        return report.as_dict()
 
     @app.get("/frame/{camera_id}")
     async def _frame(camera_id: str, at: float | None = None) -> Response:

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -208,7 +208,7 @@
       padding:0.9rem; font-size:0.92rem; line-height:1.5; display:flex; flex-direction:column; gap:0.45rem;}
     .log:empty{align-items:center; justify-content:center;}
     .log:empty::after{content:"Ask your cameras anything — tap Talk or type below."; color:var(--faint); font-size:0.85rem;}
-    .msg{max-width:82%;} .msg .who{font-weight:600; font-size:0.68rem; text-transform:uppercase; letter-spacing:0.05em; display:block; margin-bottom:3px;}
+    .msg{max-width:82%; white-space:pre-line;} .msg .who{font-weight:600; font-size:0.68rem; text-transform:uppercase; letter-spacing:0.05em; display:block; margin-bottom:3px;}
     .msg .when{font-weight:400; font-size:0.64rem; color:var(--faint); text-transform:none; letter-spacing:0; margin-left:0.45rem;}
     .msg.sys .when{margin-left:0.35rem; font-style:normal;}
     .msg.user{align-self:flex-end; background:linear-gradient(180deg,rgba(94,179,246,0.18),rgba(61,157,243,0.12));
@@ -587,6 +587,7 @@
             <div class="status" id="status">Ready.</div>
             <span class="chip" id="working" hidden></span>
             <span class="chip" id="lat" hidden title="Per-turn latency: STT · LLM · TTS · total"></span>
+            <button id="sysCheck" class="ghost" type="button" title="Exercise every capability path — frame, detector, VLM, LLM, voice, alarms, events — and report what actually works">System check</button>
             <button id="reset" class="ghost" type="button">Reset</button>
           </div>
 
@@ -830,6 +831,20 @@
       for(const id of ["loginUser","loginPass","loginTotp"]){ const el=$(id);
         if(el) el.addEventListener("keydown",e=>{ if(e.key==="Enter") doLogin(); }); } })();
     const talkBtn=$("talk"), resetBtn=$("reset"), statusEl=$("status"), logEl=$("log");
+    const sysCheckBtn=$("sysCheck");
+    if(sysCheckBtn) sysCheckBtn.addEventListener("click", async ()=>{
+      sysCheckBtn.disabled=true; sysCheckBtn.textContent="Checking…";
+      addMsg("Running a full system check — exercising each capability with a real payload…","sys");
+      try{
+        const r=await fetch("/system-check"); const rep=await r.json();
+        const lines=(rep.checks||[]).map(c=>{
+          const icon=c.status==="ok"?"✅":(c.status==="degraded"?"⚠️":"❌");
+          return icon+" "+c.name+" — "+c.detail+" ("+c.latency_ms+" ms)";
+        });
+        addMsg("System check: "+(rep.summary||"?")+"\n"+lines.join("\n"),"sys");
+      }catch(e){ addMsg("System check failed to run: "+e,"sys"); }
+      finally{ sysCheckBtn.disabled=false; sysCheckBtn.textContent="System check"; }
+    });
     const camboxEl=$("cambox"), ramEl=$("ram"), workingEl=$("working");
     const alarmbarEl=$("alarmbar"), alarmTextEl=$("alarmText"), silenceBtn=$("silence");
     const alarmListEl=$("alarmList"), monitorListEl=$("monitorList"), taskListEl=$("taskList"), reportListEl=$("reportList");

--- a/examples/camera-agent/system_check.py
+++ b/examples/camera-agent/system_check.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""End-to-end capability self-check for the camera agent.
+
+The disease this treats is *silent degradation*: every container answers its
+HTTP healthcheck while the actual capability path is broken — the caption
+adapter that was registered, healthy, and never received a single request
+(sovereignty 403); the stub detector that "runs" while detecting nothing;
+the frame source whose signed URL expired an hour ago. Process-level health
+says "up"; only exercising the REAL path with a REAL payload says "works".
+
+This module is the runner: it takes named async checks, executes each with a
+timeout, and returns a structured board. The checks themselves are built by
+the runtime (they need its clients); each returns ``(status, detail)`` where
+status is ``ok`` | ``degraded`` | ``down``. A check that raises is ``down``
+with the exception as detail; a check that hangs is ``down`` with a timeout
+note — a self-check must never wedge the agent.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+OK = "ok"
+DEGRADED = "degraded"
+DOWN = "down"
+
+_STATUS_ICON = {OK: "✅", DEGRADED: "⚠️", DOWN: "❌"}
+
+CheckFn = Callable[[], Awaitable[tuple[str, str]]]
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str
+    detail: str
+    latency_ms: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "status": self.status,
+                "detail": self.detail, "latency_ms": self.latency_ms}
+
+    def line(self) -> str:
+        icon = _STATUS_ICON.get(self.status, "❓")
+        return f"{icon} {self.name}: {self.detail} ({self.latency_ms} ms)"
+
+
+@dataclass
+class SystemReport:
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def healthy(self) -> bool:
+        return all(r.status == OK for r in self.results)
+
+    @property
+    def summary(self) -> str:
+        down = sum(1 for r in self.results if r.status == DOWN)
+        degraded = sum(1 for r in self.results if r.status == DEGRADED)
+        if not down and not degraded:
+            return "all capabilities working"
+        parts = []
+        if down:
+            parts.append(f"{down} down")
+        if degraded:
+            parts.append(f"{degraded} degraded")
+        return ", ".join(parts)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "healthy": self.healthy,
+            "summary": self.summary,
+            "checks": [r.as_dict() for r in self.results],
+        }
+
+    def lines(self) -> list[str]:
+        return [r.line() for r in self.results]
+
+
+async def run_checks(
+    checks: dict[str, CheckFn], *, timeout_s: float = 10.0,
+) -> SystemReport:
+    """Run every check (sequentially — they may share clients/models),
+    bounding each with ``timeout_s``. Never raises."""
+    report = SystemReport()
+    for name, fn in checks.items():
+        t0 = time.monotonic()
+        try:
+            status, detail = await asyncio.wait_for(fn(), timeout=timeout_s)
+        except asyncio.TimeoutError:
+            status, detail = DOWN, f"no answer within {timeout_s:.0f}s"
+        except Exception as exc:  # a check must never crash the runner
+            status, detail = DOWN, f"{type(exc).__name__}: {exc}"
+        detail = str(detail)[:300]
+        if status not in (OK, DEGRADED, DOWN):
+            status = DOWN
+        report.results.append(
+            CheckResult(name, status,
+                        detail, int((time.monotonic() - t0) * 1000))
+        )
+    return report

--- a/examples/camera-agent/tests/test_system_check.py
+++ b/examples/camera-agent/tests/test_system_check.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""System self-check: the runner's guarantees, and honest degradation in
+describe answers. The disease both treat is silent degradation — a broken
+capability path hiding behind healthy-looking processes and confident text."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from system_check import DEGRADED, DOWN, OK, run_checks
+
+
+def test_runner_statuses_latency_and_summary():
+    async def ok():
+        return OK, "fine"
+
+    async def degraded():
+        return DEGRADED, "meh"
+
+    async def boom():
+        raise RuntimeError("403 Forbidden from KAI-C")
+
+    report = asyncio.run(run_checks(
+        {"a": ok, "b": degraded, "c": boom}, timeout_s=2.0))
+    by = {r.name: r for r in report.results}
+    assert by["a"].status == OK and by["b"].status == DEGRADED
+    assert by["c"].status == DOWN and "403 Forbidden" in by["c"].detail
+    assert not report.healthy
+    assert report.summary == "1 down, 1 degraded"
+    assert all(r.latency_ms >= 0 for r in report.results)
+    # board lines carry the icon + detail
+    assert any(line.startswith("❌ c:") for line in report.lines())
+
+
+def test_runner_times_out_hung_check_without_wedging():
+    async def hang():
+        await asyncio.sleep(30)
+        return OK, "never"
+
+    report = asyncio.run(run_checks({"hung": hang}, timeout_s=0.05))
+    (r,) = report.results
+    assert r.status == DOWN and "no answer" in r.detail
+
+
+def test_runner_normalizes_bogus_status():
+    async def weird():
+        return "amazing", "detail"
+
+    report = asyncio.run(run_checks({"w": weird}))
+    assert report.results[0].status == DOWN
+
+
+# ── honest degradation in describe ─────────────────────────────────
+
+
+class _RaisingCaption:
+    async def infer(self, **kw):
+        raise RuntimeError("Client error '403 Forbidden' for url 'http://kaic/infer/ollamavlm'")
+
+
+class _Detect:
+    def __init__(self, detections):
+        self._d = detections
+    async def infer(self, **kw):
+        return {"result": {"detections": self._d}}
+
+
+def _executor(caption, detect):
+    from context import CameraContext, CameraSpec
+    from tools import CameraTools as ToolExecutor
+
+    ctx = CameraContext(cameras=[CameraSpec("cam1", "http://x/f.jpg", "front")])
+
+    class _Src:
+        def fetch(self):
+            return b"\xff\xd8jpeg"
+    ctx.register_frame_source("cam1", _Src())
+    return ToolExecutor(context=ctx, caption_client=caption,
+                        detection_client=detect, recognition_client=detect)
+
+
+def test_describe_fallback_admits_vision_is_unavailable():
+    ex = _executor(_RaisingCaption(),
+                   _Detect([{"label": "person", "score": 0.9}]))
+    out = asyncio.run(ex.describe_camera({"camera_id": "cam1"}))
+    assert "person" in out
+    assert "vision model is unavailable" in out
+    assert "blocked by KAI-C" in out              # the 403 is named, not hidden
+    assert ex.last_vision_error and "403" in ex.last_vision_error
+
+
+def test_describe_fallback_empty_scene_still_admits_degradation():
+    ex = _executor(_RaisingCaption(), _Detect([]))
+    out = asyncio.run(ex.describe_camera({"camera_id": "cam1"}))
+    assert "no objects detected" in out
+    assert "vision model is unavailable" in out
+
+
+def test_describe_healthy_path_unchanged():
+    class _Caption:
+        async def infer(self, **kw):
+            return {"result": {"caption": "a person at the door"}}
+    ex = _executor(_Caption(), _Detect([]))
+    out = asyncio.run(ex.describe_camera({"camera_id": "cam1"}))
+    assert out == "On cam1: a person at the door."   # _join_clauses phrasing
+    assert "unavailable" not in out

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -366,6 +366,9 @@ class CameraTools:
         # Cameras touched by the most recent tool call — read by /converse
         # so the UI can show which camera(s) the agent is working on.
         self.last_cameras_used: list[str] = []
+        # Why the last describe fell back from the VLM ("" = it didn't) —
+        # surfaced by the system self-check so degradation is visible.
+        self.last_vision_error: str | None = None
 
     # ── describe_camera ────────────────────────────────────────────
 
@@ -451,29 +454,61 @@ class CameraTools:
             caption = (result.get("answer") or result.get("caption") or "").strip()
             if caption:
                 return f"{camera_id}: {caption}"
-        except Exception:
-            # No caption adapter registered (e.g. the standard stack ships
-            # only the object detector). Fall back to describing the scene
-            # from detected objects so the user still gets a useful answer
-            # instead of an error.
+        except Exception as exc:
+            # No caption adapter reachable (not registered, sovereignty 403,
+            # adapter down). Fall back to the object detector — but say so:
+            # a fallback that talks like full vision invents details the
+            # system never saw (field case: a confident wrong shirt color
+            # while the VLM had never received a single request).
+            reason = self._vision_error_reason(exc)
+            self.last_vision_error = f"{type(exc).__name__}: {exc}"[:300]
             logger.warning(
                 "VISION DEGRADED: describe_camera caption adapter unavailable for %s "
-                "(not registered with KAI-C?); falling back to object detection",
-                camera_id,
+                "(%s); falling back to object detection",
+                camera_id, reason,
+            )
+            return await self._describe_via_detection(
+                camera_id, frame, degraded_reason=reason
             )
         return await self._describe_via_detection(camera_id, frame)
 
-    async def _describe_via_detection(self, camera_id: str, frame: bytes) -> str:
+    @staticmethod
+    def _vision_error_reason(exc: Exception) -> str:
+        """One short, operator-meaningful phrase for WHY vision is degraded."""
+        text = str(exc)
+        if "403" in text:
+            return "blocked by KAI-C (sovereignty policy?)"
+        if "404" in text or "not registered" in text.lower():
+            return "caption adapter not registered with KAI-C"
+        if "timed out" in text.lower() or "timeout" in text.lower():
+            return "caption adapter timed out"
+        return "caption adapter unreachable"
+
+    async def _describe_via_detection(
+        self, camera_id: str, frame: bytes, degraded_reason: str | None = None,
+    ) -> str:
         """Best-effort scene description built from the object detector,
-        used when no caption adapter is available."""
+        used when no caption adapter is available. When this IS a degraded
+        fallback, the answer says so — honesty about a missing subsystem
+        beats a confident guess."""
         try:
             response = await self._detect.infer(frame_jpeg=frame)
         except Exception:
             logger.exception("describe_camera: detection fallback failed")
+            if degraded_reason:
+                return (f"{camera_id}: I can't see right now — my vision model "
+                        f"is unavailable ({degraded_reason}) and object "
+                        f"detection also failed")
             return f"{camera_id}: scene description unavailable right now"
         summary = self._summarize_detections(
             (response.get("result") or {}).get("detections") or []
         )
+        if degraded_reason:
+            base = (f"I can see {summary}" if summary
+                    else "no objects detected")
+            return (f"{camera_id}: {base} — note: my vision model is "
+                    f"unavailable ({degraded_reason}), so I'm answering from "
+                    f"object detection only and can't describe details")
         if not summary:
             return f"{camera_id}: nothing notable visible"
         return f"{camera_id}: I can see {summary}"


### PR DESCRIPTION
Treats the class of bug behind this week's field failures — silent degradation. Every container answered its healthcheck while a real capability path was broken: the caption adapter registered, healthy, and never called (KAI-C sovereignty 403); the stub detector 'running'; the frame URL expired. Process health says 'up'; only exercising the real path with a real payload says 'works'.

run_system_check() does exactly that: live frame -> object detector ->
VLM describe -> LLM (model presence) -> STT/TTS -> alarm engine -> Tier-0 event flow, each bounded by a timeout, returning a structured board (ok/degraded/down + why + latency). Runs once ~25s after boot (logged, failures at ERROR), on demand via GET /system-check, and from the demo UI's new 'System check' button which renders the board in chat.

Honest degradation: when describe falls back from the VLM to the object detector, the ANSWER now says so — 'note: my vision model is unavailable (blocked by KAI-C (sovereignty policy?)) …' — instead of confidently inventing details a subsystem never saw. The reason is classified (403/unregistered/timeout/unreachable) and kept for the self-check.

6 new tests: runner statuses/timeout/normalization, degraded wording with the 403 named, empty-scene degradation, healthy path unchanged.