### PR TITLE
fix(detect-pipeline): close out the follow-up tail (13g, 13h, and the…

### DIFF
--- a/detect-pipeline/FOLLOWUPS.md
+++ b/detect-pipeline/FOLLOWUPS.md
@@ -503,14 +503,14 @@ CPU than steady state. `Frame.ts` is `time.monotonic()` at *read*
 completion, not capture time, so staleness is structurally unmeasurable
 today; measuring it is a prerequisite for any load-shedding.
 
-### 13g. Tentative tracks consume the cap while invisible — STILL OPEN
+### 13g. Tentative tracks consume the cap while invisible — ✅ FIXED
 
 `max_tracks` counts all internal tracks; `tier0_tracks_active` reports
 only confirmed ones. A camera can refuse new tracks
 (`tier0_track_spawns_dropped` rising) while the gauge that is supposed to
 explain why looks healthy.
 
-### 13h. Docs that overstate the code — STILL OPEN
+### 13h. Docs that overstate the code — ✅ FIXED
 
 - `README` calls adaptive-decode promotion "sub-second, no backoff"; the
   real path is up to a GOP plus process teardown and a keyframe wait.
@@ -545,21 +545,20 @@ counted as feed restarts; a stop signalled during source setup being lost;
 the Tier-1 dispatcher leaking a thread pool per gate-mode toggle; decode
 flips blocking the frame loop up to 3s; and the rfdetr crop-size mismatch.
 
-**Still open, lower severity:**
+**Also fixed in a follow-up pass:** per-series metric removal (a deleted
+camera no longer alerts forever), the drop-oldest double-drop race, the
+unreachable `max_backoff_seconds`, the `"stationary"`-vs-`"cooldown"`
+suppression label, and the `"unconfirmed"` reason (documented as a
+belt-and-braces path for callers that feed unfiltered tracks, not a
+production rail).
 
-* `Metrics` has no per-series removal, so a deleted camera's
-  `tier0_worker_up{camera=X}` stays at 0 forever and alerts on a camera that
-  no longer exists. `forget_camera` only clears the `/health` input.
-* The new drop-oldest path in `VisitPoster.submit` makes `submit` a queue
-  CONSUMER. Two workers hitting a full queue concurrently can lose two visits
-  while counting one. Rare; it undercounts the metric it exists to make honest.
-* `max_backoff_seconds` is unreachable dead config — `stream()` gives up at
-  `max_fruitless_restarts` before the delay ever escalates that far.
-* `gate.py` labels a critical-class track suppressed in cooldown as
-  `"stationary"` rather than `"cooldown"`, over-counting that reason.
-* The `"unconfirmed"` visit-drop reason cannot fire: `VisitLifecycle` is fed
-  `Tracker.tracks`, which is confirmed-only.
+**Still open — deliberately deferred:**
+
+* **13f overload behaviour.** Needs real capture timestamps to measure
+  staleness at all: `Frame.ts` is `time.monotonic()` at READ completion, so
+  "how far behind are we" is currently unanswerable, and any load-shedding
+  has to be built on top of that. This is design work, not a patch.
 * `_StderrTail.text()` iterates a deque another thread appends to, and
   `running_ids()` iterates `_workers` from the health thread. Both are safe
-  under CPython's GIL (single C-level calls) but would race on a
-  free-threaded build.
+  under CPython's GIL (single uninterruptible C-level calls) and would only
+  race on a free-threaded build, which this service does not target.

--- a/detect-pipeline/README.md
+++ b/detect-pipeline/README.md
@@ -134,6 +134,15 @@ larger candidate pool for best-frame selection; dropping to 1 buys a
 last bit of CPU back. An explicit per-camera `fps` from the discovery
 endpoint still wins.
 
+One counter-intuitive trade to know before raising it: track confirmation
+needs `fps // 2` **consecutive** matched frames, so a higher rate also
+raises the bar an object must clear to exist at all. At the default 2 that
+is a single frame; at 10 it is five in a row, and one dropped frame from an
+occlusion resets it. Brief visits therefore get *harder* to record as you
+give the box more CPU — watch `tier0_visits_dropped_total{reason="too_short"}`
+after a change.
+
+
 **Third dial: configure the substream.** Tier-0 decodes each
 camera's *substream* (a low-res second stream every mainstream camera
 provides). If a camera has no substream configured, Tier-0 falls back to
