### PR TITLE
feat(cameras): store the camera's own ONVIF substream by default

### DIFF
--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -341,7 +341,19 @@ async def create_camera(
             onvif_port = derived.get("onvif_port")
             control_scheme = derived.get("control_scheme")
             identity = derived
-            camera_create = camera_create.model_copy(update={"rtsp_url": derived["rtsp_url"]})
+            updates: dict = {"rtsp_url": derived["rtsp_url"]}
+            # Store the camera's OWN substream by default (it came from the
+            # device's ONVIF profiles, not a guess) — so Tier-0 taps the
+            # low-res stream out of the box instead of silently decoding the
+            # full main stream (~5x the CPU) until an operator pastes a URL.
+            # An operator-supplied substream_url always wins.
+            if not camera_create.substream_url and derived.get("substream_url"):
+                updates["substream_url"] = derived["substream_url"]
+                camera_logger.info(
+                    "camera %s: auto-stored ONVIF substream for Tier-0",
+                    camera_create.name,
+                )
+            camera_create = camera_create.model_copy(update=updates)
         else:
             # URL supplied — embed the credentials into it when they aren't already
             # part of the URL. MediaMTX authenticates using the userinfo in the RTSP

--- a/server/services/camera_source_resolver.py
+++ b/server/services/camera_source_resolver.py
@@ -229,6 +229,32 @@ async def fetch_identity(
     return None
 
 
+def _pick_substream_uri(profiles: list[dict], main_uri: str) -> str | None:
+    """The camera's substream URI from its ONVIF profiles, or None.
+
+    The main stream is the first profile (unchanged, long-standing behavior);
+    the substream is chosen from the REMAINING profiles with a stream URI
+    that differs from the main one — preferring the smallest advertised
+    resolution when the camera reports dimensions (that IS the substream by
+    definition), else simply the next profile (ONVIF convention: profile 2
+    is the sub-encoding). No guessing: everything here came from the device
+    itself, which is what makes storing it by default safe.
+    """
+    main_plain = html.unescape(main_uri)
+    candidates = []
+    for p in profiles[1:]:
+        uri = html.unescape(p.get("stream_uri") or "")
+        if not uri or uri == main_plain:
+            continue
+        area = (p.get("width") or 0) * (p.get("height") or 0)
+        candidates.append((area if area > 0 else float("inf"), uri))
+    if not candidates:
+        return None
+    # Smallest known resolution first; unknown resolutions sort last.
+    candidates.sort(key=lambda c: c[0])
+    return candidates[0][1]
+
+
 async def resolve_source(
     ip: str, username: str | None, password: str | None, rtsp_port: int = 554
 ) -> dict[str, Any] | None:
@@ -245,16 +271,23 @@ async def resolve_source(
     except Exception:
         info = None
     if info:
-        stream_uri = next(
-            (p.get("stream_uri") for p in info.get("profiles", []) if p.get("stream_uri")),
-            None,
-        )
+        with_uri = [p for p in info.get("profiles", []) if p.get("stream_uri")]
+        stream_uri = with_uri[0]["stream_uri"] if with_uri else None
         if stream_uri:
             # ONVIF returns the URI XML-escaped (e.g. &amp;) — unescape before use.
             stream_uri = html.unescape(stream_uri)
             dev = info.get("device_info", {}) or {}
+            sub_uri = _pick_substream_uri(with_uri, stream_uri)
             return {
                 "rtsp_url": inject_credentials(stream_uri, username, password),
+                # The camera's own SUBSTREAM, straight from ONVIF — stored by
+                # default so Tier-0 never silently decodes the full main
+                # stream on a fresh install (the ~5x CPU difference). None
+                # when the device advertises a single profile.
+                "substream_url": (
+                    inject_credentials(sub_uri, username, password)
+                    if sub_uri else None
+                ),
                 **_identity_from_device_info(
                     dev, info.get("port", 80), info.get("scheme", "http")
                 ),

--- a/server/tests/test_camera_source_resolver.py
+++ b/server/tests/test_camera_source_resolver.py
@@ -219,3 +219,58 @@ async def test_sync_camera_time_returns_false_and_never_raises(monkeypatch):
     monkeypatch.setattr(ods, "resolve_control_endpoint", fake_resolve)
     monkeypatch.setattr(ods, "set_system_datetime", fake_set)
     assert await sync_camera_time("10.0.0.5", "admin", "pw") is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_onvif_returns_substream_by_lowest_resolution(monkeypatch):
+    """ONVIF advertises BOTH encodings; the resolver must hand back the
+    camera's own substream (smallest resolution) so a fresh install taps
+    the low-res stream by default instead of decoding full main (~5x CPU)
+    until an operator pastes a URL by hand."""
+    async def fake_connect(ip, u, p, port=None, scheme=None):
+        return {
+            "port": 80, "scheme": "http", "device_info": {},
+            "profiles": [
+                {"token": "main", "width": 1920, "height": 1080,
+                 "stream_uri": "rtsp://192.168.0.104:554/avstream/channel=1/stream=0.sdp"},
+                {"token": "third", "width": 704, "height": 576,
+                 "stream_uri": "rtsp://192.168.0.104:554/avstream/channel=1/stream=2.sdp"},
+                {"token": "sub", "width": 352, "height": 288,
+                 "stream_uri": "rtsp://192.168.0.104:554/avstream/channel=1/stream=1.sdp"},
+            ],
+        }
+
+    monkeypatch.setattr(ods, "connect_and_get_profiles", fake_connect)
+    r = await resolve_source("192.168.0.104", "admin", "pw", 554)
+    assert r["rtsp_url"].endswith("stream=0.sdp")            # main unchanged
+    assert r["substream_url"] == (
+        "rtsp://admin:pw@192.168.0.104:554/avstream/channel=1/stream=1.sdp"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_onvif_substream_none_when_single_profile(monkeypatch):
+    async def fake_connect(ip, u, p, port=None, scheme=None):
+        return {"port": 80, "scheme": "http", "device_info": {},
+                "profiles": [{"token": "only",
+                              "stream_uri": "rtsp://c/main"}]}
+
+    monkeypatch.setattr(ods, "connect_and_get_profiles", fake_connect)
+    r = await resolve_source("c", "u", "p", 554)
+    assert r["substream_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_onvif_substream_skips_duplicate_uri(monkeypatch):
+    """Some cameras report two profiles pointing at the SAME stream — that is
+    not a substream; storing it would double-tap main."""
+    async def fake_connect(ip, u, p, port=None, scheme=None):
+        return {"port": 80, "scheme": "http", "device_info": {},
+                "profiles": [
+                    {"token": "a", "stream_uri": "rtsp://c/main"},
+                    {"token": "b", "stream_uri": "rtsp://c/main"},
+                ]}
+
+    monkeypatch.setattr(ods, "connect_and_get_profiles", fake_connect)
+    r = await resolve_source("c", "u", "p", 554)
+    assert r["substream_url"] is None


### PR DESCRIPTION
A fresh install's cameras had no substream stored, so Tier-0 silently decoded the full main stream (~5x the CPU) until an operator found the right vendor URL and pasted it by hand — even though ONVIF discovery had already been handed every profile's stream URI and threw the rest away.

resolve_source now also returns substream_url: the smallest-resolution remaining profile when the camera reports dimensions (that IS the substream by definition), else the next distinct-URI profile (ONVIF convention: profile 2 is the sub-encoding); duplicate-URI profiles are never stored (double-tapping main is not a substream). Camera create stores it only when the operator supplied none — an explicit substream always wins, and nothing is guessed: every URL comes from the device itself, which is what makes storing it by default safe. Main-URL selection is byte-for-byte unchanged.

Resolver tests: lowest-resolution pick with credential injection, single-profile -> None, duplicate-URI -> None. Server suite 801 green.