### PR TITLE
fix(camera-agent): report a warming-up VLM as warming up, not unreach…

### DIFF
--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -72,6 +72,10 @@ class KaicAdapterClient(_ReusableClientMixin):
     etc.). The SDK body parser unwraps these into the service.
     """
 
+    # Ceiling on a server-supplied ``retry_after_ms``: the voice loop has a
+    # live user waiting, so a bogus or huge value must not stall a turn.
+    _MAX_RETRY_BACKOFF_S: float = 10.0
+
     def __init__(
         self,
         *,
@@ -140,14 +144,37 @@ class KaicAdapterClient(_ReusableClientMixin):
                     ) if isinstance(exc, httpx.HTTPStatusError) else exc
                 last_exc = exc
                 if attempt < self._retries:
+                    backoff = self._backoff_for(resp_obj)
                     logger.warning(
                         "KAI-C infer attempt %d/%d failed (%s); retrying in %.1fs "
                         "(adapter may still be warming up)",
-                        attempt + 1, self._retries + 1, exc, self._retry_backoff_s,
+                        attempt + 1, self._retries + 1, exc, backoff,
                     )
-                    await asyncio.sleep(self._retry_backoff_s)
+                    await asyncio.sleep(backoff)
         assert last_exc is not None
         raise last_exc
+
+    def _backoff_for(self, resp_obj: Any) -> float:
+        """Seconds to wait before the next attempt.
+
+        KAI-C's transient errors carry their own ``retry_after_ms`` (an
+        auto-pulling model asks for 5s). Ignoring it meant three attempts
+        1.5s apart — ~3s of retrying against a multi-GB download, so the
+        cold-start window the retry exists for was never actually bridged.
+        Honour the server's number when it gives one, floored at the local
+        backoff and capped so a bad value can't stall the voice loop.
+        """
+        if resp_obj is None:
+            return self._retry_backoff_s
+        try:
+            error = ((resp_obj.json() or {}).get("detail") or {}).get("error") or {}
+            retry_after_ms = float(error.get("retry_after_ms") or 0)
+        except Exception:
+            return self._retry_backoff_s
+        if retry_after_ms <= 0:
+            return self._retry_backoff_s
+        return min(max(retry_after_ms / 1000.0, self._retry_backoff_s),
+                   self._MAX_RETRY_BACKOFF_S)
 
 
 class KaicCapabilitiesClient(_ReusableClientMixin):

--- a/examples/camera-agent/tests/test_system_check.py
+++ b/examples/camera-agent/tests/test_system_check.py
@@ -126,3 +126,60 @@ def test_vision_error_reason_names_the_actual_gate():
     assert "sovereignty" in r(sovereignty)
     assert r(RuntimeError("Client error '403 Forbidden'")) == "refused by KAI-C (403)"
     assert "timed out" in r(RuntimeError("request timed out"))
+
+
+def test_vision_error_reason_separates_warming_up_from_unreachable():
+    """A 503 is the adapter ANSWERING that it isn't ready — the opposite of
+    unreachable. Calling the auto-pull window "unreachable" sent an operator
+    hunting Docker networking while a multi-GB model was simply downloading."""
+    from tools import CameraTools as _T
+
+    r = _T._vision_error_reason
+    pulling = RuntimeError(
+        "Server error '503 Service Unavailable' for url "
+        "'http://opennvr-core:8100/api/v1/infer/ollamavlm' — KAI-C detail: "
+        "{'status': 'error', 'error': {'category': 'model_error', 'code': "
+        "'model_not_pulled', 'message': \"Ollama has no model 'gemma3:4b' "
+        "(auto-pull is running — retry shortly)\", 'transient': True, "
+        "'retry_after_ms': 5000}}")
+    reason = r(pulling)
+    assert "still downloading" in reason
+    assert "unreachable" not in reason
+
+    warming = r(RuntimeError("Server error '503 Service Unavailable'"))
+    assert "warming up" in warming and "unreachable" not in warming
+
+    # A 502 means KAI-C's own 30s proxy budget expired: adapter down OR a
+    # VLM too slow for this host. Both, because the operator can't tell.
+    slow = r(RuntimeError(
+        "Server error '502 Bad Gateway' — KAI-C detail: adapter unreachable: "))
+    assert "no answer in time" in slow and "too slow" in slow
+
+    # An unclassified failure still reads as unreachable.
+    assert r(RuntimeError("connection refused")) == "caption adapter unreachable"
+
+
+def test_infer_backoff_honours_server_retry_after():
+    """KAI-C's transient errors carry retry_after_ms. Ignoring it meant three
+    attempts 1.5s apart — ~3s against a multi-GB pull, so the cold-start
+    window the retry loop exists for was never actually bridged."""
+    import httpx
+    from adapter_clients import KaicAdapterClient
+
+    c = KaicAdapterClient(kaic_url="http://kaic", api_key="k",
+                          adapter_name="ollamavlm", retry_backoff_s=1.5)
+
+    def _resp(payload):
+        return httpx.Response(503, json=payload,
+                              request=httpx.Request("POST", "http://kaic"))
+
+    assert c._backoff_for(None) == 1.5                      # no response
+    assert c._backoff_for(_resp({"detail": "plain string"})) == 1.5
+    assert c._backoff_for(_resp({"detail": {"error": {}}})) == 1.5
+    assert c._backoff_for(
+        _resp({"detail": {"error": {"retry_after_ms": 5000}}})) == 5.0
+    # Never shorter than the local floor, never long enough to stall a turn.
+    assert c._backoff_for(
+        _resp({"detail": {"error": {"retry_after_ms": 200}}})) == 1.5
+    assert c._backoff_for(
+        _resp({"detail": {"error": {"retry_after_ms": 9_000_000}}})) == 10.0

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -487,8 +487,24 @@ class CameraTools:
             return "refused by KAI-C (403)"
         if "404" in text or "not registered" in text.lower():
             return "caption adapter not registered with KAI-C"
+        # A 503 from KAI-C is the adapter ANSWERING that it isn't ready yet
+        # — not a transport failure. Reporting the auto-pull window as
+        # "unreachable" sent an operator hunting Docker networking for a
+        # model that was simply still downloading; name the real state so
+        # the answer is "wait" rather than "debug the network".
+        if "model_not_pulled" in lowered or "auto-pull" in lowered:
+            return "vision model still downloading (auto-pull running — retry shortly)"
+        if "503" in text:
+            return "caption adapter warming up (503 — retry shortly)"
         if "timed out" in text.lower() or "timeout" in text.lower():
             return "caption adapter timed out"
+        # KAI-C proxies /infer with its own 30s budget: a 502 means KAI-C
+        # got no answer from the adapter in time. That is a down adapter OR
+        # a VLM too slow for this host (a large model on CPU can take
+        # minutes per frame), and the operator needs to know it's both.
+        if "502" in text:
+            return ("caption adapter gave KAI-C no answer in time "
+                    "(adapter down, or the VLM is too slow for this host)")
         return "caption adapter unreachable"
 
     async def _describe_via_detection(


### PR DESCRIPTION
…able

The system check rendered a hard "down" for vision with the reason "caption adapter unreachable" while the adapter was healthy and answering the whole time. What KAI-C actually returned was a structured transient error:

  503 {'code': 'model_not_pulled', 'transient': True,
       'retry_after_ms': 5000,
       'message': "Ollama has no model 'gemma3:4b' (auto-pull is running)"}

_vision_error_reason had no branch for it, so a model that was simply still downloading fell through to the generic "unreachable" phrase and sent an operator hunting Docker networking.

Add the missing branches, ordered ahead of the fallthrough:

  * model_not_pulled / auto-pull -> "vision model still downloading"
  * generic 503                  -> "caption adapter warming up"
  * 502                          -> "gave KAI-C no answer in time
                                     (adapter down, or the VLM is too
                                     slow for this host)"

The 502 wording names both causes deliberately: KAI-C proxies /infer on a 30s budget, and a 502 cannot distinguish a down adapter from a model too slow for the host. Measured on a CPU-only box, gemma3:4b vision took 548s for an 8x8 JPEG against that 30s budget, so "unreachable" was the wrong first thing to go check. An unclassified failure still reads as "unreachable" — the fallthrough is unchanged.

Also honour KAI-C's retry_after_ms. The retry loop existed to bridge the adapter cold-start window but slept a fixed 1.5s three times: ~3s of retrying against a multi-GB pull that the server had explicitly asked it to retry in 5000ms, so the window it exists for was never bridged. The new _backoff_for floors at the local backoff and caps at 10s, because the voice loop has a live user waiting and a bogus value must not stall a turn.