@@ -189,8 +198,9 @@ The pattern Blue Iris ships as "limit decoding unless required", ON by
 default: a camera whose scene is quiet decodes ONLY keyframes (~one frame
 per GOP) — near-zero cost — while motion is still watched at that rate.
 The first motion box or live track flips the camera back to full decode by
-respawning its ffmpeg against the local MediaMTX republish (sub-second, no
-backoff); after `DETECT_DECODE_IDLE_AFTER` quiet seconds (default 60) it
+respawning its ffmpeg against the local MediaMTX republish (no backoff,
+but budget 2-6s end to end: a GOP to notice, process teardown, a fresh RTSP
+handshake, then a wait for the next keyframe); after `DETECT_DECODE_IDLE_AFTER` quiet seconds (default 60) it
 idles again. `tier0_decode_idle{camera=...}` on `/metrics` shows who is
 idling. Recording is unaffected — the full main stream is always recorded;
 this shapes only what the detector looks at. The trade the default accepts:

--- a/detect-pipeline/detect_pipeline/events_poster.py
+++ b/detect-pipeline/detect_pipeline/events_poster.py
@@ -8,9 +8,11 @@ when the visit becomes history: one POST to core's canonical event store
 (RFC-0001 C1) with the lifecycle summary and the crop as JPEG.
 
 Design constraints honoured here:
-* the worker loop must never block on core → posts go through a small
+* the worker loop must never block ON CORE → the POST goes through a small
   bounded queue drained by one daemon thread; when the queue is full the
-  oldest visit is dropped (and counted) rather than stalling detection;
+  oldest visit is dropped (and counted) rather than stalling detection.
+  Note the best-frame JPEG encode is NOT off-thread: _finish() encodes on
+  the worker's frame loop, so a track ending costs one imencode there;
 * per-track grain, not per-frame — a busy camera posts a handful of visits
   per hour, so stdlib urllib + one thread is deliberately boring;
 * best-effort: core being down loses history, never detection. Failures
@@ -97,6 +99,7 @@ class VisitPoster:
         self._q: queue.Queue[Visit] = queue.Queue(maxsize=maxsize)
         self._dropped = 0
         self._drop_lock = threading.Lock()
+        self._evict_lock = threading.Lock()
         self._thread: threading.Thread | None = None
 
     # -- worker-side (never blocks) ---------------------------------
@@ -112,16 +115,29 @@ class VisitPoster:
         # always promised. put_nowait alone dropped the NEWEST, so a backlog
         # meant keeping a queue full of stale visits and throwing away
         # everything currently happening — the opposite of useful history.
+        #
+        # Serialised: submit is called from every worker thread and this path
+        # makes it a queue CONSUMER as well as a producer. Two workers
+        # overflowing at once could each pull one off and only one win the put
+        # back, silently losing the other thread's evicted visit while counting
+        # a single drop.
         evicted: Visit | None = None
-        try:
-            evicted = self._q.get_nowait()
-        except queue.Empty:                  # drained between the two calls
-            pass
-        try:
-            self._q.put_nowait(visit)
-            queued = True
-        except queue.Full:                   # refilled underneath us; give up
-            queued = False
+        with self._evict_lock:
+            try:
+                evicted = self._q.get_nowait()
+            except queue.Empty:              # drained between the two calls
+                pass
+            try:
+                self._q.put_nowait(visit)
+                queued = True
+            except queue.Full:               # refilled underneath us; give up
+                queued = False
+                if evicted is not None:      # put the old one back, not the new
+                    try:
+                        self._q.put_nowait(evicted)
+                        evicted = None
+                    except queue.Full:       # pragma: no cover - drained again
+                        pass
 
         lost = evicted if queued else visit
         with self._drop_lock:                # plain += raced across N workers
