### PR TITLE
feat(installer): promote field-tested qwen3:1.7b + gemma3:4b to hardw…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -261,8 +261,11 @@ OLLAMA_EXTERNAL_URL=
 # "still downloading". Any Ollama MULTIMODAL model works. moondream
 # (~1.8B) is the lightest and the safe pick for CPU-only bundled Ollama —
 # but the weakest describer (bad viewpoints/lighting can read as
-# "empty"). On a host GPU, qwen3-vl:4b is a big accuracy jump, and
-# qwen3-vl:8b bigger still.
+# "empty"). gemma3:4b is FIELD-TESTED with the agent and clearly answers
+# better — the installer suggests it wherever RAM allows (>= 8 GB); set
+# it here yourself on a copy-paste install with headroom. On a host GPU,
+# qwen3-vl:4b is a further accuracy jump, and qwen3-vl:8b bigger still
+# (both untested with the agent so far).
 OLLAMA_VLM_MODEL=moondream
 
 # Image tag for all GHCR adapter images (whisper, piper, yolov8, blip,
@@ -377,7 +380,10 @@ LOG_JSON_FORMAT=False
 # CAMERA-AGENT (voice assistant overlay)
 # ============================================================
 # Ollama model for the voice agent - must support tool calling.
-# Options: qwen2.5:0.5b (low RAM) | qwen2.5:1.5b (default) | qwen2.5:3b (better quality)
+# Options: qwen2.5:0.5b (low RAM) | qwen2.5:1.5b (default) |
+# qwen3:1.7b (FIELD-TESTED: better answers at similar speed, ~3 GB —
+# the installer suggests it where RAM allows; the agent disables its
+# thinking mode) | qwen2.5:3b (best of the qwen2.5 family)
 OLLAMA_MODEL=qwen2.5:1.5b
 
 # Whisper STT model size: tiny.en | base.en (default) | small.en (most accurate)

--- a/examples/camera-agent/MODELS_AND_LATENCY.md
+++ b/examples/camera-agent/MODELS_AND_LATENCY.md
@@ -178,9 +178,9 @@ the equivalent logic in `scripts/install.ps1`.
 
 | Where the LLM runs | Hardware | LLM default | VLM default (ollamavlm) |
 |---|---|---|---|
-| Host, Apple Silicon / NVIDIA | ≥ 16 GB RAM | `qwen2.5:3b` | `moondream` |
-| Host, GPU, < 16 GB | | `qwen2.5:1.5b` | `moondream` |
-| Any CPU-only | ≥ 16 GB + ≥ 8 cores | `qwen2.5:1.5b` | `moondream` |
+| Host, Apple Silicon / NVIDIA | ≥ 8 GB RAM | `qwen3:1.7b` | `gemma3:4b` |
+| Host, GPU, < 8 GB | | `qwen2.5:1.5b` | `moondream` |
+| Any CPU-only | ≥ 16 GB + ≥ 8 cores | `qwen3:1.7b` | `gemma3:4b` (≥ 8 GB) |
 | Any CPU-only | smaller | `qwen2.5:0.5b` | `moondream` |
 | macOS, bundled container | sized to the Docker VM's RAM, always CPU tier | | |
 
@@ -190,10 +190,13 @@ only suggested where latency would otherwise make the agent unusable.
 The **ceiling** is the tested envelope: defaults never exceed the
 largest model this agent has actually been exercised with — "this
 hardware can run a bigger model" is detectable, "bigger will be better
-for this agent's tool-calling and voice latency" is not. Machines with
-headroom (≥ 32 GB GPU-backed) are told at the prompt that `qwen2.5:7b`
-and `qwen2.5vl:3b` are worth trying; promoting them to defaults should
-follow testing, not RAM arithmetic.
+for this agent's tool-calling and voice latency" is not. The
+`qwen3:1.7b` + `gemma3:4b` pair entered that envelope by exactly this
+route: field-tested against the `qwen2.5` + `moondream` defaults with
+this agent, found clearly better at similar cost, then promoted.
+Machines with headroom (≥ 32 GB GPU-backed) are told at the prompt that
+`qwen2.5:7b` and `qwen2.5vl:3b` are worth trying; promoting them to
+defaults should follow the same testing route, not RAM arithmetic.
 
 
 ## Model catalog (what each option is actually good at)
