### PR TITLE
fix(detect-pipeline): shed detector load instead of losing the stream

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,7 +193,14 @@ DETECT_DETECTOR=onnx       # onnx (YOLOv8, default) | rfdetr (RF-DETR, needs ort
                            # an rf-detr ONNX export at DETECT_ONNX_MODEL and its
                            # input size in DETECT_ONNX_INPUT) | hog | blob | stub
 DETECT_ONNX_BACKEND=auto   # auto (cvdnn for onnx, ort for rfdetr) | cvdnn | ort
-DETECT_ONNX_PROVIDERS=     # ort EPs, e.g. OpenVINOExecutionProvider (Intel N100)
+# ORT execution providers, comma-separated, e.g.
+# OpenVINOExecutionProvider (Intel N100) or CUDAExecutionProvider.
+# NOTE: keep this comment ABOVE the line. An EMPTY value with a trailing
+# `# comment` is parsed as the comment itself — this variable used to arrive
+# in the container literally set to "# ort EPs, e.g. ...", which then warned
+# on every start. Values that are non-empty strip their comment correctly;
+# only the empty case breaks.
+DETECT_ONNX_PROVIDERS=
 # Hardware decode backend. vaapi/qsv/rpi/rkmpp also need the render node
 # passed into the detect-pipeline container — uncomment the
 # `devices: - /dev/dri:/dev/dri` block in docker-compose.yml (core reads this
@@ -212,7 +219,11 @@ DETECT_CV_THREADS=2        # detector thread cap (cv2 intra-op + BLAS); 0 = unca
 DETECT_VISITS_ENABLED=true # persist finished visits + best-frame evidence to the events store
 EVENTS_PLATE_ENRICHMENT=true # OCR vehicle visits' best frames (fast_plate_ocr) into plate_text
 DETECT_METRICS_PORT=9109   # Prometheus /metrics on the detect-pipeline (0 disables)
-DETECT_DISPATCH_KAIC_URL=  # set (e.g. http://kai-c:8100) to run the gated model via KAI-C; empty = off
+# Set (e.g. http://kai-c:8100) to run the gated model via KAI-C; empty = off.
+# Comment ABOVE the line on purpose: an empty value with a trailing comment is
+# parsed as the comment, so this arrived set to "# set (e.g. ..." — truthy, so
+# the service reported dispatch as configured against a URL that cannot resolve.
+DETECT_DISPATCH_KAIC_URL=
 
 # ============================================================
 # APPLICATION SETTINGS
@@ -294,7 +305,7 @@ INFERENCE_USE_MEDIAMTX_TAP=true
 # Image tag for ghcr.io/open-nvr/core. Pinned to the current release so a
 # fresh install gets the tested core↔adapter pairing. Set "latest" or "main"
 # for bleeding-edge main builds.
-CORE_TAG=0.1.3
+CORE_TAG=main
 
 # Camera-agent LLM runtime. EMPTY (default) = the bundled ollama
 # container — fine on Linux hosts, but on macOS / Windows the container
@@ -334,7 +345,7 @@ OLLAMA_VLM_MODEL=moondream
 
 # Image tag for all GHCR adapter images (whisper, piper, yolov8, blip,
 # moondream, …). Pinned to the current release; set "latest" for bleeding edge.
-ADAPTER_TAG=0.1.3
+ADAPTER_TAG=main
 
 # Tag for the CAPTION_ADAPTER image only (falls back to ADAPTER_TAG when
 # empty/unset). The default ollamavlm adapter ships in adapter releases

--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,15 @@ DETECT_DETECTOR=onnx       # onnx (YOLOv8, default) | rfdetr (RF-DETR, needs ort
                            # an rf-detr ONNX export at DETECT_ONNX_MODEL and its
                            # input size in DETECT_ONNX_INPUT) | hog | blob | stub
 DETECT_ONNX_BACKEND=auto   # auto (cvdnn for onnx, ort for rfdetr) | cvdnn | ort
+# Detector input square. NOTE: this is only tunable if your ONNX model was
+# exported with DYNAMIC axes. The yolov8n.onnx this project ships is exported
+# at a FIXED 640, so anything else is rejected by the graph — the service now
+# detects that at load, warns, and uses the size the model actually accepts
+# rather than failing once per region per frame. To genuinely run at 320 (the
+# single biggest CPU saving on a CPU-only box), re-export the model at 320 or
+# with dynamic axes; setting this alone will not do it.
+DETECT_ONNX_INPUT=640
+
 # ORT execution providers, comma-separated, e.g.
 # OpenVINOExecutionProvider (Intel N100) or CUDAExecutionProvider.
 # NOTE: keep this comment ABOVE the line. An EMPTY value with a trailing

--- a/.env.example
+++ b/.env.example
@@ -224,7 +224,14 @@ DETECT_ONNX_PROVIDERS=
 # — but the CPU bill stays the same as plain `cpu` until you fix it.
 DETECT_HWACCEL=cpu         # cpu | vaapi | nvidia | qsv | rpi | rkmpp | jetson
 DETECT_GATE_MODE=shadow    # shadow (default: measure only) | off | enforce (act — validate shadow first, see detect-pipeline/ENABLEMENT.md)
-DETECT_CV_THREADS=2        # detector thread cap (cv2 intra-op + BLAS); 0 = uncapped
+# Threads per inference. Leave EMPTY to let the service size it to the fleet:
+# at most min(detector-pool, cameras) inferences run at once, so the cores
+# divide between them and it is retuned as cameras come and go. A fixed cap is
+# right for a large fleet and wastes most of the box for a small one —
+# measured on 8 cores with one camera (yolov8n @640): 2 threads 449ms vs
+# 8 threads 176ms, near-linear. Set a number to pin it; it is then never
+# retuned. 0/empty = automatic.
+DETECT_CV_THREADS=
 DETECT_VISITS_ENABLED=true # persist finished visits + best-frame evidence to the events store
 EVENTS_PLATE_ENRICHMENT=true # OCR vehicle visits' best frames (fast_plate_ocr) into plate_text
 DETECT_METRICS_PORT=9109   # Prometheus /metrics on the detect-pipeline (0 disables)

