### PR TITLE
feat(agent): register one-shot grants declared permissions; 403s name…

### DIFF
--- a/docker-compose.camera-agent.yml
+++ b/docker-compose.camera-agent.yml
@@ -208,7 +208,15 @@ services:
   # Caption-adapter auto-registration (test-report S-5) — VOICE + CHAT. On a
   # clean install the caption adapter was NOT registered with KAI-C, so
   # describe_camera silently fell back to the detector. This one-shot registers
-  # the adapter selected by CAPTION_ADAPTER.
+  # the adapter selected by CAPTION_ADAPTER — and then GRANTS its declared
+  # permissions (§8/§11): an adapter that declares scope (ollamavlm declares
+  # egress to the operator's own Ollama) otherwise sits pending_approval and
+  # 403s every inference on a fresh install, with the reason visible only in
+  # the audit trail. Running this profile IS the operator's install-time
+  # consent; the grant is issued with the operator's INTERNAL_API_KEY and
+  # lands in the audit log with actor=install, exactly as governance
+  # intends. Post-install scope changes still require a fresh grant: KAI-C
+  # re-pends an adapter that re-declares more scope than was approved.
   # ──────────────────────────────────────────────────────────────
   caption-adapter-register:
     profiles: [camera-agent, camera-agent-chat]
@@ -239,7 +247,16 @@ services:
                --header="X-Internal-Api-Key: $${INTERNAL_API_KEY}" \
                --post-data="{\"name\":\"$$name\",\"url\":\"$$url\"}" \
                http://opennvr-core:8100/api/v1/adapters/register >/dev/null 2>&1; then
-            echo "Registered caption adapter '$$name'."; exit 0
+            echo "Registered caption adapter '$$name'."
+            # Grant declared permissions (install-time operator consent —
+            # see the service comment). Best-effort: an adapter with no
+            # declared scope is already approved and this is a no-op.
+            if wget -q -O-                  --header="X-Internal-Api-Key: $${INTERNAL_API_KEY}"                  --header="X-Actor: install"                  --post-data=""                  "http://opennvr-core:8100/api/v1/adapters/$$name/permissions/approve-all" >/dev/null 2>&1; then
+              echo "Approved '$$name' declared permissions (install-time grant, audited)."
+            else
+              echo "WARN: could not approve '$$name' permissions — if inference 403s, grant them via the AI models page." >&2
+            fi
+            exit 0
           fi
           i=$$((i+1)); echo "register attempt $$i/30 failed (adapter warming up?); retry in 5s"; sleep 5
         done

--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -119,6 +119,25 @@ class KaicAdapterClient(_ReusableClientMixin):
                 resp.raise_for_status()
                 return resp.json()
             except httpx.HTTPError as exc:
+                # Surface KAI-C's response body in the error: a bare
+                # "403 Forbidden" hides WHICH gate refused (permission
+                # approval vs sovereignty vs auth), and the field cost of
+                # that ambiguity was a multi-hour hunt. The detail string
+                # travels into tools' degradation reason and the user's
+                # answer.
+                detail = ""
+                resp_obj = getattr(exc, "response", None)
+                if resp_obj is not None:
+                    try:
+                        detail = str((resp_obj.json() or {}).get("detail") or "")[:300]
+                    except Exception:
+                        detail = (resp_obj.text or "")[:300]
+                if detail:
+                    exc = httpx.HTTPStatusError(
+                        f"{exc} — KAI-C detail: {detail}",
+                        request=getattr(exc, "request", None),
+                        response=resp_obj,
+                    ) if isinstance(exc, httpx.HTTPStatusError) else exc
                 last_exc = exc
                 if attempt < self._retries:
                     logger.warning(

--- a/examples/camera-agent/tests/test_system_check.py
+++ b/examples/camera-agent/tests/test_system_check.py
@@ -87,7 +87,7 @@ def test_describe_fallback_admits_vision_is_unavailable():
     out = asyncio.run(ex.describe_camera({"camera_id": "cam1"}))
     assert "person" in out
     assert "vision model is unavailable" in out
-    assert "blocked by KAI-C" in out              # the 403 is named, not hidden
+    assert "refused by KAI-C (403)" in out        # the 403 is named, not hidden
     assert ex.last_vision_error and "403" in ex.last_vision_error
 
 
@@ -106,3 +106,23 @@ def test_describe_healthy_path_unchanged():
     out = asyncio.run(ex.describe_camera({"camera_id": "cam1"}))
     assert out == "On cam1: a person at the door."   # _join_clauses phrasing
     assert "unavailable" not in out
+
+
+def test_vision_error_reason_names_the_actual_gate():
+    """A 403 is not one thing: the reason names WHICH gate refused. The
+    field cost of a bare 403 guess ('sovereignty?') was a multi-hour hunt
+    that ended at the permission-approval gate."""
+    from tools import CameraTools as _T
+
+    r = _T._vision_error_reason
+    approval = RuntimeError(
+        "Client error '403 Forbidden' — KAI-C detail: adapter 'ollamavlm' is "
+        "pending_approval: 1 declared permission(s) await operator approval "
+        "before it may serve inference")
+    assert "operator approval" in r(approval)
+    sovereignty = RuntimeError(
+        "403 — KAI-C detail: AI_SOVEREIGNTY=local_only refuses adapter: "
+        "declared network_egress entry is not on this machine")
+    assert "sovereignty" in r(sovereignty)
+    assert r(RuntimeError("Client error '403 Forbidden'")) == "refused by KAI-C (403)"
+    assert "timed out" in r(RuntimeError("request timed out"))

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -477,8 +477,14 @@ class CameraTools:
     def _vision_error_reason(exc: Exception) -> str:
         """One short, operator-meaningful phrase for WHY vision is degraded."""
         text = str(exc)
+        lowered = text.lower()
+        if "await operator" in lowered or "approval" in lowered:
+            return ("adapter awaiting operator approval in KAI-C "
+                    "(AI models page → grant permissions)")
+        if "sovereign" in lowered or "egress" in lowered:
+            return "blocked by KAI-C sovereignty policy"
         if "403" in text:
-            return "blocked by KAI-C (sovereignty policy?)"
+            return "refused by KAI-C (403)"
         if "404" in text or "not registered" in text.lower():
             return "caption adapter not registered with KAI-C"
         if "timed out" in text.lower() or "timeout" in text.lower():


### PR DESCRIPTION
… their gate

Field case, end to end: the default caption adapter (ollamavlm) declares its egress honestly, so on every fresh install it sat pending_approval in KAI-C and 403'd all inference — with the reason written only to the audit trail, the agent guessing 'sovereignty policy?', and the operator-grant step existing nowhere in the install path. Vision was dead by default behind three layers of silence.

The caption-adapter-register one-shot now grants the adapter's declared permissions right after registering: running the profile IS the operator's install-time consent, the grant is issued with the operator's INTERNAL_API_KEY, X-Actor=install, and lands in the audit log exactly as governance intends. Post-install scope changes still re-pend for a fresh grant, and a failed grant logs where to approve manually.

The guessing is gone too: adapter_clients now surfaces KAI-C's response detail inside the raised error, and the degradation reason names the actual gate — 'awaiting operator approval (AI models page)' vs 'sovereignty policy' vs plain 403 — in the log, the answer, and the system-check board. Suite 624 green.