### PR TITLE
fix(detect-pipeline): actually use DETECT_HWACCEL — it never reached …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,15 @@ DETECT_DETECTOR=onnx       # onnx (YOLOv8, default) | rfdetr (RF-DETR, needs ort
                            # input size in DETECT_ONNX_INPUT) | hog | blob | stub
 DETECT_ONNX_BACKEND=auto   # auto (cvdnn for onnx, ort for rfdetr) | cvdnn | ort
 DETECT_ONNX_PROVIDERS=     # ort EPs, e.g. OpenVINOExecutionProvider (Intel N100)
+# Hardware decode backend. IMPORTANT: vaapi/qsv/rpi/rkmpp also need the render
+# node passed into the detect-pipeline container — uncomment the
+# `devices: - /dev/dri:/dev/dri` block in docker-compose.yml (core reads this
+# setting too, but only to choose the tap stream; it never decodes, so it
+# needs no device). Without the mapping the pipeline logs a warning per
+# camera and falls back to software decode, and because core reads this same
+# setting as "this box has a GPU" it will have already switched those cameras
+# to the full-resolution MAIN stream (see INFERENCE_TAP_STREAM above) — so the
+# combination is markedly more expensive than leaving this at cpu.
 DETECT_HWACCEL=cpu         # cpu | vaapi | nvidia | qsv | rpi | rkmpp | jetson
 DETECT_GATE_MODE=shadow    # shadow (default: measure only) | off | enforce (act — validate shadow first, see detect-pipeline/ENABLEMENT.md)
 DETECT_CV_THREADS=2        # detector thread cap (cv2 intra-op + BLAS); 0 = uncapped

--- a/detect-pipeline/detect_pipeline/ffmpeg_presets.py
+++ b/detect-pipeline/detect_pipeline/ffmpeg_presets.py
@@ -91,6 +91,39 @@ def frame_size_bytes(width: int, height: int) -> int:
     return width * height * 3 // 2
 
 
+# Backends that decode through a device NODE the container must have been
+# given. docker-compose ships the `devices:` mapping COMMENTED OUT, so
+# "DETECT_HWACCEL=vaapi" without also uncommenting it is the single most
+# likely misconfiguration — and it would fail every camera at once.
+_NEEDS_DEVICE_NODE = frozenset({HwAccel.VAAPI, HwAccel.QSV, HwAccel.RPI, HwAccel.RKMPP})
+
+
+def resolve_hwaccel(
+    requested: str | None, *, device: str = "/dev/dri/renderD128", _exists=None
+) -> tuple[HwAccel, str | None]:
+    """The hwaccel we can ACTUALLY use, plus a reason if it was downgraded.
+
+    Degrading to CPU costs frames-per-core; failing to degrade costs the
+    entire fleet, because ffmpeg exits immediately on a missing render node
+    and every worker just restart-loops. Same "degrade loudly, never
+    crash-loop" rule the decode-skip parser follows.
+    """
+    import os as _os
+
+    exists = _exists or _os.path.exists
+    name = (requested or "cpu").strip().lower() or "cpu"
+    try:
+        accel = HwAccel(name)
+    except ValueError:
+        return HwAccel.CPU, f"unknown hwaccel {requested!r}"
+    if accel in _NEEDS_DEVICE_NODE and not exists(device):
+        return HwAccel.CPU, (
+            f"{accel.value} needs {device}, which this container cannot see "
+            f"(pass it through with `devices: - /dev/dri:/dev/dri`)"
+        )
+    return accel, None
+
+
 def decode_args(hwaccel: HwAccel, *, device: str = "/dev/dri/renderD128",
                 codec: str = "h264", width: int = 0, height: int = 0) -> list[str]:
     """Args to place before ``-i`` for the given backend."""

--- a/detect-pipeline/detect_pipeline/providers.py
+++ b/detect-pipeline/detect_pipeline/providers.py
@@ -178,7 +178,7 @@ def _to_spec(c: dict) -> CameraSpec:
         width=c.get("width"),
         height=c.get("height"),
         fps=int(c.get("fps", _default_fps())),