--- a/detect-pipeline/detect_pipeline/detector.py
+++ b/detect-pipeline/detect_pipeline/detector.py
@@ -92,6 +92,55 @@ def detections_to_frame(raws: list[RawDetection], region: Box) -> list[Detection
     return out
 
 
+# Input squares ONNX detectors are commonly exported at, widest first. Covers
+# both families this service ships: YOLO (640/320) and RF-DETR (384/432/560).
+STANDARD_INPUTS = (640, 576, 560, 512, 448, 432, 416, 384, 320)
+
+
+def resolve_input_size(detector, requested: int, *, candidates=STANDARD_INPUTS) -> int:
+    """The input square this model will actually accept.
+
+    Many ONNX exports are fixed-shape rather than dynamic. Feeding any other
+    size raises deep inside the graph — once per region, per frame — which the
+    pipeline now survives per region, but which would leave the camera
+    detecting NOTHING while looking correctly configured.
+
+    Deliberately detector-AGNOSTIC: it probes through the detector's own
+    ``detect``, so it exercises that family's real preprocessing and decode.
+    YOLO is not the only option here — RF-DETR variants ship at 384/432/560
+    and fail in exactly the same way, and whatever family comes next will too.
+    """
+    import numpy as np
+
+    def fits(size: int) -> bool:
+        prev = detector.input_size
+        try:
+            detector.input_size = size
+            detector.detect(np.zeros((size, size, 3), np.uint8))
+            return True
+        except Exception:
+            return False
+        finally:
+            detector.input_size = prev
+
+    if fits(requested):
+        return requested
+    for size in candidates:
+        if size != requested and fits(size):
+            log.warning(
+                "%s does not accept a %dpx input (the model is exported at a "
+                "FIXED shape); using %dpx instead. Re-export with dynamic axes "
+                "to make the input size tunable.",
+                type(detector).__name__, requested, size,
+            )
+            return size
+    log.error(
+        "%s rejected every standard input size including the configured %dpx "
+        "— detection will not run", type(detector).__name__, requested,
+    )
+    return requested
+
+
 class StubDetector:
     """A no-op detector (reference impl / test double). Returns nothing."""
 

--- a/detect-pipeline/detect_pipeline/detr_detector.py
+++ b/detect-pipeline/detect_pipeline/detr_detector.py
@@ -190,6 +190,11 @@ class OnnxDetrDetector:
         else:
             raise ValueError("OnnxDetrDetector needs a model_path or backend_impl")
         self.backend_name = getattr(self._backend, "name", "custom")
+        # RF-DETR variants ship at 384/432/560; a mismatch used to fail on
+        # every region forever. Settle it against the real graph once.
+        if model_path:
+            from .detector import resolve_input_size
+            self.input_size = resolve_input_size(self, self.input_size)
 
     def detect(self, crop: np.ndarray) -> list[RawDetection]:
         blob = preprocess_detr(crop, self.input_size)

--- a/detect-pipeline/detect_pipeline/frame_source.py
+++ b/detect-pipeline/detect_pipeline/frame_source.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import random
+import re
 import subprocess
 import threading
 import time
@@ -112,6 +113,18 @@ def _jittered(delay: float, rand: Callable[[], float]) -> float:
     return delay * 0.5 + delay * 0.5 * rand()
 
 
+def scrub_secrets(text: str) -> str:
+    """Strip signed query strings out of arbitrary text before logging it.
+
+    Redacting the URL we pass in is not enough: ffmpeg and ffprobe print the
+    URL THEY were given in their own diagnostics, and this service surfaces
+    that output deliberately (it is what makes a failure diagnosable). So the
+    credential comes back through the child's stderr even when every format
+    argument is clean.
+    """
+    return re.sub(r"(\?|&)jwt=[^\s\"'&\]]+", r"\1jwt=<redacted>", text or "")
+
+
 def redact_url(url: str) -> str:
     """Drop the query string from a stream URL before logging it.
 
@@ -157,7 +170,7 @@ class _StderrTail:
             pass
 
     def text(self) -> str:
-        return " | ".join(self._lines)
+        return scrub_secrets(" | ".join(self._lines))
 
 
 def _terminate(proc) -> None:
@@ -515,13 +528,14 @@ def probe_stream(
         if out.returncode != 0 or not out.stdout.strip():
             log.warning(
                 "ffprobe failed for %s (rc=%s): %s",
-                url, out.returncode, (out.stderr or "").strip() or "no output",
+                redact_url(url), out.returncode,
+                scrub_secrets((out.stderr or "").strip()) or "no output",
             )
             return None
         return _parse_ffprobe(out.stdout)
     except subprocess.TimeoutExpired:
-        log.warning("ffprobe timed out after %.0fs for %s", timeout, url)
+        log.warning("ffprobe timed out after %.0fs for %s", timeout, redact_url(url))
         return None
     except Exception as e:
-        log.warning("ffprobe error for %s: %s", url, e)
+        log.warning("ffprobe error for %s: %s", redact_url(url), scrub_secrets(str(e)))
         return None

--- a/detect-pipeline/detect_pipeline/onnx_detector.py
+++ b/detect-pipeline/detect_pipeline/onnx_detector.py
@@ -131,55 +131,6 @@ def postprocess_yolo(
 # tiny and the two are interchangeable.
 
 
-# Input sizes a YOLO export is commonly fixed at, tried in descending order
-# when the configured one does not fit the graph.
-_STANDARD_INPUTS = (640, 576, 512, 448, 416, 384, 320)
-
-
-def probe_input_size(net, requested: int) -> int:
-    """The input size this net will actually accept.
-
-    Many YOLO exports — including the yolov8n.onnx this project ships — are
-    exported with a FIXED input shape rather than dynamic axes. Feeding any
-    other size raises deep inside the graph ("outTotal == inpTotal"), once per
-    region, per frame. Nothing wrapped that, so it reached the worker loop and
-    killed the camera: setting the documented DETECT_ONNX_INPUT to anything
-    the model was not exported at took detection down entirely, in a restart
-    loop, with only a reshape assertion to explain it.
-
-    So establish the working size ONCE here, and adapt instead of dying.
-    """
-    import numpy as np
-
-    def _fits(size: int) -> bool:
-        try:
-            blob = cv2.dnn.blobFromImage(
-                np.zeros((size, size, 3), np.uint8), 1 / 255.0, (size, size),
-                swapRB=True, crop=False,
-            )
-            net.setInput(blob)
-            net.forward()
-            return True
-        except Exception:
-            return False
-
-    if _fits(requested):
-        return requested
-    for size in _STANDARD_INPUTS:
-        if size != requested and _fits(size):
-            log.warning(
-                "ONNX model does not accept a %dpx input (it is exported at a "
-                "FIXED shape); using %dpx instead. Re-export with dynamic axes "
-                "to make DETECT_ONNX_INPUT tunable.", requested, size,
-            )
-            return size
-    log.error(
-        "ONNX model rejected every standard input size including the "
-        "configured %dpx — detection will not run", requested,
-    )
-    return requested
-
-
 class CvDnnBackend:
     """Run the ONNX model through ``cv2.dnn`` (default; zero extra dependency, CPU)."""
 
@@ -344,9 +295,9 @@ class OnnxYoloDetector:
         # Settle the input size against the real graph ONCE, rather than
         # raising per region per frame (which killed the worker). Only the
         # cv2.dnn path can be probed cheaply; ORT reports its own shapes.
-        _net = getattr(self._backend, "_net", None)
-        if _net is not None and model_path:
-            self.input_size = probe_input_size(_net, self.input_size)
+        if model_path:
+            from .detector import resolve_input_size
+            self.input_size = resolve_input_size(self, self.input_size)
 
     def detect(self, crop: np.ndarray) -> list[RawDetection]:
         blob = cv2.dnn.blobFromImage(

--- a/detect-pipeline/detect_pipeline/onnx_detector.py
+++ b/detect-pipeline/detect_pipeline/onnx_detector.py
@@ -131,6 +131,55 @@ def postprocess_yolo(
 # tiny and the two are interchangeable.
 
 
+# Input sizes a YOLO export is commonly fixed at, tried in descending order
+# when the configured one does not fit the graph.
+_STANDARD_INPUTS = (640, 576, 512, 448, 416, 384, 320)
+
+
+def probe_input_size(net, requested: int) -> int:
+    """The input size this net will actually accept.
+
+    Many YOLO exports — including the yolov8n.onnx this project ships — are
+    exported with a FIXED input shape rather than dynamic axes. Feeding any
+    other size raises deep inside the graph ("outTotal == inpTotal"), once per
+    region, per frame. Nothing wrapped that, so it reached the worker loop and
+    killed the camera: setting the documented DETECT_ONNX_INPUT to anything
+    the model was not exported at took detection down entirely, in a restart
+    loop, with only a reshape assertion to explain it.
+
+    So establish the working size ONCE here, and adapt instead of dying.
+    """
+    import numpy as np
+
+    def _fits(size: int) -> bool:
+        try:
+            blob = cv2.dnn.blobFromImage(
+                np.zeros((size, size, 3), np.uint8), 1 / 255.0, (size, size),
+                swapRB=True, crop=False,
+            )
+            net.setInput(blob)
+            net.forward()
+            return True
+        except Exception:
+            return False
+
+    if _fits(requested):
+        return requested
+    for size in _STANDARD_INPUTS:
+        if size != requested and _fits(size):
+            log.warning(
+                "ONNX model does not accept a %dpx input (it is exported at a "
+                "FIXED shape); using %dpx instead. Re-export with dynamic axes "
+                "to make DETECT_ONNX_INPUT tunable.", requested, size,
+            )
+            return size
+    log.error(
+        "ONNX model rejected every standard input size including the "
+        "configured %dpx — detection will not run", requested,
+    )
+    return requested
+
+
 class CvDnnBackend:
     """Run the ONNX model through ``cv2.dnn`` (default; zero extra dependency, CPU)."""
 
@@ -292,6 +341,12 @@ class OnnxYoloDetector:
                 "OnnxYoloDetector needs a model_path, or an injected net/session/backend_impl"
             )
         self.backend_name = getattr(self._backend, "name", "custom")
+        # Settle the input size against the real graph ONCE, rather than
+        # raising per region per frame (which killed the worker). Only the
+        # cv2.dnn path can be probed cheaply; ORT reports its own shapes.
+        _net = getattr(self._backend, "_net", None)
+        if _net is not None and model_path:
+            self.input_size = probe_input_size(_net, self.input_size)
 
     def detect(self, crop: np.ndarray) -> list[RawDetection]:
         blob = cv2.dnn.blobFromImage(

--- a/detect-pipeline/detect_pipeline/pipeline.py
+++ b/detect-pipeline/detect_pipeline/pipeline.py
@@ -269,3 +269,89 @@ class DetectPipeline:
             result = self.process_frame(frame)
             if on_tracks is not None:
                 on_tracks(frame, result.tracks, result.calibrating)
+
+
+class RegionBudgetController:
+    """Shrink the per-frame detector budget when a camera can't keep up.
+
+    Tier-0's cost is dominated by inference, and the region budget is what
+    multiplies it: ``max_regions`` crops per frame. On hardware where a single
+    inference is slower than the whole frame budget, the worker simply falls
+    further behind every frame — and it has no way to notice. The consequence
+    is not just late detections: the worker stops draining ffmpeg's stdout,
+    ffmpeg blocks on the full pipe, MediaMTX drops the reader, and the session
+    dies. The camera then looks flaky ("Failed reading RTSP data: End of file")
+    when the real cause is us.
+
+    Measured on a live 1080p camera with the shipped defaults (8 regions,
+    640px input, 2 fps): 3.07s of inference against a 500ms budget — six times
+    over, sustained, with the stream dropping every few minutes.
+
+    So: watch actual frame latency against the budget and spend fewer regions
+    when we are over it, recovering when there is room again. Detecting less
+    per frame is a real cost, but it is strictly better than decoding a stream
+    we cannot finish and losing the session with it.
+
+    Pure and clock-injected — no I/O, no threads.
+    """
+
+    def __init__(
+        self,
+        configured: int,
+        fps: int,
+        *,
+        floor: int = 1,
+        over_budget: float = 1.2,
+        recover_at: float = 0.6,
+        settle_frames: int = 5,
+        smoothing: float = 0.3,
+    ) -> None:
+        self.configured = max(0, int(configured))
+        self.budget_s = 1.0 / max(1, int(fps))
+        self.floor = max(1, int(floor))
+        self.over_budget = over_budget
+        self.recover_at = recover_at
+        self.settle_frames = max(1, int(settle_frames))
+        self.smoothing = smoothing
+        self.current = self.configured
+        self._ema: float | None = None
+        self._streak = 0
+
+    @property
+    def shedding(self) -> bool:
+        return self.configured > 0 and self.current < self.configured
+
+    def observe(self, latency_s: float) -> bool:
+        """Feed one frame's processing time. True if the budget changed.
+
+        A single slow frame means nothing — a GOP boundary, a burst of motion,
+        the OS scheduling elsewhere. Only a sustained trend moves the budget,
+        so this smooths and requires a streak in one direction.
+        """
+        if self.configured <= 0:
+            return False
+        self._ema = (
+            latency_s if self._ema is None
+            else (self.smoothing * latency_s + (1 - self.smoothing) * self._ema)
+        )
+        over = self._ema > self.budget_s * self.over_budget
+        under = self._ema < self.budget_s * self.recover_at
+
+        if over and self.current > self.floor:
+            self._streak = self._streak + 1 if self._streak >= 0 else 1
+        elif under and self.current < self.configured:
+            self._streak = self._streak - 1 if self._streak <= 0 else -1
+        else:
+            self._streak = 0
+            return False
+
+        if abs(self._streak) < self.settle_frames:
+            return False
+        self._streak = 0
+        # Halve on the way down (the overrun is usually large), step back up
+        # one at a time so recovery cannot immediately re-saturate.
+        self.current = (
+            max(self.floor, self.current // 2) if over
+            else min(self.configured, self.current + 1)
+        )
+        return True

--- a/detect-pipeline/detect_pipeline/pipeline.py
+++ b/detect-pipeline/detect_pipeline/pipeline.py
@@ -180,6 +180,7 @@ class DetectPipeline:
         # of region crops YOLO ever runs on one frame, no matter how many
         # tracks accumulate. 0 disables (unbounded, the pre-guard behavior).
         self.max_regions = max(0, int(max_regions))
+        self.detector_errors = 0
         # Labels worth TRACKING. An NVR watching a cluttered desk has no
         # business confirming tracks for "kite"/"banana" wire false
         # positives — every phantom is a standing re-verify cost. None = all.
@@ -243,7 +244,17 @@ class DetectPipeline:
             _t = time.monotonic()
             for region in regions:
                 crop = crop_and_resize(bgr, region, self.model_size[0], self.model_size[1])
-                raws = self.detector.detect(crop)
+                try:
+                    raws = self.detector.detect(crop)
+                except Exception:
+                    # One bad inference must cost one region, not the camera.
+                    # This was unwrapped, so a model that rejected the crop
+                    # shape raised straight through process_frame into the
+                    # worker loop's "crashed" handler and the feed went dark
+                    # until the next reconcile — every frame, in a loop.
+                    self.detector_errors += 1
+                    log.debug("detector failed on one region", exc_info=True)
+                    continue
                 dets.extend(detections_to_frame(raws, region))
             if self.allowed_labels is not None:
                 dets = [d for d in dets if d.label in self.allowed_labels]

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -115,6 +115,29 @@ class ServiceConfig:
     visits_enabled: bool = True
 
 
+def _clean_env(value: str | None) -> str:
+    """Strip a value that is really a leaked inline comment.
+
+    `VAR=` followed by a trailing `# comment` in a .env file parses as the
+    COMMENT, not as empty — only the empty case, values carry their comment
+    off correctly. Seen in the wild on this project's own .env.example:
+    DETECT_DISPATCH_KAIC_URL arrived literally set to "# set (e.g. ...",
+    which is truthy, so the service reported Tier-1 dispatch as configured
+    against a URL that could never resolve.
+    """
+    v = (value or "").strip()
+    return "" if v.startswith("#") else v
+
+
+def _env_url(env: dict, name: str) -> str:
+    """A URL setting, or empty. Anything that is not http(s) is not a URL."""
+    v = _clean_env(env.get(name))
+    if v and not v.startswith(("http://", "https://")):
+        log.warning("%s=%r is not an http(s) URL; treating it as unset", name, v)
+        return ""
+    return v
+
+
 def _truthy(v: str) -> bool:
     return str(v).strip().lower() in ("1", "true", "yes", "on")
 
@@ -191,7 +214,7 @@ def config_from_env(env: dict) -> ServiceConfig:
         onnx_model=env.get("DETECT_ONNX_MODEL", "/app/model_weights/yolov8n.onnx"),
         onnx_input=_env_int(env, "DETECT_ONNX_INPUT", 640),
         onnx_backend=env.get("DETECT_ONNX_BACKEND", "auto"),
-        onnx_providers=env.get("DETECT_ONNX_PROVIDERS", ""),
+        onnx_providers=_clean_env(env.get("DETECT_ONNX_PROVIDERS")),
         hwaccel=env.get("DETECT_HWACCEL", "cpu"),
         device=env.get("DETECT_HWACCEL_DEVICE", "/dev/dri/renderD128"),
         decode_skip=_decode_skip_from_env(env),
@@ -214,7 +237,7 @@ def config_from_env(env: dict) -> ServiceConfig:
         gate_critical_classes=env.get("DETECT_GATE_CRITICAL_CLASSES", ""),
         gate_cooldown_s=_env_float(env, "DETECT_GATE_COOLDOWN_S", 30.0),
         metrics_port=_env_int(env, "DETECT_METRICS_PORT", 9109),
-        dispatch_kaic_url=env.get("DETECT_DISPATCH_KAIC_URL", ""),
+        dispatch_kaic_url=_env_url(env, "DETECT_DISPATCH_KAIC_URL"),
         dispatch_task=env.get("DETECT_DISPATCH_TASK", "caption"),
         detect_conf=_env_float(env, "DETECT_CONF", 0.4),
     )

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -508,6 +508,7 @@ def build_manager(cfg: ServiceConfig, sink, *, gate_sink=None) -> WorkerManager:
         decode_skip=cfg.decode_skip,
         detector_pool=cfg.detector_pool,
         start_spread_s=cfg.start_spread_s,
+        cv_threads_pinned=_env_int(dict(os.environ), "DETECT_CV_THREADS", 0) > 0,
         decode_threads=cfg.decode_threads,
         rtsp_timeout_s=cfg.rtsp_timeout_s,
         fast_decode=cfg.fast_decode,
@@ -673,7 +674,11 @@ def main() -> int:  # pragma: no cover - integration entrypoint
     # Reading it raw here crash-looped the container on an empty or
     # typo'd value — and "declared but empty" is what compose passes for
     # an unset ${VAR}, so env.get's default never applies.
-    threads = _env_int(dict(os.environ), "DETECT_CV_THREADS", 2)
+    # Unset means "let the manager size it to the fleet" (see
+    # WorkerManager._tune_inference_threads): a fixed cap is right for many
+    # cameras and wastes most of the box for one. An explicit value is
+    # honoured and never retuned.
+    threads = _env_int(dict(os.environ), "DETECT_CV_THREADS", 0)
     if threads > 0:
         try:
             import cv2

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -457,14 +457,25 @@ class CameraWorker:
                         self.spec.camera_id, False, target_fps=self.spec.fps
                     )
                 return
-        except Exception:
+        except Exception as exc:
             # Emit the DOWN gauge before bailing. Returning here used to skip
             # record_worker_state entirely, so a camera that never opens had
             # no tier0_worker_up series at all — not even 0 — and reconcile
             # silently re-attempted it every tick with nothing but a log line
             # to show for it. An absent series can't alert; a 0 can.
             record_worker_state(self.spec.camera_id, False, target_fps=self.spec.fps)
-            log.exception("tier0 %s: could not open source", self.spec.camera_id)
+            # A camera that is simply unreachable — powered off, unplugged,
+            # rebooting — is normal operation, not a code fault. ffprobe has
+            # already logged WHY at warning level, so a full traceback every
+            # reconcile tick just buries that reason and reads like a crash.
+            # Anything unexpected still gets its stack.
+            if isinstance(exc, RuntimeError) and "could not probe" in str(exc):
+                log.warning(
+                    "tier0 %s: source unavailable (%s) — retrying next tick",
+                    self.spec.camera_id, exc,
+                )
+            else:
+                log.exception("tier0 %s: could not open source", self.spec.camera_id)
             return
         # Substream guard: Tier-0 is designed to decode a LOW-RES substream.
         # Decoding a high-res main stream (no substream configured for this

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -48,7 +48,7 @@ from .metrics import (
     forget_camera,
 )
 from .motion import MotionConfig, MotionDetector
-from .pipeline import DetectPipeline, FrameResult
+from .pipeline import DetectPipeline, FrameResult, RegionBudgetController
 from .tracking import TrackConfig, Tracker
 
 log = logging.getLogger("detect_pipeline.service")
@@ -517,6 +517,11 @@ class CameraWorker:
                 self.spec.camera_id, self.decode_idle, self.decode_idle_after,
             )
         record_worker_state(self.spec.camera_id, True, target_fps=self.spec.fps)
+        budget = RegionBudgetController(pipe.max_regions, self.spec.fps)
+        _metrics.gauge(
+            "tier0_regions_budget", float(budget.current),
+            {"camera": self.spec.camera_id},
+        )
         prev_seq: int | None = None
         win_t0 = time.monotonic()
         win_n = 0
@@ -543,9 +548,28 @@ class CameraWorker:
                 prev_seq = seq
                 t0 = time.monotonic()
                 result = pipe.process_frame(frame)
+                frame_latency = time.monotonic() - t0
+                # Spend fewer detector crops when we cannot finish a frame in
+                # its budget. Falling behind does not just delay detections —
+                # the worker stops draining ffmpeg's stdout, ffmpeg blocks on
+                # the full pipe, and MediaMTX drops the session, which surfaces
+                # as a "flaky camera" that is really us.
+                if budget.observe(frame_latency):
+                    pipe.max_regions = budget.current
+                    _metrics.gauge(
+                        "tier0_regions_budget", float(budget.current),
+                        {"camera": self.spec.camera_id},
+                    )
+                    log.warning(
+                        "tier0 %s: frame latency %.2fs against a %.2fs budget — "
+                        "detector regions %s to %d (of %d configured)",
+                        self.spec.camera_id, frame_latency, budget.budget_s,
+                        "cut" if budget.shedding else "restored to",
+                        budget.current, budget.configured,
+                    )
                 record_frame(
                     self.spec.camera_id, result,
-                    latency_s=time.monotonic() - t0,
+                    latency_s=frame_latency,
                     detector_latency_s=getattr(result, "detect_latency_s", None),
                     stage_latency_s=getattr(result, "stage_latency_s", None),
                     model=self.model_id,

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -22,6 +22,7 @@ skipped, so per-camera opt-out works without touching the rest.
 from __future__ import annotations
 
 import logging
+import os
 import random
 import threading
 import time
@@ -678,6 +679,7 @@ class WorkerManager:
         detector_factory: Callable[[], DetectorAdapter] | None = None,
         detector_pool: int = 0,                           # 0 = one detector per worker
         start_spread_s: float = 10.0,                     # spread simultaneous dials
+        cv_threads_pinned: bool = False,                  # operator set DETECT_CV_THREADS
 
         model_size: int = 320,
         model_id: str | None = None,                      # detector identity (benchmark labels)
@@ -756,6 +758,10 @@ class WorkerManager:
         # re-minted JWT must not bounce a healthy worker) precisely because
         # this is the cheaper way to deliver it.
         self._latest_url: dict[str, str] = {}
+        # Inference width, retuned as the fleet changes size. Pinned means
+        # the operator set DETECT_CV_THREADS and we leave it alone.
+        self._cv_threads = 0
+        self._cv_threads_pinned = cv_threads_pinned
 
     def current_url(self, camera_id: str) -> str | None:
         """The freshest known stream URL for a camera (see _latest_url)."""
@@ -916,6 +922,46 @@ class WorkerManager:
                 self._workers[cid] = worker
                 self._specs[cid] = spec
                 log.info("tier0: started worker for camera %s", cid)
+        self._tune_inference_threads()
+
+    def _tune_inference_threads(self) -> None:
+        """Give each concurrent inference the cores it can actually use.
+
+        A FIXED per-inference thread cap is right for a fleet and wrong for a
+        small one. Measured on an 8-core box, one camera, yolov8n at 640:
+
+            1 thread   874 ms      4 threads  241 ms
+            2 threads  449 ms      8 threads  176 ms
+
+        Near-linear — so the shipped cap of 2 left six cores idle and made
+        every frame 2.5x more expensive than the hardware required. That is
+        what pushed this deployment six times over its frame budget.
+
+        At most min(pool, cameras) inferences run at once, so that is what the
+        cores divide between. Process-global (cv2's cap is), recomputed only
+        when the camera count changes, and never overridden when the operator
+        pinned DETECT_CV_THREADS themselves.
+        """
+        if self._cv_threads_pinned or not self._workers:
+            return
+        concurrent = len(self._workers)
+        if self._shared_detector is not None:
+            concurrent = min(concurrent, self._shared_detector.max_size)
+        cores = os.cpu_count() or 2
+        want = max(1, cores // max(1, concurrent))
+        if want == self._cv_threads:
+            return
+        try:
+            import cv2
+
+            cv2.setNumThreads(want)
+        except Exception:  # pragma: no cover - cv2 optional (stub/hog)
+            return
+        log.info(
+            "tier0: %d camera(s) on %d cores — %d inference thread(s) each "
+            "(was %d)", len(self._workers), cores, want, self._cv_threads,
+        )
+        self._cv_threads = want
 
     def _retire(self, workers: dict[str, Worker], replaced: set[str] | None = None) -> None:
         """Wind down a set of workers: signal all, then wait once.

--- a/detect-pipeline/test/test_bounded_load.py
+++ b/detect-pipeline/test/test_bounded_load.py
@@ -172,3 +172,57 @@ def test_label_allowlist_drops_phantom_classes_before_tracking():
     result = pipe.process_frame(_frame(1))
     assert {d.label for d in result.detections} == {"person"}
     assert {t.label for t in tracker.tracks} == {"person"}
+
+
+# ── load shedding: never fall so far behind that we lose the stream ──
+
+def test_budget_sheds_under_sustained_overrun_and_recovers():
+    """Measured on a live 1080p camera with the shipped defaults: 3.07s of
+    inference against a 500ms budget, sustained, with the RTSP session
+    dropping every few minutes. Falling behind is not just late detections —
+    the worker stops draining ffmpeg's stdout, ffmpeg blocks on the full pipe,
+    and MediaMTX drops the reader. The camera then looks flaky when it is us."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)          # 500ms budget
+    assert c.current == 8 and not c.shedding
+
+    for _ in range(40):
+        c.observe(3.07)
+    assert c.current < 8 and c.shedding
+    assert c.current >= 1, "must keep detecting something"
+
+    for _ in range(120):
+        c.observe(0.05)                            # hardware caught up
+    assert c.current == 8 and not c.shedding
+
+
+def test_budget_ignores_isolated_slow_frames():
+    """A GOP boundary, a burst of motion, the OS scheduling elsewhere — one
+    slow frame must not cut the budget."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    for _ in range(20):
+        c.observe(0.05)
+    c.observe(4.0)                                 # single spike
+    c.observe(0.05)
+    assert c.current == 8
+
+
+def test_budget_is_inert_when_regions_are_unbounded():
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(0, fps=2)           # 0 = no cap configured
+    for _ in range(40):
+        assert c.observe(9.0) is False
+    assert c.current == 0
+
+
+def test_budget_never_sheds_below_its_floor():
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2, floor=2)
+    for _ in range(200):
+        c.observe(30.0)                            # hopelessly over budget
+    assert c.current == 2

--- a/detect-pipeline/test/test_frame_source.py
+++ b/detect-pipeline/test/test_frame_source.py
@@ -534,3 +534,66 @@ def test_decode_flip_does_not_block_the_frame_loop():
     finally:
         proc.kill()
         proc.wait(timeout=5)
+
+
+def test_probe_failures_never_log_the_jwt():
+    """The tap URL's ?jwt= is a live wildcard-read credential. The restart
+    logs were redacted; the probe-failure logs added later were not — and a
+    powered-off camera hits exactly those, every reconcile tick."""
+    import logging
+    import subprocess
+
+    from detect_pipeline.frame_source import probe_stream
+
+    secret = "rtsp://mtx:8554/cam-1?jwt=eyJhbGciOiJSUzI1NiJ9.SECRETPAYLOAD.SIG"
+    logger = logging.getLogger("detect_pipeline.frame_source")
+
+    class _Capture(logging.Handler):
+        def __init__(self): super().__init__(); self.text = ""
+        def emit(self, record): self.text += record.getMessage()
+
+    cap = _Capture()
+    logger.addHandler(cap)
+    try:
+        # non-zero rc path
+        probe_stream(secret, timeout=0.1)
+        # timeout path
+        original = subprocess.run
+
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="ffprobe", timeout=0.1)
+
+        subprocess.run = boom
+        try:
+            probe_stream(secret, timeout=0.1)
+        finally:
+            subprocess.run = original
+    finally:
+        logger.removeHandler(cap)
+
+    assert cap.text, "expected the failure to be logged at all"
+    assert "SECRETPAYLOAD" not in cap.text, "the probe logs leaked the JWT"
+    assert "<redacted>" in cap.text
+
+
+def test_child_process_output_is_scrubbed_of_credentials():
+    """Redacting the URL we FORMAT is not enough — ffmpeg and ffprobe print
+    the URL they were given in their own diagnostics, and this service
+    surfaces that output on purpose because it is what makes a failure
+    diagnosable. The credential comes back through the child's stderr."""
+    from detect_pipeline.frame_source import _StderrTail, scrub_secrets
+
+    line = ("[rtsp @ 0x1] Could not open "
+            "rtsp://mtx:8554/cam-1?jwt=eyJhbGciOi.SECRETPAYLOAD.SIG: 401")
+    assert "SECRETPAYLOAD" not in scrub_secrets(line)
+    assert "jwt=<redacted>" in scrub_secrets(line)
+    assert scrub_secrets("no url here") == "no url here"
+    assert scrub_secrets("") == ""
+
+    # ...and the tail the restart log prints goes through it too
+    tail = _StderrTail(io.BytesIO(line.encode() + b"\n"))
+    for _ in range(200):
+        if tail.text():
+            break
+        time.sleep(0.01)
+    assert "SECRETPAYLOAD" not in tail.text()