@@ -257,6 +273,10 @@ class VisitLifecycle:
     def _finish(self, tid, v) -> Visit | None:
         end = v.get("end", v["start"])
         if not v["confirmed"]:
+            # Belt-and-braces only: observe() is fed Tracker.tracks, which is
+            # confirmed-only, so this cannot fire through the production path.
+            # Kept for callers that feed unfiltered tracks (bench, replay);
+            # it is NOT the junk-suppression rail — min_duration_s below is.
             record_visit_dropped(self.camera_id, "unconfirmed")
             return None
         if (end - v["start"]) < self.min_duration_s:

--- a/detect-pipeline/detect_pipeline/frame_source.py
+++ b/detect-pipeline/detect_pipeline/frame_source.py
@@ -196,7 +196,7 @@ class FrameSource:
         max_restarts: int | None = None,
         max_fruitless_restarts: int = 5,
         backoff_seconds: float = 1.0,
-        max_backoff_seconds: float = 15.0,
+        max_backoff_seconds: float = 8.0,
         min_healthy_seconds: float = 5.0,
         _sleep: Callable[[float], None] | None = None,
         _rand: Callable[[], float] | None = None,
@@ -229,6 +229,9 @@ class FrameSource:
         # resurrects it with a FRESH tap URL from the provider.
         self.max_fruitless_restarts = max_fruitless_restarts
         self.backoff_seconds = backoff_seconds
+        # Reachable by construction: with the default schedule the last
+        # delay before give-up is backoff * 2**(max_fruitless-2) = 8s, so a
+        # 15s cap could never bind and read as dead config.
         self.max_backoff_seconds = max_backoff_seconds
         # How long a session must last to count as "the stream works". Below
         # this, a restart is treated as fruitless (see stream()).

--- a/detect-pipeline/detect_pipeline/gate.py
+++ b/detect-pipeline/detect_pipeline/gate.py
@@ -170,6 +170,13 @@ class Gate:
                 return out(True, "critical_class")
             if in_zone:
                 return out(True, "in_zone")
+        elif is_critical or in_zone:
+            # It WOULD have been forced through; the only thing holding it back
+            # is the rate limit. Falling into the normal path below labelled a
+            # stationary critical object "stationary", which reads as "we
+            # suppress these" — the opposite of the documented contract, and it
+            # inflated gate_suppressions_total{reason="stationary"}.
+            return out(False, "cooldown")
 
         # ── normal path ──
         if not interesting:

