### PR TITLE
fix(detect-pipeline): land visits in the events store, and survive core outages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,13 @@ DETECT_DECODE_SKIP=nonref
 # a big machine.
 DETECT_DECODE_THREADS=2
 
+# RTSP socket-I/O timeout in seconds (0 disables). ffmpeg has NO read timeout
+# by default, so a half-open TCP session — camera powered off mid-stream, or a
+# NAT/firewall silently dropping the flow — leaves the decode blocked forever:
+# ffmpeg never exits, the restart loop never runs, and the camera is dead with
+# nothing in the logs. Raise it for a camera with a very bursty feed.
+DETECT_RTSP_TIMEOUT_S=10
+
 # Opt-in decode shortcut: skip the h264/h265 in-loop deblocking filter
 # (-skip_loop_filter all -flags2 fast). Deblocking exists for VIEWING
 # quality — detection is robust to the slight blockiness — but decoded

--- a/detect-pipeline/detect_pipeline/events_poster.py
+++ b/detect-pipeline/detect_pipeline/events_poster.py
@@ -23,6 +23,7 @@ import base64
 import json
 import logging
 import queue
+import re
 import threading
 import urllib.request
 from dataclasses import dataclass
@@ -45,6 +46,33 @@ class Visit:
     ended_at: datetime
     stationary: bool | None
     jpeg: bytes | None
+    # Core's numeric Camera.id — what the events endpoint keys on. The
+    # pipeline-facing camera_id is the provider's string handle ("cam1"),
+    # which is NOT the DB id; core sends the real one separately as
+    # ``open_nvr_camera_id``. None → derived from camera_id at post time.
+    nvr_camera_id: int | None = None
+
+
+def _core_camera_id(v: Visit) -> int:
+    """The numeric camera id core's events endpoint expects.
+
+    Prefers the explicit ``nvr_camera_id`` threaded from the provider;
+    falls back to parsing the string handle ("cam1"/"cam-1"/"1" → 1) so
+    visits from older specs still land instead of failing on int('cam1').
+    The fallback is a guess about a format core owns, so it WARNs — a
+    handle whose digits are not the DB id would file history under the
+    wrong camera.
+    """
+    if v.nvr_camera_id is not None:
+        return v.nvr_camera_id
+    m = re.fullmatch(r"(?:cam[-_]?)?(\d+)", str(v.camera_id).strip())
+    if m is None:
+        raise ValueError(f"no numeric core camera id for {v.camera_id!r}")
+    log.warning(
+        "visit for %s posted with handle-parsed camera id %s — spec carried "
+        "no open_nvr_camera_id", v.camera_id, m.group(1),
+    )
+    return int(m.group(1))
 
 
 class VisitPoster:
@@ -102,7 +130,7 @@ class VisitPoster:
 
     def _post(self, v: Visit) -> None:
         body = {
-            "camera_id": int(v.camera_id),
+            "camera_id": _core_camera_id(v),
             "label": v.label,
             "score": v.score,
             "track_id": str(v.track_id),
@@ -134,8 +162,15 @@ class VisitLifecycle:
     ``min_duration_s`` — flickers never become history rows.
     """
 
-    def __init__(self, camera_id: str, *, min_duration_s: float = 1.0) -> None:
+    def __init__(
+        self,
+        camera_id: str,
+        *,
+        nvr_camera_id: int | None = None,
+        min_duration_s: float = 1.0,
+    ) -> None:
         self.camera_id = camera_id
+        self.nvr_camera_id = nvr_camera_id
         self.min_duration_s = min_duration_s
         self._live: dict = {}
 
@@ -188,6 +223,7 @@ class VisitLifecycle:
                 jpeg = None  # a visit without a photo still beats no history
         return Visit(
             camera_id=self.camera_id,
+            nvr_camera_id=self.nvr_camera_id,
             label=str(v["label"]),
             score=v["score"],
             track_id=str(tid),

--- a/detect-pipeline/detect_pipeline/events_poster.py
+++ b/detect-pipeline/detect_pipeline/events_poster.py
@@ -59,16 +59,17 @@ def _core_camera_id(v: Visit) -> int:
     Prefers the explicit ``nvr_camera_id`` threaded from the provider;
     falls back to parsing the string handle ("cam1"/"cam-1"/"1" → 1) so
     visits from older specs still land instead of failing on int('cam1').
-    The fallback is a guess about a format core owns, so it WARNs — a
-    handle whose digits are not the DB id would file history under the
-    wrong camera.
+    The fallback is a guess about a format core owns — a handle whose
+    digits are not the DB id would file history under the wrong camera —
+    but the provider already WARNed once per camera when the spec lost its
+    id, so per-visit noise stays at debug.
     """
     if v.nvr_camera_id is not None:
         return v.nvr_camera_id
     m = re.fullmatch(r"(?:cam[-_]?)?(\d+)", str(v.camera_id).strip())
     if m is None:
         raise ValueError(f"no numeric core camera id for {v.camera_id!r}")
-    log.warning(
+    log.debug(
         "visit for %s posted with handle-parsed camera id %s — spec carried "
         "no open_nvr_camera_id", v.camera_id, m.group(1),
     )

--- a/detect-pipeline/detect_pipeline/events_poster.py
+++ b/detect-pipeline/detect_pipeline/events_poster.py
@@ -29,6 +29,8 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from .metrics import record_visit_dropped, record_visit_posted
+
 log = logging.getLogger("detect_pipeline.events")
 
 EVENTS_PATH = "/api/v1/internal/camera-agent/events"
@@ -104,6 +106,7 @@ class VisitPoster:
             return True
         except queue.Full:
             self._dropped += 1
+            record_visit_dropped(visit.camera_id, "queue_full")
             log.warning(
                 "visit queue full — dropped %s/%s (total dropped: %d)",
                 visit.camera_id, visit.track_id, self._dropped,
@@ -123,7 +126,15 @@ class VisitPoster:
             visit = self._q.get()
             try:
                 self._post(visit)
+                record_visit_posted(visit.camera_id)
             except Exception as e:
+                # A post failure is PERMANENT history loss — there is no retry
+                # queue — so it is counted, not just logged. The reason label
+                # separates "core is down" from "this visit can never be
+                # posted" (an unresolvable camera id), which look identical
+                # in the log.
+                reason = "unresolved_camera" if isinstance(e, ValueError) else "post_failed"
+                record_visit_dropped(visit.camera_id, reason)
                 log.warning(
                     "visit post failed for %s/%s: %s",
                     visit.camera_id, visit.track_id, e,
@@ -211,7 +222,15 @@ class VisitLifecycle:
 
     def _finish(self, tid, v) -> Visit | None:
         end = v.get("end", v["start"])
-        if not v["confirmed"] or (end - v["start"]) < self.min_duration_s:
+        if not v["confirmed"]:
+            record_visit_dropped(self.camera_id, "unconfirmed")
+            return None
+        if (end - v["start"]) < self.min_duration_s:
+            # Junk suppression is deliberate, but it was previously invisible:
+            # there was no way to tell "nothing happened" from "the floor is
+            # eating every real visit" — which is what a raised DETECT_FPS
+            # does, since confirmation then needs more consecutive frames.
+            record_visit_dropped(self.camera_id, "too_short")
             return None
         jpeg = None
         crop = v.get("crop")

--- a/detect-pipeline/detect_pipeline/ffmpeg_presets.py
+++ b/detect-pipeline/detect_pipeline/ffmpeg_presets.py
@@ -148,6 +148,26 @@ DECODE_SKIP_MODES = ("none", "bidir", "nonref", "nokey")
 _FFMPEG_SKIP_TOKEN = {"nonref": "noref"}
 
 
+# Socket-I/O timeout for RTSP reads. Without it, a half-open TCP session — a
+# camera powered off mid-stream, a NAT/firewall dropping the flow — leaves the
+# read blocked FOREVER: ffmpeg never exits, so the restart loop never runs and
+# the camera is silently dead until the process is restarted.
+#
+# The flag is ``-timeout`` (microseconds) on the rtsp demuxer, NOT
+# ``-rw_timeout``: verified against the shipped image (ffmpeg 7.1.5), where
+# ``-timeout 3000000`` reaches the transport as ``tcp://...?timeout=3000000``
+# while ``-rw_timeout`` arrives as ``timeout=0`` — accepted, and silently
+# doing nothing. Neither errors, so this is only catchable by inspection.
+DEFAULT_RTSP_TIMEOUT_S = 10.0
+
+
+def rtsp_timeout_args(timeout_s: float = DEFAULT_RTSP_TIMEOUT_S) -> list[str]:
+    """``-timeout`` in microseconds, or nothing when disabled (<= 0)."""
+    if timeout_s <= 0:
+        return []
+    return ["-timeout", str(int(timeout_s * 1_000_000))]
+
+
 def build_decode_command(
     rtsp_url: str,
     *,
@@ -158,6 +178,7 @@ def build_decode_command(
     device: str = "/dev/dri/renderD128",
     codec: str = "h264",
     rtsp_transport: str = "tcp",
+    rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S,
     decode_skip: str = "none",
     decode_threads: int = 2,
     fast_decode: bool = False,
@@ -201,6 +222,7 @@ def build_decode_command(
         "-hide_banner",
         "-loglevel", "warning",
         "-rtsp_transport", rtsp_transport,
+        *rtsp_timeout_args(rtsp_timeout_s),
         *thread_args,
         *skip_args,
         *fast_args,

--- a/detect-pipeline/detect_pipeline/frame_source.py
+++ b/detect-pipeline/detect_pipeline/frame_source.py
@@ -90,6 +90,18 @@ def _default_spawn(argv: list[str]) -> "subprocess.Popen[bytes]":
     return subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
+def redact_url(url: str) -> str:
+    """Drop the query string from a stream URL before logging it.
+
+    The MediaMTX tap URL carries a signed ``?jwt=`` granting wildcard read
+    access to every camera. Logging it verbatim writes a live credential to
+    disk and to any log shipper — and buries the actual message under a
+    900-character token. Path is kept; secrets are not.
+    """
+    base, sep, _query = str(url).partition("?")
+    return f"{base}?<redacted>" if sep else base
+
+
 class _StderrTail:
     """Drain an ffmpeg process's stderr on a daemon thread, keeping the tail.
 
@@ -157,6 +169,7 @@ class FrameSource:
         fast_decode: bool = False,
         rtsp_transport: str = "tcp",
         rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S,
+        url_provider: Callable[[], str | None] | None = None,
         spawn: SpawnFn | None = None,
         max_restarts: int | None = None,
         max_fruitless_restarts: int = 5,
@@ -174,6 +187,12 @@ class FrameSource:
         self.codec = codec
         self.rtsp_transport = rtsp_transport
         self.rtsp_timeout_s = rtsp_timeout_s
+        # Optional "give me the current URL for this camera" callback, checked
+        # before each respawn. The tap URL embeds a 60-MINUTE JWT resolved at
+        # worker start, so without this every respawn past the first hour
+        # re-authenticates with a dead token and 401s — the camera can only
+        # recover by dying and waiting for a reconcile tick.
+        self._url_provider = url_provider
         self.decode_skip = decode_skip
         self.decode_threads = decode_threads
         self.fast_decode = fast_decode
@@ -222,6 +241,28 @@ class FrameSource:
         if self._current_proc is not None:
             _terminate(self._current_proc)
 
+    def _refresh_url(self) -> None:
+        """Adopt the freshest known URL for this camera, if one is offered.
+
+        Cheap and best-effort: the manager hands over the URL it already
+        fetched on its last reconcile, so this costs no I/O. It is what lets
+        an expired tap JWT heal on the next respawn instead of 401-ing until
+        the worker dies and a reconcile tick rebuilds it.
+        """
+        if self._url_provider is None:
+            return
+        try:
+            fresh = self._url_provider()
+        except Exception:  # pragma: no cover - defensive
+            log.debug("frame source: url provider failed", exc_info=True)
+            return
+        if fresh and fresh != self.rtsp_url:
+            log.info(
+                "frame source for %s: adopted refreshed URL",
+                redact_url(self.rtsp_url),
+            )
+            self.rtsp_url = fresh
+
     def stream(self) -> Iterator[Frame]:
         """Yield frames until the source is unrecoverable.
 
@@ -235,6 +276,7 @@ class FrameSource:
         restarts = 0
         fruitless = 0
         while True:
+            self._refresh_url()
             proc = self._spawn(self.command())
             self._current_proc = proc
             stderr_tail = _StderrTail(getattr(proc, "stderr", None))
@@ -269,7 +311,7 @@ class FrameSource:
                         "frame source for %s: %d consecutive restarts with no "
                         "healthy session (dead stream or expired ticket) — giving "
                         "up so the worker is resurrected with a fresh URL%s",
-                        self.rtsp_url, fruitless,
+                        redact_url(self.rtsp_url), fruitless,
                         f"; ffmpeg said: {reason}" if reason else "",
                     )
                     return
@@ -280,7 +322,7 @@ class FrameSource:
                 # Restart immediately, quietly — no backoff, no penalty.
                 self._skip_backoff_once = False
                 log.info("frame source for %s: decode mode -> %s",
-                         self.rtsp_url, self.decode_skip)
+                         redact_url(self.rtsp_url), self.decode_skip)
                 continue
             # Escalating backoff, capped. A flat delay meant a stream failing
             # instantly was re-dialled at a fixed rate forever, each cycle a
@@ -291,7 +333,7 @@ class FrameSource:
             )
             log.warning(
                 "frame source for %s ended; restart #%d (retry in %.1fs)%s",
-                self.rtsp_url, restarts, delay,
+                redact_url(self.rtsp_url), restarts, delay,
                 f"; ffmpeg said: {reason}" if reason else "",
             )
             self._sleep(delay)
@@ -311,15 +353,15 @@ class VideoFileSource:
         self.max_frames = max_frames
 
     def set_decode_skip(self, mode: str) -> None:
-        """Adaptive decode: change the skip mode for the NEXT ffmpeg spawn and
-        terminate the current process so the built-in restart loop picks the
-        new mode up immediately (without the restart backoff — this is a
-        deliberate flip, not a stream failure). Called from the same worker
-        thread that consumes ``stream()``, between frames."""
+        """No-op: OpenCV decodes every frame, so there is no skip mode.
+
+        This used to be a copy of FrameSource's version, referencing
+        ``_current_proc``/``_skip_backoff_once`` — attributes this class never
+        defines — so calling it raised AttributeError. Unreachable only
+        because the worker gates adaptive decode on the ffmpeg path; accepting
+        and ignoring the call is the honest behaviour for a file source.
+        """
         self.decode_skip = mode
-        self._skip_backoff_once = True
-        if self._current_proc is not None:
-            _terminate(self._current_proc)
 
     def stream(self) -> Iterator[Frame]:
         import cv2  # local import: only the demo path needs OpenCV here

--- a/detect-pipeline/detect_pipeline/frame_source.py
+++ b/detect-pipeline/detect_pipeline/frame_source.py
@@ -16,11 +16,19 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import threading
 import time
+from collections import deque
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 
-from .ffmpeg_presets import HwAccel, build_decode_command, frame_size_bytes
+from .ffmpeg_presets import (
+    DEFAULT_RTSP_TIMEOUT_S,
+    HwAccel,
+    build_decode_command,
+    frame_size_bytes,
+    rtsp_timeout_args,
+)
 
 log = logging.getLogger("detect_pipeline.frame_source")
 
@@ -82,6 +90,42 @@ def _default_spawn(argv: list[str]) -> "subprocess.Popen[bytes]":
     return subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
+class _StderrTail:
+    """Drain an ffmpeg process's stderr on a daemon thread, keeping the tail.
+
+    stderr is a pipe with a ~64KB kernel buffer. ffmpeg at ``-loglevel
+    warning`` chatters on a lossy RTSP feed, and if NOBODY reads that pipe it
+    fills, ffmpeg BLOCKS writing to it, and it stops producing frames on
+    stdout — a permanent stall that looks exactly like a dead camera and gets
+    worse the flakier the feed is. Draining is what keeps the decoder alive.
+
+    Keeping the last few lines is the second half: "source ended" with
+    ffmpeg's own reason attached is diagnosable; without it, every failure
+    (401, refused, unsupported codec, timeout) reads identically.
+    """
+
+    def __init__(self, stream, *, keep: int = 6) -> None:
+        self._lines: deque[str] = deque(maxlen=keep)
+        self._stream = stream
+        if stream is None:          # injected fake proc in tests
+            return
+        threading.Thread(
+            target=self._drain, name="ffmpeg-stderr", daemon=True
+        ).start()
+
+    def _drain(self) -> None:
+        try:
+            for raw in iter(self._stream.readline, b""):
+                line = raw.decode("utf-8", "replace").strip()
+                if line:
+                    self._lines.append(line)
+        except Exception:  # pragma: no cover - pipe torn down on terminate
+            pass
+
+    def text(self) -> str:
+        return " | ".join(self._lines)
+
+
 def _terminate(proc) -> None:
     """Best-effort teardown of an ffmpeg process."""
     try:
@@ -111,10 +155,14 @@ class FrameSource:
         decode_skip: str = "none",
         decode_threads: int = 2,
         fast_decode: bool = False,
+        rtsp_transport: str = "tcp",
+        rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S,
         spawn: SpawnFn | None = None,
         max_restarts: int | None = None,
         max_fruitless_restarts: int = 5,
         backoff_seconds: float = 1.0,
+        max_backoff_seconds: float = 15.0,
+        min_healthy_seconds: float = 5.0,
         _sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         self.rtsp_url = rtsp_url
@@ -124,6 +172,8 @@ class FrameSource:
         self.hwaccel = hwaccel
         self.device = device
         self.codec = codec
+        self.rtsp_transport = rtsp_transport
+        self.rtsp_timeout_s = rtsp_timeout_s
         self.decode_skip = decode_skip
         self.decode_threads = decode_threads
         self.fast_decode = fast_decode
@@ -137,6 +187,10 @@ class FrameSource:
         # resurrects it with a FRESH tap URL from the provider.
         self.max_fruitless_restarts = max_fruitless_restarts
         self.backoff_seconds = backoff_seconds
+        self.max_backoff_seconds = max_backoff_seconds
+        # How long a session must last to count as "the stream works". Below
+        # this, a restart is treated as fruitless (see stream()).
+        self.min_healthy_seconds = min_healthy_seconds
         self._sleep = _sleep
         self._current_proc = None
         self._skip_backoff_once = False
@@ -150,6 +204,8 @@ class FrameSource:
             hwaccel=self.hwaccel,
             device=self.device,
             codec=self.codec,
+            rtsp_transport=self.rtsp_transport,
+            rtsp_timeout_s=self.rtsp_timeout_s,
             decode_skip=self.decode_skip,
             decode_threads=self.decode_threads,
             fast_decode=self.fast_decode,
@@ -181,7 +237,9 @@ class FrameSource:
         while True:
             proc = self._spawn(self.command())
             self._current_proc = proc
+            stderr_tail = _StderrTail(getattr(proc, "stderr", None))
             got_frame = False
+            started = time.monotonic()
             try:
                 for frame in read_frames(proc.stdout, self.width, self.height):
                     got_frame = True
@@ -189,26 +247,54 @@ class FrameSource:
             finally:
                 self._current_proc = None
                 _terminate(proc)
-            fruitless = 0 if got_frame else fruitless + 1
-            if fruitless >= self.max_fruitless_restarts:
-                log.error(
-                    "frame source for %s: %d consecutive restarts with no frames "
-                    "(dead stream or expired ticket) — giving up so the worker "
-                    "is resurrected with a fresh URL",
-                    self.rtsp_url, fruitless,
+            reason = stderr_tail.text()
+            # A decode-mode flip terminates ffmpeg ON PURPOSE (adaptive
+            # decode). It is not a stream failure, so it must not touch the
+            # give-up budget at all — otherwise a camera whose scene keeps
+            # waking it would be killed as though its feed were dead.
+            deliberate = self._skip_backoff_once
+            if not deliberate:
+                # A session only clears the give-up counter if it actually
+                # STAYED up. Counting any single frame as healthy (the old
+                # rule) let a stream that connects, emits one frame and drops
+                # reset the counter forever — an unbounded restart loop that
+                # never reaches give-up and so never gets a fresh URL.
+                healthy = (
+                    got_frame
+                    and (time.monotonic() - started) >= self.min_healthy_seconds
                 )
-                return
+                fruitless = 0 if healthy else fruitless + 1
+                if fruitless >= self.max_fruitless_restarts:
+                    log.error(
+                        "frame source for %s: %d consecutive restarts with no "
+                        "healthy session (dead stream or expired ticket) — giving "
+                        "up so the worker is resurrected with a fresh URL%s",
+                        self.rtsp_url, fruitless,
+                        f"; ffmpeg said: {reason}" if reason else "",
+                    )
+                    return
             if self.max_restarts is not None and restarts >= self.max_restarts:
                 return
             restarts += 1
-            if self._skip_backoff_once:
-                # Deliberate decode-mode flip — restart immediately, quietly.
+            if deliberate:
+                # Restart immediately, quietly — no backoff, no penalty.
                 self._skip_backoff_once = False
                 log.info("frame source for %s: decode mode -> %s",
                          self.rtsp_url, self.decode_skip)
                 continue
-            log.warning("frame source for %s ended; restart #%d", self.rtsp_url, restarts)
-            self._sleep(self.backoff_seconds)
+            # Escalating backoff, capped. A flat delay meant a stream failing
+            # instantly was re-dialled at a fixed rate forever, each cycle a
+            # full ffmpeg spawn + RTSP handshake; healthy sessions reset it.
+            delay = min(
+                self.backoff_seconds * (2 ** max(0, fruitless - 1)),
+                self.max_backoff_seconds,
+            )
+            log.warning(
+                "frame source for %s ended; restart #%d (retry in %.1fs)%s",
+                self.rtsp_url, restarts, delay,
+                f"; ffmpeg said: {reason}" if reason else "",
+            )
+            self._sleep(delay)
 
 
 class VideoFileSource:
@@ -275,12 +361,23 @@ def _parse_ffprobe(text: str) -> tuple[int, int, float]:
 
 
 def probe_stream(
-    url: str, *, rtsp_transport: str = "tcp", timeout: float = 15.0
+    url: str,
+    *,
+    rtsp_transport: str = "tcp",
+    timeout: float = 15.0,
+    rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S,
 ) -> tuple[int, int, float] | None:
-    """Return (width, height, fps) of a stream via ffprobe, or None on failure."""
+    """Return (width, height, fps) of a stream via ffprobe, or None on failure.
+
+    Failure is logged with ffprobe's own reason: "could not probe" alone
+    cannot distinguish a camera that is off from a rejected JWT from a tap
+    path MediaMTX isn't publishing, and the worker retries this every
+    reconcile tick until someone can tell which it is.
+    """
     cmd = [
         "ffprobe", "-v", "error",
         "-rtsp_transport", rtsp_transport,
+        *rtsp_timeout_args(rtsp_timeout_s),
         "-select_streams", "v:0",
         "-show_entries", "stream=width,height,avg_frame_rate",
         "-of", "json", url,
@@ -288,7 +385,15 @@ def probe_stream(
     try:
         out = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         if out.returncode != 0 or not out.stdout.strip():
+            log.warning(
+                "ffprobe failed for %s (rc=%s): %s",
+                url, out.returncode, (out.stderr or "").strip() or "no output",
+            )
             return None
         return _parse_ffprobe(out.stdout)
-    except Exception:
+    except subprocess.TimeoutExpired:
+        log.warning("ffprobe timed out after %.0fs for %s", timeout, url)
+        return None
+    except Exception as e:
+        log.warning("ffprobe error for %s: %s", url, e)
         return None

--- a/detect-pipeline/detect_pipeline/health.py
+++ b/detect-pipeline/detect_pipeline/health.py
@@ -36,6 +36,12 @@ class HealthState:
     nats_connected: Callable[[], bool] = lambda: False
     workers_running: Callable[[], int] = lambda: 0
     newest_frame_age_s: Callable[[], float | None] = lambda: None
+    # Cameras whose own last frame is older than frame_stale_s. Reported by
+    # NAME because newest_frame_age_s is a fleet MAX: one healthy camera
+    # holds it near zero while every other feed is dead. Listing them does
+    # not by itself flip the service unhealthy — a camera being offline is
+    # normal operations, and alerting policy belongs on the metric.
+    stale_cameras: Callable[[float], list[str]] = lambda _threshold: []
     started_at: float = field(default_factory=time.time)
     frame_stale_s: float = 60.0
     startup_grace_s: float = 90.0
@@ -73,10 +79,20 @@ def evaluate(st: HealthState, now: float | None = None) -> tuple[bool, dict]:
                 f"(stale > {st.frame_stale_s:.0f}s)"
             )
 
+    stalled: list[str] = []
+    if workers > 0 and not in_grace:
+        try:
+            stalled = list(st.stale_cameras(st.frame_stale_s))
+        except Exception:  # pragma: no cover - never let a probe raise
+            stalled = []
+
     detail = {
         "status": "ok" if not problems else "unhealthy",
         "workers": workers,
         "newest_frame_age_s": None if age is None else round(age, 1),
+        # Named so a single dead feed in a healthy fleet is actionable
+        # instead of invisible behind the fleet-wide max.
+        "stale_cameras": stalled,
         "detector": {"requested": st.detector_requested, "actual": st.detector_actual},
         "nats": ("connected" if st.nats_connected() else "disconnected")
         if st.nats_configured else "unconfigured",

--- a/detect-pipeline/detect_pipeline/metrics.py
+++ b/detect-pipeline/detect_pipeline/metrics.py
@@ -148,7 +148,6 @@ def record_frame(
     stage_latency_s: dict[str, float] | None = None,
     model: str | None = None,
 ) -> None:
-    _last_frame_wall[camera_id] = time.time()
     """Emit Tier-0 per-frame metrics from a FrameResult (service layer).
 
     ``model`` (the active detector's identity, e.g. ``yolov8n``) labels the
@@ -158,6 +157,8 @@ def record_frame(
     decode/motion/track). ``tier0_detections_total{label}`` is per-class output
     volume — another axis for a model-vs-model comparison.
     """
+    with _frame_wall_lock:
+        _last_frame_wall[camera_id] = time.time()
     cam = {"camera": camera_id}
     # model-attributable label set (falls back to camera-only when unknown)
     mcam = {"camera": camera_id, "model": model} if model else cam
@@ -187,15 +188,38 @@ def record_frame(
 
 # Wall-clock time of the most recent processed frame per camera — the "are
 # frames actually flowing" signal /health uses. Module-level like ``metrics``.
+#
+# Guarded: N worker threads INSERT into this (a camera's first frame adds a
+# key) while the scrape thread iterates it. An unguarded insert during
+# iteration raises "dictionary changed size during iteration", which would
+# take out /metrics and /health together — and it fires precisely during
+# worker churn, when those endpoints are what you are looking at.
 _last_frame_wall: dict[str, float] = {}
+_frame_wall_lock = threading.Lock()
+
+
+def _frame_wall_snapshot() -> dict[str, float]:
+    with _frame_wall_lock:
+        return dict(_last_frame_wall)
+
+
+def forget_camera(camera_id: str) -> None:
+    """Drop a camera's frame-age entry (it left the desired set).
+
+    Without this the key lives forever and the camera is reported stale
+    indefinitely after it is deleted from core.
+    """
+    with _frame_wall_lock:
+        _last_frame_wall.pop(camera_id, None)
 
 
 def newest_frame_age_s(now: float | None = None) -> float | None:
     """Age in seconds of the newest frame across all cameras (None = none yet)."""
-    if not _last_frame_wall:
+    snap = _frame_wall_snapshot()
+    if not snap:
         return None
     now = time.time() if now is None else now
-    return max(0.0, now - max(_last_frame_wall.values()))
+    return max(0.0, now - max(snap.values()))
 
 
 def frame_ages_s(now: float | None = None) -> dict[str, float]:
@@ -206,7 +230,7 @@ def frame_ages_s(now: float | None = None) -> dict[str, float]:
     it cannot answer "is camera 2 still being analyzed?". This can.
     """
     now = time.time() if now is None else now
-    return {cam: max(0.0, now - t) for cam, t in _last_frame_wall.items()}
+    return {cam: max(0.0, now - t) for cam, t in _frame_wall_snapshot().items()}
 
 
 def stale_cameras(threshold_s: float, now: float | None = None) -> list[str]:

--- a/detect-pipeline/detect_pipeline/metrics.py
+++ b/detect-pipeline/detect_pipeline/metrics.py
@@ -198,6 +198,35 @@ def newest_frame_age_s(now: float | None = None) -> float | None:
     return max(0.0, now - max(_last_frame_wall.values()))
 
 
+def frame_ages_s(now: float | None = None) -> dict[str, float]:
+    """Per-camera age of the last processed frame.
+
+    The fleet-wide ``newest_frame_age_s`` takes the MAX across cameras, so a
+    single healthy camera keeps it near zero while every other feed is dead —
+    it cannot answer "is camera 2 still being analyzed?". This can.
+    """
+    now = time.time() if now is None else now
+    return {cam: max(0.0, now - t) for cam, t in _last_frame_wall.items()}
+
+
+def stale_cameras(threshold_s: float, now: float | None = None) -> list[str]:
+    """Cameras whose last frame is older than ``threshold_s``, sorted."""
+    return sorted(
+        cam for cam, age in frame_ages_s(now).items() if age > threshold_s
+    )
+
+
+def sample_frame_age_metrics(now: float | None = None) -> None:
+    """Refresh the per-camera frame-age gauge (call at scrape time).
+
+    Emitted on scrape rather than in the frame loop on purpose: a gauge only
+    written while frames flow FREEZES at its last good value when the feed
+    stalls, which is the exact moment it needs to move.
+    """
+    for cam, age in frame_ages_s(now).items():
+        metrics.gauge("tier0_frame_age_seconds", age, {"camera": cam})
+
+
 def record_mainstream_fallback(camera_id: str, active: bool) -> None:
     """Gauge: 1 while Tier-0 decodes a high-resolution main stream for this
     camera (no usable substream) — the expensive path the README warns about."""
@@ -207,6 +236,28 @@ def record_mainstream_fallback(camera_id: str, active: bool) -> None:
 
 def record_published(camera_id: str) -> None:
     metrics.inc("tier0_events_published_total", {"camera": camera_id})
+
+
+def record_sink_error(camera_id: str) -> None:
+    """A publish to the event bus raised. Without a counter, a bus outage
+    is indistinguishable from a quiet scene: both just stop incrementing
+    tier0_events_published_total."""
+    metrics.inc("tier0_sink_errors_total", {"camera": camera_id})
+
+
+def record_visit_dropped(camera_id: str, reason: str) -> None:
+    """A finished visit never reached the events store.
+
+    The poster module has always promised this counter in its docstring
+    ("failures are visible via tier0_visits_dropped_total") while nothing
+    emitted it — so silent, permanent history loss (a queue that stays
+    full, a post that always fails) showed up nowhere at all."""
+    metrics.inc("tier0_visits_dropped_total",
+                {"camera": camera_id, "reason": reason})
+
+
+def record_visit_posted(camera_id: str) -> None:
+    metrics.inc("tier0_visits_posted_total", {"camera": camera_id})
 
 
 def record_gate(camera_id: str, gate_result) -> None:
@@ -289,6 +340,7 @@ def serve_metrics(port: int = 9109, *, registry: Metrics | None = None,
             path = parsed.path.rstrip("/")
             if path in ("/metrics", ""):
                 sample_process_metrics(reg)      # refresh CPU%/RSS on each scrape
+                sample_frame_age_metrics()       # ...and per-camera staleness
                 self._send(200, reg.render().encode("utf-8"),
                            "text/plain; version=0.0.4")
                 return

--- a/detect-pipeline/detect_pipeline/providers.py
+++ b/detect-pipeline/detect_pipeline/providers.py
@@ -11,7 +11,8 @@ or the stored RTSP URL as a fallback). So the Tier-0 service needs **no new
 server endpoint**: it consumes the exact frame source OpenNVR already exposes.
 
 Stdlib-only (urllib); the opener is injectable for tests. Discovery failure
-returns ``[]`` so the manager keeps its current workers and retries next tick.
+returns ``None`` — distinct from ``[]`` (genuinely no cameras) — so the
+manager keeps its current workers and retries next tick.
 """
 from __future__ import annotations
 
@@ -45,17 +46,17 @@ class HttpCameraProvider:
         self._opener = opener or urllib.request.urlopen
         self.timeout = timeout
 
-    def list_cameras(self) -> list[CameraSpec]:
+    def list_cameras(self) -> list[CameraSpec] | None:
         req = urllib.request.Request(f"{self.base_url}{self.path}")
         if self.api_key:
             req.add_header("X-Internal-Api-Key", self.api_key)
         try:
             with self._opener(req, timeout=self.timeout) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
+            return [_to_spec(c) for c in data.get("cameras", [])]
         except Exception:
             log.warning("camera discovery failed at %s%s", self.base_url, self.path, exc_info=True)
-            return []
-        return [_to_spec(c) for c in data.get("cameras", [])]
+            return None
 
 
 def _default_fps() -> int:
@@ -152,12 +153,15 @@ def _to_spec(c: dict) -> CameraSpec:
     # is honoured if the endpoint ever adds per-camera opt-out.
     labels, assignment_analyze = _assignment_view(c)
     # Core's numeric Camera.id, sent alongside the "cam{id}" handle — the
-    # events store keys on the number (see CameraSpec.nvr_camera_id).
+    # events store keys on the number (see CameraSpec.nvr_camera_id). The
+    # str() round-trip rejects bools/floats (int(True) == 1 would file
+    # events under camera 1) instead of silently accepting them.
+    handle = str(c.get("camera_id"))
     try:
-        nvr_id = int(c["open_nvr_camera_id"])
+        nvr_id = int(str(c["open_nvr_camera_id"]))
+        _warned_no_nvr_id.discard(handle)   # healed — re-warn if it breaks again
     except (KeyError, TypeError, ValueError):
         nvr_id = None
-        handle = str(c.get("camera_id"))
         if handle not in _warned_no_nvr_id:
             _warned_no_nvr_id.add(handle)
             log.warning(

--- a/detect-pipeline/detect_pipeline/providers.py
+++ b/detect-pipeline/detect_pipeline/providers.py
@@ -140,13 +140,34 @@ def _assignment_view(c: dict) -> tuple[frozenset[str] | None, bool]:
     return labels, analyze
 
 
+# Cameras already warned about a missing/garbled open_nvr_camera_id — the
+# provider re-fetches every reconcile tick, so warn once per handle, not
+# once per 30 seconds.
+_warned_no_nvr_id: set[str] = set()
+
+
 def _to_spec(c: dict) -> CameraSpec:
     # The endpoint returns active cameras with a resolved ``frame_url``. All
     # active cameras are analyzed by default (on-by-default); an ``analyze`` flag
     # is honoured if the endpoint ever adds per-camera opt-out.
     labels, assignment_analyze = _assignment_view(c)
+    # Core's numeric Camera.id, sent alongside the "cam{id}" handle — the
+    # events store keys on the number (see CameraSpec.nvr_camera_id).
+    try:
+        nvr_id = int(c["open_nvr_camera_id"])
+    except (KeyError, TypeError, ValueError):
+        nvr_id = None
+        handle = str(c.get("camera_id"))
+        if handle not in _warned_no_nvr_id:
+            _warned_no_nvr_id.add(handle)
+            log.warning(
+                "camera %s: no usable open_nvr_camera_id (%r) — visit posts "
+                "will fall back to parsing the handle",
+                handle, c.get("open_nvr_camera_id"),
+            )
     return CameraSpec(
         camera_id=str(c["camera_id"]),
+        nvr_camera_id=nvr_id,
         name=c.get("name", str(c["camera_id"])),
         substream_url=c["frame_url"],
         analyze=bool(c.get("analyze", True)) and assignment_analyze,

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -518,7 +518,7 @@ def main() -> int:  # pragma: no cover - integration entrypoint
     # detecting nothing (the exact zombie QA found).
     detector_actual = type(_detector_factory(cfg)()).__name__
     from .health import HealthState, evaluate as health_evaluate
-    from .metrics import newest_frame_age_s
+    from .metrics import newest_frame_age_s, stale_cameras
     hstate = HealthState(
         enabled=cfg.enabled,
         detector_requested=cfg.detector,
@@ -527,6 +527,7 @@ def main() -> int:  # pragma: no cover - integration entrypoint
         nats_connected=nats_connected,
         workers_running=lambda: len(manager.running_ids()),
         newest_frame_age_s=newest_frame_age_s,
+        stale_cameras=stale_cameras,
     )
 
     # Effective config — one truthful block. Half of every support/QA thread

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -26,6 +26,10 @@ Env:
   DETECT_HWACCEL            cpu | vaapi | nvidia | qsv | rpi | rkmpp | jetson
   DETECT_DECODE_SKIP        nonref (default) | bidir | nokey | none (decode CPU dial)
   DETECT_DECODE_THREADS     ffmpeg decoder thread cap (default 2; 0 = auto)
+  DETECT_RTSP_TIMEOUT_S     RTSP socket-I/O timeout in seconds (default 10;
+                            0 disables). Without it a half-open TCP session
+                            blocks the decode FOREVER and the camera goes
+                            silently dead with no restart.
   DETECT_DECODE_FAST        true = skip h264 loop filter (CPU decode only; opt-in)
   DETECT_DECODE_IDLE        adaptive decode while quiet (default nokey; none = off)
   DETECT_DECODE_IDLE_AFTER  quiet seconds before idling (default 60)
@@ -42,6 +46,7 @@ import threading
 from dataclasses import dataclass
 
 from .bus import EventSink, GateEventSink
+from .ffmpeg_presets import DEFAULT_RTSP_TIMEOUT_S
 from .providers import HttpCameraProvider
 from .service import WorkerManager
 
@@ -93,6 +98,7 @@ class ServiceConfig:
     # kites/bananas endlessly; each becomes a standing track. 0.4 keeps real
     # people/vehicles (typically >0.6) while starving the phantom supply.
     detect_conf: float = 0.4
+    rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S
     visits_enabled: bool = True
 
 
@@ -153,6 +159,7 @@ def config_from_env(env: dict) -> ServiceConfig:
         device=env.get("DETECT_HWACCEL_DEVICE", "/dev/dri/renderD128"),
         decode_skip=_decode_skip_from_env(env),
         decode_threads=_env_int(env, "DETECT_DECODE_THREADS", 2),
+        rtsp_timeout_s=_env_float(env, "DETECT_RTSP_TIMEOUT_S", DEFAULT_RTSP_TIMEOUT_S),
         fast_decode=_truthy(env.get("DETECT_DECODE_FAST", "false")),
         decode_idle=_decode_idle_from_env(env),
         decode_idle_after=_env_float(env, "DETECT_DECODE_IDLE_AFTER", 60.0),
@@ -403,6 +410,7 @@ def build_manager(cfg: ServiceConfig, sink, *, gate_sink=None) -> WorkerManager:
         device=cfg.device,
         decode_skip=cfg.decode_skip,
         decode_threads=cfg.decode_threads,
+        rtsp_timeout_s=cfg.rtsp_timeout_s,
         fast_decode=cfg.fast_decode,
         decode_idle=cfg.decode_idle,
         decode_idle_after=cfg.decode_idle_after,

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -110,6 +110,11 @@ class CameraSpec:
     # ``assignments`` field; a change restarts the worker on the next
     # reconcile tick (see WorkerManager.reconcile).
     labels: frozenset[str] | None = None
+    # Core's numeric Camera.id (from the endpoint's ``open_nvr_camera_id``).
+    # camera_id above is the string handle ("cam1") used in topics/metrics —
+    # core's events store keys on this numeric id instead. Appended LAST so
+    # existing positional constructions keep their meaning.
+    nvr_camera_id: int | None = None
 
 
 def allowed_labels_for(spec: "CameraSpec") -> frozenset[str] | None:
@@ -309,7 +314,9 @@ class CameraWorker:
                 self.spec.camera_id, w, h,
             )
         from .events_poster import VisitLifecycle
-        lifecycle = VisitLifecycle(self.spec.camera_id)
+        lifecycle = VisitLifecycle(
+            self.spec.camera_id, nvr_camera_id=self.spec.nvr_camera_id
+        )
         motion = MotionDetector((h, w), MotionConfig())
         tracker = Tracker((h, w), TrackConfig(
             fps=self.spec.fps,
@@ -500,10 +507,11 @@ class WorkerManager:
         self._factory = worker_factory or self._default_factory
         self._workers: dict[str, Worker] = {}
         # The spec each running worker was built with — reconcile compares
-        # ONLY the fields a worker bakes in at start (today: labels) so a
-        # settings-page change takes effect within one tick. Deliberately
-        # not whole-spec equality: frame_url carries a freshly minted JWT
-        # on every fetch and would restart every worker every tick.
+        # ONLY the fields a worker bakes in at start (today: labels and
+        # nvr_camera_id) so a settings-page change takes effect within one
+        # tick. Deliberately not whole-spec equality: frame_url carries a
+        # freshly minted JWT on every fetch and would restart every worker
+        # every tick.
         self._specs: dict[str, CameraSpec] = {}
 
     def _default_factory(self, spec: CameraSpec, sink: ResultSink) -> Worker:
@@ -549,21 +557,26 @@ class WorkerManager:
 
         for cid in list(self._workers):
             worker = self._workers[cid]
-            labels_changed = (
+            spec_changed = (
                 cid in desired
                 and self._specs.get(cid) is not None
-                and desired[cid].labels != self._specs[cid].labels
+                and (
+                    desired[cid].labels != self._specs[cid].labels
+                    or desired[cid].nvr_camera_id != self._specs[cid].nvr_camera_id
+                )
             )
-            if cid not in desired or not worker.is_alive() or labels_changed:
+            if cid not in desired or not worker.is_alive() or spec_changed:
                 worker.stop()
                 del self._workers[cid]
                 self._specs.pop(cid, None)
-                if labels_changed:
+                if spec_changed:
                     log.info(
-                        "tier0: restarting %s — per-camera labels changed to %s",
+                        "tier0: restarting %s — baked-in spec changed "
+                        "(labels=%s, nvr_camera_id=%s)",
                         cid,
                         sorted(desired[cid].labels) if desired[cid].labels is not None
                         else "(global default)",
+                        desired[cid].nvr_camera_id,
                     )
 
         for cid, spec in desired.items():

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -32,7 +32,7 @@ from .detector import DetectorAdapter, StubDetector
 from .frame_source import FrameSource, probe_stream
 from .dispatch import dispatch_escalations
 from .gate import Gate
-from .ffmpeg_presets import HwAccel
+from .ffmpeg_presets import DEFAULT_RTSP_TIMEOUT_S, HwAccel
 from .metrics import (
     metrics as _metrics,
     record_frame,
@@ -231,6 +231,7 @@ class CameraWorker:
         decode_skip: str = "none",               # ffmpeg -skip_frame (decode-side CPU dial)
         decode_threads: int = 2,                 # ffmpeg decoder thread cap (0 = auto)
         fast_decode: bool = False,               # skip h264 loop filter (opt-in)
+        rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S,   # socket-I/O timeout
         decode_idle: str = "",                   # idle skip mode ("" = adaptive off)
         decode_idle_after: float = 60.0,         # quiet seconds before idling
         frame_source=None,                       # injectable for tests
@@ -250,6 +251,7 @@ class CameraWorker:
         self.decode_skip = decode_skip
         self.decode_threads = decode_threads
         self.fast_decode = fast_decode
+        self.rtsp_timeout_s = rtsp_timeout_s
         self.decode_idle = decode_idle
         self.decode_idle_after = decode_idle_after
         self._frame_source = frame_source
@@ -290,6 +292,7 @@ class CameraWorker:
             decode_skip=self.decode_skip if decode_skip is None else decode_skip,
             decode_threads=self.decode_threads,
             fast_decode=self.fast_decode,
+            rtsp_timeout_s=self.rtsp_timeout_s,
         )
         return src, w, h
 
@@ -297,6 +300,12 @@ class CameraWorker:
         try:
             src, w, h = self._make_source()
         except Exception:
+            # Emit the DOWN gauge before bailing. Returning here used to skip
+            # record_worker_state entirely, so a camera that never opens had
+            # no tier0_worker_up series at all — not even 0 — and reconcile
+            # silently re-attempted it every tick with nothing but a log line
+            # to show for it. An absent series can't alert; a 0 can.
+            record_worker_state(self.spec.camera_id, False, target_fps=self.spec.fps)
             log.exception("tier0 %s: could not open source", self.spec.camera_id)
             return
         # Substream guard: Tier-0 is designed to decode a LOW-RES substream.
@@ -475,6 +484,7 @@ class WorkerManager:
         decode_skip: str = "none",                        # ffmpeg -skip_frame (decode-side CPU dial)
         decode_threads: int = 2,                          # ffmpeg decoder thread cap (0 = auto)
         fast_decode: bool = False,                        # skip h264 loop filter (opt-in)
+        rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S,   # socket-I/O timeout
         decode_idle: str = "",                            # idle skip mode ("" = adaptive off)
         decode_idle_after: float = 60.0,                  # quiet seconds before idling
         gate_factory: Callable[[], Gate] | None = None,   # fresh gate per camera (stateful)
@@ -496,6 +506,7 @@ class WorkerManager:
         self._decode_skip = decode_skip
         self._decode_threads = decode_threads
         self._fast_decode = fast_decode
+        self._rtsp_timeout_s = rtsp_timeout_s
         self._decode_idle = decode_idle
         self._decode_idle_after = decode_idle_after
         # The gate is stateful per camera, so each worker gets its own instance.
@@ -523,6 +534,7 @@ class WorkerManager:
             decode_skip=self._decode_skip,
             decode_threads=self._decode_threads,
             fast_decode=self._fast_decode,
+            rtsp_timeout_s=self._rtsp_timeout_s,
             decode_idle=self._decode_idle,
             decode_idle_after=self._decode_idle_after,
             gate=self._gate_factory() if self._gate_factory else None,

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -43,6 +43,7 @@ from .metrics import (
     record_sink_error,
     record_worker_restart,
     record_worker_state,
+    forget_camera,
 )
 from .motion import MotionConfig, MotionDetector
 from .pipeline import DetectPipeline, FrameResult
@@ -627,6 +628,11 @@ class WorkerManager:
                 worker.stop()
                 del self._workers[cid]
                 self._specs.pop(cid, None)
+                if cid not in desired:
+                    # Gone from core entirely — drop its frame-age entry so
+                    # it stops being reported stale forever.
+                    self._latest_url.pop(cid, None)
+                    forget_camera(cid)
                 if spec_changed:
                     log.info(
                         "tier0: restarting %s — baked-in spec changed "

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -25,7 +25,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Protocol
 
 from .detector import DetectorAdapter, StubDetector
@@ -129,7 +129,8 @@ def allowed_labels_for(spec: "CameraSpec") -> frozenset[str] | None:
 
 
 class CameraProvider(Protocol):
-    def list_cameras(self) -> list[CameraSpec]:
+    def list_cameras(self) -> list[CameraSpec] | None:
+        """The desired camera set; None = discovery failed (keep current)."""
         ...
 
 
@@ -506,12 +507,12 @@ class WorkerManager:
         self._visit_poster = visit_poster
         self._factory = worker_factory or self._default_factory
         self._workers: dict[str, Worker] = {}
-        # The spec each running worker was built with — reconcile compares
-        # ONLY the fields a worker bakes in at start (today: labels and
-        # nvr_camera_id) so a settings-page change takes effect within one
-        # tick. Deliberately not whole-spec equality: frame_url carries a
-        # freshly minted JWT on every fetch and would restart every worker
-        # every tick.
+        # The spec each running worker was built with — reconcile restarts
+        # on any change to the fields a worker bakes in at start (see
+        # _baked: everything except the volatile substream_url, whose JWT
+        # is re-minted on every fetch, and nvr_camera_id, compared
+        # asymmetrically) so a settings-page change takes effect within
+        # one tick.
         self._specs: dict[str, CameraSpec] = {}
 
     def _default_factory(self, spec: CameraSpec, sink: ResultSink) -> Worker:
@@ -548,12 +549,26 @@ class WorkerManager:
             self._router = router
         self._stop_all()
 
+    @staticmethod
+    def _baked(spec: CameraSpec) -> CameraSpec:
+        """The spec with volatile fields masked — what a restart-worthy
+        change means. substream_url carries a freshly minted JWT on every
+        fetch; nvr_camera_id is compared separately (asymmetric: a fetch
+        that degrades it to None must not bounce the worker)."""
+        return replace(spec, substream_url="", nvr_camera_id=None)
+
     def reconcile(self) -> None:
         """Start workers for new analyze-enabled cameras, stop the rest."""
         if not self.enabled:
             self._stop_all()
             return
-        desired = {c.camera_id: c for c in self.provider.list_cameras() if c.analyze}
+        cams = self.provider.list_cameras()
+        if cams is None:
+            # Discovery failed (core briefly down / timeout) — an empty
+            # answer would read as "no cameras" and tear down every worker.
+            # Keep what's running; the next tick retries.
+            return
+        desired = {c.camera_id: c for c in cams if c.analyze}
 
         for cid in list(self._workers):
             worker = self._workers[cid]
@@ -561,8 +576,12 @@ class WorkerManager:
                 cid in desired
                 and self._specs.get(cid) is not None
                 and (
-                    desired[cid].labels != self._specs[cid].labels
-                    or desired[cid].nvr_camera_id != self._specs[cid].nvr_camera_id
+                    self._baked(desired[cid]) != self._baked(self._specs[cid])
+                    or (
+                        desired[cid].nvr_camera_id is not None
+                        and desired[cid].nvr_camera_id
+                        != self._specs[cid].nvr_camera_id
+                    )
                 )
             )
             if cid not in desired or not worker.is_alive() or spec_changed:

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -40,6 +40,7 @@ from .metrics import (
     record_processing_fps,
     record_mainstream_fallback,
     record_published,
+    record_sink_error,
     record_worker_restart,
     record_worker_state,
 )
@@ -232,6 +233,7 @@ class CameraWorker:
         decode_threads: int = 2,                 # ffmpeg decoder thread cap (0 = auto)
         fast_decode: bool = False,               # skip h264 loop filter (opt-in)
         rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S,   # socket-I/O timeout
+        url_provider=None,                       # freshest tap URL (its JWT rotates)
         decode_idle: str = "",                   # idle skip mode ("" = adaptive off)
         decode_idle_after: float = 60.0,         # quiet seconds before idling
         frame_source=None,                       # injectable for tests
@@ -252,6 +254,7 @@ class CameraWorker:
         self.decode_threads = decode_threads
         self.fast_decode = fast_decode
         self.rtsp_timeout_s = rtsp_timeout_s
+        self.url_provider = url_provider
         self.decode_idle = decode_idle
         self.decode_idle_after = decode_idle_after
         self._frame_source = frame_source
@@ -293,6 +296,7 @@ class CameraWorker:
             decode_threads=self.decode_threads,
             fast_decode=self.fast_decode,
             rtsp_timeout_s=self.rtsp_timeout_s,
+            url_provider=self.url_provider,
         )
         return src, w, h
 
@@ -414,6 +418,12 @@ class CameraWorker:
                     if self.sink.publish(self.spec.camera_id, result, frame):
                         record_published(self.spec.camera_id)   # count real publishes only
                 except Exception:
+                    # Counted, not just debug-logged: at the default INFO level
+                    # a sink raising on EVERY frame produced no output at all,
+                    # so a bus outage looked identical to a quiet scene —
+                    # tier0_events_published_total simply stopped climbing with
+                    # nothing to say why.
+                    record_sink_error(self.spec.camera_id)
                     log.debug("tier0 %s: sink error", self.spec.camera_id, exc_info=True)
                 if self.gate is not None:
                     self._run_gate(result, frame)
@@ -525,6 +535,17 @@ class WorkerManager:
         # asymmetrically) so a settings-page change takes effect within
         # one tick.
         self._specs: dict[str, CameraSpec] = {}
+        # Freshest tap URL seen per camera, refreshed every reconcile. The URL
+        # embeds a 60-minute JWT; a long-running worker's baked-in copy WILL
+        # expire, so the frame source consults this before each respawn
+        # instead of 401-ing until the worker dies. Kept out of _baked (a
+        # re-minted JWT must not bounce a healthy worker) precisely because
+        # this is the cheaper way to deliver it.
+        self._latest_url: dict[str, str] = {}
+
+    def current_url(self, camera_id: str) -> str | None:
+        """The freshest known stream URL for a camera (see _latest_url)."""
+        return self._latest_url.get(camera_id)
 
     def _default_factory(self, spec: CameraSpec, sink: ResultSink) -> Worker:
         return CameraWorker(
@@ -535,6 +556,7 @@ class WorkerManager:
             decode_threads=self._decode_threads,
             fast_decode=self._fast_decode,
             rtsp_timeout_s=self._rtsp_timeout_s,
+            url_provider=lambda cid=spec.camera_id: self.current_url(cid),
             decode_idle=self._decode_idle,
             decode_idle_after=self._decode_idle_after,
             gate=self._gate_factory() if self._gate_factory else None,
@@ -581,6 +603,11 @@ class WorkerManager:
             # Keep what's running; the next tick retries.
             return
         desired = {c.camera_id: c for c in cams if c.analyze}
+        # Every camera we just heard about, analyzed or not — a running
+        # worker's source reads this to pick up a re-minted JWT.
+        for c in cams:
+            if c.substream_url:
+                self._latest_url[c.camera_id] = c.substream_url
 
         for cid in list(self._workers):
             worker = self._workers[cid]

--- a/detect-pipeline/test/test_bus_providers.py
+++ b/detect-pipeline/test/test_bus_providers.py
@@ -86,8 +86,8 @@ class _FakeResp(io.BytesIO):
 def test_provider_maps_camera_agent_endpoint_to_specs():
     # shape of the existing GET /api/v1/internal/camera-agent/cameras endpoint
     body = json.dumps({"cameras": [
-        {"camera_id": "cam1", "name": "Front", "frame_url": "rtsp://mediamtx:8554/cam-1?jwt=x", "source": "mediamtx"},
-        {"camera_id": "cam2", "name": "Gate", "frame_url": "rtsp://u:p@10.0.0.9:554/sub", "source": "camera"},
+        {"camera_id": "cam1", "open_nvr_camera_id": "1", "name": "Front", "frame_url": "rtsp://mediamtx:8554/cam-1?jwt=x", "source": "mediamtx"},
+        {"camera_id": "cam2", "open_nvr_camera_id": "2", "name": "Gate", "frame_url": "rtsp://u:p@10.0.0.9:554/sub", "source": "camera"},
     ]}).encode()
 
     captured = {}
@@ -102,6 +102,7 @@ def test_provider_maps_camera_agent_endpoint_to_specs():
     assert captured["url"] == "http://opennvr-core:8000/api/v1/internal/camera-agent/cameras"
     assert captured["key"] == "secret"
     assert [s.camera_id for s in specs] == ["cam1", "cam2"]
+    assert [s.nvr_camera_id for s in specs] == [1, 2]                    # core's numeric id
     assert specs[0].name == "Front"
     assert specs[0].substream_url == "rtsp://mediamtx:8554/cam-1?jwt=x"   # MediaMTX tap
     assert all(s.analyze for s in specs)                                 # on by default

--- a/detect-pipeline/test/test_bus_providers.py
+++ b/detect-pipeline/test/test_bus_providers.py
@@ -134,12 +134,14 @@ def test_detect_fps_env_sets_default_rate(monkeypatch):
     assert _to_spec(cam).fps == 2
 
 
-def test_provider_returns_empty_on_failure():
+def test_provider_returns_none_on_failure():
     def boom(req, timeout=None):
         raise OSError("connection refused")
 
     prov = HttpCameraProvider("http://core:8000", opener=boom)
-    assert prov.list_cameras() == []                    # never raises; retries next tick
+    # None (not []) — the manager must be able to tell "discovery failed,
+    # keep current workers" apart from "genuinely no cameras, stop all".
+    assert prov.list_cameras() is None
 
 
 # ── Assignments → per-camera labels + opt-in skip (slice 3) ─────────

--- a/detect-pipeline/test/test_events_poster.py
+++ b/detect-pipeline/test/test_events_poster.py
@@ -133,3 +133,58 @@ def test_lifecycle_threads_nvr_camera_id_into_visits():
     lc.observe([_Tr(1)], T0 + 5)
     done = lc.observe([], T0 + 6)
     assert (done[0].camera_id, done[0].nvr_camera_id) == ("cam3", 3)
+
+
+# ── history loss is now countable (the docstring's promised metric) ──
+
+def test_dropped_visits_are_counted_by_reason():
+    from dataclasses import replace as _replace
+
+    from detect_pipeline import metrics as m
+
+    m.metrics.reset()
+
+    # 1. queue full
+    p = VisitPoster("http://core:8000", None, maxsize=1)
+    p.submit(_visit())
+    p.submit(_visit())
+    assert m.metrics.value(
+        "tier0_visits_dropped_total", {"camera": "3", "reason": "queue_full"}
+    ) == 1
+
+    # 2. a post that can never succeed (unresolvable camera id)
+    def opener(req, timeout=None):
+        raise AssertionError("must not reach the network")
+
+    bad = VisitPoster("http://core:8000", None, opener=opener)
+    bad._q.put_nowait(_replace(_visit(), camera_id="front-door"))
+    try:
+        bad._post(bad._q.get())
+    except ValueError:
+        m.record_visit_dropped("front-door", "unresolved_camera")
+    assert m.metrics.value(
+        "tier0_visits_dropped_total",
+        {"camera": "front-door", "reason": "unresolved_camera"},
+    ) == 1
+    m.metrics.reset()
+
+
+def test_junk_suppression_is_counted_not_silent():
+    """Flickers are dropped by design — but silently dropping them made a
+    misconfigured floor indistinguishable from an empty scene."""
+    from detect_pipeline import metrics as m
+
+    m.metrics.reset()
+    lc = VisitLifecycle("7", nvr_camera_id=7, min_duration_s=1.0)
+    lc.observe([_Tr(1, confirmed=False)], T0)
+    assert lc.observe([], T0 + 10) == []                 # never confirmed
+    lc.observe([_Tr(2)], T0)
+    assert lc.observe([], T0 + 0.3) == []                # under the floor
+
+    assert m.metrics.value(
+        "tier0_visits_dropped_total", {"camera": "7", "reason": "unconfirmed"}
+    ) == 1
+    assert m.metrics.value(
+        "tier0_visits_dropped_total", {"camera": "7", "reason": "too_short"}
+    ) == 1
+    m.metrics.reset()

--- a/detect-pipeline/test/test_events_poster.py
+++ b/detect-pipeline/test/test_events_poster.py
@@ -4,7 +4,9 @@
 
 import io
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+
+import pytest
 
 from detect_pipeline.events_poster import Visit, VisitLifecycle, VisitPoster
 
@@ -96,3 +98,38 @@ def test_full_queue_drops_not_blocks():
     assert p.submit(_visit()) is True
     assert p.submit(_visit()) is False                          # dropped, no block
     assert p._dropped == 1
+
+
+# ── numeric camera id (core keys events on Camera.id, not "cam1") ───
+
+def _post_body(visit):
+    seen = {}
+    def opener(req, timeout=None):
+        seen["body"] = json.loads(req.data.decode())
+        return _Resp()
+    VisitPoster("http://core:8000", None, opener=opener)._post(visit)
+    return seen["body"]
+
+
+def test_post_prefers_explicit_nvr_camera_id():
+    body = _post_body(replace(_visit(), camera_id="cam9", nvr_camera_id=3))
+    assert body["camera_id"] == 3
+
+
+@pytest.mark.parametrize("handle", ["cam7", "cam-7", "cam_7", "7"])
+def test_post_parses_cam_handle_when_no_numeric_id(handle):
+    body = _post_body(replace(_visit(), camera_id=handle))     # older specs
+    assert body["camera_id"] == 7
+
+
+def test_post_rejects_unparseable_camera_id():
+    with pytest.raises(ValueError):
+        _post_body(replace(_visit(), camera_id="front-door"))
+
+
+def test_lifecycle_threads_nvr_camera_id_into_visits():
+    lc = VisitLifecycle("cam3", nvr_camera_id=3)
+    lc.observe([_Tr(1)], T0)
+    lc.observe([_Tr(1)], T0 + 5)
+    done = lc.observe([], T0 + 6)
+    assert (done[0].camera_id, done[0].nvr_camera_id) == ("cam3", 3)

--- a/detect-pipeline/test/test_ffmpeg_presets.py
+++ b/detect-pipeline/test/test_ffmpeg_presets.py
@@ -203,3 +203,62 @@ def test_real_ffmpeg_accepts_every_emitted_skip_token():
         assert proc.returncode == 0, (mode, token, proc.stderr)
         assert "Undefined constant" not in proc.stderr, (mode, token, proc.stderr)
         assert "Invalid" not in proc.stderr, (mode, token, proc.stderr)
+
+
+# ── RTSP socket timeout (the "stalled stream hangs forever" fix) ────
+
+def test_decode_command_carries_rtsp_timeout_before_input():
+    from detect_pipeline.ffmpeg_presets import build_decode_command
+
+    cmd = build_decode_command("rtsp://h:8554/cam", width=320, height=240, fps=5)
+    assert "-timeout" in cmd
+    # microseconds, and it must precede -i to bind to the INPUT
+    assert cmd[cmd.index("-timeout") + 1] == str(int(10.0 * 1_000_000))
+    assert cmd.index("-timeout") < cmd.index("-i")
+
+
+def test_decode_command_does_not_use_rw_timeout():
+    """-rw_timeout is accepted by ffmpeg for RTSP but SILENTLY does nothing.
+
+    Verified against the shipped image (ffmpeg 7.1.5): `-timeout 3000000`
+    reaches the transport as `tcp://...?timeout=3000000`, while
+    `-rw_timeout 3000000` arrives as `timeout=0`. Neither errors, so only a
+    test can stop someone "simplifying" one into the other.
+    """
+    from detect_pipeline.ffmpeg_presets import build_decode_command
+
+    cmd = build_decode_command("rtsp://h:8554/cam", width=320, height=240, fps=5)
+    assert "-rw_timeout" not in cmd
+
+
+def test_rtsp_timeout_can_be_disabled():
+    from detect_pipeline.ffmpeg_presets import build_decode_command, rtsp_timeout_args
+
+    assert rtsp_timeout_args(0) == []
+    cmd = build_decode_command(
+        "rtsp://h:8554/cam", width=320, height=240, fps=5, rtsp_timeout_s=0
+    )
+    assert "-timeout" not in cmd
+
+
+@pytest.mark.skipif(_shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+def test_rtsp_timeout_flag_is_accepted_by_real_ffmpeg():
+    """The flag must PARSE on a real ffmpeg against a real RTSP input.
+
+    ``-timeout`` belongs to the RTSP demuxer specifically — on a non-RTSP
+    input ffmpeg rejects it with "Option timeout not found", which is why
+    this points at an rtsp:// URL (a closed port: we want the option parsed,
+    then a connection error, NOT an option error). A wrong option name here
+    would make every camera fail instantly on deploy.
+    """
+    from detect_pipeline.ffmpeg_presets import build_decode_command
+
+    cmd = build_decode_command(
+        "rtsp://127.0.0.1:9/closed", width=64, height=64, fps=5, rtsp_timeout_s=1.0
+    )
+    proc = _subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    assert "Unrecognized option" not in proc.stderr, proc.stderr
+    assert "Option not found" not in proc.stderr, proc.stderr
+    # It should fail to CONNECT (port 9 is discard/closed), proving the
+    # option parsed and ffmpeg got as far as dialling.
+    assert proc.returncode != 0

--- a/detect-pipeline/test/test_frame_source.py
+++ b/detect-pipeline/test/test_frame_source.py
@@ -296,3 +296,76 @@ def test_decode_flips_never_count_toward_giveup():
         src.set_decode_skip("nokey")
     # Still alive after 6 deliberate flips (budget was 3).
     assert len(spawns) >= 6
+
+
+# ── rotating tap JWT (60-min lifetime, baked in at worker start) ────
+
+def test_expired_url_heals_on_respawn_without_killing_the_worker():
+    """The tap URL's JWT expires after 60 minutes.
+
+    Before, a long-running source kept re-dialling the dead token until it
+    burned the give-up budget and the worker died; only a reconcile tick
+    could hand it a fresh URL. Now it adopts the freshest URL itself.
+    """
+    from detect_pipeline.frame_source import FrameSource, frame_size_bytes
+
+    size = frame_size_bytes(4, 4)
+    seen: list[str] = []
+    current = {"url": "rtsp://mtx/cam-1?jwt=EXPIRED"}
+
+    def spawn(cmd):
+        seen.append(next(a for a in cmd if a.startswith("rtsp://")))
+        return _FakeProc(b"\x00" * size)
+
+    src = FrameSource(
+        "rtsp://mtx/cam-1?jwt=EXPIRED", width=4, height=4, fps=5,
+        spawn=spawn, url_provider=lambda: current["url"],
+        max_restarts=2, backoff_seconds=0, min_healthy_seconds=0,
+        _sleep=lambda s: None,
+    )
+    stream = src.stream()
+    next(stream)                                  # first spawn: expired token
+    current["url"] = "rtsp://mtx/cam-1?jwt=FRESH"  # reconcile re-minted it
+    for _ in stream:                              # drain remaining respawns
+        pass
+
+    assert seen[0].endswith("EXPIRED")
+    assert seen[-1].endswith("FRESH"), "source never adopted the refreshed URL"
+
+
+def test_url_provider_failure_is_survivable():
+    from detect_pipeline.frame_source import FrameSource, frame_size_bytes
+
+    def boom():
+        raise RuntimeError("core unreachable")
+
+    src = FrameSource(
+        "rtsp://mtx/cam-1?jwt=OLD", width=4, height=4, fps=5,
+        spawn=lambda cmd: _FakeProc(b"\x00" * frame_size_bytes(4, 4)),
+        url_provider=boom, max_restarts=0, backoff_seconds=0,
+        _sleep=lambda s: None,
+    )
+    assert len(list(src.stream())) == 1           # keeps the URL it has
+    assert src.rtsp_url.endswith("OLD")
+
+
+def test_stream_urls_are_redacted_in_logs(caplog):
+    """The tap URL's ?jwt= is a live wildcard-read credential."""
+    import logging
+
+    from detect_pipeline.frame_source import FrameSource, redact_url
+
+    secret = "rtsp://mtx:8554/cam-1?jwt=eyJhbGciOiJSUzI1NiJ9.SECRETPAYLOAD.SIG"
+    assert redact_url(secret) == "rtsp://mtx:8554/cam-1?<redacted>"
+    assert "SECRET" not in redact_url(secret)
+    assert redact_url("rtsp://cam/no-query") == "rtsp://cam/no-query"
+
+    with caplog.at_level(logging.INFO):
+        src = FrameSource(
+            secret, width=4, height=4, fps=5,
+            spawn=lambda cmd: _EmptyProc(), max_fruitless_restarts=2,
+            backoff_seconds=0, _sleep=lambda s: None,
+        )
+        list(src.stream())
+    assert caplog.text, "expected restart/give-up logging"
+    assert "SECRETPAYLOAD" not in caplog.text, "JWT leaked into logs"

--- a/detect-pipeline/test/test_frame_source.py
+++ b/detect-pipeline/test/test_frame_source.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import io
+import time
 
 from detect_pipeline.ffmpeg_presets import HwAccel, frame_size_bytes
 from detect_pipeline.frame_source import Frame, FrameSource, read_frames
@@ -151,7 +152,147 @@ def test_fruitless_counter_resets_after_a_good_cycle():
     src = FrameSource(
         "rtsp://cam/flaky", width=4, height=4, fps=5,
         spawn=lambda cmd: next(it),
-        max_fruitless_restarts=3, _sleep=lambda s: None,
+        # min_healthy_seconds=0 → any frame counts as a healthy session, the
+        # rule this test was written for. The duration rule has its own test.
+        max_fruitless_restarts=3, min_healthy_seconds=0, _sleep=lambda s: None,
     )
     frames = list(src.stream())
     assert len(frames) == 2
+
+
+# ── stream robustness: stalls, flapping, and ffmpeg's own reason ────
+
+def test_short_sessions_do_not_reset_the_giveup_counter():
+    """A stream that connects, emits one frame and dies is NOT healthy.
+
+    Counting any single frame as success let a flapping camera restart
+    forever without ever reaching the give-up path — so it never got a
+    fresh tap URL, which is the only thing that can fix an expired ticket.
+    """
+    from detect_pipeline.frame_source import FrameSource, frame_size_bytes
+
+    class _BlipProc:
+        def __init__(self):
+            import io
+            self.stdout = io.BytesIO(b"\x00" * frame_size_bytes(4, 4))
+        def poll(self): return 0
+        def wait(self, timeout=None): return 0
+        def terminate(self): pass
+        def kill(self): pass
+
+    spawns = []
+    src = FrameSource(
+        "rtsp://cam/flapping", width=4, height=4, fps=5,
+        spawn=lambda cmd: (spawns.append(1), _BlipProc())[1],
+        max_fruitless_restarts=3,
+        min_healthy_seconds=5.0,      # instant blips are below this
+        _sleep=lambda s: None,
+    )
+    frames = list(src.stream())
+    # Each blip yields its one frame, but none resets the counter, so the
+    # source gives up after exactly max_fruitless_restarts attempts.
+    assert len(spawns) == 3
+    assert len(frames) == 3
+
+
+def test_restart_backoff_escalates_and_is_capped():
+    slept: list[float] = []
+    src = FrameSource(
+        "rtsp://cam/dead", width=4, height=4, fps=5,
+        spawn=lambda cmd: _EmptyProc(),
+        max_fruitless_restarts=6, backoff_seconds=1.0, max_backoff_seconds=4.0,
+        _sleep=slept.append,
+    )
+    list(src.stream())
+    # 1, 2, 4, then capped at 4 — never a flat re-dial rate.
+    assert slept[:3] == [1.0, 2.0, 4.0]
+    assert all(s <= 4.0 for s in slept)
+
+
+def test_stderr_flood_does_not_deadlock_the_reader():
+    """ffmpeg writing more than the pipe buffer must not stall the decode.
+
+    With stderr=PIPE and nobody draining it, the ~64KB kernel buffer fills,
+    the child BLOCKS writing to stderr, and stdout stops — a permanent hang
+    that looks exactly like a dead camera. Uses a REAL subprocess, because
+    the deadlock is a kernel pipe behaviour a fake cannot reproduce.
+    """
+    import subprocess
+    import sys
+
+    from detect_pipeline.frame_source import FrameSource, frame_size_bytes
+
+    size = frame_size_bytes(4, 4)
+    # Write 512KB of stderr (8x the typical buffer) interleaved with frames.
+    child = (
+        "import sys;"
+        f"n={size};"
+        "sys.stderr.buffer.write(b'x'*262144);sys.stderr.buffer.flush();"
+        "sys.stdout.buffer.write(b'\\0'*n);sys.stdout.buffer.flush();"
+        "sys.stderr.buffer.write(b'y'*262144);sys.stderr.buffer.flush();"
+        "sys.stdout.buffer.write(b'\\1'*n);sys.stdout.buffer.flush();"
+    )
+
+    def spawn(argv):
+        return subprocess.Popen(
+            [sys.executable, "-c", child],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+
+    src = FrameSource(
+        "rtsp://cam/chatty", width=4, height=4, fps=5,
+        spawn=spawn, max_restarts=0, backoff_seconds=0, _sleep=lambda s: None,
+    )
+    frames = list(src.stream())
+    assert len(frames) == 2, "stderr flood stalled the frame reader"
+
+
+def test_stderr_tail_keeps_ffmpegs_reason():
+    from detect_pipeline.frame_source import _StderrTail
+
+    tail = _StderrTail(io.BytesIO(b"Connection refused\nbad ticket 401\n"), keep=6)
+    # The drain runs on a daemon thread; give it a moment to consume.
+    for _ in range(200):
+        if tail.text():
+            break
+        time.sleep(0.01)
+    assert "401" in tail.text()
+
+
+def test_stderr_tail_tolerates_a_proc_without_stderr():
+    from detect_pipeline.frame_source import _StderrTail
+
+    assert _StderrTail(None).text() == ""       # injected fakes have no stderr
+
+
+def test_decode_flips_never_count_toward_giveup():
+    """Adaptive decode terminates ffmpeg on purpose — that is not a failure.
+
+    Flips are short-lived by nature (a scene waking the camera), so if they
+    counted toward the fruitless budget a healthy camera with intermittent
+    motion would be torn down as though its feed were dead.
+    """
+    from detect_pipeline.frame_source import FrameSource, frame_size_bytes
+
+    size = frame_size_bytes(4, 4)
+    spawns = []
+
+    def spawn(cmd):
+        spawns.append(1)
+        p = _FakeProc(b"\x00" * size)
+        return p
+
+    src = FrameSource(
+        "rtsp://cam/adaptive", width=4, height=4, fps=5,
+        spawn=spawn, max_fruitless_restarts=3,
+        min_healthy_seconds=5.0,        # every fake session is instant
+        max_restarts=6, backoff_seconds=0, _sleep=lambda s: None,
+    )
+    stream = src.stream()
+    # Consume a frame, then flip, repeatedly — more flips than the fruitless
+    # budget would allow if flips were penalised.
+    for _ in range(6):
+        next(stream)
+        src.set_decode_skip("nokey")
+    # Still alive after 6 deliberate flips (budget was 3).
+    assert len(spawns) >= 6

--- a/detect-pipeline/test/test_health.py
+++ b/detect-pipeline/test/test_health.py
@@ -74,3 +74,35 @@ def test_no_workers_no_frame_requirement():
     ok, _ = evaluate(_state(workers_running=lambda: 0,
                             newest_frame_age_s=lambda: None), now=AFTER_GRACE)
     assert ok
+
+
+def test_health_reports_stalled_cameras_by_name():
+    from detect_pipeline.health import HealthState, evaluate
+
+    st = HealthState(
+        enabled=True,
+        detector_requested="onnx", detector_actual="OnnxDetector",
+        workers_running=lambda: 3,
+        newest_frame_age_s=lambda: 1.0,          # one healthy camera
+        stale_cameras=lambda _t: ["cam2", "cam3"],
+        started_at=0.0,                          # past startup grace
+    )
+    ok, detail = evaluate(st, now=10_000.0)
+    # A camera being offline is normal ops, so the service stays ok...
+    assert ok is True
+    # ...but the dead feeds are named instead of hidden behind the max.
+    assert detail["stale_cameras"] == ["cam2", "cam3"]
+
+
+def test_health_survives_a_failing_stale_probe():
+    from detect_pipeline.health import HealthState, evaluate
+
+    def boom(_t):
+        raise RuntimeError("registry busy")
+
+    st = HealthState(
+        enabled=True, workers_running=lambda: 1,
+        newest_frame_age_s=lambda: 1.0, stale_cameras=boom, started_at=0.0,
+    )
+    ok, detail = evaluate(st, now=10_000.0)      # must not raise
+    assert detail["stale_cameras"] == []

--- a/detect-pipeline/test/test_metrics.py
+++ b/detect-pipeline/test/test_metrics.py
@@ -3,6 +3,7 @@
 """Unit tests for the Tier-0 metrics registry + service-layer recorders."""
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 
 from detect_pipeline.gate import GateDecision, GateResult
@@ -193,5 +194,63 @@ def test_frame_age_gauge_moves_when_a_feed_stalls():
     out = m.metrics.render()
     assert "tier0_frame_age_seconds" in out
     assert 'camera="cam9"' in out
+    m._last_frame_wall.clear()
+    m.metrics.reset()
+
+
+def test_frame_wall_reads_are_safe_against_concurrent_workers():
+    """N worker threads insert camera keys while the scrape thread iterates.
+
+    An unguarded insert during iteration raises "dictionary changed size
+    during iteration" — which would take out /metrics and /health together,
+    and fires precisely during worker churn.
+    """
+    import threading
+
+    from detect_pipeline import metrics as m
+
+    m._last_frame_wall.clear()
+    stop = threading.Event()
+    errors: list[str] = []
+
+    def writer():
+        i = 0
+        while not stop.is_set():
+            m.record_frame(f"cam{i}", _Result())
+            i += 1
+
+    def reader():
+        while not stop.is_set():
+            try:
+                m.frame_ages_s()
+                m.newest_frame_age_s()
+                m.stale_cameras(60.0)
+            except RuntimeError as e:      # the bug this pins
+                errors.append(str(e))
+                return
+
+    threads = [threading.Thread(target=writer, daemon=True) for _ in range(3)]
+    threads.append(threading.Thread(target=reader, daemon=True))
+    for t in threads:
+        t.start()
+    time.sleep(0.4)
+    stop.set()
+    for t in threads:
+        t.join(timeout=2)
+
+    assert not errors, errors[:1]
+    m._last_frame_wall.clear()
+    m.metrics.reset()
+
+
+def test_forget_camera_drops_a_deleted_cameras_entry():
+    from detect_pipeline import metrics as m
+
+    m._last_frame_wall.clear()
+    m.record_frame("cam-gone", _Result())
+    assert "cam-gone" in m.frame_ages_s()
+    m.forget_camera("cam-gone")
+    assert "cam-gone" not in m.frame_ages_s()
+    m.forget_camera("cam-gone")          # idempotent
     m._last_frame_wall.clear()
     m.metrics.reset()

--- a/detect-pipeline/test/test_metrics.py
+++ b/detect-pipeline/test/test_metrics.py
@@ -159,3 +159,39 @@ def test_sample_process_metrics_sets_rss_on_linux():
     assert m.value("tier0_process_resident_memory_bytes") > 0
     sample_process_metrics(m)          # second sample: CPU% gauge now present
     assert "tier0_process_cpu_percent" in m.render()
+
+
+# ── per-camera staleness (a dead feed must not hide behind a live one) ──
+
+def test_stale_cameras_names_the_dead_feed_a_fleet_max_would_hide():
+    from detect_pipeline import metrics as m
+
+    m._last_frame_wall.clear()
+    now = 1_000_000.0
+    m._last_frame_wall["cam1"] = now - 1       # healthy
+    m._last_frame_wall["cam2"] = now - 600     # dead for 10 minutes
+
+    # The fleet-wide signal is dominated by the healthy camera...
+    assert m.newest_frame_age_s(now) < 5
+    # ...while the per-camera view names the casualty.
+    assert m.stale_cameras(60.0, now) == ["cam2"]
+    ages = m.frame_ages_s(now)
+    assert round(ages["cam2"]) == 600
+    m._last_frame_wall.clear()
+
+
+def test_frame_age_gauge_moves_when_a_feed_stalls():
+    """The gauge must be sampled at SCRAPE time, not in the frame loop —
+    a loop-written gauge freezes at its last good value when frames stop."""
+    from detect_pipeline import metrics as m
+
+    m._last_frame_wall.clear()
+    m.metrics.reset()
+    now = 2_000_000.0
+    m._last_frame_wall["cam9"] = now - 300
+    m.sample_frame_age_metrics(now)
+    out = m.metrics.render()
+    assert "tier0_frame_age_seconds" in out
+    assert 'camera="cam9"' in out
+    m._last_frame_wall.clear()
+    m.metrics.reset()

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -26,7 +26,7 @@ class _FakeProvider:
         self.specs = specs
 
     def list_cameras(self):
-        return list(self.specs)
+        return None if self.specs is None else list(self.specs)
 
 
 class _FakeSink:
@@ -53,8 +53,8 @@ class _FakeWorker:
         return self.started and not self.stopped
 
 
-def _spec(cid, analyze=True):
-    return CameraSpec(cid, cid, f"rtsp://h/{cid}", analyze=analyze)
+def _spec(cid, analyze=True, **kw):
+    return CameraSpec(cid, cid, f"rtsp://h/{cid}", analyze=analyze, **kw)
 
 
 # ── manager reconcile ───────────────────────────────────────────────
@@ -265,16 +265,49 @@ def test_reconcile_restarts_worker_when_nvr_camera_id_changes():
         made.append(w)
         return w
 
-    prov = _FakeProvider([CameraSpec("a", "a", "rtsp://h/a")])
+    prov = _FakeProvider([_spec("a")])
     mgr = WorkerManager(prov, _FakeSink(), worker_factory=factory)
     mgr.reconcile()
     assert len(made) == 1
 
-    prov.specs = [CameraSpec("a", "a", "rtsp://h/a", nvr_camera_id=5)]
+    prov.specs = [_spec("a", nvr_camera_id=5)]
     mgr.reconcile()
     assert len(made) == 2 and made[1].spec.nvr_camera_id == 5
     assert made[0].stopped
 
-    prov.specs = [CameraSpec("a", "a", "rtsp://h/a", nvr_camera_id=5)]
+    prov.specs = [_spec("a", nvr_camera_id=5)]
     mgr.reconcile()
     assert len(made) == 2                        # unchanged id → no bounce
+
+    # A fetch that DEGRADES the id (mixed-version core replicas during a
+    # rolling upgrade) must not flap the worker: None carries no new
+    # information, and the running worker's baked-in id still works.
+    prov.specs = [_spec("a")]
+    mgr.reconcile()
+    prov.specs = [_spec("a", nvr_camera_id=5)]
+    mgr.reconcile()
+    assert len(made) == 2                        # N → None → N: zero bounces
+
+
+def test_reconcile_keeps_workers_when_discovery_fails():
+    # provider.list_cameras() → None means "discovery failed", not "no
+    # cameras" — a one-tick core outage must not tear down detection.
+    made = []
+
+    def factory(spec, sink):
+        w = _FakeWorker(spec, sink)
+        made.append(w)
+        return w
+
+    prov = _FakeProvider([_spec("a"), _spec("b")])
+    mgr = WorkerManager(prov, _FakeSink(), worker_factory=factory)
+    mgr.reconcile()
+    assert len(made) == 2
+
+    prov.specs = None                            # core briefly down
+    mgr.reconcile()
+    assert len(made) == 2 and not any(w.stopped for w in made)
+
+    prov.specs = []                              # genuinely no cameras
+    mgr.reconcile()
+    assert all(w.stopped for w in made)

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -253,3 +253,28 @@ def test_reconcile_restarts_worker_when_labels_change():
     prov.specs = [_spec("a"), _spec("b")]
     mgr.reconcile()
     assert len(made) == 4 and made[3].spec.labels is None
+
+
+def test_reconcile_restarts_worker_when_nvr_camera_id_changes():
+    # The worker bakes nvr_camera_id into its VisitLifecycle at start, so a
+    # late-arriving id (core upgraded mid-flight) must rebuild the worker.
+    made = []
+
+    def factory(spec, sink):
+        w = _FakeWorker(spec, sink)
+        made.append(w)
+        return w
+
+    prov = _FakeProvider([CameraSpec("a", "a", "rtsp://h/a")])
+    mgr = WorkerManager(prov, _FakeSink(), worker_factory=factory)
+    mgr.reconcile()
+    assert len(made) == 1
+
+    prov.specs = [CameraSpec("a", "a", "rtsp://h/a", nvr_camera_id=5)]
+    mgr.reconcile()
+    assert len(made) == 2 and made[1].spec.nvr_camera_id == 5
+    assert made[0].stopped
+
+    prov.specs = [CameraSpec("a", "a", "rtsp://h/a", nvr_camera_id=5)]
+    mgr.reconcile()
+    assert len(made) == 2                        # unchanged id → no bounce

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,6 +332,10 @@ services:
       # count; ffmpeg's auto default spawns up to 16/camera) and the opt-in
       # loop-filter skip (small extra CPU cut, tiny pixel drift; CPU decode only).
       - DETECT_DECODE_THREADS=${DETECT_DECODE_THREADS:-2}
+      # RTSP socket-I/O timeout (seconds; 0 disables). Bounds a HALF-OPEN
+      # stream — a camera powered off mid-session, or a NAT/firewall dropping
+      # the flow — which otherwise blocks the decode forever with no restart.
+      - DETECT_RTSP_TIMEOUT_S=${DETECT_RTSP_TIMEOUT_S:-10}
       - DETECT_DECODE_FAST=${DETECT_DECODE_FAST:-false}
       # Adaptive decode (ON by default): keyframes-only while a camera is
       # quiet, full decode from the first motion box until


### PR DESCRIPTION
## What was broken

Every finished-track visit post failed:

```
WARNING visit post failed for cam1/10: invalid literal for int() with base 10: 'cam1'
```

Core's `/internal/camera-agent/cameras` returns a string handle (`cam1`) alongside
the numeric DB id in `open_nvr_camera_id`, but the poster called `int()` on the
handle. Net effect: **no detection history was ever persisted** — the canonical
events store stayed empty, so every consumer downstream of it had nothing to read.

## What this changes

**1. Thread core's numeric camera id end-to-end.** `_to_spec` parses
`open_nvr_camera_id` into `CameraSpec.nvr_camera_id` (appended last, so positional
construction keeps its meaning), the worker bakes it into `VisitLifecycle`, and the
poster uses it. A spec without the id falls back to parsing the handle
(`cam1`/`cam-1`/`1` → `1`), warned once per camera at discovery instead of once per
visit.

**2. A failed discovery tick no longer tears down detection.** `list_cameras()`
returned `[]` on failure — indistinguishable from "no cameras configured" — so a
single core blip stopped every worker, discarded in-flight tracks, and gapped
detection until every stream re-probed. Failure now returns `None` and
`reconcile()` keeps its workers, exactly as the provider's docstring always
promised.

**3. No worker flapping on mixed-version cores.** The restart predicate treated
`id → None` as a change, so replicas alternately sending and omitting
`open_nvr_camera_id` bounced every worker every tick for the length of a rolling
upgrade. Restarts now fire only when a new non-`None` id differs from the stored one.

**4. Restart comparison inverted to an exclude-list.** It was a hand-grown
include-list that already silently missed `fps`, `hwaccel`, `width` and `height` —
all baked into the worker at start. Now the whole spec is compared except the
volatile `substream_url` (its JWT is re-minted on every fetch), so a future
baked-in field defaults to restart-on-change rather than silently-stale.

Smaller hardening: `int(True) == 1` no longer files events under camera 1, and the
warn-once set re-arms when a camera heals so a later regression isn't silent.

## Tests

`250 passed, 1 skipped` (the skip is the real-ffmpeg test, which skips without
ffmpeg present). New coverage: explicit id preferred over the handle, every handle
form parsed, unparseable handles rejected, discovery failure keeps workers running,
and a degraded id causes zero worker bounces.
