### PR TITLE
fix(camera-agent): do not retry an adapter that is not there

### DIFF
--- a/detect-pipeline/detect_pipeline/pipeline.py
+++ b/detect-pipeline/detect_pipeline/pipeline.py
@@ -303,6 +303,18 @@ class RegionBudgetController:
     per frame is a real cost, but it is strictly better than decoding a stream
     we cannot finish and losing the session with it.
 
+    Recovery remembers. Plain additive-increase/multiplicative-decrease is
+    memoryless, and on a real camera that showed: it halved away from 8
+    regions, climbed back to 8 in about twenty seconds off cheap quiet frames,
+    blew the budget at 8 again, and repeated every three minutes — sixteen cuts
+    in one 35-minute run, every one of them from 8. So the level that failed is
+    remembered (TCP's slow-start threshold), growth below it stays free, and
+    growth back INTO it has to be paid for in sustained evidence, more each
+    time it fails again. The mark only lifts on frames that genuinely ran that
+    many regions — a quiet frame is cheap at any budget and proves nothing —
+    so a busy scene can no longer be talked into a level it cannot afford, and
+    a box that really does free up still gets its full budget back.
+
     Pure and clock-injected — no I/O, no threads.
     """
 
@@ -316,6 +328,9 @@ class RegionBudgetController:
         recover_at: float = 0.6,
         settle_frames: int = 5,
         smoothing: float = 0.3,
+        probe_factor: int = 4,
+        max_probe_backoff: int = 8,
+        probation_frames: int = 20,
     ) -> None:
         self.configured = max(0, int(configured))
         self.budget_s = 1.0 / max(1, int(fps))
@@ -324,9 +339,23 @@ class RegionBudgetController:
         self.recover_at = recover_at
         self.settle_frames = max(1, int(settle_frames))
         self.smoothing = smoothing
+        self.probe_factor = max(1, int(probe_factor))
+        self.max_probe_backoff = max(1, int(max_probe_backoff))
+        self.probation_frames = max(1, int(probation_frames))
         self.current = self.configured
         self._ema: float | None = None
         self._streak = 0
+        # The lowest region count observed to blow the budget on this box, or
+        # None if we have no such evidence. TCP's slow-start threshold: the
+        # point below which growth is free and above which it must be earned.
+        self._ceiling: int | None = None
+        # Consecutive failures at that same level. Each one makes the next
+        # probe cost more evidence, so a level that keeps failing stops being
+        # retried every few minutes — bounded, so it is never retried *never*.
+        self._ceiling_hits = 0
+        # Frames that have genuinely exercised the ceiling since we climbed
+        # back to it. Only these count towards clearing it.
+        self._held = 0
 
     @property
     def shedding(self) -> bool:
@@ -354,6 +383,7 @@ class RegionBudgetController:
         )
         over = self._ema > self.budget_s * self.over_budget
         under = self._ema < self.budget_s * self.recover_at
+        self._serve_probation(regions_run, over)
 
         if over and self.current > self.floor:
             self._streak = self._streak + 1 if self._streak >= 0 else 1
@@ -363,14 +393,76 @@ class RegionBudgetController:
             self._streak = 0
             return 0
 
-        if abs(self._streak) < self.settle_frames:
+        if abs(self._streak) < self._evidence_needed():
             return 0
         self._streak = 0
         # Halve on the way down (the overrun is usually large), step back up
         # one at a time so recovery cannot immediately re-saturate.
         before = self.current
-        self.current = (
-            max(self.floor, self.current // 2) if over
-            else min(self.configured, self.current + 1)
-        )
+        if over:
+            # This level does not work here — remember it, so recovery does
+            # not sprint straight back into it. Cost is monotone in region
+            # count (if `before` regions is too slow, so is anything above it),
+            # so while the mark stands it only ever moves DOWN. Shedding from
+            # at-or-above it means a probe we already paid for has failed
+            # again: charge more for the next one.
+            if self._ceiling is not None and before >= self._ceiling:
+                self._ceiling_hits += 1
+            else:
+                self._ceiling_hits = 1
+            self._ceiling = (
+                before if self._ceiling is None else min(self._ceiling, before)
+            )
+            self._held = 0
+            self.current = max(self.floor, self.current // 2)
+        else:
+            self.current = min(self.configured, self.current + 1)
         return self.current - before
+
+    def _serve_probation(self, regions_run: int, over: bool) -> None:
+        """Clear the remembered ceiling once the level has actually proved out.
+
+        Arriving at the level is not proof. A quiet frame costs almost nothing
+        at *any* budget because barely any regions run, so a quiet stretch will
+        happily carry the budget back to a level that the next burst of motion
+        cannot afford — which is precisely the loop this class exists to break.
+        Only a frame that really ran ``ceiling`` regions and came in on time
+        tests the ceiling.
+
+        Sustain enough of those and the evidence is genuinely stale: the box
+        freed up, the scene changed, whatever. Then the mark comes off and
+        ordinary growth resumes. Nothing is pinned permanently.
+        """
+        if self._ceiling is None or self.current < self._ceiling:
+            self._held = 0
+            return
+        if regions_run < self._ceiling or over:
+            return                              # proves nothing about this level
+        self._held += 1
+        if self._held >= self.probation_frames:
+            self._ceiling = None
+            self._ceiling_hits = 0
+            self._held = 0
+
+    def _evidence_needed(self) -> int:
+        """Frames of agreeing evidence required before the next step.
+
+        Shedding is urgent and stepping up into room we have no reason to
+        distrust is cheap, so both take the ordinary streak. Stepping up to a
+        level that has already blown the budget is a *probe*, and a wrong probe
+        is expensive: the overrun stalls the worker, ffmpeg's pipe fills and
+        MediaMTX drops the reader. So a probe has to be paid for in evidence.
+
+        Without this the controller was memoryless — it halved away from 8,
+        climbed 1 -> 8 in about twenty seconds, blew the budget at 8 again, and
+        repeated every three minutes forever (sixteen such cuts in one 35-minute
+        run, every one of them from 8). Same additive-increase/multiplicative-
+        decrease law, but now it converges on the largest level that actually
+        works instead of orbiting the one that does not.
+        """
+        if self._streak > 0:                                   # shedding
+            return self.settle_frames
+        if self._ceiling is None or self.current + 1 < self._ceiling:
+            return self.settle_frames
+        backoff = min(self._ceiling_hits, self.max_probe_backoff)
+        return self.settle_frames * self.probe_factor * max(1, backoff)

--- a/detect-pipeline/test/test_bounded_load.py
+++ b/detect-pipeline/test/test_bounded_load.py
@@ -188,12 +188,15 @@ def test_budget_sheds_under_sustained_overrun_and_recovers():
     assert c.current == 8 and not c.shedding
 
     for _ in range(40):
-        c.observe(3.07)
+        c.observe(3.07, regions_run=c.current)
     assert c.current < 8 and c.shedding
     assert c.current >= 1, "must keep detecting something"
 
-    for _ in range(120):
-        c.observe(0.05)                            # hardware caught up
+    # Recovery is deliberately cautious now — the budget will not sprint back
+    # into a level it has seen fail, and it will not take a quiet frame's word
+    # for it either — so full recovery takes real frames doing real work.
+    for _ in range(400):
+        c.observe(0.05, regions_run=c.current)     # hardware caught up
     assert c.current == 8 and not c.shedding
 
 
@@ -267,3 +270,141 @@ def test_budget_change_reports_its_direction():
 
     ups = [c.observe(0.05, c.current) for _ in range(200)]
     assert any(d > 0 for d in ups), "recovery must report a positive delta"
+
+
+def _drive(controller, frames, *, per_region=0.115, busy_every=4, period=50):
+    """Drive the controller with a production-shaped load and count budget moves.
+
+    Cost scales with the regions actually RUN, and activity comes and goes: a
+    quiet frame runs a couple of regions and is cheap at any budget, a busy one
+    runs the full budget and is not. That asymmetry is the whole problem — it
+    is why headroom measured while quiet is not evidence about a busy frame.
+    """
+    moves, dwell = 0, {}
+    for i in range(frames):
+        demand = 8 if (i // period) % busy_every == busy_every - 1 else 2
+        ran = min(controller.current, demand)
+        if controller.observe(per_region * ran, ran) != 0:
+            moves += 1
+        dwell[controller.current] = dwell.get(controller.current, 0) + 1
+    return moves, dwell
+
+
+def test_budget_stops_climbing_back_into_a_level_it_knows_fails():
+    """The production sawtooth. In one 35-minute run the budget was cut
+    sixteen times and every single cut was from 8: it halved away, climbed
+    1 -> 8 in about twenty seconds off cheap quiet frames, blew the budget at 8
+    again, and repeated every three minutes. Nothing broke; it just spent its
+    life re-learning one fact.
+
+    At 0.115s per region against a 500ms budget, 5 is the largest level a busy
+    frame can afford. The controller has to find that and stay there.
+    """
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    memoryless = RegionBudgetController(
+        8, fps=2, probe_factor=1, max_probe_backoff=1, probation_frames=1
+    )
+    remembering = RegionBudgetController(8, fps=2)
+
+    old_moves, old_dwell = _drive(memoryless, 20000)
+    new_moves, new_dwell = _drive(remembering, 20000)
+
+    assert remembering.current == 5, (
+        f"should settle on the largest level a busy frame affords, "
+        f"got {remembering.current}"
+    )
+    # The memoryless controller spends most of its life at the level that
+    # fails; this one must not go there at all once it has converged.
+    assert old_dwell.get(8, 0) > 20000 // 2
+    assert new_dwell.get(8, 0) < 20000 // 10
+    assert new_moves < old_moves // 4, (
+        f"churn should collapse, not merely improve: {new_moves} vs {old_moves}"
+    )
+
+
+def test_budget_churn_stops_once_converged():
+    """Converged means converged — no moves at all in the final stretch. A
+    controller that still steps every few minutes is still writing WARNING
+    lines and still re-paying the cost of being wrong."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    _drive(c, 30000)                                  # converge
+    tail_moves, _ = _drive(c, 10000)                  # then watch
+    assert tail_moves == 0, f"still churning after convergence: {tail_moves} moves"
+
+
+def test_a_ceiling_is_never_permanent():
+    """One bad minute must not cost detections forever. When the box genuinely
+    frees up — a neighbouring camera stopped, the scene changed — the budget
+    has to come back."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    _drive(c, 20000)
+    assert c.current < 8 and c._ceiling is not None
+
+    for _ in range(2000):                             # everything cheap now
+        c.observe(0.02 * min(c.current, 8), min(c.current, 8))
+        if c.current == 8:
+            break
+    assert c.current == 8, "a stale ceiling must not pin the budget down"
+    assert c._ceiling is None
+
+
+def test_the_ceiling_only_lifts_on_evidence_from_frames_that_tested_it():
+    """Arriving at a level is not proof it works. A quiet frame is cheap at any
+    budget because barely any regions run, so quiet frames must not be able to
+    retire the mark — that is exactly the loop being closed here."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    while c.current == 8:
+        c.observe(0.9, regions_run=8)                 # 8 is too expensive
+    assert c._ceiling == 8
+
+    # Thousands of cheap frames that never run more than 2 regions. They may
+    # walk the budget up, but they can never certify the ceiling.
+    for _ in range(3000):
+        c.observe(0.03, regions_run=2)
+    assert c._ceiling == 8, "quiet frames must not retire the ceiling"
+
+
+def test_the_ceiling_tracks_downwards_when_a_lower_level_also_fails():
+    """Cost is monotone in region count, so a failure at 4 also condemns 5-8.
+    The mark has to follow the evidence down; when it did not, every shed
+    landed somewhere new, the repeat-failure count kept resetting to 1, and the
+    probe never got expensive enough to stop the hunting."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    while c.current == 8:
+        c.observe(0.9, regions_run=8)
+    assert c._ceiling == 8
+    at = c.current
+
+    while c.current == at:                            # `at` is too slow as well
+        c.observe(2.0, regions_run=at)
+    assert c._ceiling <= at, f"ceiling must follow failure down, got {c._ceiling}"
+
+
+def test_repeated_failure_at_a_level_makes_the_next_probe_dearer():
+    """Bounded backoff: a level that keeps failing stops being retried every
+    few minutes, but never stops being retried altogether."""
+    from detect_pipeline.pipeline import RegionBudgetController
+
+    c = RegionBudgetController(8, fps=2)
+    _drive(c, 20000)
+    assert c._ceiling_hits > 1, "repeat failures must accumulate"
+
+    # Standing just below the ceiling with a recovery streak running: the cost
+    # of the next probe grows with the failures, and stops growing at the cap.
+    c._streak = -1
+    c.current = c._ceiling - 1
+    ordinary = c.settle_frames
+    cost = c._evidence_needed()
+    assert cost > ordinary, "a probe must cost more than an ordinary step"
+    assert cost <= ordinary * c.probe_factor * c.max_probe_backoff, (
+        "probe cost must stay bounded so the level is still retried eventually"
+    )

--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -143,6 +143,21 @@ class KaicAdapterClient(_ReusableClientMixin):
                         response=resp_obj,
                     ) if isinstance(exc, httpx.HTTPStatusError) else exc
                 last_exc = exc
+                # A retry exists to bridge a warming-up adapter. Some failures
+                # can never become success by waiting: 404 means the adapter
+                # route does not exist (not deployed, or a typo'd
+                # recognition_adapter), 400 means our payload is wrong. Retrying
+                # those burns two extra round trips and two WARNINGs per call —
+                # seen in the field as insightface 404s repeating on every
+                # person visit, on a stack with no face adapter installed.
+                status = getattr(resp_obj, "status_code", None)
+                if status in (400, 404):
+                    logger.warning(
+                        "KAI-C adapter unavailable (HTTP %s at %s) — not "
+                        "retrying; this cannot succeed by waiting",
+                        status, self._url,
+                    )
+                    break
                 if attempt < self._retries:
                     backoff = self._backoff_for(resp_obj)
                     logger.warning(

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1568,7 +1568,7 @@ def _letterbox_jpeg(jpeg: bytes, max_side: int = 960) -> bytes:
 
         position     squashed   centre-crop   letterboxed
         left edge      0.28        0.00           0.84
-        centre         0.00        0.54           0.77
+        centre         0.00        0.54           0.76
         right edge     0.48        0.00           0.82
 
     Note the middle column: cropping to a centre square is BLIND at both
@@ -1577,42 +1577,51 @@ def _letterbox_jpeg(jpeg: bytes, max_side: int = 960) -> bytes:
 
     ``max_side`` shrinks before padding, because the detector resizes to its
     own input regardless — sending 1920x1920 buys nothing and costs real work.
-    Downscaling here is also BETTER than letting the adapter do it, since
-    INTER_AREA resamples properly. Same person, same three positions:
+    Downscaling here is also BETTER than letting the adapter do it, because a
+    proper resampling filter beats whatever the far side does. Same person,
+    same three positions:
 
         letterbox side   1920   1280    960    640
         left edge        0.77   0.83   0.85   0.85
         centre           0.63   0.74   0.78   0.75
         right edge       0.80   0.83   0.81   0.75
-        cost              114ms   82ms   44ms   33ms
         payload            83KB   36KB   25KB   13KB
 
-    960 keeps headroom above a 640 model input while costing a third of full
-    size and a third of the bytes.
+    960 keeps headroom above a 640 model input at a third of the bytes.
+
+    Pillow, deliberately, not OpenCV: cv2 is an OPTIONAL extra here (the
+    ``device`` group, for local capture cameras) while Pillow is a core
+    dependency. Written against cv2 this degraded to "return the frame
+    unchanged" on any install without that extra — silently handing the
+    detector the squashed 16:9 frame again, which is the exact blindness this
+    function exists to remove. A safety path must not depend on an optional
+    package to work.
     """
     try:
-        import cv2
-        import numpy as np
+        import io
 
-        img = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_COLOR)
-        if img is None:
+        from PIL import Image
+
+        img = Image.open(io.BytesIO(jpeg))
+        img.load()
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        w, h = img.size
+        if w == 0 or h == 0:
             return jpeg