--- a/detect-pipeline/detect_pipeline/metrics.py
+++ b/detect-pipeline/detect_pipeline/metrics.py
@@ -27,10 +27,13 @@ baseline / gated escalations.
 """
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
 from collections import defaultdict
+
+log = logging.getLogger("detect_pipeline.metrics")
 
 _BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
 
@@ -92,6 +95,25 @@ class Metrics:
             if k in self._counters:
                 return self._counters[k]
             return self._gauges.get(k, 0.0)
+
+    def drop_label(self, label: str, value: str) -> int:
+        """Remove every series carrying ``label=value``. Returns how many.
+
+        Prometheus has no notion of "this series is over", so a camera deleted
+        from core kept reporting: tier0_worker_up{camera=X} stayed at 0 and
+        alerted forever, tier0_frame_age_seconds froze at its last scrape, and
+        only a container restart cleared them. forget_camera() cleaned the
+        /health input but nothing removed the metric an operator actually
+        alerts on.
+        """
+        pair = (label, value)
+        removed = 0
+        with self._lock:
+            for store in (self._counters, self._gauges, self._hist):
+                for key in [k for k in store if pair in k[1]]:
+                    store.pop(key, None)
+                    removed += 1
+        return removed
 
     def reset(self) -> None:
         with self._lock:
@@ -170,6 +192,13 @@ def record_frame(
     else:
         metrics.inc("tier0_detector_skipped_total", {"camera": camera_id, "reason": "no_motion"})
     metrics.gauge("tier0_tracks_active", float(len(result.tracks)), cam)
+    # ALL internal tracks, tentative included — this is the population
+    # DETECT_MAX_TRACKS caps. tracks_active counts confirmed ones only, so a
+    # camera could sit at the cap refusing new spawns while the gauge meant
+    # to explain that looked perfectly healthy.
+    population = getattr(result, "track_population", None)
+    if population is not None:
+        metrics.gauge("tier0_tracks_population", float(population), cam)
     # Bounded-load guards (#track-explosion) — never cap silently:
     if getattr(result, "regions_capped", False):
         metrics.inc("tier0_regions_capped_total", cam)
@@ -211,6 +240,11 @@ def forget_camera(camera_id: str) -> None:
     """
     with _frame_wall_lock:
         _last_frame_wall.pop(camera_id, None)
+    # ...and drop its metric series, or the camera keeps alerting after it is
+    # gone: tier0_worker_up stays 0 and tier0_frame_age_seconds freezes.
+    dropped = metrics.drop_label("camera", camera_id)
+    if dropped:
+        log.info("dropped %d metric series for removed camera %s", dropped, camera_id)
 
 
 def newest_frame_age_s(now: float | None = None) -> float | None:

--- a/detect-pipeline/detect_pipeline/pipeline.py
+++ b/detect-pipeline/detect_pipeline/pipeline.py
@@ -68,6 +68,7 @@ class FrameResult:
     # Stationary tracks whose region was NOT scanned this frame (the PR B
     # saving, made visible for metrics/tests).
     skipped_stationary: int = 0
+    track_population: int = 0
     # True when the per-frame region budget dropped at least one candidate
     # this frame (exported as tier0_regions_capped_total — no silent caps).
     regions_capped: bool = False
@@ -259,6 +260,7 @@ class DetectPipeline:
             tracks, motion_boxes, regions, False,
             detections=dets, detect_latency_s=detect_latency_s, stage_latency_s=stages,
             skipped_stationary=skipped, regions_capped=regions_capped,
+            track_population=self.tracker.population,
         )
 
     def run(self, on_tracks: OnTracks | None = None) -> None:

--- a/detect-pipeline/test/test_gate.py
+++ b/detect-pipeline/test/test_gate.py
@@ -193,3 +193,20 @@ def test_gate_event_sink_skips_empty_by_default():
     GateEventSink(lambda s, d: sent.append(s)).publish(
         "cam_1", Gate().evaluate([], now=0.0), _Frame())
     assert sent == []
+
+
+def test_critical_class_in_cooldown_is_labelled_cooldown_not_stationary():
+    """Critical classes bypass stationary suppression and are rate-limited by
+    cooldown only. A stationary critical object in cooldown fell through to
+    the stationary check, so the audit said "we suppress these" — the opposite
+    of the contract — and inflated suppressions{reason="stationary"}."""
+    g = Gate(GateConfig(shadow=False, escalate_cooldown_s=30,
+                        critical_classes=frozenset({"person"})))
+
+    first = g.evaluate([mk(label="person")], now=0.0).decisions[0]
+    assert first.escalate and first.reason == "critical_class"
+
+    # motionless past stationary_threshold -> the track reads as stationary
+    d = g.evaluate([mk(label="person", motionless=60)], now=5.0).decisions[0]
+    assert d.escalate is False
+    assert d.reason == "cooldown", d.reason