@@ -211,33 +214,35 @@ first contribution.
 | Model | ~RAM | Speed | Status | Good at |
 |---|---|---|---|---|
 | `qwen2.5:0.5b` | 1 GB | fastest | tested | Any CPU; simple questions; weakest at multi-step tool use |
-| `qwen2.5:1.5b` | 2 GB | fast | tested | The balanced default: reliable tool routing at low RAM |
-| `qwen2.5:3b` | 4 GB | medium | tested | Best answers in the tested set; wants GPU or strong CPU |
+| `qwen2.5:1.5b` | 2 GB | fast | tested | The balanced low-RAM default: reliable tool routing |
+| `qwen3:1.7b` | 3 GB | fast | tested | Field-tested: better answers than the qwen2.5 set at similar speed; the default where RAM allows |
+| `qwen2.5:3b` | 4 GB | medium | tested | Best of the qwen2.5 family; wants GPU or strong CPU |
 | `qwen2.5:7b` | 8 GB | slower | untested | Strongest family reasoning; ~2× slower per answer |
 | `llama3.2:3b` | 4 GB | medium | untested | Different family; conversational tone, solid tool calling |
-| `qwen3:1.7b` | 3 GB | fast | untested | Newer generation; better instruction-following per size |
 
 ### VLMs (the agent's eyes — used via `CAPTION_ADAPTER=ollamavlm`)
 
 These are Ollama-servable vision models; the installer annotates each
 with whether it fits your detected hardware. (`moondream` here is
 Ollama's moondream2 ~1.8b; the standalone moondream-adapter container
-ships the smaller 0.5b-int8 build — both are the same family and the
-tested default either way. `blip` remains available as a plain
+ships the smaller 0.5b-int8 build — both are the same family, tested,
+and the low-RAM pick either way. `blip` remains available as a plain
 captioner via its own adapter, outside this menu.)
 
 | Model | ~RAM | Speed | Status | Good at |
 |---|---|---|---|---|
-| `moondream` | 3 GB | fast | tested | Edge-optimized VQA at low cost; the tested default |
-| `gemma3:4b` | 4 GB | medium | untested | Well-rounded generalist; good descriptions, decent text reading |
+| `moondream` | 3 GB | fast | tested | Edge-optimized VQA at low cost; the tested low-RAM default |
+| `gemma3:4b` | 4 GB | medium | tested | Field-tested: clearly better scene answers than moondream; the default where RAM allows |
 | `qwen2.5vl:3b` | 5 GB | medium | untested | Best text READER of its size (signs, labels, plates) |
+| `qwen3-vl:4b` | 5 GB | medium | untested | Newest Qwen vision family; strong all-round scene + text reading |
 | `minicpm-v` | 6 GB | medium | untested | OCR standout: dense/small text (delivery labels, screens) |
 | `llava:7b` | 6 GB | slower | untested | Classic general VQA; most descriptive free-form answers |
 | `llama3.2-vision:11b` | 9 GB | slowest | untested | Strongest scene reasoning; wants a GPU with headroom |
 
 Picking for a security camera: **counting and "is something there" never
 needs a VLM** (YOLOv8 does that); the VLM answers "what/who/how does it
-look". `moondream` covers that cheaply. Reach for `qwen2.5vl:3b` or
+look". `gemma3:4b` is the tested all-rounder; `moondream` covers the
+same cheaply on small boxes. Reach for `qwen2.5vl:3b` or
 `minicpm-v` when your questions involve **reading** (plates, parcel
 labels, uniforms with text); reach for the big ones only when answer
 richness matters more than latency.