-        h, w = img.shape[:2]
-        if h == 0 or w == 0:
-            return jpeg
-        if max_side and max(h, w) > max_side:
-            scale = max_side / max(h, w)
-            img = cv2.resize(img, (max(1, int(w * scale)), max(1, int(h * scale))),
-                             interpolation=cv2.INTER_AREA)
-            h, w = img.shape[:2]
-        elif h == w:
+        if max_side and max(w, h) > max_side:
+            scale = max_side / max(w, h)
+            img = img.resize((max(1, int(w * scale)), max(1, int(h * scale))),
+                             Image.Resampling.LANCZOS)
+            w, h = img.size
+        elif w == h:
             return jpeg          # already square and already small enough
-        side = max(h, w)
-        canvas = np.zeros((side, side, 3), np.uint8)
-        y, x = (side - h) // 2, (side - w) // 2
-        canvas[y:y + h, x:x + w] = img
-        ok, enc = cv2.imencode(".jpg", canvas, [cv2.IMWRITE_JPEG_QUALITY, 90])
-        return enc.tobytes() if ok else jpeg
+        side = max(w, h)
+        canvas = Image.new("RGB", (side, side), (0, 0, 0))
+        canvas.paste(img, ((side - w) // 2, (side - h) // 2))
+        buf = io.BytesIO()
+        canvas.save(buf, format="JPEG", quality=90)
+        return buf.getvalue()
     except Exception:
         return jpeg
 

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1513,6 +1513,10 @@ class Alarm:
     last_triggered: float | None = None
     trigger_count: int = 0
     last_ack: float = 0.0
+    # Watermark for the always-on Tier-0 stream. A detection older than this
+    # has already been judged, so one published frame rings the alarm at most
+    # once — Tier-0 republishes the same scene several times a second.
+    last_tier0_at: float = 0.0
 
     def window_label(self) -> str:
         def fmt(m):
@@ -1537,6 +1541,47 @@ class Alarm:
         }
 
 
+def _letterbox_jpeg(jpeg: bytes) -> bytes:
+    """Pad a frame to a square, preserving aspect. Returns the input unchanged
+    if anything at all goes wrong.
+
+    Detectors resize whatever they are handed to a square input, so a 16:9
+    frame arrives crushed 1.78x horizontally — people come out too narrow for
+    a model trained on people. Padding to square first costs a few pixels of
+    scale and keeps the shapes honest.
+
+    Measured on this deployment, same detector, same person, moved across the
+    frame (best person-confidence, 0.00 = not found at all):
+
+        position     squashed   centre-crop   letterboxed
+        left edge      0.28        0.00           0.75
+        centre         0.00        0.54           0.68
+        right edge     0.49        0.00           0.82
+
+    Note the middle column: cropping to a centre square is BLIND at both
+    edges, which is exactly the part of the frame a driveway or gate camera
+    cares about. Padding is the only one of the three that works everywhere.
+    """
+    try:
+        import cv2
+        import numpy as np
+
+        img = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_COLOR)
+        if img is None:
+            return jpeg
+        h, w = img.shape[:2]
+        if h == w or h == 0 or w == 0:
+            return jpeg
+        side = max(h, w)
+        canvas = np.zeros((side, side, 3), np.uint8)
+        y, x = (side - h) // 2, (side - w) // 2
+        canvas[y:y + h, x:x + w] = img
+        ok, enc = cv2.imencode(".jpg", canvas, [cv2.IMWRITE_JPEG_QUALITY, 90])
+        return enc.tobytes() if ok else jpeg
+    except Exception:
+        return jpeg
+
+
 class AlarmManager:
     """Polls watched cameras and rings when an alarm's condition is met.
     Mirrors MonitorManager but raises sticky, acknowledgeable alarm events
@@ -1544,8 +1589,13 @@ class AlarmManager:
 
     def __init__(self, runtime: "CameraAgentRuntime", *, interval: float = 5.0,
                  rearm_cooldown: float = 20.0, max_alarms: int = 20,
-                 pulse_seconds: float = 60.0) -> None:
+                 pulse_seconds: float = 60.0,
+                 tier0_max_age: float = 30.0) -> None:
         self._pulse = pulse_seconds
+        # Absolute cap on how old a Tier-0 detection may be and still count as
+        # "present now" — a backstop for the per-cycle watermark below, so a
+        # loop that stalls for minutes cannot wake up and ring on ancient news.
+        self._tier0_max_age = tier0_max_age
         self._runtime = runtime
         self._alarms: dict[int, Alarm] = {}
         self._order: list[int] = []
@@ -1737,18 +1787,72 @@ class AlarmManager:
             alarm.last_ack = now
             logger.info("alarm #%d (pulse) stood down", alarm.id)
 
+    def _tier0_says_present(self, alarm: Alarm, cam: str, now: float) -> bool:
+        """Is the target on camera per the always-on Tier-0 stream?
+
+        The agent is already subscribed to detect-pipeline's detections, and
+        they are strictly better evidence than anything this loop can gather
+        for itself: Tier-0 watches every frame at the stream's rate and runs
+        the detector on a SQUARE crop around motion, so the object fills the
+        model's input. This loop grabs one whole 1920x1080 frame every several
+        seconds and lets the adapter squash it to 640x640 — 16:9 crushed 1.78x
+        and everything in it shrunk. Measured on this deployment, that is the
+        difference between finding a person and returning nothing at all: of
+        four people Tier-0 recorded at 0.53-0.66 confidence, the full-frame
+        path found two at ~0.28 and missed the other two entirely. Add a
+        sampling gap of one look per 8-12s against visits lasting 5-19s and
+        people walked through unannounced.
+
+        Only evidence gathered since the last look counts, so a single
+        published frame can ring the alarm exactly once, and never later.
+        """
+        ctx = getattr(self._runtime, "context", None)
+        latest = getattr(ctx, "latest_inference", None)
+        if latest is None:
+            return False
+        try:
+            ev = latest(cam, adapter="tier0")
+        except Exception:            # a read of a ring buffer must never
+            return False             # take the alarm loop down with it
+        if ev is None:
+            return False             # no Tier-0 for this camera — poll instead
+        seen = float(getattr(ev, "received_at", 0.0) or 0.0)
+        if seen <= max(alarm.last_tier0_at, now - self._tier0_max_age):
+            return False
+        tracks = (getattr(ev, "raw", None) or {}).get("tracks") or []
+        hit = any(
+            str(t.get("label") or "").strip().lower() == alarm.target
+            for t in tracks if isinstance(t, dict)
+        )
+        if hit:
+            alarm.last_tier0_at = seen
+        return hit
+
     async def _poll(self, alarm: Alarm, cam: str) -> None:
         import time
 
-        try:
-            frame = await self._runtime.context.get_frame(cam, allow_pinned=False)
-            resp = await self._runtime.detection_client.infer(frame_jpeg=frame)
-        except Exception as exc:
-            logger.info("alarm #%d: poll of %s failed (%s)", alarm.id, cam, exc)
-            return
-        detections = (resp.get("result") or {}).get("detections") or []
-        present = self._runtime.monitors._count_target(detections, alarm.target) > 0
         now = time.time()
+        source = "tier0"
+        present = self._tier0_says_present(alarm, cam, now)
+        if not present:
+            # Tier-0 has nothing to say — no coverage for this camera, the
+            # pipeline is down, or it genuinely sees nothing. Fall back to
+            # looking ourselves. Kept deliberately as a backstop rather than
+            # replaced: a safety feature must not go quiet just because one
+            # source did, and Tier-0 publishes nothing at all on a quiet
+            # scene, which is indistinguishable from Tier-0 having stopped.
+            try:
+                frame = await self._runtime.context.get_frame(cam, allow_pinned=False)
+                resp = await self._runtime.detection_client.infer(
+                    frame_jpeg=_letterbox_jpeg(frame))
+            except Exception as exc:
+                logger.info("alarm #%d: poll of %s failed (%s)", alarm.id, cam, exc)
+                return
+            detections = (resp.get("result") or {}).get("detections") or []
+            present = self._runtime.monitors._count_target(
+                detections, alarm.target) > 0
+            source = "poll"
+            now = time.time()        # the inference above is not instant
         if not present:
             return
         if alarm.ring in ("siren", "pulse"):
@@ -1775,7 +1879,8 @@ class AlarmManager:
             "emergency_contact": alarm.emergency_contact,
         })
         self._next_event_id += 1
-        logger.warning("ALARM #%d TRIGGERED (%s): %s", alarm.id, alarm.ring, text)
+        logger.warning("ALARM #%d TRIGGERED (%s, via %s): %s",
+                       alarm.id, alarm.ring, source, text)
         self._runtime.notifier.fire({
             "type": "alarm", "title": alarm.name, "text": text,
             "camera": cam,

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1513,10 +1513,14 @@ class Alarm:
     last_triggered: float | None = None
     trigger_count: int = 0
     last_ack: float = 0.0
-    # Watermark for the always-on Tier-0 stream. A detection older than this
-    # has already been judged, so one published frame rings the alarm at most
-    # once — Tier-0 republishes the same scene several times a second.
-    last_tier0_at: float = 0.0
+    # Watermark into the always-on Tier-0 stream, PER CAMERA. A detection at
+    # or before this has already been judged, so one published frame rings the
+    # alarm at most once — Tier-0 republishes the same scene several times a
+    # second. Per camera because one alarm can watch several: a single shared
+    # watermark lets the busiest camera hold it permanently ahead of a quiet
+    # one's timestamps, and the quiet camera — the driveway nobody walks up —
+    # would silently never use Tier-0 at all.
+    last_tier0_at: dict[str, float] = field(default_factory=dict)
 
     def window_label(self) -> str:
         def fmt(m):
@@ -1541,7 +1545,7 @@ class Alarm:
         }
 
 
-def _letterbox_jpeg(jpeg: bytes) -> bytes:
+def _letterbox_jpeg(jpeg: bytes, max_side: int = 960) -> bytes:
     """Pad a frame to a square, preserving aspect. Returns the input unchanged
     if anything at all goes wrong.
 