--- a/detect-pipeline/test/test_onnx_detector.py
+++ b/detect-pipeline/test/test_onnx_detector.py
@@ -218,36 +218,57 @@ def test_ort_session_options_survive_a_garbage_value(monkeypatch):
 
 # ── fixed-shape exports must not take the camera down ───────────────
 
-class _FixedShapeNet:
-    """A net exported at ONE input size, like the shipped yolov8n.onnx."""
+class _FixedShapeDetector:
+    """Stands in for ANY family whose ONNX export is fixed-shape.
 
-    def __init__(self, accepts: int):
+    Deliberately not a cv2 net: the probe must work for RF-DETR (384/432/560)
+    and whatever comes next, not just YOLO — so it goes through the
+    detector's own detect().
+    """
+
+    def __init__(self, accepts: int, requested: int):
         self.accepts = accepts
-        self._blob = None
+        self.input_size = requested
+        self.calls: list[int] = []
 
-    def setInput(self, blob):          # noqa: N802 - cv2 API shape
-        self._blob = blob
-
-    def forward(self):
-        if self._blob.shape[-1] != self.accepts:
-            raise cv2.error("outTotal == inpTotal in function 'getOutShape'")
-        return np.zeros((1, 84, 8400), np.float32)
+    def detect(self, crop):
+        self.calls.append(self.input_size)
+        if self.input_size != self.accepts:
+            raise RuntimeError("outTotal == inpTotal in function 'getOutShape'")
+        return []
 
 
 def test_probe_adopts_the_size_the_model_actually_accepts():
     """The shipped yolov8n.onnx is exported at a FIXED 640. Feeding 320 raised
-    deep in the graph — once per region, per frame — and nothing wrapped it, so
-    it reached the worker loop and the camera went dark in a restart loop. A
+    deep in the graph — once per region, per frame. Nothing wrapped it, so it
+    reached the worker loop and the camera went dark in a restart loop: a
     documented env knob could take detection down entirely."""
