### PR TITLE
fix(detect-pipeline): stop the fleet in one budget, and stop orphanin…

### DIFF
--- a/detect-pipeline/detect_pipeline/frame_source.py
+++ b/detect-pipeline/detect_pipeline/frame_source.py
@@ -176,7 +176,7 @@ class FrameSource:
         backoff_seconds: float = 1.0,
         max_backoff_seconds: float = 15.0,
         min_healthy_seconds: float = 5.0,
-        _sleep: Callable[[float], None] = time.sleep,
+        _sleep: Callable[[float], None] | None = None,
     ) -> None:
         self.rtsp_url = rtsp_url
         self.width = width
@@ -210,7 +210,12 @@ class FrameSource:
         # How long a session must last to count as "the stream works". Below
         # this, a restart is treated as fruitless (see stream()).
         self.min_healthy_seconds = min_healthy_seconds
-        self._sleep = _sleep
+        # Set by close(): ends the restart loop and interrupts the backoff
+        # sleep, so a worker parked in backoff stops in milliseconds instead
+        # of holding its caller's join() open for the full delay.
+        self._closing = False
+        self._wake = threading.Event()
+        self._sleep = _sleep or (lambda secs: self._wake.wait(secs))
         self._current_proc = None
         self._skip_backoff_once = False
 
@@ -240,6 +245,36 @@ class FrameSource:
         self._skip_backoff_once = True
         if self._current_proc is not None:
             _terminate(self._current_proc)
+
+    def close(self) -> None:
+        """Stop the restart loop and unblock the reader NOW.
+
+        Without this a stopping worker is unreachable: it is parked in a
+        blocking ``proc.stdout.read()`` (up to the RTSP timeout) or in the
+        restart backoff (up to max_backoff_seconds), and only notices the
+        stop flag between frames. Terminating the process makes the read
+        return at once, and waking the sleep drops the backoff — so join()
+        succeeds in milliseconds instead of timing out and leaving an
+        orphaned thread and ffmpeg behind.
+
+        Safe to call from another thread, and more than once.
+
+        Signals only — it must NOT wait for the process. ``_terminate``
+        blocks up to 3s reaping the child, which would make a caller
+        stopping N sources pay that serially (measured: 15s for 6 real
+        cameras). SIGTERM is enough: the child exits, its stdout closes, the
+        blocked read returns, and the stream loop's own ``finally`` does the
+        full terminate-and-reap.
+        """
+        self._closing = True
+        self._wake.set()
+        proc = self._current_proc
+        if proc is not None:
+            try:
+                if proc.poll() is None:
+                    proc.terminate()
+            except Exception:  # pragma: no cover - defensive
+                log.debug("frame source: error signalling ffmpeg", exc_info=True)
 
     def _refresh_url(self) -> None:
         """Adopt the freshest known URL for this camera, if one is offered.
@@ -276,6 +311,8 @@ class FrameSource:
         restarts = 0
         fruitless = 0
         while True:
+            if self._closing:
+                return
             self._refresh_url()
             proc = self._spawn(self.command())
             self._current_proc = proc
@@ -289,6 +326,8 @@ class FrameSource:
             finally:
                 self._current_proc = None
                 _terminate(proc)
+            if self._closing:      # closed mid-session: do not respawn
+                return
             reason = stderr_tail.text()
             # A decode-mode flip terminates ffmpeg ON PURPOSE (adaptive
             # decode). It is not a stream failure, so it must not touch the

--- a/detect-pipeline/detect_pipeline/metrics.py
+++ b/detect-pipeline/detect_pipeline/metrics.py
@@ -262,6 +262,15 @@ def record_published(camera_id: str) -> None:
     metrics.inc("tier0_events_published_total", {"camera": camera_id})
 
 
+def record_worker_straggler(camera_id: str) -> None:
+    """A worker did not exit within the fleet stop budget.
+
+    Previously invisible: the manager moved on regardless, so a thread that
+    outlived its join kept its ffmpeg alive and its replacement quietly
+    duplicated it."""
+    metrics.inc("tier0_worker_stop_timeouts_total", {"camera": camera_id})
+
+
 def record_sink_error(camera_id: str) -> None:
     """A publish to the event bus raised. Without a counter, a bus outage
     is indistinguishable from a quiet scene: both just stop incrementing

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -43,6 +43,7 @@ from .metrics import (
     record_sink_error,
     record_worker_restart,
     record_worker_state,
+    record_worker_straggler,
     forget_camera,
 )
 from .motion import MotionConfig, MotionDetector