-        hwaccel=c.get("hwaccel", "cpu"),
+        hwaccel=(c.get("hwaccel") or None),   # None = not declared → global applies
         labels=labels,
     )
 

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -408,6 +408,7 @@ def build_manager(cfg: ServiceConfig, sink, *, gate_sink=None) -> WorkerManager:
         model_id=cfg.model_id,
         best_frames=best_frames,
         device=cfg.device,
+        hwaccel=cfg.hwaccel,
         decode_skip=cfg.decode_skip,
         decode_threads=cfg.decode_threads,
         rtsp_timeout_s=cfg.rtsp_timeout_s,

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -32,7 +32,7 @@ from .detector import DetectorAdapter, StubDetector
 from .frame_source import FrameSource, probe_stream
 from .dispatch import dispatch_escalations
 from .gate import Gate
-from .ffmpeg_presets import DEFAULT_RTSP_TIMEOUT_S, HwAccel
+from .ffmpeg_presets import DEFAULT_RTSP_TIMEOUT_S, HwAccel, resolve_hwaccel
 from .metrics import (
     metrics as _metrics,
     record_frame,
@@ -104,7 +104,11 @@ class CameraSpec:
     width: int | None = None      # if the provider knows it; else we ffprobe
     height: int | None = None
     fps: int = 5
-    hwaccel: str = "cpu"
+    # Per-camera decode backend, if the discovery endpoint ever declares one.
+    # None = not declared → the service-wide DETECT_HWACCEL applies. It
+    # defaulted to "cpu", which was indistinguishable from "core said cpu"
+    # and silently pinned every camera to software decode.
+    hwaccel: str | None = None
     # Per-camera label set from the camera's ``object_detection`` assignment
     # ("camera 4 wants person + truck"). None = no per-camera declaration →
     # the global DETECT_LABELS applies, exactly as before assignments
@@ -117,6 +121,17 @@ class CameraSpec:
     # core's events store keys on this numeric id instead. Appended LAST so
     # existing positional constructions keep their meaning.
     nvr_camera_id: int | None = None
+
+
+def hwaccel_for(spec: "CameraSpec", default: str) -> str:
+    """The decode backend THIS camera should use.
+
+    Same precedence as ``allowed_labels_for``: a per-camera declaration wins
+    when present, otherwise the service-wide setting. Hardware decode is a
+    property of the HOST, so the service-wide value is the one that normally
+    applies — it just never used to reach here.
+    """
+    return spec.hwaccel or default
 
 
 def allowed_labels_for(spec: "CameraSpec") -> frozenset[str] | None:
@@ -230,6 +245,7 @@ class CameraWorker:
         model_id: str | None = None,             # detector identity for benchmarking labels
         best_frames=None,                        # shared BestFrameStore (on-demand best frame)
         device: str = "/dev/dri/renderD128",
+        hwaccel: str = "cpu",             # service-wide DETECT_HWACCEL default
         decode_skip: str = "none",               # ffmpeg -skip_frame (decode-side CPU dial)
         decode_threads: int = 2,                 # ffmpeg decoder thread cap (0 = auto)
         fast_decode: bool = False,               # skip h264 loop filter (opt-in)
@@ -251,6 +267,7 @@ class CameraWorker:
         self.model_id = model_id
         self.best_frames = best_frames
         self.device = device
+        self.hwaccel = hwaccel
         self.decode_skip = decode_skip
         self.decode_threads = decode_threads
         self.fast_decode = fast_decode
@@ -281,6 +298,29 @@ class CameraWorker:
     def is_alive(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
+    def _effective_hwaccel(self) -> HwAccel:
+        """Resolve this camera's decode backend, degrading loudly if unusable.
+
+        Announced per camera because the consequence is a ~6x CPU difference
+        and it is otherwise invisible: core hands the pipeline the MAIN
+        stream whenever hwaccel is configured (it assumes a GPU will absorb
+        it), so silently falling back to software decode would leave the
+        camera decoding full-resolution video on the CPU.
+        """
+        requested = hwaccel_for(self.spec, self.hwaccel)
+        accel, downgrade = resolve_hwaccel(requested, device=self.device)
+        if downgrade:
+            log.warning(
+                "tier0 %s: hwaccel %r unusable — falling back to CPU decode: %s",
+                self.spec.camera_id, requested, downgrade,
+            )
+        elif accel is not HwAccel.CPU:
+            log.info(
+                "tier0 %s: hardware decode via %s (%s)",
+                self.spec.camera_id, accel.value, self.device,
+            )
+        return accel
+
     def _make_source(self, decode_skip: str | None = None):
         if self._frame_source is not None:
             return self._frame_source, self._frame_source.width, self._frame_source.height
@@ -292,7 +332,7 @@ class CameraWorker:
             w, h, _fps = probed
         src = FrameSource(
             self.spec.substream_url, width=w, height=h, fps=self.spec.fps,
-            hwaccel=HwAccel(self.spec.hwaccel), device=self.device,
+            hwaccel=self._effective_hwaccel(), device=self.device,
             decode_skip=self.decode_skip if decode_skip is None else decode_skip,
             decode_threads=self.decode_threads,
             fast_decode=self.fast_decode,
@@ -492,6 +532,7 @@ class WorkerManager:
         model_id: str | None = None,                      # detector identity (benchmark labels)
         best_frames=None,                                 # shared BestFrameStore (thread-safe)
         device: str = "/dev/dri/renderD128",
+        hwaccel: str = "cpu",                             # service-wide DETECT_HWACCEL
         decode_skip: str = "none",                        # ffmpeg -skip_frame (decode-side CPU dial)
         decode_threads: int = 2,                          # ffmpeg decoder thread cap (0 = auto)
         fast_decode: bool = False,                        # skip h264 loop filter (opt-in)
@@ -514,6 +555,7 @@ class WorkerManager:
         self._model_id = model_id
         self._best_frames = best_frames
         self._device = device
+        self._hwaccel = hwaccel
         self._decode_skip = decode_skip
         self._decode_threads = decode_threads
         self._fast_decode = fast_decode
@@ -553,6 +595,7 @@ class WorkerManager:
             spec, sink, detector=self._detector_factory(),
             model_size=self._model_size, model_id=self._model_id,
             best_frames=self._best_frames, device=self._device,
+            hwaccel=self._hwaccel,
             decode_skip=self._decode_skip,
             decode_threads=self._decode_threads,
             fast_decode=self._fast_decode,

--- a/detect-pipeline/test/test_bus_providers.py
+++ b/detect-pipeline/test/test_bus_providers.py
@@ -195,3 +195,17 @@ def test_skip_unassigned_is_opt_in(monkeypatch):
     # ...and NO assignments at all is never skipped (no restriction declared).
     assert _to_spec(_cam()).analyze is True
     assert _to_spec(_cam(assignments=[])).analyze is True
+
+
+def test_provider_leaves_hwaccel_undeclared_when_core_omits_it():
+    """Core does not send `hwaccel` per camera. The old default of "cpu"
+    was indistinguishable from an explicit "cpu" and silently overrode the
+    service-wide DETECT_HWACCEL for every camera."""
+    from detect_pipeline.providers import _to_spec
+
+    spec = _to_spec({"camera_id": "cam1", "frame_url": "rtsp://m/cam-1"})
+    assert spec.hwaccel is None
+    # ...and an explicit declaration is still honoured if it ever appears.
+    declared = _to_spec({"camera_id": "cam1", "frame_url": "rtsp://m/cam-1",
+                         "hwaccel": "vaapi"})
+    assert declared.hwaccel == "vaapi"

--- a/detect-pipeline/test/test_ffmpeg_presets.py
+++ b/detect-pipeline/test/test_ffmpeg_presets.py
@@ -262,3 +262,51 @@ def test_rtsp_timeout_flag_is_accepted_by_real_ffmpeg():
     # It should fail to CONNECT (port 9 is discard/closed), proving the
     # option parsed and ffmpeg got as far as dialling.
     assert proc.returncode != 0
+
+
+# ── hwaccel resolution (degrade loudly, never fail every camera) ────
+
+def test_resolve_hwaccel_keeps_a_usable_backend():
+    from detect_pipeline.ffmpeg_presets import HwAccel, resolve_hwaccel
+
+    accel, why = resolve_hwaccel("vaapi", _exists=lambda p: True)
+    assert (accel, why) == (HwAccel.VAAPI, None)
+    assert resolve_hwaccel("cpu", _exists=lambda p: False)[0] is HwAccel.CPU
+
+
+def test_resolve_hwaccel_degrades_when_the_render_node_is_missing():
+    """docker-compose ships `devices:` COMMENTED OUT, so DETECT_HWACCEL=vaapi
+    without uncommenting it is the likeliest misconfiguration — and ffmpeg
+    would exit instantly on every camera, not just one."""
+    from detect_pipeline.ffmpeg_presets import HwAccel, resolve_hwaccel
+
+    accel, why = resolve_hwaccel("vaapi", _exists=lambda p: False)
+    assert accel is HwAccel.CPU
+    assert why and "/dev/dri" in why
+
+
+def test_resolve_hwaccel_degrades_on_an_unknown_name():
+    from detect_pipeline.ffmpeg_presets import HwAccel, resolve_hwaccel
+
+    accel, why = resolve_hwaccel("vaapii", _exists=lambda p: True)
+    assert accel is HwAccel.CPU and why
+    # empty/None mean "unset", not "broken"
+    assert resolve_hwaccel(None)[0] is HwAccel.CPU
+    assert resolve_hwaccel("")[1] is None
+
+
+def test_nvidia_needs_no_device_node():
+    from detect_pipeline.ffmpeg_presets import HwAccel, resolve_hwaccel
+
+    accel, why = resolve_hwaccel("nvidia", _exists=lambda p: False)
+    assert (accel, why) == (HwAccel.NVIDIA, None)
+
+
+def test_decode_command_carries_hwaccel_args_when_resolved():
+    from detect_pipeline.ffmpeg_presets import HwAccel, build_decode_command
+
+    cmd = build_decode_command("rtsp://h/cam", width=704, height=576, fps=2,
+                               hwaccel=HwAccel.VAAPI, device="/dev/dri/renderD128")
+    assert "-hwaccel" in cmd and cmd[cmd.index("-hwaccel") + 1] == "vaapi"
+    assert "/dev/dri/renderD128" in cmd
+    assert "scale_vaapi" in cmd[cmd.index("-vf") + 1]

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -311,3 +311,45 @@ def test_reconcile_keeps_workers_when_discovery_fails():
     prov.specs = []                              # genuinely no cameras
     mgr.reconcile()
     assert all(w.stopped for w in made)
+
+
+# ── DETECT_HWACCEL actually reaching the workers ────────────────────
+
+def test_service_wide_hwaccel_reaches_the_worker():
+    """The regression this pins: DETECT_HWACCEL was parsed and LOGGED but
+    never passed to WorkerManager, so every camera decoded on CPU no matter
+    what was configured — while core, keying off the same setting, handed
+    the pipeline the full-resolution MAIN stream."""
+    from detect_pipeline.service import CameraWorker
+
+    mgr = WorkerManager(
+        _FakeProvider([_spec("a")]), _FakeSink(),
+        hwaccel="vaapi", device="/dev/dri/renderD128",
+    )
+    worker = mgr._default_factory(_spec("a"), _FakeSink())
+    assert isinstance(worker, CameraWorker)
+    assert worker.hwaccel == "vaapi"
+    assert worker.device == "/dev/dri/renderD128"
+
+
+def test_hwaccel_precedence_camera_declaration_then_global():
+    from detect_pipeline.service import hwaccel_for
+
+    # Nothing declared per camera → the service-wide value applies. This is
+    # the normal case: core does not send `hwaccel` per camera.
+    assert hwaccel_for(_spec("a"), "vaapi") == "vaapi"
+    # A per-camera declaration wins, mirroring allowed_labels_for.
+    assert hwaccel_for(_spec("a", hwaccel="qsv"), "vaapi") == "qsv"
+    assert hwaccel_for(_spec("a"), "cpu") == "cpu"
+
+
+def test_worker_degrades_to_cpu_when_the_device_is_absent():
+    from detect_pipeline.ffmpeg_presets import HwAccel
+
+    mgr = WorkerManager(
+        _FakeProvider([_spec("a")]), _FakeSink(),
+        hwaccel="vaapi", device="/definitely/not/here",
+    )
+    worker = mgr._default_factory(_spec("a"), _FakeSink())
+    # Degrades rather than failing every camera at ffmpeg spawn.
+    assert worker._effective_hwaccel() is HwAccel.CPU

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,6 +399,12 @@ services:
     # DETECT_HWACCEL=vaapi in .env (uncomment):
     # devices:
     #   - /dev/dri:/dev/dri
+    # Setting DETECT_HWACCEL without this mapping is the expensive mistake:
+    # core reads the same setting as "this box has a GPU" and switches these
+    # cameras to the full-resolution MAIN stream, while the pipeline — unable
+    # to see the render node — falls back to software decode. It warns per
+    # camera rather than failing, but that combination costs several times
+    # what plain cpu decode on the substream does.
     networks:
       - opennvr_internal
 


### PR DESCRIPTION
…the workers

DETECT_HWACCEL was parsed into ServiceConfig and printed in the startup banner, but build_manager never passed it on and WorkerManager had no hwaccel parameter at all. The worker instead read HwAccel(spec.hwaccel), and the spec got its value from `c.get("hwaccel", "cpu")` against core's camera list — which does not emit that key. So it was "cpu" for every camera, always: hardware decode has never actually been reachable.

The asymmetry that hid it: DETECT_HWACCEL_DEVICE *was* wired end to end, so the render-node path reached ffmpeg while the backend meant to use it was dropped on the floor.

Worse than inert. Core reads the same setting (internal_camera_agent.py: `use_sub = has_sub and hw in ("", "cpu")`) as "this box has a GPU, it can afford full resolution" and hands those cameras the MAIN stream. So configuring hwaccel moved the fleet onto ~5x the pixels AND still decoded them in software — per the project's own docs, ~2 cores per camera instead of ~0.3. The single biggest capacity lever was inverted.

Wiring only; core's tap rule is left alone, because it is correct once the pipeline honours the setting — which is exactly what docker-compose already claims ("same DETECT_HWACCEL the detect-pipeline container gets, so both sides agree on what the hardware can do").

* CameraSpec.hwaccel now defaults to None ("not declared") instead of "cpu", which was indistinguishable from core explicitly saying cpu and silently overrode the service-wide value. hwaccel_for() gives it the same precedence allowed_labels_for() already uses: per-camera declaration wins, else the service-wide setting.
* resolve_hwaccel() degrades to CPU with an actionable per-camera warning when the backend needs a render node the container cannot see. This matters because compose ships `devices:` COMMENTED OUT, so setting DETECT_HWACCEL=vaapi without uncommenting it would otherwise make ffmpeg exit instantly on every camera at once. Same degrade-loudly rule the decode-skip parser follows. nvidia/jetson need no node and are left alone.
* .env.example and compose spell out the device-passthrough requirement and what it costs to get it half-right.

Verified end to end: with the node present the command carries `-hwaccel vaapi -hwaccel_device ...` and the scale_vaapi/hwdownload filter chain; without it, one warning per camera and software decode.