@@ -1551,16 +1555,32 @@ def _letterbox_jpeg(jpeg: bytes) -> bytes:
     scale and keeps the shapes honest.
 
     Measured on this deployment, same detector, same person, moved across the
-    frame (best person-confidence, 0.00 = not found at all):
+    frame (best person-confidence, 0.00 = not found at all) — the last column
+    is this function end to end:
 
         position     squashed   centre-crop   letterboxed
-        left edge      0.28        0.00           0.75
-        centre         0.00        0.54           0.68
-        right edge     0.49        0.00           0.82
+        left edge      0.28        0.00           0.84
+        centre         0.00        0.54           0.77
+        right edge     0.48        0.00           0.82
 
     Note the middle column: cropping to a centre square is BLIND at both
     edges, which is exactly the part of the frame a driveway or gate camera
     cares about. Padding is the only one of the three that works everywhere.
+
+    ``max_side`` shrinks before padding, because the detector resizes to its
+    own input regardless — sending 1920x1920 buys nothing and costs real work.
+    Downscaling here is also BETTER than letting the adapter do it, since
+    INTER_AREA resamples properly. Same person, same three positions:
+
+        letterbox side   1920   1280    960    640
+        left edge        0.77   0.83   0.85   0.85
+        centre           0.63   0.74   0.78   0.75
+        right edge       0.80   0.83   0.81   0.75
+        cost              114ms   82ms   44ms   33ms
+        payload            83KB   36KB   25KB   13KB
+
+    960 keeps headroom above a 640 model input while costing a third of full
+    size and a third of the bytes.
     """
     try:
         import cv2
@@ -1570,8 +1590,15 @@ def _letterbox_jpeg(jpeg: bytes) -> bytes:
         if img is None:
             return jpeg
         h, w = img.shape[:2]
-        if h == w or h == 0 or w == 0:
+        if h == 0 or w == 0:
             return jpeg
+        if max_side and max(h, w) > max_side:
+            scale = max_side / max(h, w)
+            img = cv2.resize(img, (max(1, int(w * scale)), max(1, int(h * scale))),
+                             interpolation=cv2.INTER_AREA)
+            h, w = img.shape[:2]
+        elif h == w:
+            return jpeg          # already square and already small enough
         side = max(h, w)
         canvas = np.zeros((side, side, 3), np.uint8)
         y, x = (side - h) // 2, (side - w) // 2
@@ -1817,7 +1844,8 @@ class AlarmManager:
         if ev is None:
             return False             # no Tier-0 for this camera — poll instead
         seen = float(getattr(ev, "received_at", 0.0) or 0.0)
-        if seen <= max(alarm.last_tier0_at, now - self._tier0_max_age):
+        watermark = alarm.last_tier0_at.get(cam, 0.0)
+        if seen <= max(watermark, now - self._tier0_max_age):
             return False
         tracks = (getattr(ev, "raw", None) or {}).get("tracks") or []
         hit = any(
@@ -1825,7 +1853,7 @@ class AlarmManager:
             for t in tracks if isinstance(t, dict)
         )
         if hit:
-            alarm.last_tier0_at = seen
+            alarm.last_tier0_at[cam] = seen
         return hit
 
     async def _poll(self, alarm: Alarm, cam: str) -> None:

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1834,27 +1834,38 @@ class AlarmManager:
         published frame can ring the alarm exactly once, and never later.
         """
         ctx = getattr(self._runtime, "context", None)