-    from detect_pipeline.onnx_detector import probe_input_size
+    from detect_pipeline.detector import resolve_input_size
 
-    assert probe_input_size(_FixedShapeNet(640), 320) == 640
-    assert probe_input_size(_FixedShapeNet(640), 640) == 640
-    assert probe_input_size(_FixedShapeNet(416), 640) == 416
+    d = _FixedShapeDetector(accepts=640, requested=320)
+    assert resolve_input_size(d, 320) == 640
+    assert d.input_size == 320, "probing must not leave the size mutated"
+
+
+def test_probe_covers_the_detr_family_too():
+    """RF-DETR ships at 384/432/560 and fails identically — the probe is
+    family-agnostic on purpose."""
+    from detect_pipeline.detector import resolve_input_size
+
+    assert resolve_input_size(_FixedShapeDetector(432, 640), 640) == 432
+    assert resolve_input_size(_FixedShapeDetector(560, 384), 384) == 560
+
+
+def test_probe_keeps_a_size_that_already_works():
+    from detect_pipeline.detector import resolve_input_size
+
+    d = _FixedShapeDetector(accepts=640, requested=640)
+    assert resolve_input_size(d, 640) == 640
+    assert d.calls == [640], "a working size must not trigger extra probing"
 
 
 def test_probe_returns_the_request_when_nothing_fits():