@@ -158,11 +159,48 @@ class ResultSink(Protocol):
 
 
 class Worker(Protocol):
-    """A per-camera worker handle (thread-backed in production, fake in tests)."""
+    """A per-camera worker handle (thread-backed in production, fake in tests).
+
+    ``request_stop``/``join`` are optional: when a worker provides them the
+    manager stops the fleet in two phases (signal everyone, then wait once).
+    A worker with only the blocking ``stop`` still works — it is just stopped
+    serially, which is fine for fakes and single cameras.
+    """
 
     def start(self) -> None: ...
     def stop(self) -> None: ...
     def is_alive(self) -> bool: ...
+
+
+# How long the manager waits for the whole fleet to wind down. This is a
+# budget for ALL workers together, not per worker: paying it serially is what
+# turned a gate-mode toggle on 50 cameras into minutes of downtime.
+STOP_TIMEOUT_S = 5.0
+
+
+def _signal_stop(worker) -> None:
+    """Phase 1 — tell a worker to stop without waiting for it."""
+    request = getattr(worker, "request_stop", None)
+    if request is not None:
+        request()
+    else:                       # legacy/fake worker: blocking stop is all it has
+        worker.stop()
+
+
+def _join_workers(workers: dict[str, Worker], timeout: float) -> list[str]:
+    """Phase 2 — wait for signalled workers against ONE shared deadline.
+
+    Returns the ids that did not exit in time.
+    """
+    deadline = time.monotonic() + timeout
+    stragglers: list[str] = []
+    for cid, worker in workers.items():
+        join = getattr(worker, "join", None)
+        if join is None:        # already stopped synchronously in phase 1
+            continue
+        if not join(max(0.0, deadline - time.monotonic())):
+            stragglers.append(cid)
+    return stragglers
 
 
 # ── adaptive decode (Blue Iris-style "limit decoding unless required") ──
@@ -283,6 +321,9 @@ class CameraWorker:
         self.visit_poster = visit_poster
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
+        # The live source, so request_stop() can unblock the reader.
+        self._src = None
+        self._superseded = False
 
     def start(self) -> None:
         self._thread = threading.Thread(
@@ -290,10 +331,44 @@ class CameraWorker:
         )
         self._thread.start()
 
-    def stop(self) -> None:
+    def request_stop(self) -> None:
+        """Signal the worker to stop and unblock it — never waits.
+
+        Split from the join so a manager stopping N cameras can signal them
+        all first and then wait ONCE, instead of paying the timeout serially
+        per camera. Closing the source is what makes the wait short: the
+        thread is otherwise parked in a blocking read or the restart backoff
+        and only notices the flag between frames.
+        """
         self._stop.set()
-        if self._thread is not None:
-            self._thread.join(timeout=5)
+        src = self._src
+        if src is not None:
+            close = getattr(src, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except Exception:  # pragma: no cover - defensive
+                    log.debug("tier0 %s: error closing source",
+                              self.spec.camera_id, exc_info=True)
+
+    def join(self, timeout: float) -> bool:
+        """Wait up to ``timeout`` for the thread to exit; True if it did."""
+        if self._thread is None:
+            return True
+        self._thread.join(timeout=max(0.0, timeout))
+        return not self._thread.is_alive()
+
+    def mark_superseded(self) -> None:
+        """A replacement worker for this camera now owns the metrics.
+
+        Without this, a worker that outlived its join would later write
+        tier0_worker_up=0 and zero the gauge of the healthy replacement.
+        """
+        self._superseded = True
+
+    def stop(self, timeout: float = 5.0) -> bool:
+        self.request_stop()
+        return self.join(timeout)
 
     def is_alive(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
@@ -344,6 +419,7 @@ class CameraWorker:
     def _run(self) -> None:
         try:
             src, w, h = self._make_source()
+            self._src = src
         except Exception:
             # Emit the DOWN gauge before bailing. Returning here used to skip
             # record_worker_state entirely, so a camera that never opens had
@@ -490,7 +566,8 @@ class CameraWorker:
             if self.visit_poster is not None:
                 for visit in lifecycle.flush():
                     self.visit_poster.submit(visit)
-            record_worker_state(self.spec.camera_id, False)
+            if not self._superseded:
+                record_worker_state(self.spec.camera_id, False)
             log.info("tier0 %s: stopped", self.spec.camera_id)
 
     def _run_gate(self, result, frame) -> None:
@@ -619,7 +696,12 @@ class WorkerManager:
         and the pipeline applies it live. Gates are stateful per camera, so
         the only correct swap is stop-everything — the next reconcile tick
         rebuilds every worker with the new factory. A few seconds of gap on
-        an explicit admin action is fine; a redeploy is not."""
+        an explicit admin action is fine; a redeploy is not.
+
+        "A few seconds" is now true at fleet scale: the wind-down signals
+        every worker first and then waits ONCE (see _retire). Stopping them
+        serially made this cost STOP_TIMEOUT_S per camera — minutes of total
+        blackout on a large install, from one click in the UI."""
         self._gate_factory = gate_factory
         if dispatcher is not None:
             self._dispatcher = dispatcher
@@ -653,6 +735,7 @@ class WorkerManager:
             if c.substream_url:
                 self._latest_url[c.camera_id] = c.substream_url
 
+        doomed: dict[str, Worker] = {}
         for cid in list(self._workers):
             worker = self._workers[cid]
             spec_changed = (
@@ -668,7 +751,7 @@ class WorkerManager:
                 )
             )
             if cid not in desired or not worker.is_alive() or spec_changed:
-                worker.stop()
+                doomed[cid] = worker
                 del self._workers[cid]
                 self._specs.pop(cid, None)
                 if cid not in desired:
@@ -686,6 +769,12 @@ class WorkerManager:
                         desired[cid].nvr_camera_id,
                     )
 