-        latest = getattr(ctx, "latest_inference", None)
-        if latest is None:
+        recent = getattr(ctx, "recent_events", None)
+        if recent is None:
             return False
         try:
-            ev = latest(cam, adapter="tier0")
+            events = recent(camera_id=cam, window_seconds=self._tier0_max_age)
         except Exception:            # a read of a ring buffer must never
             return False             # take the alarm loop down with it
-        if ev is None:
-            return False             # no Tier-0 for this camera — poll instead
-        seen = float(getattr(ev, "received_at", 0.0) or 0.0)
-        watermark = alarm.last_tier0_at.get(cam, 0.0)
-        if seen <= max(watermark, now - self._tier0_max_age):
-            return False
-        tracks = (getattr(ev, "raw", None) or {}).get("tracks") or []
-        hit = any(
-            str(t.get("label") or "").strip().lower() == alarm.target
-            for t in tracks if isinstance(t, dict)
-        )
-        if hit:
-            alarm.last_tier0_at[cam] = seen
-        return hit
+        # Judged-already, or too old to mean "now". Checked here and not left
+        # to the ring's own windowing: whether evidence is current is the
+        # safety property of this function, not a collaborator's to guarantee.
+        floor_ = max(alarm.last_tier0_at.get(cam, 0.0), now - self._tier0_max_age)
+        for ev in events or ():                      # newest first
+            if getattr(ev, "adapter", None) != "tier0":
+                continue
+            seen = float(getattr(ev, "received_at", 0.0) or 0.0)
+            if seen <= floor_:
+                break        # this and everything older is stale or judged
+            tracks = (getattr(ev, "raw", None) or {}).get("tracks") or []
+            if not tracks:
+                # Tier-0 publishes its GATE decisions — the audit of
+                # non-events — on the same adapter and into the same ring as
+                # detections, and they carry no tracks. They are also more
+                # frequent, so reading only the newest Tier-0 record meant
+                # almost always reading an empty one and concluding nobody was
+                # there. An empty record is not evidence of absence; skip past
+                # it to the last record that actually looked.
+                continue
+            if any(str(t.get("label") or "").strip().lower() == alarm.target
+                   for t in tracks if isinstance(t, dict)):
+                alarm.last_tier0_at[cam] = seen
+                return True
+        return False
 
     async def _poll(self, alarm: Alarm, cam: str) -> None:
         import time

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -907,6 +907,14 @@ def _frames_for(runtime, max_frames: int = 3) -> list[dict]:
         })
         if len(out) >= max_frames:
             break