--- a/examples/camera-agent/model_catalog.txt
+++ b/examples/camera-agent/model_catalog.txt
@@ -15,17 +15,18 @@
 #
 # Ordering within a kind = menu order. Keep "tested" entries first.
 llm|qwen2.5:0.5b|1|yes|fastest|Snappy on any CPU; fine for simple questions; weakest at multi-step tool use
-llm|qwen2.5:1.5b|2|yes|fast|The balanced default: reliable tool routing at low RAM; good on CPU-only boxes
-llm|qwen2.5:3b|4|yes|medium|Best answers in the tested set; noticeably better reasoning and phrasing; wants GPU or a strong CPU
+llm|qwen2.5:1.5b|2|yes|fast|The balanced low-RAM default: reliable tool routing; good on CPU-only boxes
+llm|qwen3:1.7b|3|yes|fast|Field-tested with this agent: better answers than the qwen2.5 set at similar speed; the suggested default where RAM allows (the agent disables its thinking mode for snappy tool calls)
+llm|qwen2.5:3b|4|yes|medium|Best of the qwen2.5 family; strong reasoning and phrasing; wants GPU or a strong CPU
 llm|qwen2.5:7b|8|no|slower|Strongest reasoning in the family; ~2x slower per answer than 3b; untested with this agent
 llm|llama3.2:3b|4|no|medium|Different family, solid tool calling and a more conversational tone; untested with this agent
-llm|qwen3:1.7b|3|no|fast|Newer generation; better instruction-following than same-size qwen2.5; untested with this agent
 # VLM entries apply to CAPTION_ADAPTER=ollamavlm (vision served by your
 # Ollama). Note: 'moondream' here is Ollama's moondream2 (~1.8b) — the
 # separate moondream-adapter container ships the smaller 0.5b-int8 build.
-vlm|moondream|3|yes|fast|Edge-optimized VQA: answers questions about the scene at low cost; the tested default
-vlm|gemma3:4b|4|no|medium|Well-rounded multimodal generalist; good scene descriptions and decent text reading for its size
+vlm|moondream|3|yes|fast|Edge-optimized VQA: answers questions about the scene at low cost; the tested low-RAM default
+vlm|gemma3:4b|4|yes|medium|Field-tested with this agent: clearly better scene answers than moondream; the suggested default where RAM allows
 vlm|qwen2.5vl:3b|5|no|medium|Strong scene understanding and the best READER of its size (signs, labels, plates); GPU recommended
+vlm|qwen3-vl:4b|5|no|medium|Newest Qwen vision family: strong all-round scene answers and text reading; untested with this agent
 vlm|minicpm-v|6|no|medium|OCR standout: reads dense or small text (delivery labels, screens) better than most; 8b-class
 vlm|llava:7b|6|no|slower|The classic general VQA: most descriptive free-form answers; weaker at reading text than qwen2.5vl
 vlm|llama3.2-vision:11b|9|no|slowest|Strongest scene reasoning of the set; heavy — really wants a GPU with headroom

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -512,18 +512,20 @@ function Choose-Example {
                 try { & nvidia-smi -L *> $null; if ($LASTEXITCODE -eq 0) { $accel = 'cuda' } } catch {}
             }
         }