-    """Never loop forever or invent a size: report and let the error surface."""
-    from detect_pipeline.onnx_detector import probe_input_size
+    """Never loop forever or invent a size: report and let it surface."""
+    from detect_pipeline.detector import resolve_input_size
 
-    assert probe_input_size(_FixedShapeNet(99), 640) == 640
+    assert resolve_input_size(_FixedShapeDetector(99, 640), 640) == 640

--- a/detect-pipeline/test/test_onnx_detector.py
+++ b/detect-pipeline/test/test_onnx_detector.py
@@ -214,3 +214,40 @@ def test_ort_session_options_survive_a_garbage_value(monkeypatch):
 
     monkeypatch.setenv("DETECT_CV_THREADS", "banana")
     assert _ort_session_options(_FakeOrt).intra_op_num_threads == 2   # the default
+
+
+# ── fixed-shape exports must not take the camera down ───────────────
+
+class _FixedShapeNet:
+    """A net exported at ONE input size, like the shipped yolov8n.onnx."""
+
+    def __init__(self, accepts: int):
+        self.accepts = accepts
+        self._blob = None
+
+    def setInput(self, blob):          # noqa: N802 - cv2 API shape
+        self._blob = blob
+
+    def forward(self):
+        if self._blob.shape[-1] != self.accepts:
+            raise cv2.error("outTotal == inpTotal in function 'getOutShape'")
+        return np.zeros((1, 84, 8400), np.float32)
+
+
+def test_probe_adopts_the_size_the_model_actually_accepts():
+    """The shipped yolov8n.onnx is exported at a FIXED 640. Feeding 320 raised
+    deep in the graph — once per region, per frame — and nothing wrapped it, so
+    it reached the worker loop and the camera went dark in a restart loop. A
+    documented env knob could take detection down entirely."""
+    from detect_pipeline.onnx_detector import probe_input_size
+
+    assert probe_input_size(_FixedShapeNet(640), 320) == 640
+    assert probe_input_size(_FixedShapeNet(640), 640) == 640
+    assert probe_input_size(_FixedShapeNet(416), 640) == 416
+
+
+def test_probe_returns_the_request_when_nothing_fits():
+    """Never loop forever or invent a size: report and let the error surface."""
+    from detect_pipeline.onnx_detector import probe_input_size
+
+    assert probe_input_size(_FixedShapeNet(99), 640) == 640