+    # Remembered best-frames from the events store, for answers about the
+    # PAST. Appended after the live ones and never deduped against them: they
+    # are different moments, and several visits on one camera are several
+    # photos, not one. Each carries its own timestamp caption.
+    for ev in (getattr(runtime.tools, "last_evidence_frames", None) or []):
+        if len(out) >= max_frames:
+            break
+        out.append(dict(ev))
     return out
 
 
@@ -5693,6 +5701,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         import time as _t
         t0 = _t.perf_counter()
         runtime.tools.last_cameras_used = []
+        runtime.tools.last_evidence_frames = []
         # Fresh frame per question (see /converse): each turn sees the current
         # moment, not a frame cached from a question seconds ago.
         runtime.context.invalidate_frame_cache()
@@ -5856,6 +5865,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         #    agent, Hey-Siri style: she acknowledges, and the UI then treats the
         #    NEXT utterance as the question without needing the wake word again.
         runtime.tools.last_cameras_used = []
+        runtime.tools.last_evidence_frames = []
         armed = bool(require_wake and not question)
         if armed:
             reply = "Yes?"

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1199,9 +1199,13 @@
         if(frames&&frames.length){ const fr=document.createElement("div"); fr.className="frames";
           frames.forEach(f=>{ const wrap=document.createElement("div");
             const im=document.createElement("img"); im.className="frame-thumb";
-            im.src="data:image/jpeg;base64,"+f.jpeg_b64; im.alt=im.title=f.role||f.camera_id;
-            im.addEventListener("click",()=>openLightbox(im.src,f.role||f.camera_id));
-            const cap=document.createElement("div"); cap.className="frame-cap"; cap.textContent=f.role||f.camera_id;
+            // caption wins over role: a remembered best-frame carries its own
+            // timestamp ("#38 · 16:25"), and showing a past photo under a bare
+            // camera name would read as the live view.
+            const lbl=f.caption||f.role||f.camera_id;
+            im.src="data:image/jpeg;base64,"+f.jpeg_b64; im.alt=im.title=lbl;
+            im.addEventListener("click",()=>openLightbox(im.src,lbl));
+            const cap=document.createElement("div"); cap.className="frame-cap"; cap.textContent=lbl;
             wrap.appendChild(im); wrap.appendChild(cap); fr.appendChild(wrap); });
           d.appendChild(fr); } }
       logEl.appendChild(d); logEl.scrollTop=logEl.scrollHeight; }

