### PR TITLE
fix(installer): size the models to the machine as a SET, not one at a…

### DIFF
--- a/examples/camera-agent/MODELS_AND_LATENCY.md
+++ b/examples/camera-agent/MODELS_AND_LATENCY.md
@@ -171,18 +171,52 @@ including one on another LAN machine. The installer offers this as the
 ## What the installer suggests (hardware-aware defaults)
 
 The installer detects the machine that will RUN the LLM (host vs the
-Docker VM) and sizes the default model accordingly. Suggestions only —
-type any Ollama model at the prompt. Keep this table in sync with
-`suggest_llm_model` / `suggest_vlm_model` in `scripts/install.sh` and
+Docker VM) and sizes the defaults to it. Suggestions only — type any
+Ollama model at the prompt. Keep this table in sync with
+`suggest_models` / `suggest_whisper_model` in `scripts/install.sh` and
 the equivalent logic in `scripts/install.ps1`.
 
-| Where the LLM runs | Hardware | LLM default | VLM default (ollamavlm) |
-|---|---|---|---|
-| Host, Apple Silicon / NVIDIA | ≥ 8 GB RAM | `qwen3:1.7b` | `gemma3:4b` |
-| Host, GPU, < 8 GB | | `qwen2.5:1.5b` | `moondream` |
-| Any CPU-only | ≥ 16 GB + ≥ 8 cores | `qwen3:1.7b` | `gemma3:4b` (≥ 8 GB) |
-| Any CPU-only | smaller | `qwen2.5:0.5b` | `moondream` |
-| macOS, bundled container | sized to the Docker VM's RAM, always CPU tier | | |
+Both Ollama models are **resident at once** — the shipped compose sets
+`OLLAMA_KEEP_ALIVE=-1` so answers stay snappy — and they share the box
+with the OpenNVR stack. So the installer budgets them **together**:
+
+```
+model budget = RAM − 3 GB (the stack: 13 containers hold ~2 GB RSS,
+                           plus Docker Desktop's VM overhead)
+                   − 2 GB (the operator's own machine)
+```
+
+The LLM is chosen first, from the largest *tested* catalog entry that
+fits both the budget and a speed ceiling; the vision model gets what is
+left. When nothing is left, scene description falls back to the
+`moondream` **adapter** — a ~0.5b-int8 build in its own container, far
+smaller than anything in the Ollama catalog and still a real VQA answer.
+
+Sizing them independently is what put a 4 GB vision model on 8 GB
+machines: `gemma3:4b` was gated on `RAM ≥ 8` alone, so an 8 GB box got
+5 GB of models on top of a 3 GB stack and thrashed.
+
+| Machine | LLM | Vision | Adapter | Whisper |
+|---|---|---|---|---|
+| 4 GB / 2 cores, CPU | `qwen2.5:0.5b` | — | `moondream` | `tiny.en` |
+| 8 GB / 4 cores, CPU | `qwen2.5:1.5b` | — | `moondream` | `base.en` |
+| 8 GB / 8 threads, CPU | `qwen3:1.7b` | — | `moondream` | `base.en` |
+| 16 GB / 8 threads, CPU | `qwen3:1.7b` | `gemma3:4b` | `ollamavlm` | `small.en` |
+| 16 GB / 4 cores, CPU | `qwen2.5:1.5b` | `gemma3:4b` | `ollamavlm` | `base.en` |
+| 32 GB / 16 cores, CPU | `qwen3:1.7b` | `gemma3:4b` | `ollamavlm` | `small.en` |
+| 8 GB, GPU | `qwen3:1.7b` | — | `moondream` | `base.en` |
+| 16 GB, GPU | `qwen2.5:3b` | `gemma3:4b` | `ollamavlm` | `small.en` |
+| 32 GB, Apple Silicon | `qwen2.5:3b` | `gemma3:4b` | `ollamavlm` | `small.en` |
+| detection failed | `qwen2.5:0.5b` | — | `moondream` | `tiny.en` |
+
+Detection failing sizes DOWN, never up: an unknown machine is treated as
+a small one, because the cost of guessing high is an install that does
+not run.
+
+CPU-only machines are tiered by cores as well as RAM, because "it fits"
+and "it answers before the operator gives up" are different questions —
+and a machine with fewer than 4 cores skips the Ollama vision path
+entirely, whatever the RAM arithmetic says.
 
 Two constraints shape the tiers. The **floor** is tool-calling quality:
 below ~1.5b the agent misroutes tools noticeably, so the tiny tier is

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -416,7 +416,9 @@ function Pick-ModelFromCatalog([string]$Kind, [string]$Suggest, [string]$Label, 
         $mark = ''
         if ($f[1] -eq $Suggest) { $mark = '  <- suggested'; $defaultIdx = [string]($i + 1) }
         $fit = ''
-        if ($RamGb -gt 0 -and [int]$f[2] -gt $RamGb) { $fit = "  [needs ~$($f[2]) GB - detected $RamGb GB]" }
+        # Against the BUDGET, not total RAM: a 4 GB model on an 8 GB box
+        # "fits" only if you ignore the stack and the other model.
+        if ($RamGb -gt 0 -and [int]$f[2] -gt $RamGb) { $fit = "  [needs ~$($f[2]) GB - only ~$RamGb GB free for models]" }
         $tested = if ($f[3] -eq 'yes') { 'tested' } else { 'untested' }
         Write-Host ('   {0}. {1,-16} ~{2}GB  {3,-8} {4,-8} {5}{6}{7}' -f ($i + 1), $f[1], $f[2], $f[4], $tested, $f[5], $fit, $mark)
     }
