### PR TITLE
feat: negotiate the tap stream from real decode capability, not a sha…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,11 +70,16 @@ DETECT_SKIP_UNASSIGNED=false
 
 # Which stream Tier-0 detection (and the agent's frame grabs) decode when a
 # camera has a substream: auto (default — substream on CPU-only decode, the
-# full MAIN stream when DETECT_HWACCEL is set: a GPU box can afford full-res
-# decode and gets full-res evidence crops; detection accuracy is equal
-# either way, the model input is a fixed square), sub (always the substream
-# when one exists), main (always full-res). Cameras with no substream use
-# the main stream regardless.
+# full MAIN stream when the reader can genuinely hardware-decode: a GPU box
+# can afford full-res decode and gets full-res evidence crops; detection
+# accuracy is equal either way, the model input is a fixed square), sub
+# (always the substream when one exists), main (always full-res). Cameras
+# with no substream use the main stream regardless.
+#
+# On 'auto' the decision follows the reader's RESOLVED capability, which the
+# detect-pipeline reports on every discovery request — not DETECT_HWACCEL on
+# its own. Declaring a GPU you cannot reach no longer buys the main stream.
+# 'sub' and 'main' are explicit operator choices and outrank all of it.
 INFERENCE_TAP_STREAM=auto
 # Detector confidence floor (default 0.4). Real people/vehicles usually
 # score >0.6; wire-phantoms live in the 0.25-0.4 band.
@@ -157,15 +162,18 @@ DETECT_DETECTOR=onnx       # onnx (YOLOv8, default) | rfdetr (RF-DETR, needs ort
                            # input size in DETECT_ONNX_INPUT) | hog | blob | stub
 DETECT_ONNX_BACKEND=auto   # auto (cvdnn for onnx, ort for rfdetr) | cvdnn | ort
 DETECT_ONNX_PROVIDERS=     # ort EPs, e.g. OpenVINOExecutionProvider (Intel N100)
-# Hardware decode backend. IMPORTANT: vaapi/qsv/rpi/rkmpp also need the render
-# node passed into the detect-pipeline container — uncomment the
+# Hardware decode backend. vaapi/qsv/rpi/rkmpp also need the render node
+# passed into the detect-pipeline container — uncomment the
 # `devices: - /dev/dri:/dev/dri` block in docker-compose.yml (core reads this
 # setting too, but only to choose the tap stream; it never decodes, so it
-# needs no device). Without the mapping the pipeline logs a warning per
-# camera and falls back to software decode, and because core reads this same
-# setting as "this box has a GPU" it will have already switched those cameras
-# to the full-resolution MAIN stream (see INFERENCE_TAP_STREAM above) — so the
-# combination is markedly more expensive than leaving this at cpu.
+# needs no device).
+#
+# Getting it half-right is now safe rather than expensive: the pipeline
+# resolves what it can ACTUALLY do at startup and reports that to core, so a
+# container that cannot see the render node is kept on the cheap substream
+# instead of being handed the full-resolution main stream it could only
+# decode in software. You get a warning per camera naming the missing device
+# — but the CPU bill stays the same as plain `cpu` until you fix it.
 DETECT_HWACCEL=cpu         # cpu | vaapi | nvidia | qsv | rpi | rkmpp | jetson
 DETECT_GATE_MODE=shadow    # shadow (default: measure only) | off | enforce (act — validate shadow first, see detect-pipeline/ENABLEMENT.md)
 DETECT_CV_THREADS=2        # detector thread cap (cv2 intra-op + BLAS); 0 = uncapped

--- a/detect-pipeline/detect_pipeline/providers.py
+++ b/detect-pipeline/detect_pipeline/providers.py
@@ -39,17 +39,26 @@ class HttpCameraProvider:
         path: str = DEFAULT_PATH,
         opener=None,
         timeout: float = 10.0,
+        hwaccel: str | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.path = path
         self._opener = opener or urllib.request.urlopen
         self.timeout = timeout