--- a/examples/camera-agent/tests/test_adapter_clients.py
+++ b/examples/camera-agent/tests/test_adapter_clients.py
@@ -1,0 +1,49 @@
+
+
+# ── retries must bridge a warming adapter, not a missing one ────────
+
+def _client_with(status: int, calls: dict, retries: int = 2):
+    import httpx
+
+    from adapter_clients import KaicAdapterClient as _C
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] = calls.get("n", 0) + 1
+        return httpx.Response(status, json={"detail": "x"})
+
+    c = _C(kaic_url="http://kaic", api_key="k", adapter_name="insightface",
+           retries=retries, retry_backoff_s=0.0)
+    c._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return c
+
+
+def test_a_404_is_not_retried():
+    """The retry exists for an adapter that is still warming up. A 404 means
+    the route does not exist — not deployed, or a typo'd recognition_adapter —
+    and cannot become success by waiting. Seen in the field as insightface
+    404s repeating three times on every person visit, on a stack with no face
+    adapter installed."""
+    import asyncio
+
+    import httpx
+    import pytest
+
+    calls: dict = {}
+    c = _client_with(404, calls)
+    with pytest.raises(httpx.HTTPError):
+        asyncio.run(c.infer(frame_jpeg=b"x"))
+    assert calls.get("n") == 1, f"404 attempted {calls.get('n')} times"
+
+
+def test_a_503_is_still_retried():
+    """A warming adapter is exactly what the retry is for."""
+    import asyncio
+
+    import httpx
+    import pytest
+
+    calls: dict = {}
+    c = _client_with(503, calls)
+    with pytest.raises(httpx.HTTPError):
+        asyncio.run(c.infer(frame_jpeg=b"x"))
+    assert calls.get("n") == 3, f"503 attempted only {calls.get('n')} times"

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -795,7 +795,11 @@ def test_letterbox_squares_a_widescreen_frame():
     arrives crushed 1.78x and people come out too narrow to recognise. Pad
     first; never crop — a centre crop measured 0.00 at both frame edges."""
     from camera_agent import _letterbox_jpeg
-    assert _dims(_letterbox_jpeg(_jpeg(1920, 1080))) == (1920, 1920)
+    w, h = _dims(_letterbox_jpeg(_jpeg(1920, 1080)))
+    assert w == h, f"output must be square, got {w}x{h}"
+    # ...and shrunk on the way, since the detector resizes to its own input
+    # regardless: sending 1920x1920 costs real work and buys nothing.
+    assert w <= 960, f"expected a downscaled square, got {w}"
 
 
 def test_letterbox_keeps_the_whole_frame():
@@ -804,14 +808,17 @@ def test_letterbox_keeps_the_whole_frame():
     import cv2, numpy as np
     from camera_agent import _letterbox_jpeg
     src = np.full((1080, 1920, 3), 30, np.uint8)
-    src[:, :40] = 255                      # a marker at the extreme left
-    src[:, -40:] = 255                     # ...and the extreme right
+    src[:, :192] = 255                     # the leftmost tenth of the frame
+    src[:, -192:] = 255                    # ...and the rightmost tenth
     out = cv2.imdecode(
         np.frombuffer(_letterbox_jpeg(cv2.imencode(".jpg", src)[1].tobytes()),
                       np.uint8), cv2.IMREAD_COLOR)
+    # Padding goes top/bottom for a landscape frame, so the middle row is all
+    # content and the marked tenths must still be at its two ends.
     band = out[out.shape[0] // 2]
-    assert band[:40].mean() > 200, "left edge of the frame was lost"
-    assert band[-40:].mean() > 200, "right edge of the frame was lost"
+    tenth = max(1, band.shape[0] // 10)
+    assert band[:tenth].mean() > 200, "left edge of the frame was lost"
+    assert band[-tenth:].mean() > 200, "right edge of the frame was lost"
 
 
 def test_letterbox_leaves_a_square_frame_alone():
@@ -826,3 +833,50 @@ def test_letterbox_never_breaks_the_poll():
     from camera_agent import _letterbox_jpeg
     assert _letterbox_jpeg(b"not a jpeg") == b"not a jpeg"
     assert _letterbox_jpeg(b"") == b""
+
+
+def test_a_busy_camera_does_not_starve_a_quiet_one_on_the_same_alarm():
+    """One alarm can watch several cameras. A single shared watermark lets the
+    busiest camera hold it permanently ahead of the quiet camera's timestamps,
+    so the quiet one — the side gate nobody walks up — would silently never use
+    Tier-0 at all and fall back to the weak full-frame poll forever."""
+    import time
+    from context import CameraSpec
+
+    cfg = AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+        cameras=[CameraSpec(camera_id="cam1", frame_url="http://x/1.jpg", role="front"),
+                 CameraSpec(camera_id="cam2", frame_url="http://x/2.jpg", role="gate")],
+    )
+    rt = CameraAgentRuntime(cfg)
+    polls = []
+
+    async def fake_get_frame(cam, **_kw):
+        return b"\xff\xd8\xff"
+
+    async def counting_infer(*, frame_jpeg, **kw):
+        polls.append(1)
+        return {"result": {"detections": []}}   # the poll finds nothing
+
+    rt.context.get_frame = fake_get_frame
+    rt.detection_client.infer = counting_infer
+
+    now = time.time()
+    # cam1 is busy and its newest event is NEWER than cam2's.
+    evs = {"cam1": _Ev(now, [{"label": "person"}]),
+           "cam2": _Ev(now - 3.0, [{"label": "person"}])}
+    rt.context.latest_inference = lambda cam, adapter="tier0": evs.get(cam)
+
+    async def go():
+        alarm = rt.alarms.create(name="Both", target="person",
+                                 camera_ids=["cam1", "cam2"])
+        await rt.alarms._poll(alarm, "cam1")
+        alarm.triggered = False                 # unlatch so cam2 gets its turn
+        alarm.last_ack = 0.0
+        await rt.alarms._poll(alarm, "cam2")
+        rt.alarms.stop(alarm.id)
+        assert alarm.last_tier0_at.get("cam2"), (
+            "cam2's own Tier-0 evidence was discarded because cam1's was newer")
+        assert not polls, "cam2 should not have needed the fallback poll"
+
+    asyncio.run(go())

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -777,16 +777,21 @@ def test_a_broken_tier0_ring_cannot_take_the_alarm_loop_down():
 # ── the backstop poll's framing ────────────────────────────────────────
 
 
-def _jpeg(w, h):
-    import cv2, numpy as np
-    img = np.full((h, w, 3), 90, np.uint8)
-    return cv2.imencode(".jpg", img)[1].tobytes()
+def _jpeg(w, h, colour=(90, 90, 90)):
+    """Pillow, not OpenCV: cv2 is an optional extra for this package, so a
+    test written against it fails wherever the extra is absent — which is
+    exactly where the code under test must still work."""
+    import io
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), colour).save(buf, format="JPEG")
+    return buf.getvalue()
 
 
 def _dims(jpeg):
-    import cv2, numpy as np
-    img = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_COLOR)
-    return img.shape[1], img.shape[0]
+    import io
+    from PIL import Image
+    return Image.open(io.BytesIO(jpeg)).size
 
 
 def test_letterbox_squares_a_widescreen_frame():
@@ -804,20 +809,26 @@ def test_letterbox_squares_a_widescreen_frame():
 def test_letterbox_keeps_the_whole_frame():
     """Nothing may be cut: the edges of a driveway or gate view are exactly
     where the thing you armed the alarm for walks in."""
-    import cv2, numpy as np
+    import io
+    from PIL import Image
     from camera_agent import _letterbox_jpeg
-    src = np.full((1080, 1920, 3), 30, np.uint8)
-    src[:, :192] = 255                     # the leftmost tenth of the frame
-    src[:, -192:] = 255                    # ...and the rightmost tenth
-    out = cv2.imdecode(
-        np.frombuffer(_letterbox_jpeg(cv2.imencode(".jpg", src)[1].tobytes()),
-                      np.uint8), cv2.IMREAD_COLOR)
+
+    src = Image.new("RGB", (1920, 1080), (30, 30, 30))
+    white = Image.new("RGB", (192, 1080), (255, 255, 255))
+    src.paste(white, (0, 0))               # the leftmost tenth of the frame
+    src.paste(white, (1920 - 192, 0))      # ...and the rightmost tenth
+    buf = io.BytesIO(); src.save(buf, format="JPEG")
+
+    out = Image.open(io.BytesIO(_letterbox_jpeg(buf.getvalue()))).convert("RGB")
     # Padding goes top/bottom for a landscape frame, so the middle row is all
     # content and the marked tenths must still be at its two ends.
-    band = out[out.shape[0] // 2]
-    tenth = max(1, band.shape[0] // 10)
-    assert band[:tenth].mean() > 200, "left edge of the frame was lost"
-    assert band[-tenth:].mean() > 200, "right edge of the frame was lost"
+    w, h = out.size
+    y = h // 2
+    tenth = max(1, w // 10)
+    left = [out.getpixel((x, y))[0] for x in range(tenth)]
+    right = [out.getpixel((x, y))[0] for x in range(w - tenth, w)]
+    assert sum(left) / len(left) > 200, "left edge of the frame was lost"
+    assert sum(right) / len(right) > 200, "right edge of the frame was lost"
 
 
 def test_letterbox_leaves_a_square_frame_alone():

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -614,3 +614,215 @@ def test_busy_yield_is_bounded():
     assert alarm.triggered, (
         "the capped yield must let the poll through and fire the alarm"
     )
+
+
+# ── Tier-0 as the trigger source ───────────────────────────────────────
+# The agent is already subscribed to detect-pipeline's detections and they
+# are far better evidence than this loop's own full-frame poll: Tier-0 runs
+# the detector on a SQUARE crop around motion at the stream's frame rate,
+# the poll squashes a whole 1920x1080 frame to 640x640 once every several
+# seconds. On a live deployment that was the difference between finding a
+# person and returning nothing — four people recorded by Tier-0 at 0.53-0.66
+# confidence, of which the full-frame path found two at ~0.28 and missed two
+# outright, while visits lasting 5-19s were sampled once per 8-12s.
+
+
+class _Ev:
+    """Minimal stand-in for context.EventRecord."""
+
+    def __init__(self, received_at, tracks, adapter="tier0"):
+        self.received_at = received_at
+        self.adapter = adapter
+        self.raw = {"tracks": tracks}
+
+
+def _tier0_runtime(tracks, *, age=0.0, poll_detections=None):
+    """A runtime whose Tier-0 ring holds one event, and whose own poll finds
+    ``poll_detections`` (nothing, by default — so a trigger can only have
+    come from Tier-0)."""
+    import time
+    rt = _runtime(detections=poll_detections if poll_detections is not None else [])
+    polls = []
+
+    async def counting_infer(*, frame_jpeg, **kw):
+        polls.append(1)
+        return {"result": {"detections": poll_detections or []}}
+
+    rt.detection_client.infer = counting_infer
+    ev = _Ev(time.time() - age, tracks)
+    rt.context.latest_inference = lambda cam, adapter="tier0": (
+        ev if adapter == "tier0" else None)
+    return rt, polls
+
+
+def test_alarm_triggers_off_tier0_without_polling():
+    """The live failure: Tier-0 saw the person, the alarm's own full-frame
+    poll did not, and nothing rang."""
+    rt, polls = _tier0_runtime([{"label": "person", "score": 0.61}])
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(60):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.02)
+        data = rt.alarms.list()[0]
+        rt.alarms.stop(alarm.id)
+        assert data["triggered"] is True, "Tier-0 evidence must ring the alarm"
+        assert not polls, "no need to run our own inference when Tier-0 already saw it"
+
+    asyncio.run(go())
+
+
+def test_stale_tier0_evidence_does_not_ring():
+    """'A person was here five minutes ago' is not 'a person is here'."""
+    rt, _polls = _tier0_runtime([{"label": "person"}], age=600.0)
+    rt.alarms._interval = 0.01        # many passes, all of them stale
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        await asyncio.sleep(0.25)
+        triggered = rt.alarms.list()[0]["triggered"]
+        rt.alarms.stop(alarm.id)
+        assert triggered is False
+
+    asyncio.run(go())
+
+
+def test_one_tier0_frame_rings_once():
+    """Tier-0 republishes the same scene many times a second. Acknowledging
+    an alarm must not be undone by the frame that raised it still being the
+    newest thing on the ring."""
+    rt, _polls = _tier0_runtime([{"label": "person"}])
+    rt.alarms._rearm = 0.0            # cooldown cannot be what holds it back
+    rt.alarms._interval = 0.01        # ...and the loop must actually come round
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(60):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.02)
+        assert rt.alarms.acknowledge(alarm.id) == 1
+        await asyncio.sleep(0.3)      # ~30 further loop passes
+        again = rt.alarms.list()[0]["triggered"]
+        rt.alarms.stop(alarm.id)
+        assert again is False, "the same published frame must not re-ring"
+
+    asyncio.run(go())
+
+
+def test_tier0_without_the_target_still_falls_back_to_polling():
+    """Tier-0 publishes only frames that produced tracks, so silence from it
+    means 'quiet scene' and 'pipeline down' alike. The alarm's own look has
+    to stay as a backstop — a safety feature must not go quiet because one
+    source did."""
+    rt, polls = _tier0_runtime([{"label": "cat"}],
+                               poll_detections=[{"label": "person"}])
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(60):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.02)
+        data = rt.alarms.list()[0]
+        rt.alarms.stop(alarm.id)
+        assert data["triggered"] is True, "the backstop poll must still ring"
+        assert polls, "Tier-0 seeing a cat is not evidence about a person"
+
+    asyncio.run(go())
+
+
+def test_no_tier0_stream_behaves_exactly_as_before():
+    """Cameras with no Tier-0 coverage keep the original behaviour."""
+    rt = _runtime(detections=[{"label": "person"}])
+    rt.context.latest_inference = lambda cam, adapter="tier0": None
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(60):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.02)
+        data = rt.alarms.list()[0]
+        rt.alarms.stop(alarm.id)
+        assert data["triggered"] is True
+
+    asyncio.run(go())
+
+
+def test_a_broken_tier0_ring_cannot_take_the_alarm_loop_down():
+    """The ring read is defensive: alarms are a safety feature and must not
+    stop ringing because a context accessor raised."""
+    rt = _runtime(detections=[{"label": "person"}])
+
+    def boom(cam, adapter="tier0"):
+        raise RuntimeError("ring exploded")
+
+    rt.context.latest_inference = boom
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(60):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.02)
+        data = rt.alarms.list()[0]
+        rt.alarms.stop(alarm.id)
+        assert data["triggered"] is True, "must fall back, not die"
+
+    asyncio.run(go())
+
+
+# ── the backstop poll's framing ────────────────────────────────────────
+
+
+def _jpeg(w, h):
+    import cv2, numpy as np
+    img = np.full((h, w, 3), 90, np.uint8)
+    return cv2.imencode(".jpg", img)[1].tobytes()
+
+
+def _dims(jpeg):
+    import cv2, numpy as np
+    img = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_COLOR)
+    return img.shape[1], img.shape[0]
+
+
+def test_letterbox_squares_a_widescreen_frame():
+    """A detector resizes whatever it gets to a square input, so a 16:9 frame
+    arrives crushed 1.78x and people come out too narrow to recognise. Pad
+    first; never crop — a centre crop measured 0.00 at both frame edges."""
+    from camera_agent import _letterbox_jpeg
+    assert _dims(_letterbox_jpeg(_jpeg(1920, 1080))) == (1920, 1920)
+
+
+def test_letterbox_keeps_the_whole_frame():
+    """Nothing may be cut: the edges of a driveway or gate view are exactly
+    where the thing you armed the alarm for walks in."""
+    import cv2, numpy as np
+    from camera_agent import _letterbox_jpeg
+    src = np.full((1080, 1920, 3), 30, np.uint8)
+    src[:, :40] = 255                      # a marker at the extreme left
+    src[:, -40:] = 255                     # ...and the extreme right
+    out = cv2.imdecode(
+        np.frombuffer(_letterbox_jpeg(cv2.imencode(".jpg", src)[1].tobytes()),
+                      np.uint8), cv2.IMREAD_COLOR)
+    band = out[out.shape[0] // 2]
+    assert band[:40].mean() > 200, "left edge of the frame was lost"
+    assert band[-40:].mean() > 200, "right edge of the frame was lost"
+
+
+def test_letterbox_leaves_a_square_frame_alone():
+    from camera_agent import _letterbox_jpeg
+    square = _jpeg(640, 640)
+    assert _letterbox_jpeg(square) is square
+
+
+def test_letterbox_never_breaks_the_poll():
+    """Alarms are a safety feature: garbage in must mean 'unchanged', not an
+    exception that stops the loop looking."""
+    from camera_agent import _letterbox_jpeg
+    assert _letterbox_jpeg(b"not a jpeg") == b"not a jpeg"
+    assert _letterbox_jpeg(b"") == b""

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -650,8 +650,7 @@ def _tier0_runtime(tracks, *, age=0.0, poll_detections=None):
 
     rt.detection_client.infer = counting_infer
     ev = _Ev(time.time() - age, tracks)
-    rt.context.latest_inference = lambda cam, adapter="tier0": (
-        ev if adapter == "tier0" else None)
+    rt.context.recent_events = lambda *, camera_id, window_seconds: [ev]
     return rt, polls
 
 
@@ -737,7 +736,7 @@ def test_tier0_without_the_target_still_falls_back_to_polling():
 def test_no_tier0_stream_behaves_exactly_as_before():
     """Cameras with no Tier-0 coverage keep the original behaviour."""
     rt = _runtime(detections=[{"label": "person"}])
-    rt.context.latest_inference = lambda cam, adapter="tier0": None
+    rt.context.recent_events = lambda *, camera_id, window_seconds: []
 
     async def go():
         alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
@@ -757,10 +756,10 @@ def test_a_broken_tier0_ring_cannot_take_the_alarm_loop_down():
     stop ringing because a context accessor raised."""
     rt = _runtime(detections=[{"label": "person"}])
 