--- a/detect-pipeline/test/test_pipeline.py
+++ b/detect-pipeline/test/test_pipeline.py
@@ -308,3 +308,30 @@ def test_dedup_alone_is_not_reported_as_capped():
     boxes = [(100, 100, 160, 200), (105, 100, 165, 205)]
     regions, capped = select_regions(boxes, [], BIG, min_region=320, max_regions=8)
     assert len(regions) == 1 and capped is False
+
+
+def test_one_failing_region_does_not_kill_the_frame():
+    """detector.detect() was unwrapped, so a model rejecting a crop shape
+    raised through process_frame into the worker loop's 'crashed' handler and
+    the feed went dark until the next reconcile — every frame, in a loop.
+    That is reachable from a documented env knob: the shipped yolov8n.onnx is
+    exported at a FIXED 640, so DETECT_ONNX_INPUT=320 made every inference
+    raise."""
+    class _Flaky:
+        def __init__(self): self.n = 0
+        def detect(self, crop):
+            self.n += 1
+            if self.n == 1:
+                raise RuntimeError("model rejected this crop shape")
+            return [RawDetection("person", 0.9, (0.1, 0.1, 0.5, 0.8))]
+
+    det = _Flaky()
+    tracker = Tracker((H, W), TrackConfig(fps=2))
+    p = DetectPipeline(_FakeSource(4), _FakeMotion(calibrating=False), det, tracker)
+
+    results = [p.process_frame(f) for f in _FakeSource(4).stream()]   # must not raise
+    assert any(r.regions for r in results), "no regions — test would prove nothing"
+    assert p.detector_errors == 1
+    assert det.n > 1, "pipeline stopped calling the detector after the failure"
+    assert any(r.tracks or r.detections for r in results), \
+        "later regions must still produce detections"

