### PR TITLE
fix(installer): skip the bundled ollama pull when an external LLM is set

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -621,7 +621,15 @@ function Pull-AndBuild {
     Check-DockerVmAllowance
     $script:ComposeArgs = @('-f', $BaseCompose)
     if ($script:ExampleCompose) {
-        $script:ComposeArgs += @('-f', $script:ExampleCompose, '--profile', $script:ExampleProfile)
+        $script:ComposeArgs += @('-f', $script:ExampleCompose)
+        # External-LLM overlay, same condition as Get-ComposeArgs in start.ps1.
+        # Without it the bundled ollama/ollama-model-pull services are still
+        # in an ACTIVE profile here, so `pull` downloads the 3.7 GB
+        # ollama/ollama image for containers the launcher then never starts.
+        if ((Get-EnvValue OLLAMA_EXTERNAL_URL) -and $script:ExampleCompose -like '*camera-agent.yml') {
+            $script:ComposeArgs += @('-f', 'docker-compose.camera-agent.external-llm.yml')
+        }
+        $script:ComposeArgs += @('--profile', $script:ExampleProfile)
         Info "Pulling images for $script:ExampleName..."
         docker compose @script:ComposeArgs pull --ignore-buildable
         if ($LASTEXITCODE -ne 0) { Fail "Failed to pull $script:ExampleName" }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -702,7 +702,15 @@ pull_and_build() {
     check_docker_vm_allowance
     COMPOSE_ARGS=(-f "$BASE_COMPOSE")
     if [[ -n "$EXAMPLE_COMPOSE" ]]; then
-        COMPOSE_ARGS+=(-f "$EXAMPLE_COMPOSE" --profile "$EXAMPLE_PROFILE")
+        COMPOSE_ARGS+=(-f "$EXAMPLE_COMPOSE")
+        # External-LLM overlay, same condition as compose_args in start.sh.
+        # Without it the bundled ollama/ollama-model-pull services are still
+        # in an ACTIVE profile here, so `pull` downloads the 3.7 GB
+        # ollama/ollama image for containers the launcher then never starts.
+        if [[ -n "$(env_get OLLAMA_EXTERNAL_URL)" && "$EXAMPLE_COMPOSE" == *camera-agent.yml ]]; then
+            COMPOSE_ARGS+=(-f docker-compose.camera-agent.external-llm.yml)
+        fi
+        COMPOSE_ARGS+=(--profile "$EXAMPLE_PROFILE")
         info "Pulling images for $EXAMPLE_NAME..."
         docker compose "${COMPOSE_ARGS[@]}" pull --ignore-buildable
     fi


### PR DESCRIPTION
pull_and_build / Pull-AndBuild built their Compose args from the base file plus the example manifest only, never appending the external-LLM overlay. So even after the installer prints "The bundled ollama container will be skipped entirely", ollama and ollama-model-pull were still in an active profile at pull time and `docker compose pull` downloaded the 3.7 GB ollama/ollama image for containers the launcher then parks on the inert external-llm-inert profile and never starts.

Mirror the condition the launchers already use (compose_args in start.sh, Get-ComposeArgs in start.ps1): append
docker-compose.camera-agent.external-llm.yml when OLLAMA_EXTERNAL_URL is set and the chosen example is the camera-agent manifest. The overlay has to land after the example file and before --profile, so COMPOSE_ARGS is now built in three steps instead of one.

The following `docker compose build` picks this up too — a no-op today since neither ollama service builds, but it closes the same gap.