--- a/detect-pipeline/test/test_metrics.py
+++ b/detect-pipeline/test/test_metrics.py
@@ -254,3 +254,40 @@ def test_forget_camera_drops_a_deleted_cameras_entry():
     m.forget_camera("cam-gone")          # idempotent
     m._last_frame_wall.clear()
     m.metrics.reset()
+
+
+def test_forget_camera_drops_its_metric_series_too():
+    """Prometheus has no "this series is over": a deleted camera kept
+    reporting tier0_worker_up=0 and alerting forever, and only a container
+    restart cleared it. forget_camera cleaned the /health input but not the
+    metric an operator actually alerts on."""
+    from detect_pipeline import metrics as m
+
+    m.metrics.reset()
+    m._last_frame_wall.clear()
+    m.record_worker_state("cam-gone", True, target_fps=2)
+    m.metrics.inc("tier0_frames_total", {"camera": "cam-gone"})
+    m.metrics.observe("tier0_frame_latency_seconds", 0.1, {"camera": "cam-gone"})
+    m.metrics.inc("tier0_frames_total", {"camera": "cam-stays"})
+
+    m.forget_camera("cam-gone")
+    out = m.metrics.render()
+    assert "cam-gone" not in out
+    assert "cam-stays" in out, "removing one camera must not touch the others"
+    m.metrics.reset()
+
+
+def test_track_population_gauge_shows_what_the_cap_counts():
+    """DETECT_MAX_TRACKS counts ALL internal tracks; tier0_tracks_active
+    reports confirmed ones only, so a camera could sit at the cap refusing
+    spawns while the gauge meant to explain it looked healthy."""
+    from detect_pipeline import metrics as m
+
+    m.metrics.reset()
+    r = _Result(tracks=[1, 2])
+    r.track_population = 7                      # 5 of them still tentative
+    m.record_frame("cam1", r)
+    cam = {"camera": "cam1"}
+    assert m.metrics.value("tier0_tracks_active", cam) == 2.0
+    assert m.metrics.value("tier0_tracks_population", cam) == 7.0
+    m.metrics.reset()


### PR DESCRIPTION
… 14 opens)

Small, real items — the last ones worth fixing before the release.

* Tier-0 exposed no gauge for the population DETECT_MAX_TRACKS actually caps. tier0_tracks_active counts CONFIRMED tracks only, so a camera could sit at the cap refusing spawns (tier0_track_spawns_dropped climbing) while the gauge meant to explain it looked healthy. Adds tier0_tracks_population. Note Tracker.population was added in an earlier pass and never wired to anything — it was dead code until now.

* A deleted camera alerted forever. Prometheus has no "this series is over", so tier0_worker_up{camera=X} stayed at 0 and tier0_frame_age_seconds froze at its last scrape until the container restarted. forget_camera cleaned the /health input but not the metric operators actually alert on; it now drops that camera's series and leaves every other camera untouched.

* The drop-oldest path made submit() a queue CONSUMER as well as a producer. Two workers overflowing at once could each pull one off with only one winning the put back, silently losing the other's evicted visit while counting a single drop. Serialised, and the evicted visit is put back if the re-insert loses.

* A critical-class track suppressed purely by cooldown was labelled "stationary" — the opposite of the documented contract (critical classes bypass stationary suppression and are rate-limited by cooldown only), and it inflated gate_suppressions_total{reason="stationary"}.

* max_backoff_seconds was unreachable dead config: give-up fires at max_fruitless_restarts before the delay ever escalated to 15s. Set to the 8s the schedule actually reaches.

* Docs corrected where they overstated the code: adaptive-decode promotion is not "sub-second" (budget 2-6s), the events_poster docstring implied the best-frame encode is off-thread when it runs on the frame loop, and the README recommended raising DETECT_FPS without noting that it also raises the track-confirmation bar — so brief visits get HARDER to record as you give the box more CPU.

Gate label and metric removal both verified by sabotage. 13f (overload behaviour) is deliberately left: it needs real capture timestamps before staleness is even measurable, which is design work rather than a patch.