### PR TITLE
fix(agent): pre-pull the VLM at up — a picked gemma3/qwen2.5vl no lon…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,15 +248,21 @@ CORE_TAG=0.1.3
 # break fresh Linux installs where nothing listens on the host.
 OLLAMA_EXTERNAL_URL=
 
-# Vision (caption/VQA) model when CAPTION_ADAPTER=ollamavlm — the
-# Ollama-proxy VLM adapter (adapter releases after 0.1.3). It follows
-# OLLAMA_EXTERNAL_URL, so scene descriptions run on the same host
-# Ollama (GPU on macOS) as the LLM; the adapter auto-pulls a missing
-# model. Any Ollama multimodal model works. moondream (~1.8B) is the
-# lightest and the safe pick for CPU-only bundled Ollama — but it's also
-# the weakest describer (bad viewpoints/lighting can read as "empty").
-# When Ollama runs on a host GPU, qwen3-vl:4b (~3.5 GB at Q4) is a big
-# accuracy jump for scene questions, and qwen3-vl:8b bigger still.
+# Vision (caption/VQA) model when CAPTION_ADAPTER=ollamavlm — the OLLAMA
+# MODEL the adapter asks your Ollama to run. Naming note, because it trips
+# people: this "moondream" is Ollama's moondream2 MODEL and has nothing to
+# do with choosing the moondream ADAPTER above — with CAPTION_ADAPTER=
+# ollamavlm no in-container weights are downloaded at all; Ollama serves
+# whatever model this names. It follows OLLAMA_EXTERNAL_URL, so scene
+# descriptions run on the same host Ollama (GPU on macOS) as the LLM. The
+# stack pre-pulls this model at ``up`` (bundled Ollama) or tells you the
+# host command (host Ollama); large models (gemma3:4b, qwen2.5vl) are
+# multi-GB, so until the pull finishes describe answers honestly report
+# "still downloading". Any Ollama MULTIMODAL model works. moondream
+# (~1.8B) is the lightest and the safe pick for CPU-only bundled Ollama —
+# but the weakest describer (bad viewpoints/lighting can read as
+# "empty"). On a host GPU, qwen3-vl:4b is a big accuracy jump, and
+# qwen3-vl:8b bigger still.
 OLLAMA_VLM_MODEL=moondream
 
 # Image tag for all GHCR adapter images (whisper, piper, yolov8, blip,

--- a/docker-compose.camera-agent.yml
+++ b/docker-compose.camera-agent.yml
@@ -347,8 +347,14 @@ services:
   # ──────────────────────────────────────────────────────────────
   # Ollama model pull — one-shot (VOICE + CHAT). Runs AUTOMATICALLY on ``up``
   # because the agent depends_on it (service_completed_successfully), so the
-  # model is present before the agent starts. Model = OLLAMA_MODEL in .env
-  # (default qwen2.5:1.5b).
+  # model is present before the agent starts. Pulls OLLAMA_MODEL (the LLM
+  # brain) and, when CAPTION_ADAPTER=ollamavlm, OLLAMA_VLM_MODEL (the eyes)
+  # — previously only the LLM was pre-pulled, so the FIRST describe question
+  # cold-pulled the VLM through the adapter: fine-ish for moondream (1.7GB),
+  # but a picked gemma3:4b / qwen2.5vl meant minutes of 503s that read as
+  # "the vision model doesn't work". The VLM pull is best-effort: a typo'd
+  # model name must not take down the whole agent profile — the adapter's
+  # auto-pull remains the fallback and the failure is named in the log.
   # ──────────────────────────────────────────────────────────────
   ollama-model-pull:
     profiles: [camera-agent, camera-agent-chat]
@@ -367,9 +373,21 @@ services:
         MODEL="$${OLLAMA_MODEL:-qwen2.5:1.5b}"
         echo "Pulling Ollama model: $$MODEL"
         OLLAMA_HOST=http://ollama:11434 ollama pull "$$MODEL"
-        echo "Model ready."
+        echo "LLM model ready."
+        if [ "$${CAPTION_ADAPTER}" = "ollamavlm" ] && [ -n "$${OLLAMA_VLM_MODEL}" ]; then
+          echo "Pulling vision model: $${OLLAMA_VLM_MODEL}"
+          if OLLAMA_HOST=http://ollama:11434 ollama pull "$${OLLAMA_VLM_MODEL}"; then
+            echo "Vision model ready."
+          else
+            echo "WARN: could not pull vision model '$${OLLAMA_VLM_MODEL}' —" >&2
+            echo "describe answers stay degraded until the adapter's auto-pull succeeds" >&2
+            echo "or you pull it manually (ollama pull $${OLLAMA_VLM_MODEL})." >&2
+          fi
+        fi
     environment:
       - OLLAMA_MODEL=${OLLAMA_MODEL:-qwen2.5:1.5b}
+      - OLLAMA_VLM_MODEL=${OLLAMA_VLM_MODEL:-moondream}
+      - CAPTION_ADAPTER=${CAPTION_ADAPTER:-moondream}
     volumes:
       - opennvr_ollama_models:/root/.ollama
     networks:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -600,6 +600,9 @@ choose_example() {
                 fi
             else
                 warn "Before first use, pull the model ON THE HOST:  ollama pull ${ext_model}"
+                if [[ "$(env_get CAPTION_ADAPTER)" == "ollamavlm" ]]; then
+                    warn "And the vision model:                        ollama pull $(env_get OLLAMA_VLM_MODEL)"
+                fi
             fi
         fi
         if [[ "$EXAMPLE_PROFILE" == "camera-agent" ]]; then


### PR DESCRIPTION
…ger arrives broken

The ollama-model-pull one-shot fetched only OLLAMA_MODEL (the LLM), so the vision model cold-pulled through the adapter on the FIRST describe question. moondream's 1.7GB masked the gap; picking gemma3:4b or qwen2.5vl from the installer's catalog meant minutes of 503s that read as 'the VLM doesn't work'. The one-shot now also pulls OLLAMA_VLM_MODEL when CAPTION_ADAPTER=ollamavlm — best-effort, so a typo'd model name degrades to the adapter's auto-pull with a named warning instead of taking down the agent profile. The host-Ollama install path now prints the vision model's 'ollama pull' line next to the LLM's.

Also untangles the two-moondreams confusion in .env.example: 'moondream' the OLLAMA MODEL (what OLLAMA_VLM_MODEL names) vs 'moondream' the ADAPTER (a different delivery of the same family) — choosing ollamavlm downloads no in-container weights at all.