+        # Our RESOLVED decode backend, sent with every discovery request. Core
+        # picks the tap stream from it: full-resolution main only when the
+        # reader can genuinely hardware-decode. Must be the effective value
+        # (post resolve_hwaccel), never the configured one — reporting an
+        # intent we cannot honour is the whole bug this closes.
+        self.hwaccel = hwaccel
 
     def list_cameras(self) -> list[CameraSpec] | None:
         req = urllib.request.Request(f"{self.base_url}{self.path}")
         if self.api_key:
             req.add_header("X-Internal-Api-Key", self.api_key)
+        if self.hwaccel:
+            req.add_header("X-Detect-Hwaccel", self.hwaccel)
         try:
             with self._opener(req, timeout=self.timeout) as resp:
                 data = json.loads(resp.read().decode("utf-8"))

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -47,7 +47,7 @@ import threading
 from dataclasses import dataclass
 
 from .bus import EventSink, GateEventSink
-from .ffmpeg_presets import DEFAULT_RTSP_TIMEOUT_S
+from .ffmpeg_presets import DEFAULT_RTSP_TIMEOUT_S, resolve_hwaccel
 from .providers import HttpCameraProvider
 from .service import WorkerManager
 
@@ -373,7 +373,20 @@ def _detector_factory(cfg: ServiceConfig):
 
 
 def build_manager(cfg: ServiceConfig, sink, *, gate_sink=None) -> WorkerManager:
-    provider = HttpCameraProvider(cfg.core_url, api_key=cfg.api_key)
+    # Resolve the decode backend ONCE here and tell core what we can actually
+    # do. Core hands out the full-resolution main stream only when the reader
+    # really can hardware-decode, so this must be the post-resolution value:
+    # claiming vaapi without the render node is what used to buy us the main
+    # stream AND software decode.
+    effective_hwaccel, hw_downgrade = resolve_hwaccel(cfg.hwaccel, device=cfg.device)
+    if hw_downgrade:
+        log.warning(
+            "hwaccel %r unusable — reporting 'cpu' to core so it keeps us on "
+            "the substream: %s", cfg.hwaccel, hw_downgrade,
+        )
+    provider = HttpCameraProvider(
+        cfg.core_url, api_key=cfg.api_key, hwaccel=effective_hwaccel.value,
+    )
     # Region crops match the detector input so the model sees full-detail crops.
     model_size = cfg.onnx_input if cfg.detector == "onnx" else cfg.model_size
     # #10 Tier-1 dispatch: built only when a KAI-C URL is configured (off by

--- a/detect-pipeline/test/test_bus_providers.py
+++ b/detect-pipeline/test/test_bus_providers.py
@@ -209,3 +209,47 @@ def test_provider_leaves_hwaccel_undeclared_when_core_omits_it():
     declared = _to_spec({"camera_id": "cam1", "frame_url": "rtsp://m/cam-1",
                          "hwaccel": "vaapi"})
     assert declared.hwaccel == "vaapi"
+
+
+# ── capability handshake: tell core what we can ACTUALLY decode ─────
+
+def test_provider_reports_its_resolved_capability():
+    """Core hands out the full-resolution main stream only to a reader that
+    can really hardware-decode, so the header must carry the RESOLVED value."""
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["hw"] = req.get_header("X-detect-hwaccel")
+        return _FakeResp(json.dumps({"cameras": []}).encode())
+
+    prov = HttpCameraProvider("http://core:8000", opener=opener, hwaccel="vaapi")
+    prov.list_cameras()
+    assert seen["hw"] == "vaapi"
+
+
+def test_provider_omits_the_header_when_it_has_nothing_to_report():
+    """No claim is better than a false one: core then falls back to its own
+    setting rather than being told something untrue."""
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["hw"] = req.get_header("X-detect-hwaccel")
+        return _FakeResp(json.dumps({"cameras": []}).encode())
+
+    HttpCameraProvider("http://core:8000", opener=opener).list_cameras()
+    assert seen["hw"] is None
+
+
+def test_build_manager_reports_cpu_when_the_render_node_is_missing():
+    """End of the trap: DETECT_HWACCEL=vaapi with no /dev/dri must report cpu,
+    so core keeps this reader on the cheap substream instead of handing it
+    full-res video it can only decode in software."""
+    from detect_pipeline.run import build_manager, config_from_env
+
+    class _Sink:
+        def publish(self, *a): return True
+
+    cfg = config_from_env({"DETECT_HWACCEL": "vaapi",
+                           "DETECT_HWACCEL_DEVICE": "/definitely/not/here"})
+    mgr = build_manager(cfg, _Sink())
+    assert mgr.provider.hwaccel == "cpu"

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -256,8 +256,23 @@ def _mint_mediamtx_jwt() -> str | None:
 
 
 @router.get("/cameras", dependencies=[Depends(_require_internal_key)])
