### PR TITLE
fix(detect-pipeline): the load shedder was recovering on evidence tha…

### DIFF
--- a/detect-pipeline/detect_pipeline/pipeline.py
+++ b/detect-pipeline/detect_pipeline/pipeline.py
@@ -332,15 +332,22 @@ class RegionBudgetController:
     def shedding(self) -> bool:
         return self.configured > 0 and self.current < self.configured
 
-    def observe(self, latency_s: float) -> bool:
-        """Feed one frame's processing time. True if the budget changed.
+    def observe(self, latency_s: float, regions_run: int = 1) -> int:
+        """Feed one frame. Returns the DELTA applied to the budget (0 = none).
 
         A single slow frame means nothing — a GOP boundary, a burst of motion,
         the OS scheduling elsewhere. Only a sustained trend moves the budget,
         so this smooths and requires a streak in one direction.
+
+        ``regions_run`` is what makes the signal honest. A frame on which the
+        detector never ran costs ~0ms, and treating that as "we have headroom"
+        let a quiet scene walk the budget straight back up to the configured
+        maximum on evidence that says nothing about the cost of a BUSY frame —
+        so the next burst of motion immediately blew the budget again and it
+        sawtoothed. Idle frames are simply not evidence either way.
         """
-        if self.configured <= 0:
-            return False
+        if self.configured <= 0 or regions_run <= 0:
+            return 0
         self._ema = (
             latency_s if self._ema is None
             else (self.smoothing * latency_s + (1 - self.smoothing) * self._ema)
@@ -354,15 +361,16 @@ class RegionBudgetController:
             self._streak = self._streak - 1 if self._streak <= 0 else -1
         else:
             self._streak = 0
-            return False
+            return 0
 
         if abs(self._streak) < self.settle_frames:
-            return False
+            return 0
         self._streak = 0
         # Halve on the way down (the overrun is usually large), step back up
         # one at a time so recovery cannot immediately re-saturate.
+        before = self.current
         self.current = (
             max(self.floor, self.current // 2) if over
             else min(self.configured, self.current + 1)
         )
-        return True
+        return self.current - before

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -566,17 +566,24 @@ class CameraWorker:
                 # the worker stops draining ffmpeg's stdout, ffmpeg blocks on
                 # the full pipe, and MediaMTX drops the session, which surfaces
                 # as a "flaky camera" that is really us.
-                if budget.observe(frame_latency):
+                delta = budget.observe(frame_latency, len(result.regions))
+                if delta:
                     pipe.max_regions = budget.current
                     _metrics.gauge(
                         "tier0_regions_budget", float(budget.current),
                         {"camera": self.spec.camera_id},
                     )
-                    log.warning(
+                    # Shedding is a capability loss and deserves a warning;
+                    # getting capacity back is routine. The direction comes
+                    # from the DELTA — "shedding" (below configured) is still
+                    # true while recovering, so keying off it reported a step
+                    # UP as a cut.
+                    log.log(
+                        logging.WARNING if delta < 0 else logging.INFO,
                         "tier0 %s: frame latency %.2fs against a %.2fs budget — "
-                        "detector regions %s to %d (of %d configured)",
+                        "detector regions %s %d (of %d configured)",
                         self.spec.camera_id, frame_latency, budget.budget_s,
-                        "cut" if budget.shedding else "restored to",
+                        "cut to" if delta < 0 else "restored to",
                         budget.current, budget.configured,
                     )
                 record_frame(

--- a/detect-pipeline/test/test_bounded_load.py
+++ b/detect-pipeline/test/test_bounded_load.py
@@ -215,7 +215,7 @@ def test_budget_is_inert_when_regions_are_unbounded():
 
     c = RegionBudgetController(0, fps=2)           # 0 = no cap configured
     for _ in range(40):
-        assert c.observe(9.0) is False
+        assert c.observe(9.0) == 0
     assert c.current == 0
 
 
@@ -226,3 +226,44 @@ def test_budget_never_sheds_below_its_floor():
     for _ in range(200):
         c.observe(30.0)                            # hopelessly over budget
     assert c.current == 2
+
+
+def test_idle_frames_are_not_evidence_of_headroom():
+    """A frame on which the detector never ran costs ~0ms. Counting that as
+    "we have headroom" let a quiet scene walk the budget straight back to the
+    configured maximum on evidence that says nothing about a BUSY frame — so
+    the next burst of motion blew the budget again and it sawtoothed.
+
+    Observed in production: 'frame latency 0.00s ... regions cut to 6' —
+    stepping the budget UP off zero-cost frames, and mislabelling it too.
+    """
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    for _ in range(40):
+        c.observe(3.07, regions_run=8)          # sustained real overrun
+    shed_to = c.current
+    assert shed_to < 8
+
+    for _ in range(200):
+        c.observe(0.0, regions_run=0)           # quiet scene, no detector work
+    assert c.current == shed_to, "idle frames must not restore the budget"
+
+    for _ in range(200):
+        c.observe(0.05, regions_run=shed_to)    # real frames, real headroom
+    assert c.current == 8
+
+
+def test_budget_change_reports_its_direction():
+    """`shedding` is true while RECOVERING too (still below configured), so
+    keying the log off it reported a step up as a cut — production logged
+    'regions cut to 6' while climbing 5->6, and 'restored to to 8'."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    deltas = [c.observe(3.07, 8) for _ in range(40)]
+    assert any(d < 0 for d in deltas), "shedding must report a negative delta"
+    assert all(d <= 0 for d in deltas)
+
+    ups = [c.observe(0.05, c.current) for _ in range(200)]
+    assert any(d > 0 for d in ups), "recovery must report a positive delta"


### PR DESCRIPTION
…t wasn't

Three bugs, all visible in one paste of production logs:

    frame latency 0.00s against a 0.50s budget — detector regions cut to 6
    frame latency 0.00s against a 0.50s budget — detector regions restored to to 8

* A frame on which the detector never ran costs ~0ms. The controller counted that as headroom, so a quiet scene walked the budget straight back to the configured maximum on evidence that says nothing about the cost of a BUSY frame — and the next burst of motion blew the budget again. The result sawtoothed between 2 and 8 instead of settling near real capacity. Frames that ran no regions are now not evidence in either direction.

* The direction label read off `shedding`, which is "below configured" — true while RECOVERING too. So a step UP from 5 to 6 was logged as a cut. The change now reports a signed delta and the log follows it.

* "restored to" concatenated with " to %d" gave "restored to to 8".

Also: shedding is a capability loss and stays a warning, but getting capacity back is routine and drops to info — the sawtooth above was emitting a warning per step, which is exactly the kind of noise that trains people to ignore warnings.