-        # Ceiling = the tested envelope: never suggest beyond qwen2.5:3b
-        # (the largest model this agent is exercised with); bigger-is-
-        # runnable is detectable, bigger-is-better is not. VLM default is
-        # ALWAYS moondream — an untested model through the new ollamavlm
-        # adapter would stack unknowns; headroom is advertised in the
-        # prompt note instead.
+        # Ceiling = the tested envelope. qwen3:1.7b is field-tested with
+        # this agent and answers BETTER than the qwen2.5 set at similar
+        # speed (~3 GB; the shipped configs disable its thinking mode), so
+        # it is the suggestion wherever RAM allows. Likewise gemma3:4b was
+        # field-tested through ollamavlm and clearly beats moondream, so
+        # it is the VLM suggestion on >= 8 GB; moondream stays the tested
+        # low-RAM pick. Bigger-is-runnable is detectable, bigger-is-better
+        # is not — untested headroom stays a prompt note, never a default.
         $llmSuggest = if ($accel -ne 'cpu') {
-            if ($ramGb -ge 16) { 'qwen2.5:3b' } else { 'qwen2.5:1.5b' }
+            if ($ramGb -ge 8) { 'qwen3:1.7b' } else { 'qwen2.5:1.5b' }
         } else {
-            if ($ramGb -ge 16 -and $cores -ge 8) { 'qwen2.5:1.5b' } else { 'qwen2.5:0.5b' }
+            if ($ramGb -ge 16 -and $cores -ge 8) { 'qwen3:1.7b' } else { 'qwen2.5:0.5b' }
         }
-        $vlmSuggest = 'moondream'
+        $vlmSuggest = if ($ramGb -ge 8) { 'gemma3:4b' } else { 'moondream' }
         $hwDesc = "$(if ($accel -eq 'cuda') { 'NVIDIA GPU (CUDA), ' } else { 'CPU only, ' })$ramGb GB RAM, $cores cores"
         Ok "Detected: $hwDesc -> suggesting $llmSuggest"
 