+        # Stop them together. Signalling every doomed worker BEFORE waiting on
+        # any of them is what keeps the wind-down bounded by one timeout
+        # instead of one-per-camera; the old serial loop turned a spec change
+        # across a fleet into minutes of blocked reconcile.
+        self._retire(doomed)
+
         for cid, spec in desired.items():
             if cid not in self._workers:
                 worker = self._factory(spec, self.sink)
@@ -694,9 +783,34 @@ class WorkerManager:
                 self._specs[cid] = spec
                 log.info("tier0: started worker for camera %s", cid)
 
+    def _retire(self, workers: dict[str, Worker]) -> None:
+        """Wind down a set of workers: signal all, then wait once.
+
+        A straggler is reported rather than silently orphaned. Its source has
+        already been closed by the signal, so it is no longer decoding or
+        publishing — but it is marked superseded so that when it finally
+        exits it cannot zero the health gauge of its replacement.
+        """
+        if not workers:
+            return
+        for worker in workers.values():
+            _signal_stop(worker)
+        stragglers = _join_workers(workers, STOP_TIMEOUT_S)
+        for cid in stragglers:
+            supersede = getattr(workers[cid], "mark_superseded", None)
+            if supersede is not None:
+                supersede()
+            record_worker_straggler(cid)
+        if stragglers:
+            log.warning(
+                "tier0: %d worker(s) did not exit within %.0fs: %s — their "
+                "sources are closed; they are superseded and will not report "
+                "state for the cameras that replace them",
+                len(stragglers), STOP_TIMEOUT_S, ", ".join(sorted(stragglers)),
+            )
+
     def _stop_all(self) -> None:
-        for worker in self._workers.values():
-            worker.stop()
+        self._retire(dict(self._workers))
         self._workers.clear()
         self._specs.clear()
 

--- a/detect-pipeline/test/test_frame_source.py
+++ b/detect-pipeline/test/test_frame_source.py
@@ -369,3 +369,106 @@ def test_stream_urls_are_redacted_in_logs(caplog):
         list(src.stream())
     assert caplog.text, "expected restart/give-up logging"
     assert "SECRETPAYLOAD" not in caplog.text, "JWT leaked into logs"
