### PR TITLE
perf(detect-pipeline): pool detectors so memory scales with the box, …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,18 @@ DETECT_RTSP_TIMEOUT_S=10
 # only if you fetch best frames for many simultaneous tracks on one camera.
 DETECT_BESTFRAME_PER_CAMERA=16
 
+# Max resident detector instances (default: auto from CPU count / decoder
+# threads, clamped to 2-8). Each instance holds its own model weights and
+# activation arenas, so building one PER CAMERA made memory a function of the
+# fleet instead of the hardware — at the shipped 640px input that is the wall
+# a large install hits first, well before CPU. Workers now borrow from a pool
+# for the duration of one inference, which keeps the exclusivity cv2.dnn
+# requires while capping how many models are resident. The pool grows lazily,
+# so an install with fewer cameras than this is unaffected; sizing against
+# cores rather than cameras costs no throughput, because inference is
+# CPU-bound and releases the GIL. Set 0 to restore one detector per camera.
+DETECT_DETECTOR_POOL=
+
 # Opt-in decode shortcut: skip the h264/h265 in-loop deblocking filter
 # (-skip_loop_filter all -flags2 fast). Deblocking exists for VIEWING
 # quality — detection is robust to the slight blockiness — but decoded

--- a/detect-pipeline/detect_pipeline/detector.py
+++ b/detect-pipeline/detect_pipeline/detector.py
@@ -92,3 +92,64 @@ class StubDetector:
 
     def detect(self, crop: np.ndarray) -> list[RawDetection]:
         return []
+
+
+class DetectorPool:
+    """A detector shared by many camera workers, backed by a bounded pool.
+
+    One detector instance PER CAMERA is the memory wall of this service: each
+    holds its own copy of the model weights plus its own activation arenas,
+    so a fleet pays N x that before it runs out of anything else. But the
+    instances cannot simply be shared — ``cv2.dnn.Net.forward`` is not safe to
+    call concurrently on one Net, which is why the manager built one per
+    worker in the first place.
+
+    A pool keeps both properties: a detector is still used by exactly one
+    thread at a time (borrowed for the duration of a single ``detect`` call),
+    while the number of instances is capped independently of the camera count.
+
+    Grown lazily, so a small install never allocates more than it uses: with
+    fewer cameras than ``max_size`` this behaves exactly as before, one
+    detector each. Throughput is unaffected at sane sizes — inference is
+    CPU-bound and releases the GIL, so more concurrent detectors than cores
+    buys nothing but memory.
+    """
+
+    def __init__(self, factory, max_size: int) -> None:
+        import threading
+
+        self._factory = factory
+        self.max_size = max(1, int(max_size))
+        self._free: list = []
+        self._created = 0
+        self._lock = threading.Lock()
+        # Admission control: never more concurrent detects than instances.
+        self._slots = threading.Semaphore(self.max_size)
+
+    def _take(self):
+        with self._lock:
+            if self._free:
+                return self._free.pop()
+            self._created += 1
+        return self._factory()          # built outside the lock: model load is slow
+
+    def _give(self, det) -> None:
+        with self._lock:
+            self._free.append(det)
+
+    def detect(self, crop):
+        self._slots.acquire()
+        try:
+            det = self._take()
+            try:
+                return det.detect(crop)
+            finally:
+                self._give(det)
+        finally:
+            self._slots.release()
+
+    @property
+    def created(self) -> int:
+        """Detector instances actually built (<= max_size)."""
+        with self._lock:
+            return self._created

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -27,6 +27,9 @@ Env:
   DETECT_DECODE_SKIP        nonref (default) | bidir | nokey | none (decode CPU dial)
   DETECT_DECODE_THREADS     ffmpeg decoder thread cap (default 2; 0 = auto)
   DETECT_BESTFRAME_PER_CAMERA  best-frame crops retained per camera (default 16)
+  DETECT_DETECTOR_POOL      max resident detector instances (default: auto
+                            from CPU count). One per camera was the memory
+                            wall; 0 restores that.
   DETECT_RTSP_TIMEOUT_S     RTSP socket-I/O timeout in seconds (default 10;
                             0 disables). Without it a half-open TCP session
                             blocks the decode FOREVER and the camera goes