@@ -565,7 +567,7 @@ function Choose-Example {
             'Describes what a camera sees. ollamavlm proxies to your Ollama (GPU-fast when the LLM runs on this machine - the default in that case; needs an adapter tag newer than 0.1.3); moondream/blip run inside Docker (moondream answers questions, blip writes plain captions).' 'yes' `
             'moondream | blip | ollamavlm - all local.'
         if ((Get-EnvValue CAPTION_ADAPTER) -eq 'ollamavlm') {
-            Explain 'Multimodal Ollama model the ollamavlm adapter uses for scene questions; the adapter auto-pulls it. moondream is the tested default.' 'yes' $vlmSuggest
+            Explain 'Multimodal Ollama model the ollamavlm adapter uses for scene questions; the adapter auto-pulls it. gemma3:4b (tested - clearly better answers) is suggested where RAM allows; moondream is the tested low-RAM pick.' 'yes' $vlmSuggest
             Set-EnvValue OLLAMA_VLM_MODEL (Pick-ModelFromCatalog 'vlm' $vlmSuggest 'Vision model (Ollama)' $ramGb)
         }
     } else {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -400,31 +400,37 @@ detect_llm_hardware() {
 #     tools noticeably, so tiny tiers are only suggested where latency
 #     would otherwise make it unusable.
 #   * CEILING — the tested envelope: suggestions never exceed the
-#     largest model this agent has been exercised with (qwen2.5:3b).
-#     "This hardware CAN run a bigger model" is detectable; "bigger
-#     will be BETTER for this agent's tool-calling and voice latency"
-#     is not — 7b doubles latency for untested gain, so machines with
-#     headroom get it as a note to try, never as the default.
-# Staying inside one family (qwen2.5) keeps the chat template and
-# tool-call format identical across tiers.
+#     largest model this agent has been exercised with. That envelope
+#     now includes qwen3:1.7b, field-tested against qwen2.5 with this
+#     agent and giving BETTER answers at similar speed (~3 GB), so it
+#     is the suggestion wherever RAM allows. "This hardware CAN run a
+#     bigger model" is detectable; "bigger will be BETTER for this
+#     agent's tool-calling and voice latency" is not — 7b doubles
+#     latency for untested gain, so machines with headroom get it as a
+#     note to try, never as the default.
+# qwen3 is a "thinking" family; the shipped configs set llm_think:false
+# so it answers snappily — the chat template difference vs qwen2.5 is
+# handled by Ollama's per-model templates, not by us.
 suggest_llm_model() {
     if [[ "$HW_ACCEL" != "cpu" ]]; then
-        if (( HW_RAM_GB >= 16 )); then echo "qwen2.5:3b"
+        if (( HW_RAM_GB >= 8 )); then echo "qwen3:1.7b"
         else echo "qwen2.5:1.5b"; fi
     else
-        if   (( HW_RAM_GB >= 16 && HW_CORES >= 8 )); then echo "qwen2.5:1.5b"
+        if   (( HW_RAM_GB >= 16 && HW_CORES >= 8 )); then echo "qwen3:1.7b"
         else echo "qwen2.5:0.5b"; fi
     fi
 }
 
 # suggest_vlm_model → caption/VQA model for CAPTION_ADAPTER=ollamavlm.
-# ALWAYS moondream: it is the project's tested VQA default, and the
-# ollamavlm adapter is itself new — defaulting an untested model
-# through a new adapter based on a RAM check would stack unknowns.
-# Capable machines are told (in the prompt note) that qwen2.5vl:3b is
-# worth trying; that stays an operator decision.
+# gemma3:4b was field-tested with this agent through ollamavlm and gives
+# clearly better scene answers than moondream, so it is the suggestion
+# wherever RAM allows (~4 GB working set + headroom). moondream stays the
+# low-RAM default: still tested, still cheap. Capable machines are told
+# (in the prompt note) that qwen2.5vl:3b is the better text READER;
+# trying it stays an operator decision.
 suggest_vlm_model() {
-    echo "moondream"
+    if (( HW_RAM_GB >= 8 )); then echo "gemma3:4b"
+    else echo "moondream"; fi
 }
 
 # ── Catalog-driven model menu ───────────────────────────────────────
@@ -626,7 +632,7 @@ choose_example() {
             "moondream | blip | ollamavlm — all local."
         # ollamavlm chosen → suggest a VLM sized like the LLM was.
         if [[ "$(env_get CAPTION_ADAPTER)" == "ollamavlm" ]]; then
-            explain "Multimodal Ollama model the ollamavlm adapter uses for scene questions; the adapter auto-pulls it. moondream is the tested default." \
+            explain "Multimodal Ollama model the ollamavlm adapter uses for scene questions; the adapter auto-pulls it. gemma3:4b (tested — clearly better answers) is suggested where RAM allows; moondream is the tested low-RAM pick." \
                 "yes" "$vlm_suggest"
             pick_model_from_catalog vlm "$vlm_suggest" "Vision model (Ollama)"
             env_set OLLAMA_VLM_MODEL "$PICKED_MODEL"


### PR DESCRIPTION
…are-sized defaults

The qwen3:1.7b (LLM) + gemma3:4b (vision via ollamavlm) pair was field-tested with the camera agent against the qwen2.5 + moondream defaults and gives clearly better answers at similar cost — so it enters the tested envelope and becomes the installer suggestion where hardware allows:

- model_catalog.txt: both marked tested with honest summaries; tested entries reordered first; qwen3-vl:4b added as a new untested option.
- install.sh / install.ps1: suggest_llm_model tiers pick qwen3:1.7b on GPU boxes >= 8 GB and strong CPU boxes (>= 16 GB + 8 cores); suggest_vlm_model is now hardware-aware — gemma3:4b >= 8 GB RAM, moondream below (still tested, still the low-RAM pick). Prompt notes updated to match.
- MODELS_AND_LATENCY.md: defaults table + both catalog tables synced; the promotion path documented (tested against the old defaults, found better, then promoted — never RAM arithmetic).
- .env.example: OLLAMA_MODEL / OLLAMA_VLM_MODEL comments name the field-tested picks (static defaults stay the low-RAM-safe ones; the installer writes the sized suggestion).

Agent suite: 627 passed, 7 skipped (branch is off main; PR #311's tests land separately).