-    def boom(cam, adapter="tier0"):
+    def boom(*, camera_id, window_seconds):
         raise RuntimeError("ring exploded")
 
-    rt.context.latest_inference = boom
+    rt.context.recent_events = boom
 
     async def go():
         alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
@@ -865,7 +864,9 @@ def test_a_busy_camera_does_not_starve_a_quiet_one_on_the_same_alarm():
     # cam1 is busy and its newest event is NEWER than cam2's.
     evs = {"cam1": _Ev(now, [{"label": "person"}]),
            "cam2": _Ev(now - 3.0, [{"label": "person"}])}
-    rt.context.latest_inference = lambda cam, adapter="tier0": evs.get(cam)
+    rt.context.recent_events = (
+        lambda *, camera_id, window_seconds:
+            [evs[camera_id]] if camera_id in evs else [])
 
     async def go():
         alarm = rt.alarms.create(name="Both", target="person",
@@ -878,5 +879,61 @@ def test_a_busy_camera_does_not_starve_a_quiet_one_on_the_same_alarm():
         assert alarm.last_tier0_at.get("cam2"), (
             "cam2's own Tier-0 evidence was discarded because cam1's was newer")
         assert not polls, "cam2 should not have needed the fallback poll"
+
+    asyncio.run(go())
+
+
+def test_a_gate_audit_record_does_not_mask_a_real_detection():
+    """Caught in production, not in review. Tier-0 publishes its GATE
+    decisions — the audit of *non*-events — on the same adapter and into the
+    same ring as detections, and they carry no tracks. They are also more
+    frequent, so reading only the newest Tier-0 record meant almost always
+    reading an empty one: every single alarm fired 'via poll' while the
+    pipeline was detecting people a second earlier.
+
+    An empty record is not evidence of absence. Skip past it to the last
+    record that actually looked.
+    """
+    import time
+    rt, polls = _tier0_runtime([{"label": "person"}])
+    now = time.time()
+    # Exactly the production shape: a detection, then a newer gate audit.
+    detection = _Ev(now - 1.0, [{"label": "person", "score": 0.61}])
+    gate = _Ev(now, [])
+    rt.context.recent_events = (
+        lambda *, camera_id, window_seconds: [gate, detection])   # newest first
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(60):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.02)
+        data = rt.alarms.list()[0]
+        rt.alarms.stop(alarm.id)
+        assert data["triggered"] is True, (
+            "a gate audit with no tracks masked the detection behind it")
+        assert not polls, "should have rung from Tier-0, not fallen back to the poll"
+
+    asyncio.run(go())
+
+
+def test_an_empty_ring_still_falls_back_to_the_poll():
+    """All gate audits and no detections is genuinely 'Tier-0 has nothing to
+    say' — the backstop must still run."""
+    rt, polls = _tier0_runtime([{"label": "cat"}], poll_detections=[{"label": "person"}])
+    import time
+    rt.context.recent_events = (
+        lambda *, camera_id, window_seconds: [_Ev(time.time(), [])])
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(60):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.02)
+        data = rt.alarms.list()[0]
+        rt.alarms.stop(alarm.id)
+        assert data["triggered"] is True and polls, "the backstop must still run"
 
     asyncio.run(go())