--- a/detect-pipeline/test/test_run_config.py
+++ b/detect-pipeline/test/test_run_config.py
@@ -325,3 +325,35 @@ def test_run_module_functions_reference_no_undefined_globals():
             unresolved.append(f"{name}() -> {g}")
 
     assert not unresolved, "undefined global(s) in detect_pipeline.run: " + ", ".join(unresolved)
+
+
+# ── .env inline-comment leakage ─────────────────────────────────────
+
+def test_leaked_inline_comments_are_not_treated_as_values():
+    """`VAR=` followed by a trailing `# comment` in a .env file parses as the
+    COMMENT — only the EMPTY case; non-empty values strip theirs correctly.
+    Found live on this project's own .env.example: the container really had
+    DETECT_DISPATCH_KAIC_URL set to "# set (e.g. http://kai-c:8100) ...",
+    which is truthy, so the service reported Tier-1 dispatch as configured
+    against a URL that could never resolve."""
+    bogus_url = "# set (e.g. http://kai-c:8100) to run the gated model; empty = off"
+    cfg = config_from_env({
+        "DETECT_DISPATCH_KAIC_URL": bogus_url,
+        "DETECT_ONNX_PROVIDERS": "# ort EPs, e.g. OpenVINOExecutionProvider",
+    })
+    assert cfg.dispatch_kaic_url == ""
+    assert cfg.onnx_providers == ""
+
+
+def test_a_non_url_dispatch_target_is_refused():
+    cfg = config_from_env({"DETECT_DISPATCH_KAIC_URL": "kai-c:8100"})   # no scheme
+    assert cfg.dispatch_kaic_url == ""
+
+
+def test_real_values_are_untouched():
+    cfg = config_from_env({
+        "DETECT_DISPATCH_KAIC_URL": "http://kai-c:8100",
+        "DETECT_ONNX_PROVIDERS": "OpenVINOExecutionProvider,CPUExecutionProvider",
+    })
+    assert cfg.dispatch_kaic_url == "http://kai-c:8100"
+    assert cfg.onnx_providers == "OpenVINOExecutionProvider,CPUExecutionProvider"

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -716,3 +716,62 @@ def test_gate_change_closes_the_outgoing_dispatcher():
     mgr.apply_gate_change(lambda: None, dispatcher=None)
     assert new.closed
     assert mgr._dispatcher is None
