### PR TITLE
fix(agent): ship system_check.py in the image — /system-check 500'd w…

### DIFF
--- a/examples/camera-agent/Dockerfile
+++ b/examples/camera-agent/Dockerfile
@@ -74,6 +74,7 @@ COPY examples/camera-agent/services.py        ./services.py
 COPY examples/camera-agent/tools.py           ./tools.py
 COPY examples/camera-agent/footage_index.py   ./footage_index.py
 COPY examples/camera-agent/monitor_host.py    ./monitor_host.py
+COPY examples/camera-agent/system_check.py    ./system_check.py
 # The count/crossing conversational monitors instantiate the SAME SDK rule
 # classes the standalone catalog apps use — one rule library, two front doors
 # (app-sdk-spec §07). monitor_host loads them by file path from OPENNVR_RULES_DIR

--- a/examples/camera-agent/tests/test_dockerfile_modules.py
+++ b/examples/camera-agent/tests/test_dockerfile_modules.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The Dockerfile copies agent modules by EXPLICIT list — safe against
+shipping stray files, but a newly added module silently missing from the
+image imports fine in dev and 500s in production (field case: /system-check
+raised ModuleNotFoundError because system_check.py wasn't COPYed). This
+test pins the invariant: every top-level agent module is in the Dockerfile."""
+from __future__ import annotations
+
+from pathlib import Path
+
+AGENT_DIR = Path(__file__).resolve().parents[1]
+
+
+def test_every_agent_module_is_copied_into_the_image():
+    dockerfile = (AGENT_DIR / "Dockerfile").read_text()
+    missing = [
+        py.name
+        for py in sorted(AGENT_DIR.glob("*.py"))
+        if f"/{py.name} " not in dockerfile and f"/{py.name}\n" not in dockerfile
+        and f"{py.name} " not in dockerfile
+    ]
+    assert not missing, (
+        f"module(s) not COPYed into the camera-agent image: {missing} — "
+        f"add COPY lines to examples/camera-agent/Dockerfile"
+    )


### PR DESCRIPTION
…ithout it

The Dockerfile copies agent modules by explicit list; the new system_check module wasn't on it, so the published image raised ModuleNotFoundError on every /system-check call (and on the boot-time board) — a 500 behind a working button. Added the COPY line, and a test that pins the invariant: every top-level agent module must appear in the Dockerfile, so a future module can't silently miss the image again.