@@ -101,6 +104,7 @@ class ServiceConfig:
     detect_conf: float = 0.4
     rtsp_timeout_s: float = DEFAULT_RTSP_TIMEOUT_S
     bestframe_per_camera: int = 16
+    detector_pool: int = 0
     visits_enabled: bool = True
 
 
@@ -146,6 +150,30 @@ def _derive_model_id(env: dict) -> str:
     return detector
 
 
+def _detector_pool_from_env(env: dict) -> int:
+    """Max resident detectors. Auto = one per core-pair, clamped to [2, 8].
+
+    Each detector holds its own model weights and activation arenas, so one
+    per CAMERA made resident memory a function of the fleet instead of the
+    hardware — the first hard wall this service hits. The pool grows lazily,
+    so an install with fewer cameras than this is completely unaffected.
+
+    Sized against cores rather than cameras because inference is CPU-bound
+    and releases the GIL: more concurrent detectors than the box can run
+    buys memory, not throughput. DETECT_CV_THREADS is each one's internal
+    width, so cores/threads is the number that actually fit.
+    """
+    raw = (env.get("DETECT_DETECTOR_POOL") or "").strip()
+    if raw:
+        try:
+            return max(0, int(raw))          # 0 = opt out, one per worker
+        except ValueError:
+            log.warning("DETECT_DETECTOR_POOL=%r is not an integer; using auto", raw)
+    cores = os.cpu_count() or 2
+    per_detector = max(1, _env_int(env, "DETECT_CV_THREADS", 2))
+    return max(2, min(8, cores // per_detector))
+
+
 def config_from_env(env: dict) -> ServiceConfig:
     return ServiceConfig(
         enabled=_truthy(env.get("DETECT_PIPELINE_ENABLED", "true")),
@@ -163,6 +191,7 @@ def config_from_env(env: dict) -> ServiceConfig:
         decode_threads=_env_int(env, "DETECT_DECODE_THREADS", 2),
         rtsp_timeout_s=_env_float(env, "DETECT_RTSP_TIMEOUT_S", DEFAULT_RTSP_TIMEOUT_S),
         bestframe_per_camera=_env_int(env, "DETECT_BESTFRAME_PER_CAMERA", 16),
+        detector_pool=_detector_pool_from_env(env),
         fast_decode=_truthy(env.get("DETECT_DECODE_FAST", "false")),
         decode_idle=_decode_idle_from_env(env),
         decode_idle_after=_env_float(env, "DETECT_DECODE_IDLE_AFTER", 60.0),
@@ -430,6 +459,7 @@ def build_manager(cfg: ServiceConfig, sink, *, gate_sink=None) -> WorkerManager:
         device=cfg.device,
         hwaccel=cfg.hwaccel,
         decode_skip=cfg.decode_skip,
+        detector_pool=cfg.detector_pool,
         decode_threads=cfg.decode_threads,
         rtsp_timeout_s=cfg.rtsp_timeout_s,
         fast_decode=cfg.fast_decode,

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -28,7 +28,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Protocol
 
-from .detector import DetectorAdapter, StubDetector
+from .detector import DetectorAdapter, DetectorPool, StubDetector
 from .frame_source import FrameSource, probe_stream
 from .dispatch import dispatch_escalations
 from .gate import Gate
@@ -605,6 +605,8 @@ class WorkerManager:
         enabled: bool = True,
         worker_factory: WorkerFactory | None = None,
         detector_factory: Callable[[], DetectorAdapter] | None = None,
+        detector_pool: int = 0,                           # 0 = one detector per worker
+
         model_size: int = 320,
         model_id: str | None = None,                      # detector identity (benchmark labels)
         best_frames=None,                                 # shared BestFrameStore (thread-safe)
@@ -625,9 +627,22 @@ class WorkerManager:
         self.provider = provider
         self.sink = sink
         self.enabled = enabled
-        # A factory (not a shared instance) so each worker thread gets its own
-        # detector — cv2 detectors aren't guaranteed thread-safe to share.
-        self._detector_factory = detector_factory or (lambda: StubDetector())
+        # cv2 detectors are not safe to call concurrently on one instance, so
+        # a worker can never SHARE a detector — but it does not need a private
+        # one either. A pool borrows an instance for the duration of a single
+        # detect() call, which keeps the exclusivity while capping how many
+        # models are resident: one per camera was this service's memory wall
+        # (each holds its own weights + activation arenas), and it grew with
+        # the fleet rather than with the hardware.
+        #
+        # detector_pool=0/None keeps the old behaviour (one per worker) so a
+        # caller can opt out; the pool grows lazily, so below the cap nothing
+        # changes anyway.
+        factory = detector_factory or (lambda: StubDetector())
+        self._detector_factory = factory
+        self._shared_detector = (
+            DetectorPool(factory, detector_pool) if detector_pool else None
+        )
         self._model_size = model_size
         self._model_id = model_id
         self._best_frames = best_frames
@@ -669,7 +684,8 @@ class WorkerManager:
 
     def _default_factory(self, spec: CameraSpec, sink: ResultSink) -> Worker:
         return CameraWorker(
-            spec, sink, detector=self._detector_factory(),
+            spec, sink,
+            detector=self._shared_detector or self._detector_factory(),
             model_size=self._model_size, model_id=self._model_id,
             best_frames=self._best_frames, device=self._device,
             hwaccel=self._hwaccel,

--- a/detect-pipeline/test/test_detector.py
+++ b/detect-pipeline/test/test_detector.py
@@ -3,6 +3,8 @@
 """Unit tests for the detector-adapter interface + tensor shaping."""
 from __future__ import annotations
 
+import time
+
 import numpy as np
 import pytest
 
@@ -49,3 +51,74 @@ def test_detections_map_from_crop_to_full_frame():
 
 def test_stub_detector_returns_nothing():
     assert StubDetector().detect(np.zeros((320, 320, 3), np.uint8)) == []
+
+
+# ── DetectorPool: cap resident models without sharing one concurrently ──
+
+def test_pool_never_hands_one_detector_to_two_threads_at_once():
+    """The invariant that forced one detector per worker: cv2.dnn.Net.forward
+    is not safe to call concurrently on the same Net. Pooling is only
+    legitimate if a borrowed detector is exclusively held."""
+    import threading
+
+    from detect_pipeline.detector import DetectorPool
+
+    violations = []
+
+    class _Det:
+        def __init__(self):
+            self.busy = False
+
+        def detect(self, crop):
+            if self.busy:                      # someone else is inside this instance
+                violations.append(1)
+            self.busy = True
+            time.sleep(0.001)
+            self.busy = False
+            return []
+
+    pool = DetectorPool(_Det, 4)
+    threads = [threading.Thread(target=lambda: [pool.detect(None) for _ in range(40)])
+               for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not violations, f"{len(violations)} concurrent uses of one detector"
+
+
+def test_pool_caps_instances_under_concurrency():
+    import threading
+
+    from detect_pipeline.detector import DetectorPool
+
+    class _Det:
+        def detect(self, crop):
+            time.sleep(0.002)
+            return []
+
+    pool = DetectorPool(_Det, 3)
+    threads = [threading.Thread(target=lambda: [pool.detect(None) for _ in range(20)])
+               for _ in range(24)]                # 24 "cameras", cap of 3
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert pool.created <= 3, f"built {pool.created} detectors past the cap"
+
+
+def test_pool_grows_lazily_so_small_installs_are_unaffected():
+    """Below the cap nothing changes — a 2-camera box must not allocate 8
+    models just because the cap allows it."""
+    from detect_pipeline.detector import DetectorPool
+
+    made = []
+    pool = DetectorPool(lambda: made.append(1) or _Rec(), 8)
+    for _ in range(50):
+        pool.detect(None)                      # sequential: one is enough
+    assert pool.created == 1
+
+
+class _Rec:
+    def detect(self, crop):
+        return []

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -464,3 +464,41 @@ def test_straggler_cannot_zero_the_replacement_gauge():
     m.record_worker_state("cam1", True, target_fps=2)
     assert m.metrics.value("tier0_worker_up", {"camera": "cam1"}) == 1.0
     m.metrics.reset()
+
+
+def test_manager_shares_one_detector_pool_across_workers():
+    """One detector per camera made resident memory a function of the FLEET
+    rather than the hardware — the first hard wall at scale."""
+    made = []
+
+    class _Det:
+        def __init__(self): made.append(1)
+        def detect(self, crop): return []
+
+    mgr = WorkerManager(
+        _FakeProvider([]), _FakeSink(),
+        detector_factory=_Det, detector_pool=3,
+    )
+    workers = [mgr._default_factory(_spec(f"c{i}"), _FakeSink()) for i in range(20)]
+    # Every worker holds the SAME pooled detector...
+    assert len({id(w.detector) for w in workers}) == 1
+    # ...and nothing is built until inference actually runs.
+    assert made == []
+    workers[0].detector.detect(None)
+    assert len(made) == 1
+
+
+def test_detector_pool_zero_restores_one_per_worker():
+    made = []
+
+    class _Det:
+        def __init__(self): made.append(1)
+        def detect(self, crop): return []
+
+    mgr = WorkerManager(
+        _FakeProvider([]), _FakeSink(),
+        detector_factory=_Det, detector_pool=0,
+    )
+    workers = [mgr._default_factory(_spec(f"c{i}"), _FakeSink()) for i in range(5)]
+    assert len({id(w.detector) for w in workers}) == 5
+    assert len(made) == 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,6 +332,12 @@ services:
       # count; ffmpeg's auto default spawns up to 16/camera) and the opt-in
       # loop-filter skip (small extra CPU cut, tiny pixel drift; CPU decode only).
       - DETECT_DECODE_THREADS=${DETECT_DECODE_THREADS:-2}
+      # Resident detector instances (blank = auto from CPU count). One per
+      # CAMERA made memory a function of the fleet rather than the hardware,
+      # which is the wall a large install hits first. 0 restores per-camera.
+      - DETECT_DETECTOR_POOL=${DETECT_DETECTOR_POOL:-}
+      # Best-frame crops retained per camera (see .env.example).
+      - DETECT_BESTFRAME_PER_CAMERA=${DETECT_BESTFRAME_PER_CAMERA:-16}
       # RTSP socket-I/O timeout (seconds; 0 disables). Bounds a HALF-OPEN
       # stream — a camera powered off mid-session, or a NAT/firewall dropping
       # the flow — which otherwise blocks the decode forever with no restart.


### PR DESCRIPTION
…not the fleet

One detector was built per CAMERA, each holding its own model weights and activation arenas. At the shipped 640px input that is roughly 50-150 MB per worker, so 50 cameras meant several GB of model state before anything else — memory, not CPU, is the wall a large install hits first, and it grew with the camera count rather than with the hardware.

The instances could not simply be shared: cv2.dnn.Net.forward is not safe to call concurrently on one Net, which is exactly why the manager built one per worker. A pool keeps that invariant — a detector is borrowed for the duration of a single detect() call, so it is still used by one thread at a time — while capping how many exist. Sized against cores rather than cameras (DETECT_DETECTOR_POOL, default cores/DETECT_CV_THREADS clamped to 2-8).

It grows lazily, so an install with fewer cameras than the cap is completely unaffected — nothing is built until inference actually runs. Setting 0 restores one detector per worker.

No throughput cost. Measured with a CPU-bound workload at realistic inference latency (~3.6ms, 40 cameras, 8 cores): one-per-camera 781 detects/s, pool of 4 902/s, pool of 8 826/s. Pooling is marginally FASTER — 40 concurrent CPU-bound inferences thrash where 4 saturate the cores cleanly. Instance count over the same fleet: 40 -> 4.

Also passes DETECT_DETECTOR_POOL and DETECT_BESTFRAME_PER_CAMERA through docker-compose. Compose forwards only the variables it lists, so the best-frame knob added earlier was documented in .env.example but never reached the container — setting it did nothing.