### PR TITLE
fix(cameras): show the port the camera actually streams on

### DIFF
--- a/app/src/views/Cameras.tsx
+++ b/app/src/views/Cameras.tsx
@@ -744,8 +744,22 @@ export function Cameras() {
               <Field label="IP address">
                 <input className={EDIT_INPUT} value={form.ip_address} onChange={(e) => setForm({ ...form, ip_address: e.target.value })} required />
               </Field>
+              {/* The RTSP URL is what MediaMTX pulls, so when one is set its
+                  port is the camera's port — the server derives the column
+                  from it on save. Showing an editable field here would offer a
+                  value that is silently discarded, which is how the two came
+                  to disagree in the first place. */}
               <Field label="Port">
-                <input type="number" className={EDIT_INPUT} value={form.port} onChange={(e) => setForm({ ...form, port: Number(e.target.value) })} min={1} max={65535} />
+                <input
+                  type="number"
+                  className={`${EDIT_INPUT} disabled:opacity-60`}
+                  value={rtspPortFromUrl(form.rtsp_url) ?? form.port}
+                  onChange={(e) => setForm({ ...form, port: Number(e.target.value) })}
+                  min={1}
+                  max={65535}
+                  disabled={rtspPortFromUrl(form.rtsp_url) !== null}
+                  title={rtspPortFromUrl(form.rtsp_url) !== null ? 'Taken from the RTSP URL below' : undefined}
+                />
               </Field>
               <Field label="Username">
                 <input className={EDIT_INPUT} value={form.username || ''} onChange={(e) => setForm({ ...form, username: e.target.value })} />
@@ -901,6 +915,27 @@ const EDIT_INPUT =
 // column.
 const ICON_BTN =
   'inline-flex items-center justify-center rounded border border-[var(--border)] bg-[var(--panel-2)] p-1.5 text-[var(--text-dim)] transition-colors hover:bg-[var(--panel)] hover:text-[var(--text)]'
+
+// The port a camera actually streams on, read off its RTSP URL — the same rule
+// the server applies on save (rtsp defaults to 554, rtsps to 322 when the URL
+// omits it). null when there is nothing to read, so callers fall back to the
+// stored value rather than showing a guess.
+const RTSP_DEFAULT_PORTS: Record<string, number> = { 'rtsp:': 554, 'rtsps:': 322 }
+
+function rtspPortFromUrl(url: string | null | undefined): number | null {
+  if (!url) return null
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  const fallback = RTSP_DEFAULT_PORTS[parsed.protocol]
+  if (fallback === undefined) return null
+  if (!parsed.port) return fallback
+  const port = Number(parsed.port)
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null
+}
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/server/migrations/versions/bb88cc99dd00_camera_port_from_rtsp_url.py
+++ b/server/migrations/versions/bb88cc99dd00_camera_port_from_rtsp_url.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""backfill cameras.port from rtsp_url
+
+``cameras.port`` is the camera's RTSP port, but nothing kept it in step with
+``cameras.rtsp_url``. A camera added with an explicit URL on a non-standard
+port (``rtsp://host:8554/...``) kept the 554 column default, so the cameras
+list rendered ``host:554`` — an address nothing answers on, and the first
+thing an operator checks when a stream drops.
+
+The create/update paths now derive the column from the URL. This backfills the
+rows that predate them. Only rows where the URL yields a different port are
+touched; a camera with no URL, a non-rtsp URL, or an unparseable one is left
+exactly as it is rather than overwritten with a guess.
+
+Revision ID: bb88cc99dd00
+Revises: aa77bb88cc99
+Create Date: 2026-08-24 09:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from urllib.parse import urlparse
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "bb88cc99dd00"
+down_revision: str | None = "aa77bb88cc99"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Scheme defaults for an rtsp(s) URL that omits the port (RFC 7826). Kept in
+# step with ``services.camera_source_resolver._RTSP_DEFAULT_PORTS``; inlined
+# because a migration must not import application code that may have moved on.
+_DEFAULT_PORTS = {"rtsp": 554, "rtsps": 322}
+
+
+def _port_from(url: str | None) -> int | None:
+    if not url:
+        return None
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    scheme = parsed.scheme.lower()
+    if scheme not in _DEFAULT_PORTS:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        # Malformed authority, e.g. "host:abc".
+        return None
+    if port is None:
+        return _DEFAULT_PORTS[scheme]
+    return port if 1 <= port <= 65535 else None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text("SELECT id, port, rtsp_url FROM cameras WHERE rtsp_url IS NOT NULL")
+    ).fetchall()
+
+    # Grouped by target port so a fleet on one non-standard port costs one
+    # statement, not one per camera.
+    by_port: dict[int, list[int]] = {}
+    for camera_id, port, rtsp_url in rows:
+        derived = _port_from(rtsp_url)
+        if derived is None or derived == port:
+            continue
+        by_port.setdefault(derived, []).append(camera_id)
+
+    for derived, ids in by_port.items():
+        conn.execute(
+            sa.text("UPDATE cameras SET port = :port WHERE id IN :ids").bindparams(
+                sa.bindparam("ids", expanding=True)
+            ),
+            {"port": derived, "ids": ids},
+        )
+
+
+def downgrade() -> None:
+    # The pre-backfill values are unrecoverable (and were wrong), so there is
+    # nothing to restore. Leaving the corrected ports in place is the safe
+    # no-op: they describe where each camera actually streams.
+    pass

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -402,6 +402,24 @@ async def create_camera(
             control_scheme,
         )
 
+    # Keep the stored RTSP port in step with the URL that will actually be
+    # pulled. `port` defaults to 554, so a camera added with an explicit URL on
+    # another port (rtsp://host:8554/...) used to keep the default and the
+    # cameras list then rendered "host:554" — an address nothing answers on,
+    # which is the first thing an operator checks when the stream drops.
+    # Derived here, after both branches above have settled `rtsp_url`.
+    from services.camera_source_resolver import rtsp_port_from_url
+
+    _stream_port = rtsp_port_from_url(camera_create.rtsp_url)
+    if _stream_port is not None and _stream_port != camera_create.port:
+        camera_logger.info(
+            "camera %s: port %s -> %s, taken from the RTSP URL",
+            camera_create.name,
+            camera_create.port,
+            _stream_port,
+        )
+        camera_create = camera_create.model_copy(update={"port": _stream_port})
+
     # Duplicate guard — compared after RTSP derivation/credential injection so
     # the final URL is what's matched. 409 carries the matches so the client
     # can show "already added — add anyway?" and retry with ?force=true.
@@ -1006,8 +1024,26 @@ async def update_camera(
         # Refactoring: Since we have the camera, we can use it.
         # But we need to update it.
         was_active = bool(camera.is_active)
-        for field, value in camera_update.model_dump(exclude_unset=True).items():
+        update_fields = camera_update.model_dump(exclude_unset=True)
+        for field, value in update_fields.items():
             setattr(camera, field, value)
+
+        # Re-point `port` whenever the stream URL moves, for the same reason the
+        # create path derives it: MediaMTX pulls `rtsp_url`, so that URL's port
+        # is the only one worth showing. A `port` sent in the same request loses
+        # to the URL rather than leaving the two contradicting each other.
+        if "rtsp_url" in update_fields:
+            from services.camera_source_resolver import rtsp_port_from_url
+
+            stream_port = rtsp_port_from_url(camera.rtsp_url)
+            if stream_port is not None and stream_port != camera.port:
+                camera_logger.info(
+                    "camera %s: port %s -> %s, taken from the updated RTSP URL",
+                    camera.id,
+                    camera.port,
+                    stream_port,
+                )
+                camera.port = stream_port
 
         db.commit()
         db.refresh(camera)

--- a/server/services/camera_drivers/registry.py
+++ b/server/services/camera_drivers/registry.py
@@ -160,7 +160,6 @@ def select_driver_class(manufacturer: str | None) -> type[CameraDriver]:
 async def resolve_endpoint(
     camera_id: int,
     ip: str,
-    camera_port: int | None,
     onvif_port: int | None = None,
     control_scheme: str | None = None,
 ) -> tuple[str, int]:
@@ -171,16 +170,17 @@ async def resolve_endpoint(
       1. a persisted ``(control_scheme, onvif_port)`` is verified once, then trusted;
       2. otherwise the shared candidate ports are scanned, http then https;
       3. default ``("http", 80)``.
+
+    ``cameras.port`` is deliberately NOT consulted. It used to serve as a hint
+    whenever it wasn't 554, on the assumption it held something other than the
+    RTSP port — but it is the RTSP port, now kept in step with ``rtsp_url``, so
+    a camera streaming on 8554 would have handed ONVIF an 8554 hint and paid two
+    dead probes for it. The candidate scan already covers the real control ports.
     """
     if camera_id in _ENDPOINT_CACHE:
         return _ENDPOINT_CACHE[camera_id]
 
-    # Prefer the persisted ONVIF port as the hint; else the camera's own
-    # configured port when it isn't the RTSP port.
-    hint = onvif_port or (
-        camera_port if camera_port and camera_port not in (554, 0) else None
-    )
-    scheme, port = await ods.resolve_control_endpoint(ip, hint, control_scheme)
+    scheme, port = await ods.resolve_control_endpoint(ip, onvif_port, control_scheme)
     _ENDPOINT_CACHE[camera_id] = (scheme, port)
     return scheme, port
 
@@ -263,7 +263,6 @@ async def get_driver_for_camera(
     scheme, port = await resolve_endpoint(
         camera_id,
         camera.ip_address,
-        camera.port,
         getattr(camera, "onvif_port", None),
         getattr(camera, "control_scheme", None),
     )

--- a/server/services/camera_source_resolver.py
+++ b/server/services/camera_source_resolver.py
@@ -86,6 +86,41 @@ def derive_substream_url(main_url: str | None) -> str | None:
     return None
 
 
+# Scheme defaults for an rtsp(s) URL that omits the port (RFC 7826).
+_RTSP_DEFAULT_PORTS = {"rtsp": 554, "rtsps": 322}
+
+
+def rtsp_port_from_url(url: str | None) -> int | None:
+    """Return the TCP port an rtsp(s) URL actually streams on.
+
+    ``cameras.port`` is the camera's RTSP port, but nothing used to keep it in
+    step with ``cameras.rtsp_url`` — a camera added with an explicit URL on a
+    non-standard port kept the 554 default and the UI then showed an address
+    the stream was never on. Callers use this to derive the column from the URL,
+    which is what MediaMTX actually pulls.
+
+    Returns None for a missing/unparseable URL or a non-rtsp scheme, so callers
+    can leave the stored value alone rather than overwrite it with a guess.
+    """
+    if not url:
+        return None
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    scheme = parsed.scheme.lower()
+    if scheme not in _RTSP_DEFAULT_PORTS:
+        return None
+    try:
+        # Raises ValueError on a malformed authority (e.g. "host:abc").
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is None:
+        return _RTSP_DEFAULT_PORTS[scheme]
+    return port if 1 <= port <= 65535 else None
+
+
 def inject_credentials(url: str | None, username: str | None, password: str | None) -> str | None:
     """Embed ``user:pass@`` into an rtsp(s) URL's authority (no-op if the URL
     already has userinfo, isn't rtsp, or no username is given)."""

--- a/server/tests/test_camera_delete_deactivate.py
+++ b/server/tests/test_camera_delete_deactivate.py
@@ -328,3 +328,80 @@ def test_force_bypasses_duplicate_conflict(env):
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["ip_address"] == "10.0.0.9"
+
+
+# ---- `port` mirrors the RTSP URL ----
+# `cameras.port` is the RTSP port, but nothing kept it in step with `rtsp_url`.
+# A camera added with an explicit URL on 8554 kept the 554 default, so the
+# cameras list rendered "host:554" — an address nothing answers on, and the
+# first thing an operator checks when the stream drops.
+
+
+def test_create_takes_port_from_the_rtsp_url(env):
+    resp = env.client.post(
+        "/api/v1/cameras/",
+        json=_payload(ip_address="10.0.0.5", rtsp_url="rtsp://10.0.0.5:8554/"),
+        headers=_auth(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["port"] == 8554
+    stored = env.db.query(Camera).filter(Camera.id == resp.json()["id"]).first()
+    assert stored.port == 8554
+
+
+def test_create_falls_back_to_the_scheme_default_port(env):
+    """A URL with no port streams on 554 — say 554, not whatever was typed."""
+    resp = env.client.post(
+        "/api/v1/cameras/",
+        json=_payload(ip_address="10.0.0.5", port=8000, rtsp_url="rtsp://10.0.0.5/ch1"),
+        headers=_auth(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["port"] == 554
+
+
+def test_create_without_an_rtsp_url_keeps_the_given_port(env):
+    """Nothing to derive from — the operator's value stands rather than being
+    overwritten with a guess."""
+    resp = env.client.post(
+        "/api/v1/cameras/",
+        json=_payload(ip_address="10.0.0.5", port=8000),
+        headers=_auth(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["port"] == 8000
+
+
+def test_update_repoints_port_when_the_rtsp_url_moves(env):
+    cam = env.make_camera(ip_address="10.0.0.5", port=554,
+                          rtsp_url="rtsp://10.0.0.5:554/ch1")
+    resp = env.client.put(
+        f"/api/v1/cameras/{cam.id}",
+        json={"rtsp_url": "rtsp://10.0.0.5:8554/ch1"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["port"] == 8554
+
+
+def test_update_url_wins_over_a_port_sent_in_the_same_request(env):
+    """MediaMTX pulls the URL, so the URL's port is the only one worth showing —
+    the alternative is leaving the two fields contradicting each other."""
+    cam = env.make_camera(ip_address="10.0.0.5", rtsp_url="rtsp://10.0.0.5:554/ch1")
+    resp = env.client.put(
+        f"/api/v1/cameras/{cam.id}",
+        json={"rtsp_url": "rtsp://10.0.0.5:8554/ch1", "port": 554},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["port"] == 8554
+
+
+def test_update_leaves_port_alone_when_the_url_is_untouched(env):
+    cam = env.make_camera(ip_address="10.0.0.5", port=8000,
+                          rtsp_url="rtsp://10.0.0.5:8554/ch1")
+    resp = env.client.put(
+        f"/api/v1/cameras/{cam.id}", json={"name": "Renamed"}, headers=_auth()
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["port"] == 8000

--- a/server/tests/test_camera_port_backfill_migration.py
+++ b/server/tests/test_camera_port_backfill_migration.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""The ``bb88cc99dd00`` backfill puts ``cameras.port`` on the port its
+``rtsp_url`` actually streams on.
+
+The create/update paths derive the column now, but existing deployments carry
+rows written before them — a camera added with an explicit URL on 8554 kept the
+554 default, so the cameras list showed an address nothing answers on. This
+covers the migration's row selection, because the failure mode is a silent one:
+overwriting a port it had no business guessing at is worse than the bug.
+
+Run with:
+
+    cd server && pytest tests/test_camera_port_backfill_migration.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import sqlalchemy as sa
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = (
+    SERVER_ROOT / "migrations" / "versions" / "bb88cc99dd00_camera_port_from_rtsp_url.py"
+)
+
+
+@pytest.fixture(scope="module")
+def mig():
+    spec = importlib.util.spec_from_file_location("_backfill_mig", MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# (rtsp_url, stored port, port after the backfill)
+ROWS = [
+    # Derived: an explicit non-standard port, credentials and IPv6 included.
+    ("rtsp://admin:pw@10.0.0.1:8554/", 554, 8554),
+    ("rtsp://admin:pw@10.0.0.2:8554/", 554, 8554),  # same target, one statement
+    ("rtsp://[fe80::1]:8554/s", 554, 8554),
+    ("rtsps://10.0.0.8/ch1", 554, 322),  # scheme default when the URL omits it
+    # Already correct — nothing to write.
+    ("rtsp://10.0.0.3:554/ch1", 554, 554),
+    ("rtsp://10.0.0.4/ch1", 554, 554),
+    # Nothing to derive from: the stored value stands rather than being
+    # replaced by a guess.
+    (None, 8000, 8000),
+    ("http://10.0.0.6:8554/", 8000, 8000),
+    ("not a url", 8000, 8000),
+    ("rtsp://10.0.0.7:abc/x", 554, 554),
+    ("rtsp://10.0.0.9:0/x", 554, 554),
+]
+
+
+def test_backfill_only_rewrites_rows_the_url_can_speak_for(mig):
+    eng = sa.create_engine("sqlite://")
+    with eng.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE cameras "
+                "(id INTEGER PRIMARY KEY, port INTEGER, rtsp_url TEXT)"
+            )
+        )
+        conn.execute(
+            sa.text("INSERT INTO cameras (id, port, rtsp_url) VALUES (:id, :p, :u)"),
+            [
+                {"id": i, "p": port, "u": url}
+                for i, (url, port, _) in enumerate(ROWS, start=1)
+            ],
+        )
+
+    conn = eng.connect()
+    with mock.patch.object(mig.op, "get_bind", return_value=conn):
+        with conn.begin():
+            mig.upgrade()
+        after = dict(conn.execute(sa.text("SELECT id, port FROM cameras")).fetchall())
+    conn.close()
+
+    expected = {i: port for i, (_, _, port) in enumerate(ROWS, start=1)}
+    assert after == expected
+
+
+def test_downgrade_is_a_no_op(mig):
+    """The pre-backfill values are unrecoverable, and were wrong — leaving the
+    corrected ports in place is the safe direction."""
+    eng = sa.create_engine("sqlite://")
+    with eng.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE cameras "
+                "(id INTEGER PRIMARY KEY, port INTEGER, rtsp_url TEXT)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO cameras (id, port, rtsp_url) "
+                "VALUES (1, 8554, 'rtsp://10.0.0.1:8554/')"
+            )
+        )
+
+    conn = eng.connect()
+    with mock.patch.object(mig.op, "get_bind", return_value=conn):
+        mig.downgrade()
+        assert conn.execute(sa.text("SELECT port FROM cameras")).scalar() == 8554
+    conn.close()

--- a/server/tests/test_camera_source_resolver.py
+++ b/server/tests/test_camera_source_resolver.py
@@ -50,6 +50,7 @@ from services.camera_source_resolver import (  # noqa: E402
     fetch_identity,
     inject_credentials,
     resolve_source,
+    rtsp_port_from_url,
     sync_camera_time,
 )
 
@@ -274,3 +275,38 @@ async def test_resolve_onvif_substream_skips_duplicate_uri(monkeypatch):
     monkeypatch.setattr(ods, "connect_and_get_profiles", fake_connect)
     r = await resolve_source("c", "u", "p", 554)
     assert r["substream_url"] is None
+
+
+# --- rtsp_port_from_url ----------------------------------------------------
+# `cameras.port` is the RTSP port but was never derived from `rtsp_url`, so a
+# camera on 8554 showed as ":554" in the list — an address nothing answers on.
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Explicit port wins, standard or not.
+        ("rtsp://10.0.0.5:8554/stream", 8554),
+        ("rtsp://10.0.0.5:554/stream", 554),
+        ("rtsp://admin:p%40ss@192.168.29.226:8554/", 8554),
+        # Credentials, paths and queries must not confuse the parse.
+        ("rtsp://u:p@host:2020/cam/realmonitor?channel=1&subtype=0", 2020),
+        # Omitted port falls back to the scheme default.
+        ("rtsp://10.0.0.5/stream", 554),
+        ("rtsps://10.0.0.5/stream", 322),
+        ("rtsps://10.0.0.5:8555/stream", 8555),
+        # IPv6 literals keep their brackets out of the port.
+        ("rtsp://[fe80::1]:8554/s", 8554),
+        ("rtsp://[fe80::1]/s", 554),
+        # Nothing to derive — callers must leave the stored value alone rather
+        # than overwrite it with a guess.
+        (None, None),
+        ("", None),
+        ("http://10.0.0.5:8554/stream", None),
+        ("10.0.0.5:8554", None),
+        ("rtsp://10.0.0.5:abc/stream", None),
+        ("rtsp://10.0.0.5:0/stream", None),
+    ],
+)
+def test_rtsp_port_from_url(url, expected):
+    assert rtsp_port_from_url(url) == expected

--- a/server/tests/test_driver_registry.py
+++ b/server/tests/test_driver_registry.py
@@ -166,7 +166,7 @@ def _isolate(monkeypatch):
     """Neutralize network + per-process caches for selection tests."""
     registry._DRIVER_CACHE.clear()
 
-    async def _endpoint(cid, ip, p, onvif_port=None, control_scheme=None):
+    async def _endpoint(cid, ip, onvif_port=None, control_scheme=None):
         return ("http", 80)
 
     monkeypatch.setattr(registry, "resolve_endpoint", _endpoint)


### PR DESCRIPTION
`cameras.port` is the RTSP port, but nothing kept it in step with `cameras.rtsp_url`. A camera added with an explicit URL on a non-standard port kept the 554 column default, so the cameras list rendered "192.168.29.226:554" for a stream MediaMTX was pulling from :8554 — an address nothing answers on, and the first thing an operator checks when that camera goes Disconnected.

Derive the column from the URL that will actually be pulled, on create (after both the ONVIF-derived and operator-supplied branches settle `rtsp_url`) and on update whenever the URL moves. A `port` sent alongside a new URL loses to the URL rather than leaving the two contradicting each other. Nothing to derive from — no URL, a non-rtsp URL, an unparseable one — leaves the stored value alone rather than overwriting it with a guess.

The edit dialog's Port field follows: it shows the URL's port and goes read-only while a URL is set, instead of taking input that the save silently discards.

Backfill migration for rows written before this, same row selection.

Also stop feeding `camera.port` to `resolve_endpoint` as an ONVIF control port hint. That worked only while the column disagreed with the RTSP URL — now that it holds 8554 for a camera streaming on 8554, the hint would buy two dead 4s probes and, when no ONVIF port answers at all, persist 8554 as `onvif_port`. The candidate scan already covers the real control ports.