### PR TITLE
fix(camera-agent): resolve camera ids against the live roster, not a …

### DIFF
--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -2853,14 +2853,28 @@ class CameraAgentRuntime:
                     cfg.footage_index_path,
                 )
 
-        # Agent camera id → pipeline camera id (the OpenNVR camera id on the Tier-0
-        # bus subject / best-frame endpoint). Used by BOTH camera_snapshot (ring
-        # lookup) and describe_camera (best-frame fetch) so they agree on the camera.
-        _cam_map = {
-            cam.camera_id: str(cam.opennvr_camera_id)
-            for cam in cfg.cameras if cam.opennvr_camera_id is not None
-        }
-        _resolve_camera = lambda cid: _cam_map.get(cid, cid)  # noqa: E731
+        # Agent camera id → OpenNVR camera id (used on the Tier-0 bus subject,
+        # the best-frame endpoint, and the events store). Resolved AT CALL TIME
+        # against the live roster.
+        #
+        # This used to be a dict comprehension captured in a closure, which
+        # froze the roster as it looked during startup assembly. The background
+        # reconcile exists precisely because the agent usually boots before the
+        # core has its cameras ready — so on a normal cold start the snapshot
+        # was EMPTY, and it stayed empty for the life of the process even as
+        # reconcile logged "loaded 1 camera(s)" every 30s. Every history query
+        # then failed with "camera 'camN' has no server-side id", which the LLM
+        # relayed to users as "The camera appears to be offline" — a camera
+        # that was online the whole time. camera_snapshot and describe_camera's
+        # best-frame path resolve through here too, so they broke the same way.
+        def _resolve_camera(cid: str) -> str:
+            # self.context is the LIVE roster — both _register_opennvr_cameras
+            # and _remove_opennvr_cameras act on it, while cfg.cameras is only
+            # the boot-time config list.
+            for cam in self.context.cameras:
+                if cam.camera_id == cid and cam.opennvr_camera_id is not None:
+                    return str(cam.opennvr_camera_id)
+            return cid
 
         # Best-frame fetch (optional): describe_camera runs the VLM on Tier-0's best
         # frame when the detect-pipeline origin is configured.

--- a/examples/camera-agent/tests/test_camera_reconcile.py
+++ b/examples/camera-agent/tests/test_camera_reconcile.py
@@ -178,3 +178,50 @@ def test_reconcile_successful_fetch_adds_and_removes(monkeypatch):
     assert rt.context.known_camera("cam9")
     assert _enum_ids(rt) == {"cam2", "cam9"}
     assert rt._opennvr_managed == {"cam2", "cam9"}
+
+
+# ── the camera-id map must not freeze at boot either ────────────────
+#
+# Same class as the tool-enum staleness above, one layer down. The agent
+# resolved "cam1" -> the OpenNVR camera id through a dict comprehension
+# captured in a closure at startup. The reconcile loop exists BECAUSE the
+# agent usually boots before the core has cameras ready — so on a normal cold
+# start that snapshot was empty and stayed empty for the life of the process,
+# even while reconcile logged "loaded 1 camera(s)" every 30s.
+#
+# Field symptom: every past-tense question returned "The camera appears to be
+# offline." search_history got ERROR: camera 'cam1' has no server-side id, and
+# the LLM turned that into an offline claim about a camera that was online the
+# whole time. camera_snapshot and describe_camera's best-frame fetch resolve
+# through the same function and broke identically.
+
+
+def _nvr_spec(cid: str, oid: int) -> CameraSpec:
+    return CameraSpec(camera_id=cid, frame_url=f"http://x/{cid}.jpg", role=cid,
+                      opennvr_camera_id=oid)
+
+
+def test_camera_added_after_boot_resolves_to_its_server_side_id():
+    rt = _runtime()                              # boots with NO cameras
+    assert rt.tools._resolve_camera("cam1") == "cam1"   # nothing to resolve yet
+
+    rt._register_opennvr_cameras([_nvr_spec("cam1", 1)])
+    rt._sync_camera_roster()
+
+    assert rt.tools._resolve_camera("cam1") == "1", (
+        "resolver froze the boot-time roster; history/snapshot stay broken "
+        "for the life of the process"
+    )
+
+
+def test_resolver_follows_a_removed_camera_too():
+    rt = _runtime()
+    rt._register_opennvr_cameras([_nvr_spec("cam1", 1), _nvr_spec("cam2", 2)])
+    rt._opennvr_managed |= {"cam1", "cam2"}      # what the reconcile loop adopts
+    rt._sync_camera_roster()
+    assert rt.tools._resolve_camera("cam2") == "2"
+
+    rt._remove_opennvr_cameras({"cam2"})
+    rt._sync_camera_roster()
+    assert rt.tools._resolve_camera("cam2") == "cam2"   # unknown again
+    assert rt.tools._resolve_camera("cam1") == "1"      # survivor unaffected


### PR DESCRIPTION
…boot snapshot

Field report: every past-tense question answered "The camera appears to be offline" while the camera was online, streaming, and its detections were being recorded. The camera was never offline — the LLM invented that from a failing tool.

The agent resolved "cam1" -> the OpenNVR camera id through a dict comprehension captured in a closure during startup assembly. The background reconcile loop exists precisely BECAUSE the agent usually boots before the core has its cameras ready, so on a normal cold start that snapshot was empty — and it stayed empty for the life of the process even while reconcile logged "loaded 1 camera(s)" every 30 seconds.

So search_history returned "ERROR: camera 'cam1' has no server-side id", and the model relayed that to the user as an offline camera. camera_snapshot and describe_camera's best-frame fetch resolve through the same function and broke identically — which is why live description failed too.

Resolution now walks self.context.cameras at call time. That is the live roster: both _register_opennvr_cameras and _remove_opennvr_cameras act on it, while cfg.cameras is only the boot-time config list, so a camera added OR removed after boot is now followed in both directions.

Same class as the tool-enum staleness already documented in test_camera_reconcile.py — that one was fixed, this one layer down was missed. Tests live alongside it, and both fail against the old closure.

Confirmed on a live stack: the events store had the visits all along (person and car with evidence on camera 1); only the lookup was broken.