### PR TITLE
fix(detect): CRITICAL — nonref emitted a token ffmpeg rejects; detect…

### DIFF
--- a/detect-pipeline/detect_pipeline/ffmpeg_presets.py
+++ b/detect-pipeline/detect_pipeline/ffmpeg_presets.py
@@ -138,6 +138,15 @@ def scale_filter(hwaccel: HwAccel, *, width: int, height: int, fps: int) -> str:
 #           fine for "is someone there" alarms, coarse for fast events.
 DECODE_SKIP_MODES = ("none", "bidir", "nonref", "nokey")
 
+# Mode name → the token ffmpeg's CLI actually accepts. The mode is named
+# after libavcodec's constant (AVDISCARD_NONREF), but the CLI string is
+# "noref" — passing "nonref" makes ffmpeg reject the option and exit with
+# ZERO frames produced, which the worker sees as a dead stream and
+# crash-loops on (field-diagnosed via Dozzle on the first deployed build).
+# The real-ffmpeg regression test in test_ffmpeg_presets.py exists so a
+# token can never drift from what ffmpeg accepts again.
+_FFMPEG_SKIP_TOKEN = {"nonref": "noref"}
+
 
 def build_decode_command(
     rtsp_url: str,
@@ -161,11 +170,16 @@ def build_decode_command(
     """
     if not rtsp_url.startswith(("rtsp://", "rtsps://")):
         raise ValueError(f"expected an rtsp(s):// substream URL, got {rtsp_url!r}")
+    if decode_skip == "noref":          # accept ffmpeg's own spelling too
+        decode_skip = "nonref"
     if decode_skip not in DECODE_SKIP_MODES:
         raise ValueError(
             f"decode_skip must be one of {DECODE_SKIP_MODES}, got {decode_skip!r}"
         )
-    skip_args = [] if decode_skip == "none" else ["-skip_frame", decode_skip]
+    skip_args = (
+        [] if decode_skip == "none"
+        else ["-skip_frame", _FFMPEG_SKIP_TOKEN.get(decode_skip, decode_skip)]
+    )
     # Decoder thread cap (before -i). ffmpeg's default is AUTO — up to 16
     # frame threads PER CAMERA, which on a small substream is pure scheduling
     # overhead multiplied by the fleet (Frigate pins -threads 2 for the same

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -107,6 +107,8 @@ def _decode_skip_from_env(env: dict) -> str:
     from .ffmpeg_presets import DECODE_SKIP_MODES
 
     value = str(env.get("DETECT_DECODE_SKIP", "nonref")).strip().lower()
+    if value == "noref":                 # ffmpeg's own spelling of nonref
+        value = "nonref"
     if value not in DECODE_SKIP_MODES:
         log.warning(
             "DETECT_DECODE_SKIP=%r is not one of %s; using 'none' (full decode)",
@@ -176,6 +178,8 @@ def _decode_idle_from_env(env: dict) -> str:
     from .ffmpeg_presets import DECODE_SKIP_MODES
 
     value = str(env.get("DETECT_DECODE_IDLE", "nokey")).strip().lower()
+    if value == "noref":                 # ffmpeg's own spelling of nonref
+        value = "nonref"
     if value in ("", "none", "off", "false"):
         return ""
     if value not in DECODE_SKIP_MODES:

--- a/detect-pipeline/test/test_adaptive_decode.py
+++ b/detect-pipeline/test/test_adaptive_decode.py
@@ -79,7 +79,7 @@ def test_set_decode_skip_respawns_with_new_mode_and_no_backoff():
     frames = src.stream()
     next(frames)                                       # first spawn is live
     assert "-skip_frame" in spawned[0]
-    assert spawned[0][spawned[0].index("-skip_frame") + 1] == "nonref"
+    assert spawned[0][spawned[0].index("-skip_frame") + 1] == "noref"   # ffmpeg token for nonref
     src.set_decode_skip("nokey")                       # flip mid-stream
     for _ in frames:                                   # drain to the respawn
         pass

--- a/detect-pipeline/test/test_ffmpeg_presets.py
+++ b/detect-pipeline/test/test_ffmpeg_presets.py
@@ -109,11 +109,12 @@ def test_decode_skip_inserts_before_input():
 
 
 def test_decode_skip_all_modes_accepted():
-    for mode in ("bidir", "nonref", "nokey"):
+    # mode name -> the token ffmpeg's CLI accepts (nonref maps to noref)
+    for mode, token in (("bidir", "bidir"), ("nonref", "noref"), ("nokey", "nokey")):
         cmd = build_decode_command(
             RTSP, width=640, height=360, fps=5, decode_skip=mode,
         )
-        assert cmd[cmd.index("-skip_frame") + 1] == mode
+        assert cmd[cmd.index("-skip_frame") + 1] == token
 
 
 def test_decode_skip_rejects_unknown_mode():
@@ -156,3 +157,49 @@ def test_fast_decode_cpu_only():
 def test_fast_decode_off_by_default():
     cmd = build_decode_command(RTSP, width=640, height=360, fps=5)
     assert "-skip_loop_filter" not in cmd
+
+
+# ── the token ffmpeg ACTUALLY accepts (field regression) ───────────────
+# The nonref mode shipped emitting "-skip_frame nonref"; ffmpeg's CLI token
+# is "noref", so ffmpeg rejected the option and produced ZERO frames — every
+# worker crash-looped ("5 consecutive restarts with no frames"). These tests
+# pin the mapping, and the real-ffmpeg test proves every emitted token is
+# one ffmpeg accepts, so a token can never drift again.
+
+
+def test_nonref_mode_emits_ffmpeg_noref_token():
+    cmd = build_decode_command(RTSP, width=640, height=360, fps=5,
+                               decode_skip="nonref")
+    assert cmd[cmd.index("-skip_frame") + 1] == "noref"
+
+
+def test_ffmpeg_own_spelling_accepted_as_alias():
+    cmd = build_decode_command(RTSP, width=640, height=360, fps=5,
+                               decode_skip="noref")
+    assert cmd[cmd.index("-skip_frame") + 1] == "noref"
+
+
+import shutil as _shutil
+import subprocess as _subprocess
+
+
+@pytest.mark.skipif(_shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+def test_real_ffmpeg_accepts_every_emitted_skip_token():
+    """Feed each mode's EMITTED token to a real ffmpeg decode: the option
+    must parse (no 'Undefined constant' / 'Invalid argument' on stderr)."""
+    from detect_pipeline.ffmpeg_presets import DECODE_SKIP_MODES, _FFMPEG_SKIP_TOKEN
+
+    for mode in DECODE_SKIP_MODES:
+        if mode == "none":
+            continue
+        token = _FFMPEG_SKIP_TOKEN.get(mode, mode)
+        proc = _subprocess.run(
+            ["ffmpeg", "-hide_banner", "-loglevel", "error",
+             "-skip_frame", token,
+             "-f", "lavfi", "-i", "testsrc=duration=0.2:size=64x64",
+             "-f", "null", "-"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert proc.returncode == 0, (mode, token, proc.stderr)
+        assert "Undefined constant" not in proc.stderr, (mode, token, proc.stderr)
+        assert "Invalid" not in proc.stderr, (mode, token, proc.stderr)


### PR DESCRIPTION
…ion was dead by default

The nonref decode-skip mode (default since #292) emitted '-skip_frame nonref', named after libavcodec's AVDISCARD_NONREF — but ffmpeg's CLI token is 'noref'. ffmpeg rejected the option and exited with ZERO frames, so every worker crash-looped ('5 consecutive restarts with no frames … giving up') and Tier-0 detected nothing on any install running the new image. Field-diagnosed in minutes via the new Dozzle log viewer and the detector-identity startup lines from #297.

build_decode_command now maps mode names to ffmpeg tokens (nonref -> noref), accepts ffmpeg's own spelling as an alias in both the API and the env parsers, and — the real fix — a real-ffmpeg regression test feeds every emitted token to an actual ffmpeg decode and asserts it parses, so a token can never drift from what ffmpeg accepts again. Suite: 242 green (the argv-only tests that let this through now assert the mapped tokens).