### PR TITLE
fix(installer): the vision model needs the speed ceiling too, not jus…

### DIFF
--- a/examples/camera-agent/MODELS_AND_LATENCY.md
+++ b/examples/camera-agent/MODELS_AND_LATENCY.md
@@ -201,9 +201,9 @@ machines: `gemma3:4b` was gated on `RAM ≥ 8` alone, so an 8 GB box got
 | 4 GB / 2 cores, CPU | `qwen2.5:0.5b` | — | `moondream` | `tiny.en` |
 | 8 GB / 4 cores, CPU | `qwen2.5:1.5b` | — | `moondream` | `base.en` |
 | 8 GB / 8 threads, CPU | `qwen3:1.7b` | — | `moondream` | `base.en` |
-| 16 GB / 8 threads, CPU | `qwen3:1.7b` | `gemma3:4b` | `ollamavlm` | `small.en` |
-| 16 GB / 4 cores, CPU | `qwen2.5:1.5b` | `gemma3:4b` | `ollamavlm` | `base.en` |
-| 32 GB / 16 cores, CPU | `qwen3:1.7b` | `gemma3:4b` | `ollamavlm` | `small.en` |
+| 16 GB / 8 threads, CPU | `qwen3:1.7b` | `moondream` | `ollamavlm` | `small.en` |
+| 16 GB / 4 cores, CPU | `qwen2.5:1.5b` | `moondream` | `ollamavlm` | `base.en` |
+| 32 GB / 16 cores, CPU | `qwen3:1.7b` | `moondream` | `ollamavlm` | `small.en` |
 | 8 GB, GPU | `qwen3:1.7b` | — | `moondream` | `base.en` |
 | 16 GB, GPU | `qwen2.5:3b` | `gemma3:4b` | `ollamavlm` | `small.en` |
 | 32 GB, Apple Silicon | `qwen2.5:3b` | `gemma3:4b` | `ollamavlm` | `small.en` |
@@ -217,6 +217,13 @@ CPU-only machines are tiered by cores as well as RAM, because "it fits"
 and "it answers before the operator gives up" are different questions —
 and a machine with fewer than 4 cores skips the Ollama vision path
 entirely, whatever the RAM arithmetic says.