+
+
+# ── close(): make a parked source stoppable ────────────────────────
+
+def test_close_unblocks_a_real_blocking_read():
+    """A REAL child that never writes: without close() terminating it, the
+    reader sits in stdout.read() until the RTSP timeout and the owning
+    worker cannot be joined."""
+    import subprocess
+    import sys
+    import threading
+
+    from detect_pipeline.frame_source import FrameSource
+
+    def spawn(argv):
+        # Sleeps without ever writing a frame — a stalled feed.
+        return subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+
+    src = FrameSource("rtsp://cam/stalled", width=4, height=4, fps=5,
+                      spawn=spawn, backoff_seconds=0)
+    done = threading.Event()
+
+    def drain():
+        list(src.stream())
+        done.set()
+
+    threading.Thread(target=drain, daemon=True).start()
+    time.sleep(0.4)                      # let it reach the blocking read
+    t0 = time.monotonic()
+    src.close()
+    assert done.wait(timeout=10), "close() did not unblock the reader"
+    assert time.monotonic() - t0 < 8.0
+
+
+def test_close_interrupts_the_restart_backoff():
+    """A source waiting out its backoff must stop immediately, not after the
+    full (escalating, up to max_backoff_seconds) delay."""
+    import threading
+
+    from detect_pipeline.frame_source import FrameSource
+
+    src = FrameSource(
+        "rtsp://cam/dead", width=4, height=4, fps=5,
+        spawn=lambda cmd: _EmptyProc(),
+        max_fruitless_restarts=50,        # would loop a long time
+        backoff_seconds=5.0, max_backoff_seconds=30.0,
+    )
+    done = threading.Event()
+    threading.Thread(target=lambda: (list(src.stream()), done.set()), daemon=True).start()
+    time.sleep(0.3)                      # now parked in the backoff sleep
+    t0 = time.monotonic()
+    src.close()
+    assert done.wait(timeout=5), "close() did not interrupt the backoff"
+    assert time.monotonic() - t0 < 3.0
+
+
+def test_close_stops_the_loop_from_respawning():
+    spawns = []
+    from detect_pipeline.frame_source import FrameSource
+
+    src = FrameSource("rtsp://cam/x", width=4, height=4, fps=5,
+                      spawn=lambda cmd: (spawns.append(1), _EmptyProc())[1],
+                      max_fruitless_restarts=10, backoff_seconds=0,
+                      _sleep=lambda s: src.close())   # close during backoff
+    list(src.stream())
+    assert len(spawns) == 1, "closed source must not respawn ffmpeg"
+
+
+def test_close_does_not_block_on_the_child():
+    """close() must SIGNAL, never reap.
+
+    _terminate() waits up to 3s for the child. Calling it here made close()
+    blocking, so a manager stopping N sources paid that serially — measured
+    at 15s for 6 real cameras before this was fixed. The child below ignores
+    SIGTERM, so a reaping close() would stall for the full wait.
+    """
+    import signal
+    import subprocess
+    import sys
+
+    from detect_pipeline.frame_source import FrameSource
+
+    child = (
+        "import signal,time;"
+        "signal.signal(signal.SIGTERM, lambda *a: None);"   # ignore SIGTERM
+        "time.sleep(30)"
+    )
+    proc = subprocess.Popen([sys.executable, "-c", child],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    src = FrameSource("rtsp://cam/x", width=4, height=4, fps=5,
+                      spawn=lambda cmd: proc)
+    src._current_proc = proc
+    try:
+        t0 = time.monotonic()
+        src.close()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 1.0, f"close() blocked for {elapsed:.1f}s — it must not reap"
+    finally:
+        proc.kill()
+        proc.wait(timeout=5)

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -353,3 +353,114 @@ def test_worker_degrades_to_cpu_when_the_device_is_absent():
     worker = mgr._default_factory(_spec("a"), _FakeSink())
     # Degrades rather than failing every camera at ffmpeg spawn.
     assert worker._effective_hwaccel() is HwAccel.CPU
+
+
+# ── fleet shutdown: bounded, interruptible, and non-orphaning ───────
+
+class _BlockingSource:
+    """A source parked in a blocking read until close() releases it.
+
+    Models the real failure: the worker only checks the stop flag BETWEEN
+    frames, so a source that isn't producing frames leaves it unreachable.
+    """
+
+    width, height = W, H
+
+    def __init__(self):
+        import threading as _t
+        self.released = _t.Event()
+        self.closed = False
+
+    def stream(self):
+        self.released.wait(timeout=30)      # unblocked only by close()
+        return
+        yield                                # pragma: no cover - generator marker
+
+    def close(self):
+        self.closed = True
+        self.released.set()
+
+
+def test_stop_unblocks_a_worker_parked_in_a_blocking_read():
+    """Before: join(5) always timed out here and the thread was orphaned."""
+    import time as _time
+
+    from detect_pipeline.service import CameraWorker
+
+    src = _BlockingSource()
+    worker = CameraWorker(_spec("cam-stuck"), _FakeSink(), frame_source=src)
+    worker.start()
+    for _ in range(200):                     # let it reach the blocking read
+        if worker.is_alive():
+            break
+        _time.sleep(0.01)
+
+    t0 = _time.monotonic()
+    exited = worker.stop(timeout=5.0)
+    elapsed = _time.monotonic() - t0
+
+    assert exited, "worker did not exit — join timed out"
+    assert src.closed, "stop() must close the source to unblock the reader"
+    assert elapsed < 2.0, f"took {elapsed:.1f}s; the source was not interrupted"
+
+
+def test_fleet_stop_costs_one_timeout_not_one_per_camera(monkeypatch):
+    """The regression: reconcile stopped workers serially with a 5s join
+    each, so a spec change across a fleet blocked the loop for minutes and
+    an admin gate toggle took N x 5s with every camera dark."""
+    import time as _time
+
+    from detect_pipeline import service as svc
+
+    monkeypatch.setattr(svc, "STOP_TIMEOUT_S", 0.4)
+
+    class _Deaf:
+        """Never exits — worst case for the join."""
+        def __init__(self, *a):
+            self.signalled = False
+            self.superseded = False
+
+        def start(self): pass
+        def is_alive(self): return True
+        def request_stop(self): self.signalled = True
+        def join(self, timeout):
+            _time.sleep(timeout)             # burn the whole budget
+            return False
+        def mark_superseded(self): self.superseded = True
+        def stop(self, timeout=5.0): self.request_stop(); return self.join(timeout)
+
+    made = []
+    prov = _FakeProvider([_spec(c) for c in "abcdefgh"])   # 8 cameras
+    mgr = WorkerManager(prov, _FakeSink(),
+                        worker_factory=lambda s, k: (made.append(_Deaf()), made[-1])[1])
+    mgr.reconcile()
+    assert len(made) == 8
+
+    prov.specs = []                                        # all removed
+    t0 = _time.monotonic()
+    mgr.reconcile()
+    elapsed = _time.monotonic() - t0
+
+    assert all(w.signalled for w in made), "every worker must be signalled first"
+    # One shared budget, not 8 x 0.4s.
+    assert elapsed < 8 * 0.4 * 0.6, f"{elapsed:.2f}s looks serial"
+    # Stragglers are superseded so they cannot clobber a replacement's gauge.
+    assert all(w.superseded for w in made)
+
+
+def test_straggler_cannot_zero_the_replacement_gauge():
+    from detect_pipeline import metrics as m
+    from detect_pipeline.service import CameraWorker
+
+    m.metrics.reset()
+    src = _BlockingSource()
+    old = CameraWorker(_spec("cam1"), _FakeSink(), frame_source=src)
+    old.start()
+    old.mark_superseded()                    # manager replaced it
+    old.request_stop()
+    old.join(5.0)
+
+    # The replacement's UP gauge must survive the old worker's teardown.
+    m.record_worker_state("cam1", True, target_fps=2)
+    assert m.metrics.value("tier0_worker_up", {"camera": "cam1"}) == 1.0
+    m.metrics.reset()


### PR DESCRIPTION
…g ffmpeg

reconcile stopped workers one at a time, each with join(timeout=5), and the worker only checked its stop flag BETWEEN frames — so a camera parked in a blocking read (up to the RTSP timeout) or in the restart backoff (up to 15s) always burned the full 5s. 50 cameras meant ~250s of blocked reconcile, and apply_gate_change — one admin click flipping gate mode — stopped everything serially: minutes with the whole fleet dark.

Worse, stop() ignored whether the join succeeded. reconcile deleted the worker and started a replacement in the SAME tick, so the old thread kept its ffmpeg process and MediaMTX session: duplicate decode, duplicate bus events, duplicate visits — and when it finally exited it wrote tier0_worker_up=0, zeroing the healthy replacement's gauge.

* Workers gain request_stop()/join(): signal everyone, then wait ONCE against a shared deadline (STOP_TIMEOUT_S). Workers exposing only the blocking stop() still work, so fakes and older callers are unaffected.
* FrameSource.close() ends the restart loop, wakes the backoff (the sleep is now an interruptible Event wait), and SIGTERMs the child so the blocked read returns at once.
* A straggler is reported (tier0_worker_stop_timeouts_total) and marked superseded, so it can no longer clobber its replacement's health gauge. Its source is already closed, so it is not decoding or publishing either.

close() signals but deliberately does NOT reap: _terminate() waits up to 3s per child, which kept phase 1 serial. Caught only by testing against real ffmpeg — 6 live cameras took 15.11s with the reaping version. Pinned by a test whose child ignores SIGTERM.

Measured on 6 cameras decoding a real MediaMTX stream: fleet stop went from up to 30s (serial worst case) to 0.03s, with zero orphaned decoders left.