+
+
+def test_inference_threads_follow_the_fleet_size():
+    """A fixed per-inference thread cap is right for a fleet and wrong for a
+    small one. Measured on an 8-core box, one camera, yolov8n at 640: 2
+    threads 449ms vs 8 threads 176ms — near-linear, so the shipped cap of 2
+    left six cores idle and made every frame 2.5x more expensive than the
+    hardware required."""
+    import detect_pipeline.service as svc
+
+    seen: list[int] = []
+
+    class _Cv2:
+        @staticmethod
+        def setNumThreads(n): seen.append(n)
+
+    import sys
+    sys.modules["cv2"] = _Cv2                       # intercept the global cap
+
+    prov = _FakeProvider([_spec(f"c{i}") for i in range(2)])
+    mgr = WorkerManager(prov, _FakeSink(), worker_factory=_FakeWorker)
+    mgr._shared_detector = None
+    original = svc.os.cpu_count
+    svc.os.cpu_count = lambda: 8
+    try:
+        mgr.reconcile()
+        assert seen and seen[-1] == 4, seen        # 8 cores / 2 cameras
+
+        prov.specs = [_spec(f"c{i}") for i in range(8)]
+        mgr.reconcile()
+        assert seen[-1] == 1, seen                 # 8 cores / 8 cameras
+    finally:
+        svc.os.cpu_count = original
+        sys.modules.pop("cv2", None)
+
+
+def test_pinned_cv_threads_are_never_retuned():
+    """An operator who set DETECT_CV_THREADS meant it."""
+    import sys
+
+    import detect_pipeline.service as svc
+
+    seen: list[int] = []
+
+    class _Cv2:
+        @staticmethod
+        def setNumThreads(n): seen.append(n)
+
+    sys.modules["cv2"] = _Cv2
+    original = svc.os.cpu_count
+    svc.os.cpu_count = lambda: 8
+    try:
+        mgr = WorkerManager(_FakeProvider([_spec("a")]), _FakeSink(),
+                            worker_factory=_FakeWorker, cv_threads_pinned=True)
+        mgr.reconcile()
+        assert seen == [], seen
+    finally:
+        svc.os.cpu_count = original
+        sys.modules.pop("cv2", None)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -370,7 +370,8 @@ services:
       - DETECT_METRICS_PORT=${DETECT_METRICS_PORT:-9109}
       # Thread cap for the detector (cv2 intra-op + BLAS). Prevents Tier-0
       # from starving CPU-bound co-tenants; raise it on big machines.
-      - DETECT_CV_THREADS=${DETECT_CV_THREADS:-2}
+      # Empty = sized to the fleet (cores / concurrent inferences).
+      - DETECT_CV_THREADS=${DETECT_CV_THREADS:-}
       # Per-camera analysis rate. Detection runs on every analyzed frame,
       # so this is the pipeline's main CPU dial — see .env.example.
       - DETECT_FPS=${DETECT_FPS:-2}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -318,6 +318,9 @@ services:
       # model is missing — the container never crash-loops).
       - DETECT_DETECTOR=${DETECT_DETECTOR:-onnx}
       - DETECT_ONNX_MODEL=/app/model_weights/yolov8n.onnx
+      # Only tunable with a dynamic-axes export; the shipped model is fixed
+      # at 640 and the service adapts (with a warning) if this disagrees.
+      - DETECT_ONNX_INPUT=${DETECT_ONNX_INPUT:-640}
       # Inference backend: cvdnn (zero-dep CPU, default) or ort (ONNX Runtime).
       # For an accelerator, set backend=ort + providers (and install the matching
       # onnxruntime wheel in a derived image) — see detect-pipeline/README.md.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,10 +292,12 @@ services:
   # ──────────────────────────────────────────────────────────────
   detect-pipeline:
     # Pulled from GHCR (built + published by publish-detect-pipeline.yml), like
-    # opennvr-core and yolov8-adapter — no local build. To build from source
-    # instead: `docker compose build` with a build: override, or run the
-    # component directly (see detect-pipeline/README.md).
-    image: ghcr.io/open-nvr/detect-pipeline:${CORE_TAG:-latest}
+    # opennvr-core and yolov8-adapter — no local build. To run a locally built
+    # image (e.g. to test a change against a live stack), set
+    # DETECT_PIPELINE_IMAGE=opennvr/detect-pipeline:mytag — no compose edit and
+    # nothing to remember to undo. Otherwise build from source per
+    # detect-pipeline/README.md.
+    image: ${DETECT_PIPELINE_IMAGE:-ghcr.io/open-nvr/detect-pipeline:${CORE_TAG:-latest}}
     container_name: opennvr_detect_pipeline
     logging: *svc-logs
     restart: unless-stopped


### PR DESCRIPTION
Diagnosed on a live 1080p camera. The reported symptom was a "flaky camera" dropping its RTSP session every few minutes with "Failed reading RTSP data: End of file". The camera was fine — we were the cause.

Measured on that box (native arm64, 8 cores, one camera):

  detect  3.07 s/frame      <- 99.8% of the time
  decode  2.2 ms
  motion  1.4 ms
  track   0.02 ms
  processing_fps 0.27 against a target of 2

Eight region crops at a 640px model input, on CPU, is ~3s of inference against a 500ms frame budget — six times over, sustained, with nothing in the pipeline able to notice. Falling behind is not merely late detections: the worker stops draining ffmpeg's stdout, ffmpeg blocks on the full pipe, MediaMTX drops the reader, and the session dies. Then we respawn, which costs more than steady state. That is the reconnect spiral described in FOLLOWUPS 13f, observed in production.

RegionBudgetController watches real frame latency against the budget and spends fewer detector crops when over it, recovering as headroom returns. Smoothed and streak-gated so a GOP boundary or a burst of motion cannot move it; halves on the way down, steps back up one at a time; never goes below a floor, so a camera always keeps detecting something. Detecting less per frame is a real cost — but it is strictly better than decoding a stream we cannot finish and losing the session with it. Exposed as tier0_regions_budget and logged on every change.

Also fixes two shipped .env.example lines that handed the container a comment as a value. `VAR=` with a trailing `# comment` parses as the COMMENT — only when the value is empty; non-empty values strip theirs correctly. Confirmed live: DETECT_DISPATCH_KAIC_URL really was set to "# set (e.g. ...", which is truthy, so the service reported Tier-1 dispatch as configured against a URL that could never resolve, and DETECT_ONNX_PROVIDERS warned on every start. Comments moved above the lines, and config now refuses a value that is plainly a leaked comment or a non-http dispatch target — operator .env files will hit the same footgun.