### PR TITLE
fix(discovery): probe 8000 in the liveness gate so odd-port cameras s…

### DIFF
--- a/server/services/onvif_service.py
+++ b/server/services/onvif_service.py
@@ -239,10 +239,21 @@ async def probe_onvif_device(
 # port's SYN-ACK can arrive late, which is how real cameras got missed).
 _GATE_TIMEOUT = 2.5
 
-# Any normal TCP stack answers a SYN on a *closed* port with an RST, so one or
-# two silent ports are enough to call a host dead. 80/443 are the universal
-# web ports; a camera serving ONVIF only on e.g. 8899 still RSTs these.
-_LIVENESS_PORTS = (80, 443)
+# Any normal TCP stack answers a SYN on a *closed* port with an RST, so a few
+# silent ports are enough to call a host dead. 80/443 are the universal web
+# ports; 8000 is the most common alternate ONVIF control port.
+#
+# 8000 is in this list for RELIABILITY, not coverage -- phase 2 sweeps it
+# anyway. A camera listening on NONE of the liveness ports is judged alive
+# purely by how fast its RST comes back, and under sweep load Docker Desktop's
+# NAT relay delivers that RST *later* than _GATE_TIMEOUT: both liveness ports
+# read "dead", the host is dropped, and phase 2 never probes the port the
+# camera actually serves. Measured on a /24 against a camera serving ONVIF on
+# 8000 only (nothing on 80/443): 80/443 alone found it in 2 of 5 sweeps;
+# adding 8000 found it in 5 of 5, costing ~9s on a /24. An open port answers
+# with a SYN-ACK from the device itself, so it doesn't depend on RST latency --
+# positive evidence beats waiting for silence to be disproved.
+_LIVENESS_PORTS = (80, 443, 8000)
 
 
 async def _tcp_state(ip: str, port: int, timeout: float = _GATE_TIMEOUT) -> str:


### PR DESCRIPTION
…urvive

Phase 1 of scan_onvif_subnets calls a host dead when it stays silent on _LIVENESS_PORTS, and only live hosts reach the phase-2 sweep that probes the full ONVIF candidate list. The comment justified 80/443 on the grounds that a camera serving ONVIF elsewhere "still RSTs these" - true of the camera, but not of the path to it.

A camera listening on NEITHER liveness port is judged alive purely by how fast its RST comes back. Docker Desktop's NAT relay already delivers a closed-port RST ~2s late, which is what _GATE_TIMEOUT=2.5 was tuned around; under the load of a /24 sweep that margin goes. Traced against a camera serving ONVIF on 8000 only:

  in isolation     80: dead   443: closed   8000: open
  during a sweep   80: dead   443: dead     (both at 2.5s, the gate)

Both liveness ports read dead, the host is dropped, and phase 2 never probes 8000. /discover returns HTTP 200 with an empty list, so the UI reports "No cameras found" with nothing to suggest the scan was wrong - and because it turns on RST timing it is intermittent: the same camera on the same host was found in only 2 of 5 sweeps.

Add 8000, the most common alternate ONVIF control port. This adds no coverage - 8000 is already in ONVIF_CANDIDATE_PORTS and phase 2 sweeps it - it adds a positive signal: an open port answers with a SYN-ACK from the device itself, which owes nothing to RST latency. Phase 1 stays a fixed small number of connects per host, well inside the concurrency budget the sweep was tuned to.

Measured over five /24 sweeps each, same camera and host:

  (80, 443)        found 2/5   avg 15.3s
  (80, 443, 8000)  found 5/5   avg 24.3s

This does not close the general case: a camera on e.g. 8899 with nothing on 80/443/8000 still rests on RST timing. Separating "timed out under load" from "confirmed silent" would, and is noted in the issue as follow-up.

Fixes #300