@@ -512,27 +514,64 @@ function Choose-Example {
                 try { & nvidia-smi -L *> $null; if ($LASTEXITCODE -eq 0) { $accel = 'cuda' } } catch {}
             }
         }
-        # Ceiling = the tested envelope. qwen3:1.7b is field-tested with
-        # this agent and answers BETTER than the qwen2.5 set at similar
-        # speed (~3 GB; the shipped configs disable its thinking mode), so
-        # it is the suggestion wherever RAM allows. Likewise gemma3:4b was
-        # field-tested through ollamavlm and clearly beats moondream, so
-        # it is the VLM suggestion on >= 8 GB; moondream stays the tested
-        # low-RAM pick. Bigger-is-runnable is detectable, bigger-is-better
-        # is not — untested headroom stays a prompt note, never a default.
-        $llmSuggest = if ($accel -ne 'cpu') {
-            if ($ramGb -ge 8) { 'qwen3:1.7b' } else { 'qwen2.5:1.5b' }
-        } else {
-            if ($ramGb -ge 16 -and $cores -ge 8) { 'qwen3:1.7b' } else { 'qwen2.5:0.5b' }
+        # Both Ollama models are RESIDENT AT ONCE (the shipped compose sets
+        # OLLAMA_KEEP_ALIVE=-1), and they share the box with the OpenNVR
+        # stack. What has to fit is the SUM, not either model alone - sizing
+        # them independently is what put a 4 GB vision model on 8 GB machines.
+        # Measured on a running install: the 13 stack containers hold ~2 GB,
+        # and Docker Desktop adds its VM overhead on top. Keep-in-sync with
+        # compute_model_budget / suggest_models in install.sh.
+        $stackGb = 3; $osHeadroomGb = 2
+        $budgetGb = [math]::Max(0, $ramGb - $stackGb - $osHeadroomGb)
+
+        # Ceiling = the tested envelope; never suggest past what this agent
+        # has been exercised with. Speed ceiling too: a model that fits can
+        # still be unusable, so CPU-only boxes are tiered by cores.
+        $capLlm = if ($accel -ne 'cpu') { 4 } elseif ($cores -ge 8) { 3 } elseif ($cores -ge 4) { 2 } else { 1 }
+        if ($capLlm -gt $budgetGb) { $capLlm = $budgetGb }
+
+        function Pick-FromCatalog([string]$Kind, [int]$Cap) {
+            $catalog = 'examples/camera-agent/model_catalog.txt'
+            if (-not (Test-Path $catalog)) { return $null }
+            $best = $null; $bestRam = -1
+            foreach ($line in (Get-Content $catalog | Where-Object { $_ -and -not $_.StartsWith('#') })) {
+                $f = $line -split '\|'
+                if ($f[0] -ne $Kind -or $f[3] -ne 'yes') { continue }
+                $r = [int]$f[2]
+                if ($r -le $Cap -and $r -gt $bestRam) { $best = $f[1]; $bestRam = $r }
+            }
+            # ,@(...): PowerShell unrolls a returned array into the output
+            # stream; the comma operator keeps it as ONE object so [0]/[1] hold.
+            if ($best) { return ,@($best, $bestRam) } else { return $null }
         }
-        $vlmSuggest = if ($ramGb -ge 8) { 'gemma3:4b' } else { 'moondream' }
-        $hwDesc = "$(if ($accel -eq 'cuda') { 'NVIDIA GPU (CUDA), ' } else { 'CPU only, ' })$ramGb GB RAM, $cores cores"
-        Ok "Detected: $hwDesc -> suggesting $llmSuggest"
+
+        $pick = Pick-FromCatalog 'llm' $capLlm
+        if ($pick) { $llmSuggest = $pick[0]; $llmRam = $pick[1] }
+        else { $llmSuggest = 'qwen2.5:0.5b'; $llmRam = 1 }
+
+        # Whatever the LLM did not take. A vision model the machine cannot
+        # hold is worse than a smaller one: it evicts the LLM every question.
+        $remaining = [math]::Max(0, $budgetGb - $llmRam)
+        if ($accel -eq 'cpu' -and $cores -lt 4) { $remaining = 0 }
+        $pick = Pick-FromCatalog 'vlm' $remaining
+        if ($pick) { $vlmSuggest = $pick[0]; $captionSuggest = 'ollamavlm' }
+        else { $vlmSuggest = ''; $captionSuggest = 'moondream' }
+
+        # Transcription is on the voice critical path, so weak machines get
+        # the fast tier and strong ones the accurate one.
+        $whisperSuggest = if ($cores -ge 8 -and $ramGb -ge 16) { 'small.en' } elseif ($cores -ge 4) { 'base.en' } else { 'tiny.en' }
+
+        Ok "Detected: $hwDesc -> ~$budgetGb GB for models after the stack"
+        if ($vlmSuggest) {
+            Ok "Suggesting $llmSuggest + $vlmSuggest (both stay resident)"
+        } else {
+            Ok "Suggesting $llmSuggest; too little left for an Ollama vision model, so scene description falls back to the small in-container moondream"
+        }
 
         Write-Host ''
         Write-Host '  -- Camera Agent models (all local, no API keys) -------'
         Explain "The local chat model that answers your questions; must support tool calling. The suggestion is sized for this machine ($hwDesc), capped at the largest model this agent is tested with - 'untested' entries are known-good models nobody has validated with THIS agent yet." 'yes' $llmSuggest
-        Set-EnvValue OLLAMA_MODEL (Pick-ModelFromCatalog 'llm' $llmSuggest 'Local LLM model (Ollama)' $ramGb)
+        Set-EnvValue OLLAMA_MODEL (Pick-ModelFromCatalog 'llm' $llmSuggest 'Local LLM model (Ollama)' $budgetGb)
         # Pull offer AFTER the model choice, so it pulls what was chosen.
         if ($llmWhere -eq 'host') {
             $extModel = Get-EnvValue OLLAMA_MODEL; if (-not $extModel) { $extModel = $llmSuggest }
@@ -551,9 +590,9 @@ function Choose-Example {
             }
         }
         if ($prof -eq 'camera-agent') {
-            Configure-Value WHISPER_MODEL_SIZE 'Whisper speech-to-text model' 'base.en' `
-                'Transcribes your spoken questions (voice mode only).' 'yes' `
-                'tiny.en (fastest) | base.en (default) | small.en (most accurate).'
+            Configure-Value WHISPER_MODEL_SIZE 'Whisper speech-to-text model' $whisperSuggest `
+                'Transcribes your spoken questions (voice mode only). Sized for this machine - transcription is on the voice critical path, so weak boxes get the fast tier.' 'yes' `
+                'tiny.en (fastest) | base.en (balanced) | small.en (most accurate).'
         }
         # When the LLM already runs on the host Ollama, the VLM belongs there
         # too: the ollamavlm adapter proxies scene questions to the same
@@ -561,14 +600,17 @@ function Choose-Example {
         # the in-container weights). Same adapter contract, same audited
         # KAI-C path - only where the weights execute changes. On the
         # bundled-container path the in-VM moondream stays the default.
+        # ...but only if there is RAM for it. Both Ollama models stay
+        # resident, so proxying vision to Ollama on a machine that cannot
+        # hold both means every scene question evicts the chat model.
         $captionDefault = 'moondream'
-        if ($llmWhere -eq 'host') { $captionDefault = 'ollamavlm' }
+        if ($llmWhere -eq 'host' -and $captionSuggest -eq 'ollamavlm') { $captionDefault = 'ollamavlm' }
         Configure-Value CAPTION_ADAPTER 'Scene-description model' $captionDefault `
             'Describes what a camera sees. ollamavlm proxies to your Ollama (GPU-fast when the LLM runs on this machine - the default in that case; needs an adapter tag newer than 0.1.3); moondream/blip run inside Docker (moondream answers questions, blip writes plain captions).' 'yes' `
             'moondream | blip | ollamavlm - all local.'
         if ((Get-EnvValue CAPTION_ADAPTER) -eq 'ollamavlm') {
             Explain 'Multimodal Ollama model the ollamavlm adapter uses for scene questions; the adapter auto-pulls it. gemma3:4b (tested - clearly better answers) is suggested where RAM allows; moondream is the tested low-RAM pick.' 'yes' $vlmSuggest
-            Set-EnvValue OLLAMA_VLM_MODEL (Pick-ModelFromCatalog 'vlm' $vlmSuggest 'Vision model (Ollama)' $ramGb)
+            Set-EnvValue OLLAMA_VLM_MODEL (Pick-ModelFromCatalog 'vlm' $vlmSuggest 'Vision model (Ollama)' $budgetGb)
         }
     } else {
         Prompt-OverlayDefaults $manifest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -394,43 +394,102 @@ detect_llm_hardware() {
     fi
 }
 
-# suggest_llm_model → echoes the suggested Ollama model for the detected
-# hardware. Two constraints shape the tiers, deliberately:
-#   * FLOOR — tool-calling quality: below ~1.5b the agent misroutes
-#     tools noticeably, so tiny tiers are only suggested where latency
-#     would otherwise make it unusable.
-#   * CEILING — the tested envelope: suggestions never exceed the
-#     largest model this agent has been exercised with. That envelope
-#     now includes qwen3:1.7b, field-tested against qwen2.5 with this
-#     agent and giving BETTER answers at similar speed (~3 GB), so it
-#     is the suggestion wherever RAM allows. "This hardware CAN run a
-#     bigger model" is detectable; "bigger will be BETTER for this
-#     agent's tool-calling and voice latency" is not — 7b doubles
-#     latency for untested gain, so machines with headroom get it as a
-#     note to try, never as the default.
-# qwen3 is a "thinking" family; the shipped configs set llm_think:false
-# so it answers snappily — the chat template difference vs qwen2.5 is
-# handled by Ollama's per-model templates, not by us.
-suggest_llm_model() {
-    if [[ "$HW_ACCEL" != "cpu" ]]; then
-        if (( HW_RAM_GB >= 8 )); then echo "qwen3:1.7b"
-        else echo "qwen2.5:1.5b"; fi
+# ── Sizing the models to the machine ───────────────────────────────
+# Both Ollama models are RESIDENT AT ONCE (the shipped compose sets
+# OLLAMA_KEEP_ALIVE=-1 so answers stay snappy), and they share the box with
+# the OpenNVR stack itself. So what has to fit is the SUM, not either model
+# on its own — sizing them independently is what put a 4 GB vision model on
+# 8 GB machines and left them thrashing.
+#
+# Measured on a running install: the 13 stack containers hold ~2 GB RSS, and
+# Docker Desktop adds its VM overhead on top of that. Leave the operator's
+# own machine some room too — a desktop with zero free RAM is a broken one.
+OPENNVR_STACK_GB=3
+OPENNVR_OS_HEADROOM_GB=2
+
+# compute_model_budget → sets HW_MODEL_BUDGET_GB, the RAM left for models.
+compute_model_budget() {
+    HW_MODEL_BUDGET_GB=$(( HW_RAM_GB - OPENNVR_STACK_GB - OPENNVR_OS_HEADROOM_GB ))
+    (( HW_MODEL_BUDGET_GB < 0 )) && HW_MODEL_BUDGET_GB=0
+    return 0
+}
+
+# catalog_pick <kind> <max_ram_gb> → largest TESTED model of that kind whose
+# working set fits, or empty. Reads the catalog so the tiers can never drift
+# from the menu the operator is shown.
+catalog_pick() {
+    local kind="$1" cap="$2" catalog="examples/camera-agent/model_catalog.txt"
+    local k model min_ram tested rest best="" best_ram=-1
+    [[ -f "$catalog" ]] || return 0
+    while IFS='|' read -r k model min_ram tested rest; do
+        [[ "$k" == "$kind" && "$tested" == "yes" ]] || continue
+        (( min_ram <= cap )) || continue
+        (( min_ram > best_ram )) && { best="$model"; best_ram="$min_ram"; }
+    done < <(grep -v '^#' "$catalog")
+    printf '%s|%s' "$best" "$best_ram"
+}
+
+# suggest_models → sets SUGGEST_LLM, SUGGEST_VLM, SUGGEST_CAPTION_ADAPTER.
+#
+# Two ceilings, deliberately:
+#   * SPEED — a model that fits in RAM can still be unusable. CPU-only boxes
+#     get a tier matched to their cores, because "it fits" and "it answers
+#     before the operator gives up" are different questions.
+#   * TESTED — never suggest past the envelope this agent has actually been
+#     exercised with. "This machine CAN run a bigger model" is detectable;
+#     "bigger will be BETTER at tool-calling and voice latency" is not, so
+#     untested headroom stays a note in the menu, never a default.
+#
+# The tool-routing floor still applies: below ~1.5b the agent misroutes tools
+# noticeably, so the tiny tier is only chosen where nothing else fits.
+suggest_models() {
+    compute_model_budget
+    local cap_llm
+    if [[ "$HW_ACCEL" != "cpu" ]]; then cap_llm=4        # GPU: up to qwen2.5:3b
+    elif (( HW_CORES >= 8 )); then      cap_llm=3        # strong CPU: qwen3:1.7b
+    elif (( HW_CORES >= 4 )); then      cap_llm=2        # modest CPU: qwen2.5:1.5b
+    else                                cap_llm=1        # weak CPU: the tiny tier
+    fi
+    (( cap_llm > HW_MODEL_BUDGET_GB )) && cap_llm=$HW_MODEL_BUDGET_GB
+
+    local picked llm_ram
+    picked=$(catalog_pick llm "$cap_llm")
+    SUGGEST_LLM="${picked%%|*}"; llm_ram="${picked##*|}"
+    if [[ -z "$SUGGEST_LLM" ]]; then
+        # Nothing fits the budget. Suggest the smallest tested model anyway —
+        # the operator may know something we do not (swap, a spare box, an
+        # external Ollama) — and let the menu's own fit warning speak.
+        SUGGEST_LLM="qwen2.5:0.5b"; llm_ram=1
+    fi
+
+    # Whatever the LLM did not take. A vision model this machine cannot hold
+    # is worse than a smaller one: it evicts the LLM on every question.
+    local remaining=$(( HW_MODEL_BUDGET_GB - llm_ram ))
+    (( remaining < 0 )) && remaining=0
+    # On a weak CPU, serving vision through Ollama is slow enough to be a
+    # worse experience than the small in-container model, whatever fits.
+    if [[ "$HW_ACCEL" == "cpu" ]] && (( HW_CORES < 4 )); then remaining=0; fi
+    picked=$(catalog_pick vlm "$remaining")
+    SUGGEST_VLM="${picked%%|*}"
+    if [[ -n "$SUGGEST_VLM" ]]; then
+        SUGGEST_CAPTION_ADAPTER="ollamavlm"
     else
-        if   (( HW_RAM_GB >= 16 && HW_CORES >= 8 )); then echo "qwen3:1.7b"
-        else echo "qwen2.5:0.5b"; fi
+        # No room to serve vision from Ollama: fall back to the moondream
+        # ADAPTER, a ~0.5b-int8 build in its own container — far smaller than
+        # anything in the Ollama catalog, and still a real VQA answer.
+        SUGGEST_CAPTION_ADAPTER="moondream"
+        SUGGEST_VLM=""
     fi
 }
 
-# suggest_vlm_model → caption/VQA model for CAPTION_ADAPTER=ollamavlm.
-# gemma3:4b was field-tested with this agent through ollamavlm and gives
-# clearly better scene answers than moondream, so it is the suggestion
-# wherever RAM allows (~4 GB working set + headroom). moondream stays the
-# low-RAM default: still tested, still cheap. Capable machines are told
-# (in the prompt note) that qwen2.5vl:3b is the better text READER;
-# trying it stays an operator decision.
-suggest_vlm_model() {
-    if (( HW_RAM_GB >= 8 )); then echo "gemma3:4b"
-    else echo "moondream"; fi
+# suggest_whisper_model → speech-to-text sized to the CPU that will run it.
+# Transcription is on the voice critical path: a model that takes four
+# seconds to transcribe "is anyone at the door" makes the agent feel broken,
+# so weak machines get the fast tier and strong ones the accurate one.
+suggest_whisper_model() {
+    if   (( HW_CORES >= 8 && HW_RAM_GB >= 16 )); then echo "small.en"
+    elif (( HW_CORES >= 4 )); then                    echo "base.en"
+    else                                              echo "tiny.en"; fi
 }
 
 # ── Catalog-driven model menu ───────────────────────────────────────
@@ -456,8 +515,10 @@ pick_model_from_catalog() {
         idx=$((idx + 1))
         names[$idx]="$model"
         local fit="" mark=""
-        if (( HW_RAM_GB > 0 && min_ram > HW_RAM_GB )); then
-            fit="  [needs ~${min_ram} GB — this machine detected ${HW_RAM_GB} GB]"
+        if (( HW_RAM_GB > 0 && min_ram > HW_MODEL_BUDGET_GB )); then
+            # Against the BUDGET, not total RAM: a 4 GB model on an 8 GB box
+            # "fits" only if you ignore the stack and the other model.
+            fit="  [needs ~${min_ram} GB — only ~${HW_MODEL_BUDGET_GB} GB free for models]"
         fi
         [[ "$model" == "$suggest" ]] && { mark="  ← suggested"; default_idx="$idx"; }
         printf '   %d. %-16s ~%sGB  %-8s %-8s %s%s%s\n' \
@@ -572,9 +633,10 @@ choose_example() {
         # Size the defaults for the machine that will actually run the
         # model. Suggestions only — type any Ollama model to override.
         detect_llm_hardware "$llm_where"
+        suggest_models
         local llm_suggest vlm_suggest hw_desc
-        llm_suggest=$(suggest_llm_model)
-        vlm_suggest=$(suggest_vlm_model)
+        llm_suggest="$SUGGEST_LLM"
+        vlm_suggest="$SUGGEST_VLM"
         hw_desc="${HW_RAM_GB} GB RAM, ${HW_CORES} cores"
         case "$HW_ACCEL" in
             metal) hw_desc="Apple Silicon GPU (Metal), $hw_desc" ;;
@@ -584,7 +646,12 @@ choose_example() {
         if [[ "$llm_where" == "container" && "$PLATFORM" == "macOS" ]]; then
             hw_desc="$hw_desc (Docker VM allowance)"
         fi
-        ok "Detected: $hw_desc → suggesting $llm_suggest"
+        ok "Detected: $hw_desc → ~${HW_MODEL_BUDGET_GB} GB for models after the stack"
+        if [[ -n "$vlm_suggest" ]]; then
+            ok "Suggesting ${llm_suggest} + ${vlm_suggest} (both stay resident)"
+        else
+            ok "Suggesting ${llm_suggest}; too little left for an Ollama vision model, so scene description falls back to the small in-container moondream"
+        fi
 
         printf '\n  ── Camera Agent models (all local, no API keys) ───────\n'
         explain "The local chat model that answers your questions; must support tool calling. The suggestion is sized for this machine ($hw_desc), capped at the largest model this agent is tested with — 'untested' entries are known-good models nobody has validated with THIS agent yet." \
@@ -612,9 +679,10 @@ choose_example() {
             fi
         fi
         if [[ "$EXAMPLE_PROFILE" == "camera-agent" ]]; then
-            configure_value WHISPER_MODEL_SIZE "Whisper speech-to-text model" "base.en" \
-                "Transcribes your spoken questions (voice mode only)." "yes" \
-                "tiny.en (fastest) | base.en (default) | small.en (most accurate)."
+            configure_value WHISPER_MODEL_SIZE "Whisper speech-to-text model" \
+                "$(suggest_whisper_model)" \
+                "Transcribes your spoken questions (voice mode only). Sized for this machine — transcription is on the voice critical path, so weak boxes get the fast tier." "yes" \
+                "tiny.en (fastest) | base.en (balanced) | small.en (most accurate)."
         fi
         # When the LLM already runs on the host Ollama, the VLM belongs there
         # too: the ollamavlm adapter proxies scene questions to the same
@@ -623,8 +691,11 @@ choose_example() {
         # audited KAI-C path — only where the weights execute changes. On
         # the bundled-container path the in-VM moondream stays the default
         # (there may be no host Ollama at all on a Linux server).
+        # ...but only if there is RAM for it. Both Ollama models stay
+        # resident, so proxying vision to Ollama on a machine that cannot
+        # hold both means every scene question evicts the chat model.
         local caption_default="moondream"
-        if [[ "$llm_where" == "host" ]]; then
+        if [[ "$llm_where" == "host" && "$SUGGEST_CAPTION_ADAPTER" == "ollamavlm" ]]; then
             caption_default="ollamavlm"
         fi
         configure_value CAPTION_ADAPTER "Scene-description model" "$caption_default" \

--- a/tests/host-hardening/test_installer_model_sizing.sh
+++ b/tests/host-hardening/test_installer_model_sizing.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Regression tests for the installer's hardware-aware model sizing.
+#
+# The field bug: the installer suggested `qwen3:1.7b` + `gemma3:4b` on every
+# machine an operator tried, including low-end Windows and Linux boxes, and
+# the camera agent then failed to run. The vision model was gated on
+# `RAM >= 8` ALONE, so an 8 GB machine was handed 5 GB of models on top of a
+# ~3 GB stack — the whole machine — and thrashed.
+#
+# The rule these tests defend: both Ollama models are RESIDENT AT ONCE
+# (OLLAMA_KEEP_ALIVE=-1 in the shipped compose) and share the box with the
+# OpenNVR stack, so they must be budgeted TOGETHER, never independently.
+set -u
+
+. "$(dirname "$0")/_lib.sh"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+start_test() { TESTS_RUN=$((TESTS_RUN + 1)); printf "  [%2d] %s ... " "$TESTS_RUN" "$1"; }
+pass() { echo "PASS"; }
+fail() { echo "FAIL"; echo "      $1"; TESTS_FAILED=$((TESTS_FAILED + 1)); }
+
+echo "Running installer model-sizing tests"
+echo ""
+
+# Pull just the sizing block out of install.sh and run it in this shell, so
+# the tests exercise the REAL logic rather than a copy that can drift.
+SIZING=$(awk '/^OPENNVR_STACK_GB=/,/^# ── Catalog-driven model menu/' scripts/install.sh | sed '$d')
+if [[ -z "$SIZING" ]]; then
+    echo "✗ could not extract the sizing block from scripts/install.sh" >&2
+    exit 1
+fi
+eval "$SIZING"
+
+# size <ram_gb> <cores> <accel> → "LLM|VLM|adapter|whisper"
+size() {
+    HW_RAM_GB="$1"; HW_CORES="$2"; HW_ACCEL="$3"
+    suggest_models
+    printf '%s|%s|%s|%s' "$SUGGEST_LLM" "$SUGGEST_VLM" \
+        "$SUGGEST_CAPTION_ADAPTER" "$(suggest_whisper_model)"
+}
+
+# ── 1. the reported failure ──
+start_test "8 GB / 4 cores does not get a 4 GB vision model"
+got=$(size 8 4 cpu)
+vlm=$(cut -d'|' -f2 <<<"$got")
+if [[ -z "$vlm" ]]; then
+    pass
+else
+    fail "8 GB box was handed Ollama vision model '${vlm}' (got: ${got})"
+fi
+
+start_test "8 GB / 4 cores falls back to the small in-container adapter"
+adapter=$(cut -d'|' -f3 <<<"$(size 8 4 cpu)")
+[[ "$adapter" == "moondream" ]] && pass \
+    || fail "expected the moondream adapter, got '${adapter}'"
+
+# ── 2. the models are budgeted together, not independently ──
+start_test "LLM + vision never exceed the machine's model budget"
+catalog="examples/camera-agent/model_catalog.txt"
+ram_of() {  # model name → its catalog min_ram_gb (0 if absent/empty)
+    [[ -n "$1" ]] || { echo 0; return; }
+    awk -F'|' -v m="$1" '$2 == m { print $3; found=1 } END { if (!found) print 0 }' \
+        <(grep -v '^#' "$catalog")
+}
+# Smallest tested LLM in the catalog — the floor the installer may fall back
+# to on a machine too small for anything, because suggesting NOTHING is not a
+# usable install. That fallback is the one permitted overshoot.
+FLOOR_RAM=$(awk -F'|' '$1 == "llm" && $4 == "yes" { if (min == "" || $3 < min) min = $3 }
+                       END { print min + 0 }' <(grep -v '^#' "$catalog"))
+over=""
+for spec in "4 2 cpu" "8 4 cpu" "8 8 cpu" "16 8 cpu" "16 4 cpu" \
+            "32 16 cpu" "8 8 cuda" "16 8 cuda" "32 12 metal"; do
+    read -r ram cores accel <<<"$spec"
+    got=$(size "$ram" "$cores" "$accel")
+    HW_RAM_GB="$ram"; compute_model_budget
+    total=$(( $(ram_of "$(cut -d'|' -f1 <<<"$got")") \
+            + $(ram_of "$(cut -d'|' -f2 <<<"$got")") ))
+    if (( HW_MODEL_BUDGET_GB < FLOOR_RAM )); then
+        # Too small for even the floor: the only acceptable answer is that
+        # floor alone, with vision pushed to the small container adapter.
+        (( total > FLOOR_RAM )) && over="${over} [${spec}: ${total}GB where only the ${FLOOR_RAM}GB floor is allowed]"
+    elif (( total > HW_MODEL_BUDGET_GB )); then
+        over="${over} [${spec}: ${total}GB of models vs ${HW_MODEL_BUDGET_GB}GB budget]"
+    fi
+done
+[[ -z "$over" ]] && pass || fail "over budget:${over}"
+
+# ── 3. capability actually changes the answer ──
+start_test "a weak machine and a strong one get different models"
+weak=$(size 4 2 cpu)
+strong=$(size 32 16 cpu)
+[[ "$weak" != "$strong" ]] && pass \
+    || fail "same suggestion for a 4 GB mini PC and a 32 GB server: ${weak}"
+
+start_test "cores matter on CPU-only, not just RAM"
+a=$(cut -d'|' -f1 <<<"$(size 16 4 cpu)")
+b=$(cut -d'|' -f1 <<<"$(size 16 8 cpu)")
+[[ "$a" != "$b" ]] && pass \
+    || fail "4-core and 8-core 16 GB boxes both got '${a}'"
+
+start_test "a GPU lifts the tier above the CPU-only answer"
+cpu=$(cut -d'|' -f1 <<<"$(size 16 8 cpu)")
+gpu=$(cut -d'|' -f1 <<<"$(size 16 8 cuda)")
+[[ "$cpu" != "$gpu" ]] && pass \
+    || fail "GPU and CPU-only 16 GB boxes both got '${cpu}'"
+
+# ── 4. failing to detect must size DOWN, never up ──
+start_test "undetectable hardware is treated as a small machine"
+got=$(size 0 0 cpu)
+llm=$(cut -d'|' -f1 <<<"$got"); vlm=$(cut -d'|' -f2 <<<"$got")
+if [[ "$llm" == "qwen2.5:0.5b" && -z "$vlm" ]]; then
+    pass
+else
+    fail "detection failure should size down, got: ${got}"
+fi
+
+# A machine smaller than the stack itself drives the budget NEGATIVE. It must
+# clamp to zero and pick the floor — not wrap, and not be read as "unlimited".
+# Plenty of threads here on purpose, so the core tier cannot mask the bug.
+start_test "a machine smaller than the stack clamps to the floor"
+HW_RAM_GB=2; compute_model_budget
+if (( HW_MODEL_BUDGET_GB != 0 )); then
+    fail "2 GB machine reported a ${HW_MODEL_BUDGET_GB} GB model budget"
+else
+    got=$(size 2 8 cpu)
+    llm=$(cut -d'|' -f1 <<<"$got"); vlm=$(cut -d'|' -f2 <<<"$got")
+    if [[ "$llm" == "qwen2.5:0.5b" && -z "$vlm" ]]; then
+        pass
+    else
+        fail "2 GB / 8 threads should get the floor and no Ollama vision, got: ${got}"
+    fi
+fi
+
+# ── 5. never suggest past the tested envelope ──
+start_test "suggestions stay inside the tested set"
+bad=""
+for spec in "4 2 cpu" "8 4 cpu" "16 8 cpu" "32 16 cpu" "32 12 metal" "64 32 cuda"; do
+    read -r ram cores accel <<<"$spec"
+    got=$(size "$ram" "$cores" "$accel")
+    for m in "$(cut -d'|' -f1 <<<"$got")" "$(cut -d'|' -f2 <<<"$got")"; do
+        [[ -n "$m" ]] || continue
+        tested=$(awk -F'|' -v m="$m" '$2 == m { print $4 }' <(grep -v '^#' "$catalog"))
+        [[ "$tested" == "yes" ]] || bad="${bad} [${spec} → ${m} is '${tested:-not in catalog}']"
+    done
+done
+[[ -z "$bad" ]] && pass || fail "untested model suggested:${bad}"
+
+# ── 6. the two installers must not drift apart ──
+start_test "install.ps1 carries the same budget arithmetic"
+if grep -q 'stackGb = 3; \$osHeadroomGb = 2' scripts/install.ps1 \
+   && grep -q 'budgetGb = \[math\]::Max(0, \$ramGb - \$stackGb - \$osHeadroomGb)' scripts/install.ps1; then
+    pass
+else
+    fail "install.ps1's budget no longer matches install.sh's"
+fi
+
+start_test "install.ps1 gates the Ollama vision path on the budget"
+grep -q 'captionSuggest -eq .ollamavlm.' scripts/install.ps1 && pass \
+    || fail "install.ps1 no longer lets the budget veto CAPTION_ADAPTER=ollamavlm"
+
+echo ""
+if (( TESTS_FAILED > 0 )); then
+    echo "✗ ${TESTS_FAILED} of ${TESTS_RUN} tests failed"
+    exit 1
+fi
+echo "✓ all ${TESTS_RUN} tests passed"


### PR DESCRIPTION
… time

Reported from the field: the installer suggested qwen3:1.7b + gemma3:4b on every machine tried — Windows and Linux, low-end boxes included — and the camera agent then failed to run there.

The suggestions were computed independently, and the vision one was gated on `RAM >= 8` ALONE — no cores, no accelerator, no awareness of what the LLM had already claimed. Nearly every machine passes `RAM >= 8`, which is why the answer looked identical everywhere. On an 8 GB box that meant 5 GB of models (qwen2.5:0.5b + gemma3:4b) on top of a ~3 GB stack: the whole machine.

Both Ollama models are RESIDENT AT ONCE — the shipped compose sets OLLAMA_KEEP_ALIVE=-1 so answers stay snappy — and they share the box with OpenNVR itself. So budget them together:

    budget = RAM - 3 GB (stack: 13 containers hold ~2 GB RSS, measured on a
                         running install, plus Docker Desktop's VM overhead)
                 - 2 GB (the operator's own machine; a desktop with no free
                         RAM is a broken one)

The LLM takes the largest TESTED catalog entry that fits both the budget and a speed ceiling; vision gets what is left. When nothing is left, scene description falls back to the moondream ADAPTER — a ~0.5b-int8 build in its own container, far smaller than anything in the Ollama catalog and still a real VQA answer, instead of an Ollama model that evicts the chat model on every question.

CPU-only machines are now tiered by cores as well as RAM, because "it fits" and "it answers before the operator gives up" are different questions. Whisper is sized too: it was a flat base.en, and transcription is on the voice critical path. Menu fit-warnings compare against the budget rather than total RAM — a 4 GB model on an 8 GB box "fits" only if you ignore everything else.

    machine                     LLM            vision      adapter     whisper
    4GB / 2 cores CPU           qwen2.5:0.5b   -           moondream   tiny.en
    8GB / 4 cores CPU           qwen2.5:1.5b   -           moondream   base.en
    8GB / 8 threads CPU         qwen3:1.7b     -           moondream   base.en
    16GB / 8 threads CPU        qwen3:1.7b     gemma3:4b   ollamavlm   small.en
    16GB / 4 cores CPU          qwen2.5:1.5b   gemma3:4b   ollamavlm   base.en
    32GB / 16 cores CPU         qwen3:1.7b     gemma3:4b   ollamavlm   small.en
    8GB GPU                     qwen3:1.7b     -           moondream   base.en
    16GB GPU                    qwen2.5:3b     gemma3:4b   ollamavlm   small.en
    32GB Apple Silicon          qwen2.5:3b     gemma3:4b   ollamavlm   small.en
    detection failed            qwen2.5:0.5b   -           moondream   tiny.en

Failed detection sizes DOWN, never up: an unknown machine is treated as a small one, because the cost of guessing high is an install that does not run. The tested-envelope ceiling is unchanged — bigger-is-runnable is detectable, bigger-is-better is not.

Both installers verified to produce that table identically; install.ps1 also had its catalog helper hardened against PowerShell unrolling a returned array. New regression suite covers the reported failure, the joint budget, the negative-budget clamp, capability actually changing the answer, and the two installers not drifting apart.