-def list_camera_agent_sources(db: Session = Depends(get_db)) -> dict[str, object]:
+def list_camera_agent_sources(
+    db: Session = Depends(get_db),
+    x_detect_hwaccel: str | None = Header(default=None, alias="X-Detect-Hwaccel"),
+) -> dict[str, object]:
     """Return active cameras as frame sources for camera-agent.
+
+    ``X-Detect-Hwaccel`` is the caller's **resolved** decode backend — what it
+    can actually do, not what it was configured to want. When present it wins
+    over ``settings.detect_hwaccel`` for the auto tap decision below.
+
+    Why: handing out the full-resolution main stream is a bet that the reader
+    has a GPU to absorb it. That bet used to be placed on a setting BOTH sides
+    read independently, so a deployment with ``DETECT_HWACCEL=vaapi`` but no
+    ``/dev/dri`` passed through got the main stream *and* software decode —
+    several times the intended cost, silently. The reader is the only party
+    that knows whether the render node is really there, so it now says so and
+    we believe it. A caller that sends no header keeps the old behaviour.
 
     Prefer the MediaMTX internal RTSP tap so OpenNVR remains the owner of the
     camera connection. If the deployment disables that tap, fall back to the
@@ -320,7 +335,14 @@ def list_camera_agent_sources(db: Session = Depends(get_db)) -> dict[str, object
             elif mode == "sub":
                 use_sub = has_sub
             else:  # auto (and any unknown value degrades to auto)
-                hw = (settings.detect_hwaccel or "cpu").strip().lower()
+                # The caller's REPORTED capability wins; the setting is only a
+                # declaration of intent. No header = pre-handshake caller, so
+                # keep reading the setting for it.
+                hw = (
+                    x_detect_hwaccel
+                    if x_detect_hwaccel is not None
+                    else (settings.detect_hwaccel or "cpu")
+                ).strip().lower()
                 use_sub = has_sub and hw in ("", "cpu")
             tap_name = substream_name(stream_name) if use_sub else stream_name
             frame_url = f"{base}/{tap_name}"

--- a/server/tests/test_tier0_substream_tap.py
+++ b/server/tests/test_tier0_substream_tap.py
@@ -171,3 +171,59 @@ def test_forced_sub_uses_it_even_with_hardware_decode(client, monkeypatch):
     # never turns a derivation guess into the detector's source either.
     assert cams["cam2"]["source"] == "mediamtx"
     assert cams["cam3"]["source"] == "mediamtx"
+
+
+# ── Capability handshake: the reader's ACTUAL decode ability wins ───
+#
+# Handing out the main stream is a bet that the reader has a GPU. That bet
+# used to be placed on a setting BOTH services read independently, so a
+# deployment with DETECT_HWACCEL=vaapi but no /dev/dri passed through got the
+# main stream AND software decode — several times the intended cost, silently.
+# The reader now reports what it RESOLVED and we believe it over the setting.
+
+
+def _cams_hw(client, hwaccel: str | None) -> dict[str, dict]:
+    headers = {} if hwaccel is None else {"X-Detect-Hwaccel": hwaccel}
+    body = client.get("/internal/camera-agent/cameras", headers=headers).json()
+    return {c["camera_id"]: c for c in body["cameras"]}
+
+
+def test_reported_cpu_keeps_the_substream_despite_the_setting(client, monkeypatch):
+    """THE trap this closes: configured for vaapi, but the container cannot
+    see the render node, so the pipeline reports cpu — it must not be handed
+    full-resolution video it can only decode in software."""
+    monkeypatch.setattr(settings, "detect_hwaccel", "vaapi")
+    cams = _cams_hw(client, "cpu")
+    assert cams["cam1"]["source"] == "mediamtx-sub"
+    assert cams["cam1"]["frame_url"].endswith("-sub")
+
+
+def test_reported_hwaccel_earns_the_main_stream(client, monkeypatch):
+    """The converse: the reader really can hardware-decode, so full-res is
+    affordable even though the server-side setting was never updated."""
+    monkeypatch.setattr(settings, "detect_hwaccel", "cpu")
+    cams = _cams_hw(client, "vaapi")
+    assert cams["cam1"]["source"] == "mediamtx"
+    assert not cams["cam1"]["frame_url"].endswith("-sub")
+
+
+def test_absent_header_preserves_the_pre_handshake_behaviour(client, monkeypatch):
+    """The endpoint is shared with the camera-agent, which does not report a
+    capability — those callers must keep reading the setting."""
+    monkeypatch.setattr(settings, "detect_hwaccel", "vaapi")
+    assert _cams_hw(client, None)["cam1"]["source"] == "mediamtx"
+    monkeypatch.setattr(settings, "detect_hwaccel", "cpu")
+    assert _cams_hw(client, None)["cam1"]["source"] == "mediamtx-sub"
+
+
+def test_forced_tap_modes_still_override_the_report(client, monkeypatch):
+    """An explicit operator choice outranks the negotiation entirely."""
+    monkeypatch.setattr(settings, "inference_tap_stream", "sub")
+    assert _cams_hw(client, "vaapi")["cam1"]["source"] == "mediamtx-sub"
+    monkeypatch.setattr(settings, "inference_tap_stream", "main")
+    assert _cams_hw(client, "cpu")["cam1"]["source"] == "mediamtx"
+
+
+def test_reported_capability_is_case_and_space_tolerant(client, monkeypatch):
+    monkeypatch.setattr(settings, "detect_hwaccel", "vaapi")
+    assert _cams_hw(client, " CPU ")["cam1"]["source"] == "mediamtx-sub"


### PR DESCRIPTION
…red env var

Handing out the full-resolution main stream is a bet that the reader has a GPU to absorb it. That bet was placed on DETECT_HWACCEL, which core and the detect-pipeline read INDEPENDENTLY — so they could disagree, and the failure was silent and expensive: a deployment configured for vaapi without /dev/dri passed through got the main stream from core AND software decode in the pipeline. Roughly 2 cores per camera instead of 0.3, for a setting the operator believed made things faster.

The reader is the only party that knows whether the render node is actually there, so it now says so and core believes it:

* The pipeline resolves its backend once at startup and sends the RESOLVED value as X-Detect-Hwaccel on every discovery request. Reporting an intent it cannot honour is the whole bug, so this is deliberately the post- resolve_hwaccel value — a container missing the device reports "cpu".
* Core's 'auto' tap decision reads that header in preference to settings.detect_hwaccel.

Fails safe in both directions. No header means a pre-handshake caller (the camera-agent shares this endpoint) and keeps the old setting-based behaviour; a reader that cannot hardware-decode is simply kept on the cheap substream. The explicit 'sub'/'main' tap modes still outrank everything — an operator's stated choice is not up for negotiation.

Verified end to end with the real provider driving the real endpoint: misconfigured GPU box reports cpu and is kept on the substream; a genuine one is handed the main stream even when the server-side setting still says cpu; a plain CPU box is unchanged. The six existing tap tests pass untouched.