--- a/examples/camera-agent/tests/test_tools.py
+++ b/examples/camera-agent/tests/test_tools.py
@@ -512,3 +512,65 @@ def test_search_history_speaks_plates(anyio_backend=None):
     out = asyncio.run(tools.search_history({"label": "car", "plate": "KA01"}))
     assert "plate KA01AB1234" in out
     assert ec.searches[0]["plate"] == "KA01"
+
+
+# ── remembered photos reach the chat ────────────────────────────────
+
+
+def test_search_history_publishes_the_remembered_photos(anyio_backend=None):
+    """The answer already said "(photo kept)" and the crop was already being
+    fetched to face-match — then thrown away, so an answer about 16:25 arrived
+    as bare text. Put the photo on the turn so the UI can show it."""
+    import asyncio, base64
+    ec = _FakeEventsClient(
+        [_FakeEvent(7), _FakeEvent(8), _FakeEvent(9, has_evidence=False)],
+        crops={7: b"crop-7", 8: b"crop-8"},
+    )
+    tools = _history_tools(ec)
+    asyncio.run(tools.search_history({"label": "person"}))
+
+    frames = tools.last_evidence_frames
+    assert len(frames) == 2, "both visits with a kept photo should be published"
+    assert [base64.b64decode(f["jpeg_b64"]) for f in frames] == [b"crop-7", b"crop-8"]
+    # A visit with no evidence contributes nothing rather than a broken image.
+    assert all(f["jpeg_b64"] for f in frames)
+
+
+def test_published_photos_are_captioned_with_their_time(anyio_backend=None):
+    """Every frame the chat has ever rendered was the LIVE view. An
+    uncaptioned crop from this afternoon sitting in an answer would read as
+    "here is your camera now" — the wrong thing to get wrong in a security
+    product. Each historical frame carries its own identity and time."""
+    import asyncio
+    ec = _FakeEventsClient([_FakeEvent(42)], crops={42: b"crop"})
+    tools = _history_tools(ec)
+    asyncio.run(tools.search_history({"label": "person"}))
+    cap = tools.last_evidence_frames[0]["caption"]
+    assert "#42" in cap, f"caption must identify the visit, got {cap!r}"
+    assert any(ch.isdigit() for ch in cap.split("·")[-1]), (
+        f"caption must carry a time, got {cap!r}")
+
+
+def test_publishing_photos_is_capped(anyio_backend=None):
+    """A busy afternoon must not dump twenty images into the chat."""
+    import asyncio
+    events = [_FakeEvent(i) for i in range(1, 11)]
+    ec = _FakeEventsClient(events, crops={i: b"c%d" % i for i in range(1, 11)})
+    tools = _history_tools(ec)
+    asyncio.run(tools.search_history({"label": "person"}))
+    assert len(tools.last_evidence_frames) == 3
+
+
+def test_a_failed_evidence_fetch_does_not_break_the_answer(anyio_backend=None):
+    """The text answer is the thing that must survive; the photo is a bonus."""
+    import asyncio
+
+    class _Broken(_FakeEventsClient):
+        async def evidence(self, event_id):
+            raise RuntimeError("store went away")
+
+    ec = _Broken([_FakeEvent(1)], crops={})
+    tools = _history_tools(ec)
+    out = asyncio.run(tools.search_history({"label": "person"}))
+    assert "1 person visit(s)" in out
+    assert tools.last_evidence_frames == []

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -23,6 +23,7 @@ metadata + the event ring.
 """
 from __future__ import annotations
 
+import base64
 import logging
 import time
 from typing import Any
@@ -366,6 +367,12 @@ class CameraTools:
         # Cameras touched by the most recent tool call — read by /converse
         # so the UI can show which camera(s) the agent is working on.
         self.last_cameras_used: list[str] = []
+        # Stored best-frame photos this turn dug out of the events store, so
+        # an answer about the PAST can show what it is talking about. Kept
+        # apart from the live per-turn frame cache on purpose: these are
+        # historical, and each carries its own timestamp caption so the UI
+        # can never present a photo from 16:25 as the current view.
+        self.last_evidence_frames: list[dict] = []
         # Why the last describe fell back from the VLM ("" = it didn't) —
         # surfaced by the system self-check so degradation is visible.
         self.last_vision_error: str | None = None
@@ -978,12 +985,48 @@ class CameraTools:
         summary = (f"I remember {len(events)} {label} visit(s)"
                    f"{self._window_phrase(start, end)}: " + "; ".join(clauses) + ".")
 
+        # Hand the remembered photos to the UI. The answer names times and
+        # says "(photo kept)" — the photo is right there in the store and was
+        # already being fetched to face-match, so showing it costs one small
+        # extra read and turns "I saw someone at 16:25" into something the
+        # operator can actually check.
+        await self._attach_evidence_frames(events)
+
         # Face-match the evidence for person questions (best-effort, capped).
         if label == "person" and bool(args.get("identify_faces", True)):
             names = await self._identify_visit_faces(events)
             if names:
                 summary += " Recognised: " + ", ".join(sorted(names)) + "."
         return summary
+
+    async def _attach_evidence_frames(self, events, cap: int = 3) -> None:
+        """Publish up to ``cap`` remembered best-frames onto this turn.
+
+        Each carries its own timestamp caption. That is not decoration: every
+        frame the UI has ever rendered in a chat bubble was the LIVE view, so
+        an uncaptioned crop from 16:25 sitting in an answer about this
+        afternoon would read as "here is your camera now" — the wrong thing to
+        get wrong in a security product.
+        """
+        if self._events is None:
+            return
+        for e in events:
+            if len(self.last_evidence_frames) >= cap:
+                break
+            if not getattr(e, "has_evidence", False):
+                continue
+            try:
+                crop = await self._events.evidence(e.id)
+            except Exception:
+                logger.warning("search_history: evidence fetch failed for #%s", e.id)
+                continue
+            if not crop or len(crop) > 2_000_000:      # same cap as live frames
+                continue
+            self.last_evidence_frames.append({
+                "camera_id": str(e.camera_id),
+                "caption": f"#{e.id} · {self._clock_phrase(e.started_at)}",
+                "jpeg_b64": base64.b64encode(crop).decode("ascii"),
+            })
 
     async def _identify_visit_faces(self, events, cap: int = 4) -> set:
         names: set = set()
@@ -993,7 +1036,14 @@ class CameraTools:
                 break
             if not e.has_evidence:
                 continue
-            crop = await self._events.evidence(e.id)
+            try:
+                crop = await self._events.evidence(e.id)
+            except Exception:
+                # A photo we cannot fetch costs a NAME, not the answer. This
+                # was unguarded, so one bad read turned "I remember 3 visits
+                # at 15:12, 15:40 and 16:25" into no answer at all.
+                logger.warning("search_history: evidence fetch failed for #%s", e.id)
+                continue
             if not crop:
                 continue
             checked += 1


### PR DESCRIPTION
Found in a fresh install's logs: insightface 404s repeating three times on every person visit, on a stack with no face-recognition adapter deployed.

The retry loop caught httpx.HTTPError and treated every failure the same, warning that "adapter may still be warming up". That is the right story for a 503 or a dropped connection — the model really may still be loading. It is the wrong story for a 404, which means the route does not exist (the adapter is not deployed, or recognition_adapter is misspelled) and cannot become success by waiting. Same for a 400: our payload is wrong and resending it unchanged will not help.

Those two now fail fast with one line naming the status and the URL, instead of two extra round trips and two misleading warnings per call. 503 and the rest still retry exactly as before — that path is what the cold-start window needs.