+
+The vision model carries that same speed ceiling, not just a RAM one. A
+4B vision model costs ~25 s per caption on CPU against ~1-2 s on a GPU,
+so CPU-only machines are capped at the catalog's *fast* tier however
+much RAM is spare. Without that cap every machine with room landed on
+`gemma3:4b` — it fits, so it won — and the suggestion stopped varying
+with the hardware at all.
 
 Two constraints shape the tiers. The **floor** is tool-calling quality:
 below ~1.5b the agent misroutes tools noticeably, so the tiny tier is

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -530,7 +530,16 @@ function Choose-Example {
         $capLlm = if ($accel -ne 'cpu') { 4 } elseif ($cores -ge 8) { 3 } elseif ($cores -ge 4) { 2 } else { 1 }
         if ($capLlm -gt $budgetGb) { $capLlm = $budgetGb }
 
-        function Pick-FromCatalog([string]$Kind, [int]$Cap) {
+        # The catalog's speed column is editorial prose; this is the only
+        # place that turns it into an ordering. Keep in sync with speed_rank
+        # in install.sh.
+        function Get-SpeedRank([string]$Speed) {
+            switch ($Speed) {
+                'fastest' { 0 } 'fast' { 1 } 'medium' { 2 }
+                'slower'  { 3 } 'slowest' { 4 } default { 2 }
+            }
+        }
+        function Pick-FromCatalog([string]$Kind, [int]$Cap, [int]$SpeedCap = 9) {
             $catalog = 'examples/camera-agent/model_catalog.txt'
             if (-not (Test-Path $catalog)) { return $null }
             $best = $null; $bestRam = -1
@@ -538,7 +547,9 @@ function Choose-Example {
                 $f = $line -split '\|'
                 if ($f[0] -ne $Kind -or $f[3] -ne 'yes') { continue }
                 $r = [int]$f[2]
-                if ($r -le $Cap -and $r -gt $bestRam) { $best = $f[1]; $bestRam = $r }
+                if ($r -gt $Cap) { continue }
+                if ((Get-SpeedRank $f[4]) -gt $SpeedCap) { continue }
+                if ($r -gt $bestRam) { $best = $f[1]; $bestRam = $r }
             }
             # ,@(...): PowerShell unrolls a returned array into the output
             # stream; the comma operator keeps it as ONE object so [0]/[1] hold.
@@ -553,7 +564,12 @@ function Choose-Example {
         # hold is worse than a smaller one: it evicts the LLM every question.
         $remaining = [math]::Max(0, $budgetGb - $llmRam)
         if ($accel -eq 'cpu' -and $cores -lt 4) { $remaining = 0 }
-        $pick = Pick-FromCatalog 'vlm' $remaining
+        # Vision gets a SPEED ceiling too, not just a RAM one - the same rule
+        # the LLM got. Without it every machine with room landed on the same
+        # 4B model: it fits, so it wins, even CPU-only where a caption costs
+        # ~25 s against ~1-2 s on a GPU.
+        $vlmSpeedCap = if ($accel -eq 'cpu') { 1 } else { 9 }
+        $pick = Pick-FromCatalog 'vlm' $remaining $vlmSpeedCap
         if ($pick) { $vlmSuggest = $pick[0]; $captionSuggest = 'ollamavlm' }
         else { $vlmSuggest = ''; $captionSuggest = 'moondream' }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -414,16 +414,27 @@ compute_model_budget() {
     return 0
 }
 
-# catalog_pick <kind> <max_ram_gb> → largest TESTED model of that kind whose
-# working set fits, or empty. Reads the catalog so the tiers can never drift
-# from the menu the operator is shown.
+# speed_rank <speed> → 0 (fastest) .. 4 (slowest). The catalog's speed column
+# is editorial prose; this is the only place that turns it into an ordering.
+speed_rank() {
+    case "$1" in
+        fastest) echo 0 ;; fast) echo 1 ;; medium) echo 2 ;;
+        slower)  echo 3 ;; slowest) echo 4 ;; *) echo 2 ;;
+    esac
+}
+
+# catalog_pick <kind> <max_ram_gb> [max_speed_rank] → largest TESTED model of
+# that kind that fits BOTH ceilings, or empty. Reads the catalog so the tiers
+# can never drift from the menu the operator is shown.
 catalog_pick() {
-    local kind="$1" cap="$2" catalog="examples/camera-agent/model_catalog.txt"
-    local k model min_ram tested rest best="" best_ram=-1
+    local kind="$1" cap="$2" speed_cap="${3:-9}"
+    local catalog="examples/camera-agent/model_catalog.txt"
+    local k model min_ram tested speed rest best="" best_ram=-1
     [[ -f "$catalog" ]] || return 0
-    while IFS='|' read -r k model min_ram tested rest; do
+    while IFS='|' read -r k model min_ram tested speed rest; do
         [[ "$k" == "$kind" && "$tested" == "yes" ]] || continue
         (( min_ram <= cap )) || continue
+        (( $(speed_rank "$speed") <= speed_cap )) || continue
         (( min_ram > best_ram )) && { best="$model"; best_ram="$min_ram"; }
     done < <(grep -v '^#' "$catalog")
     printf '%s|%s' "$best" "$best_ram"
@@ -469,7 +480,14 @@ suggest_models() {
     # On a weak CPU, serving vision through Ollama is slow enough to be a
     # worse experience than the small in-container model, whatever fits.
     if [[ "$HW_ACCEL" == "cpu" ]] && (( HW_CORES < 4 )); then remaining=0; fi
-    picked=$(catalog_pick vlm "$remaining")
+    # Vision gets a SPEED ceiling too, not just a RAM one — the same rule the
+    # LLM already got. Without it every machine with room landed on the same
+    # 4B model: it fits, so it wins, even CPU-only where a caption costs ~25 s
+    # against ~1-2 s on a GPU. Fitting in RAM and answering before the
+    # operator gives up are different questions.
+    local vlm_speed_cap=9
+    [[ "$HW_ACCEL" == "cpu" ]] && vlm_speed_cap=1        # CPU: the fast tier only
+    picked=$(catalog_pick vlm "$remaining" "$vlm_speed_cap")
     SUGGEST_VLM="${picked%%|*}"
     if [[ -n "$SUGGEST_VLM" ]]; then
         SUGGEST_CAPTION_ADAPTER="ollamavlm"

--- a/tests/host-hardening/test_installer_model_sizing.sh
+++ b/tests/host-hardening/test_installer_model_sizing.sh
@@ -108,6 +108,39 @@ gpu=$(cut -d'|' -f1 <<<"$(size 16 8 cuda)")
 [[ "$cpu" != "$gpu" ]] && pass \
     || fail "GPU and CPU-only 16 GB boxes both got '${cpu}'"
 
+# ── the second field report: "LLM is machine specific now, but the VLM is
+# still gemma on every machine". It was — the LLM got a speed ceiling and the
+# vision model only got a RAM one, so every box with room landed on the same
+# 4B model. It fits, so it won, even CPU-only where a caption costs ~25 s
+# against ~1-2 s on a GPU.
+start_test "the vision model varies with hardware, not just the LLM"
+seen=$(for spec in "8 4 cpu" "16 8 cpu" "32 16 cpu" "16 8 cuda" "32 12 metal"; do
+           read -r ram cores accel <<<"$spec"
+           cut -d'|' -f2 <<<"$(size "$ram" "$cores" "$accel")"
+       done | sort -u | wc -l | tr -d ' ')
+(( seen > 1 )) && pass \
+    || fail "every machine got the same vision answer across CPU, GPU and Metal"
+
+start_test "a heavyweight vision model is not suggested on a CPU-only box"
+catalog="examples/camera-agent/model_catalog.txt"
+speed_of() { awk -F'|' -v m="$1" '$2 == m { print $5 }' <(grep -v '^#' "$catalog"); }
+slow=""
+for spec in "16 8 cpu" "32 16 cpu" "64 32 cpu"; do
+    read -r ram cores accel <<<"$spec"
+    vlm=$(cut -d'|' -f2 <<<"$(size "$ram" "$cores" "$accel")")
+    [[ -n "$vlm" ]] || continue
+    sp=$(speed_of "$vlm")
+    [[ "$sp" == "fastest" || "$sp" == "fast" ]] \
+        || slow="${slow} [${spec} → ${vlm} (${sp})]"
+done
+[[ -z "$slow" ]] && pass || fail "slow vision model on CPU-only:${slow}"
+
+start_test "a GPU still gets the better vision model"
+gpu_vlm=$(cut -d'|' -f2 <<<"$(size 16 8 cuda)")
+cpu_vlm=$(cut -d'|' -f2 <<<"$(size 16 8 cpu)")
+[[ -n "$gpu_vlm" && "$gpu_vlm" != "$cpu_vlm" ]] && pass \
+    || fail "GPU box got '${gpu_vlm:-nothing}', same as CPU-only — the speed ceiling should only bind on CPU"
+
 # ── 4. failing to detect must size DOWN, never up ──
 start_test "undetectable hardware is treated as a small machine"
 got=$(size 0 0 cpu)


### PR DESCRIPTION
…t RAM

Reported after the last fix landed: the LLM is machine-specific now, but the vision model is still gemma3:4b on every machine.

It was. The LLM got two ceilings — budget AND a cores-based speed tier — and the vision model only got the budget. So every box with room landed on the largest tested vision model, because it fits and therefore wins. The result looked like the sizing was ignored, when in fact one half of it was.

It also fits badly. A 4B vision model costs ~25 s per caption on CPU against ~1-2 s on a GPU — the compose file says exactly this a few lines from where the adapter is wired. Fitting in RAM and answering before the operator gives up are different questions, which is already the stated rule for the LLM.

So vision takes a speed cap too, read from the catalog's own speed column rather than a hardcoded size: CPU-only machines get the *fast* tier, anything with a GPU is unconstrained.

    machine                     LLM            vision      adapter
    8GB / 4 cores CPU           qwen2.5:1.5b   -           moondream
    16GB / 8 threads CPU        qwen3:1.7b     moondream   ollamavlm
    32GB / 16 cores CPU         qwen3:1.7b     moondream   ollamavlm
    16GB GPU                    qwen2.5:3b     gemma3:4b   ollamavlm
    32GB Apple Silicon          qwen2.5:3b     gemma3:4b   ollamavlm

gemma3:4b keeps its place where a GPU makes it fast — the point is not that it is too big, it is that nothing was asking whether the machine could run it in reasonable time.

Both installers verified to produce that table identically. Three new regression tests: the vision answer must vary across CPU/GPU/Metal, a CPU-only box must never be handed a slow tier, and a GPU box must still get the better model — that last one so the cap cannot be over-applied. Removing the ceiling fails two of them, applying it on GPU too fails the third.