### PR TITLE
fix(camera-agent): ring on Tier-0 evidence during a conversation, and…

### DIFF
--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1983,12 +1983,20 @@ class AlarmManager:
                 return
         alarm.last_triggered = now
         alarm.trigger_count += 1
+        # The event carries WHEN THE PERSON WAS SEEN, not when the loop got
+        # around to ringing. A Tier-0 ring can lag its evidence by a few
+        # seconds (track confirmation + the poll interval), and the activity
+        # click seeks the recording to this timestamp — anchored at ring time
+        # it landed on a frame the person had already left, which read as
+        # "the alarm fired on nothing". Cooldown/re-arm mechanics above stay
+        # on ``now``: those govern the RINGING, not the sighting.
+        seen_ts = alarm.last_tier0_at.get(cam, now) if source == "tier0" else now
         text = f"{alarm.name}: {alarm.target} detected on {cam}"
         if alarm.emergency_contact:
             text += f" (would alert {alarm.emergency_contact})"
         self._events.append({
             "id": self._next_event_id, "alarm_id": alarm.id, "name": alarm.name,
-            "text": text, "camera": cam, "ts": now, "ring": alarm.ring,
+            "text": text, "camera": cam, "ts": seen_ts, "ring": alarm.ring,
             "emergency_contact": alarm.emergency_contact,
         })
         self._next_event_id += 1
@@ -1996,9 +2004,8 @@ class AlarmManager:
                        alarm.id, alarm.ring, source, text)
         self._runtime.notifier.fire({
             "type": "alarm", "title": alarm.name, "text": text,
-            "camera": cam,
+            "camera": cam, "ts": seen_ts,
             "severity": "critical" if alarm.ring == "siren" else "medium",
-            "ts": now,
         })
 
 

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -1529,6 +1529,9 @@ class Alarm:
     # one's timestamps, and the quiet camera — the driveway nobody walks up —
     # would silently never use Tier-0 at all.
     last_tier0_at: dict[str, float] = field(default_factory=dict)
+    # When this alarm last ran its own fallback inference, per camera — the
+    # throttle clock for the backstop while Tier-0 is verifiably alive.
+    last_fallback_at: dict[str, float] = field(default_factory=dict)
 
     def window_label(self) -> str:
         def fmt(m):
@@ -1634,12 +1637,21 @@ class AlarmManager:
     def __init__(self, runtime: "CameraAgentRuntime", *, interval: float = 5.0,
                  rearm_cooldown: float = 20.0, max_alarms: int = 20,
                  pulse_seconds: float = 60.0,
-                 tier0_max_age: float = 30.0) -> None:
+                 tier0_max_age: float = 30.0,
+                 tier0_fallback_every: float = 15.0) -> None:
         self._pulse = pulse_seconds
         # Absolute cap on how old a Tier-0 detection may be and still count as
         # "present now" — a backstop for the per-cycle watermark below, so a
         # loop that stalls for minutes cannot wake up and ring on ancient news.
         self._tier0_max_age = tier0_max_age
+        # While Tier-0 is verifiably alive for a camera, run the backstop
+        # inference at most this often instead of every cycle. The backstop's
+        # own full-frame inference burns seconds of the SAME CPU detect-pipeline
+        # needs — measured live: the moment a person appeared, Tier-0's frame
+        # latency blew its budget (1.32s vs 0.50s), the load shedder cut its
+        # detector regions 8 -> 2, and the pipeline went half-blind exactly when
+        # it mattered, publishing nothing. Part of that load was us, polling.
+        self._fallback_every = tier0_fallback_every
         self._runtime = runtime
         self._alarms: dict[int, Alarm] = {}
         self._order: list[int] = []
@@ -1780,13 +1792,20 @@ class AlarmManager:
             return mins >= a
         return mins < b
 
-    # How many consecutive poll cycles an alarm may yield to interactive
-    # turns before polling anyway. The yield keeps voice-turn latency
-    # snappy on CPU, but UNBOUNDED it silently pauses a safety feature:
-    # on a busy box each turn runs tens of seconds, so chained
-    # conversation kept alarms unpolled for minutes — the field report
-    # was 'armed a siren, walked in, nothing... it fired much later'.
+    # How many consecutive poll cycles an alarm may yield its own INFERENCE
+    # to interactive turns before running it anyway. The yield keeps
+    # voice-turn latency snappy on CPU, but UNBOUNDED it silently pauses a
+    # safety feature: on a busy box each turn runs tens of seconds, so
+    # chained conversation kept alarms unpolled for minutes — the field
+    # report was 'armed a siren, walked in, nothing... it fired much later'.
     # 4 skips at the 5s interval bounds worst-case added delay to ~20s.
+    #
+    # Only the inference yields. The Tier-0 check is a ring-buffer read —
+    # microseconds, no model touched — so deferring it bought the user's
+    # turn nothing and cost the alarm up to those same 20s. Second field
+    # report, verified in the logs: the operator armed an alarm, tested it
+    # by TALKING TO THE AGENT, and the ring came >30s after the person did
+    # ('yielded 4 cycles' immediately followed by the trigger).
     _MAX_BUSY_SKIPS = 4
 
     async def _loop(self, alarm: Alarm) -> None:
@@ -1794,21 +1813,22 @@ class AlarmManager:
         try:
             while alarm.active and not self._runtime._stop_event.is_set():
                 if self._in_window(alarm):
-                    if (self._runtime.interactive_busy()
-                            and busy_skips < self._MAX_BUSY_SKIPS):
+                    busy = (self._runtime.interactive_busy()
+                            and busy_skips < self._MAX_BUSY_SKIPS)
+                    if busy:
                         busy_skips += 1
                     else:
                         if busy_skips >= self._MAX_BUSY_SKIPS:
-                            log_fn = logger.info
-                            log_fn("alarm #%d: polling despite an active turn "
-                                   "(yielded %d cycles — a safety check must "
-                                   "not wait out a conversation)",
-                                   alarm.id, busy_skips)
+                            logger.info(
+                                "alarm #%d: polling despite an active turn "
+                                "(yielded %d cycles — a safety check must "
+                                "not wait out a conversation)",
+                                alarm.id, busy_skips)
                         busy_skips = 0
-                        for cam in alarm.camera_ids:
-                            if not alarm.active:
-                                break
-                            await self._poll(alarm, cam)
+                    for cam in alarm.camera_ids:
+                        if not alarm.active:
+                            break
+                        await self._poll(alarm, cam, allow_infer=not busy)
                 self._maybe_stand_down(alarm)
                 await asyncio.sleep(self._interval)
         except asyncio.CancelledError:  # pragma: no cover
@@ -1884,7 +1904,29 @@ class AlarmManager:
                 return True
         return False
 
-    async def _poll(self, alarm: Alarm, cam: str) -> None:
+    def _tier0_alive(self, cam: str, now: float) -> bool:
+        """Has Tier-0 published ANYTHING for this camera recently?
+
+        Liveness, not presence: gate audit records with no tracks count — an
+        audit of a non-event is still proof the pipeline is up and watching
+        this camera. (A genuinely quiet scene publishes nothing at all, so
+        silence stays ambiguous and the backstop stays un-throttled there.)
+        """
+        ctx = getattr(self._runtime, "context", None)
+        recent = getattr(ctx, "recent_events", None)
+        if recent is None:
+            return False
+        try:
+            events = recent(camera_id=cam, window_seconds=self._tier0_max_age)
+        except Exception:
+            return False
+        return any(getattr(e, "adapter", None) == "tier0" for e in events or ())
+
+    def _fallback_due(self, alarm: Alarm, cam: str, now: float) -> bool:
+        return (now - alarm.last_fallback_at.get(cam, 0.0)) >= self._fallback_every
+
+    async def _poll(self, alarm: Alarm, cam: str, *,
+                    allow_infer: bool = True) -> None:
         import time
 
         now = time.time()
@@ -1897,6 +1939,21 @@ class AlarmManager:
             # replaced: a safety feature must not go quiet just because one
             # source did, and Tier-0 publishes nothing at all on a quiet
             # scene, which is indistinguishable from Tier-0 having stopped.
+            #
+            # But the backstop is not free: its full-frame inference costs
+            # seconds of the same CPU detect-pipeline needs. So it yields to
+            # an interactive turn (the Tier-0 read above already ran — that
+            # part must never wait out a conversation), and while Tier-0 is
+            # demonstrably alive for this camera it runs on a throttle
+            # instead of every cycle. Measured live: our own polling was part
+            # of the load that blew Tier-0's frame budget the moment a person
+            # appeared, shedding its detector to near-blindness exactly when
+            # it mattered.
+            if not allow_infer:
+                return
+            if self._tier0_alive(cam, now) and not self._fallback_due(alarm, cam, now):
+                return
+            alarm.last_fallback_at[cam] = now
             try:
                 frame = await self._runtime.context.get_frame(cam, allow_pinned=False)
                 resp = await self._runtime.detection_client.infer(

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1698,7 +1698,10 @@
       try{ await loadRecordings(cam); }catch{}
       const seg=_recs.find(x=>{ const s0=Date.parse(x.start)/1000;
         return ts>=s0-2&&ts<=s0+(x.duration||0)+2; });
-      if(seg) playRecording(cam,seg,null);
+      // Seek INSIDE the segment: the alarm at 20:00 lives in a segment that
+      // began at 19:53, and opening it from 0:00 showed an empty room seven
+      // minutes before the person — which read as "the alarm fired on nothing".
+      if(seg) playRecording(cam,seg,null,ts);
       // else: live view (openCamScreen already did that)
     }
 
@@ -1741,7 +1744,7 @@
         b.querySelector("small").textContent=mins+" min";
         b.addEventListener("click",()=>playRecording(cam,seg,b));
         segs.appendChild(b); } }
-    async function playRecording(cam,seg,btn){
+    async function playRecording(cam,seg,btn,atTs){
       try{ const r=await fetch("/recordings/"+encodeURIComponent(cam)+"/play?start="+
           encodeURIComponent(seg.start)+"&duration="+encodeURIComponent(seg.duration||60));
         const d=await r.json().catch(()=>({}));
@@ -1754,6 +1757,11 @@
         // Autoplay: the click gesture is gone after the fetch, so an
         // unmuted play() may be blocked — fall back to muted (controls
         // let the user unmute), never to a frozen first frame.
+        if(atTs){ const offSec=Math.max(0,atTs-Date.parse(seg.start)/1000);
+          if(offSec>0&&offSec<(seg.duration||1e9)){
+            const seekTo=()=>{ try{ v.currentTime=offSec; }catch{} };
+            if(v.readyState>=1) seekTo();
+            else v.addEventListener("loadedmetadata",seekTo,{once:true}); } }
         v.muted=false;
         v.play().catch(()=>{ v.muted=true; v.play().catch(()=>{}); });
         setMode("playback");

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -948,3 +948,127 @@ def test_an_empty_ring_still_falls_back_to_the_poll():
         assert data["triggered"] is True and polls, "the backstop must still run"
 
     asyncio.run(go())
+
+
+# ── latency under load ─────────────────────────────────────────────────
+# Second field report, verified in the logs: operator armed an alarm, tested
+# it by TALKING TO THE AGENT, and the ring came >30s after the person did —
+# 'yielded 4 cycles' immediately followed by the trigger. Two causes, each
+# pinned below: the cheap Tier-0 ring-read was being deferred by the
+# interactive yield along with the expensive inference, and the backstop's
+# own full-frame inference was burning the CPU detect-pipeline needed (its
+# frame budget blew 8 -> 2 regions the moment the person appeared).
+
+
+def test_tier0_evidence_rings_even_during_an_interactive_turn():
+    """The yield exists to keep the user's turn snappy by not running MODELS.
+    Reading the Tier-0 ring touches no model and costs microseconds — deferring
+    it bought the turn nothing and cost the alarm up to ~20s."""
+    rt, polls = _tier0_runtime([{"label": "person", "score": 0.61}])
+    rt.interactive_busy = lambda: True          # a conversation, forever
+    rt.alarms._interval = 0.01
+    # Make the bounded-skip escape hatch unreachable within this test, so it
+    # cannot mask the property under test: the ring must come from the Tier-0
+    # check running DURING the yield, not from the yield running out. (At the
+    # real 5s interval those 4 skips are the ~20s the operator waited.)
+    rt.alarms._MAX_BUSY_SKIPS = 10_000
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        for _ in range(100):
+            if rt.alarms.list()[0]["triggered"]:
+                break
+            await asyncio.sleep(0.01)
+        data = rt.alarms.list()[0]
+        rt.alarms.stop(alarm.id)
+        assert data["triggered"] is True, (
+            "Tier-0 evidence must ring immediately, conversation or not")
+        assert not polls, "no inference may run while yielding to the turn"
+
+    asyncio.run(go())
+
+
+def test_backstop_inference_still_yields_to_the_turn_boundedly():
+    """The expensive half keeps the original yield semantics: skip while a
+    turn is active, but never more than _MAX_BUSY_SKIPS cycles — a safety
+    check must not wait out a conversation."""
+    rt, polls = _tier0_runtime([], poll_detections=[{"label": "person"}])
+    rt.context.recent_events = lambda *, camera_id, window_seconds: []
+    rt.interactive_busy = lambda: True
+    rt.alarms._interval = 0.01
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        await asyncio.sleep(0.03)                # a few cycles: still yielding
+        yielded_early = not polls
+        for _ in range(200):
+            if polls:
+                break
+            await asyncio.sleep(0.01)
+        rt.alarms.stop(alarm.id)
+        assert yielded_early, "inference should yield to the turn at first"
+        assert polls, "but a bounded number of skips later it must look anyway"
+
+    asyncio.run(go())
+
+
+def test_backstop_throttles_while_tier0_is_alive():
+    """While Tier-0 is demonstrably watching this camera, the backstop runs on
+    a clock, not every cycle — its full-frame inference was part of the load
+    that shed Tier-0's detector to near-blindness the moment a person arrived."""
+    import time
+    rt, polls = _tier0_runtime([{"label": "cat"}])   # alive, but no person
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        rt.alarms.stop(alarm.id)                 # drive _poll by hand
+        alarm.active = True
+        for _ in range(6):
+            await rt.alarms._poll(alarm, "cam1")
+        assert len(polls) == 1, (
+            f"expected one due inference then throttle, got {len(polls)}")
+        # The clock, not luck: age the stamp past the throttle and it looks again.
+        alarm.last_fallback_at["cam1"] -= rt.alarms._fallback_every + 1
+        await rt.alarms._poll(alarm, "cam1")
+        assert len(polls) == 2
+
+    asyncio.run(go())
+
+
+def test_backstop_unthrottled_when_tier0_is_silent():
+    """Silence is ambiguous — quiet scene and dead pipeline look identical —
+    so with no Tier-0 records at all the backstop keeps its full cadence."""
+    rt, polls = _tier0_runtime([], poll_detections=[])
+    rt.context.recent_events = lambda *, camera_id, window_seconds: []
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        rt.alarms.stop(alarm.id)
+        alarm.active = True
+        for _ in range(4):
+            await rt.alarms._poll(alarm, "cam1")
+        assert len(polls) == 4, (
+            f"no liveness signal -> every cycle must look, got {len(polls)}")
+
+    asyncio.run(go())
+
+
+def test_gate_audit_records_prove_liveness_for_the_throttle():
+    """A gate record has no tracks but is still proof the pipeline is up and
+    watching — an audit of a non-event. It must throttle the backstop even
+    though it can never ring the alarm."""
+    import time
+    rt, polls = _tier0_runtime([])
+    rt.context.recent_events = (
+        lambda *, camera_id, window_seconds: [_Ev(time.time(), [])])
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person", camera_ids=["cam1"])
+        rt.alarms.stop(alarm.id)
+        alarm.active = True
+        for _ in range(6):
+            await rt.alarms._poll(alarm, "cam1")
+        assert len(polls) == 1, (
+            f"gate records prove liveness; expected 1 inference, got {len(polls)}")
+
+    asyncio.run(go())

--- a/examples/camera-agent/tests/test_alarms.py
+++ b/examples/camera-agent/tests/test_alarms.py
@@ -1072,3 +1072,30 @@ def test_gate_audit_records_prove_liveness_for_the_throttle():
             f"gate records prove liveness; expected 1 inference, got {len(polls)}")
 
     asyncio.run(go())
+
+
+def test_alarm_event_carries_the_sighting_time_not_the_ring_time():
+    """The activity click seeks the recording to the event's ts. A Tier-0 ring
+    can lag its evidence by track-confirmation plus a poll interval; anchored
+    at ring time the click landed on a frame the person had already left,
+    which read as 'the alarm fired on nothing'."""
+    import time
+    rt, _polls = _tier0_runtime([])
+    seen_at = time.time() - 8.0                    # seen 8s before the ring
+    rt.context.recent_events = (
+        lambda *, camera_id, window_seconds: [_Ev(seen_at, [{"label": "person"}])])
+
+    async def go():
+        alarm = rt.alarms.create(name="Front", target="person",
+                                 camera_ids=["cam1"], ring="chime")
+        rt.alarms.stop(alarm.id)
+        alarm.active = True
+        await rt.alarms._poll(alarm, "cam1")
+        ev = rt.alarms.events()[-1]
+        assert abs(ev["ts"] - seen_at) < 0.5, (
+            f"event ts must be the sighting ({seen_at}), got {ev['ts']}")
+        # ...while the ring mechanics stay anchored at ring time, or the
+        # re-arm window would be silently shortened by the evidence lag.
+        assert alarm.last_triggered > seen_at + 5
+
+    asyncio.run(go())

--- a/examples/camera-agent/tests/test_tools.py
+++ b/examples/camera-agent/tests/test_tools.py
@@ -574,3 +574,59 @@ def test_a_failed_evidence_fetch_does_not_break_the_answer(anyio_backend=None):
     out = asyncio.run(tools.search_history({"label": "person"}))
     assert "1 person visit(s)" in out
     assert tools.last_evidence_frames == []
+
+
+# ── history + the visit still being written ─────────────────────────
+
+
+class _RingEv:
+    def __init__(self, tracks, camera_id="cam1", age=2.0):
+        import time
+        self.received_at = time.time() - age
+        self.adapter = "tier0"
+        self.camera_id = camera_id
+        self.raw = {"tracks": tracks}
+
+
+def test_history_admits_a_visit_still_in_progress(anyio_backend=None):
+    """A visit enters the store only when it ENDS. Field report: the operator
+    walked in to test, asked 'did any person come today', and was denied while
+    standing on camera — the visit was still being written. The live Tier-0
+    ring knows; the answer must say so."""
+    import asyncio
+    tools = _history_tools(_FakeEventsClient([]))
+    tools._ctx.recent_events = (
+        lambda *, camera_id, window_seconds: [_RingEv([{"label": "person"}])])
+    out = asyncio.run(tools.search_history({"label": "person"}))
+    assert "No person visits remembered" in out
+    assert "right now" in out and "still in progress" in out, out
+
+
+def test_no_in_progress_note_when_the_ring_is_quiet(anyio_backend=None):
+    import asyncio
+    tools = _history_tools(_FakeEventsClient([]))
+    tools._ctx.recent_events = lambda *, camera_id, window_seconds: []
+    out = asyncio.run(tools.search_history({"label": "person"}))
+    assert "right now" not in out
+
+
+def test_in_progress_note_matches_the_asked_label(anyio_backend=None):
+    """A cat on camera is not evidence about a person question."""
+    import asyncio
+    tools = _history_tools(_FakeEventsClient([]))
+    tools._ctx.recent_events = (
+        lambda *, camera_id, window_seconds: [_RingEv([{"label": "cat"}])])
+    out = asyncio.run(tools.search_history({"label": "person"}))
+    assert "right now" not in out
+
+
+def test_a_broken_ring_never_breaks_the_history_answer(anyio_backend=None):
+    import asyncio
+    tools = _history_tools(_FakeEventsClient([_FakeEvent(1)], crops={1: b"c"}))
+
+    def boom(*, camera_id, window_seconds):
+        raise RuntimeError("ring exploded")
+
+    tools._ctx.recent_events = boom
+    out = asyncio.run(tools.search_history({"label": "person"}))
+    assert "1 person visit(s)" in out

--- a/examples/camera-agent/tools.py
+++ b/examples/camera-agent/tools.py
@@ -970,7 +970,8 @@ class CameraTools:
                     "or the time range wasn't understood) — please try again.")
         if not events:
             window = self._window_phrase(start, end)
-            return f"No {label} visits remembered{window}."
+            return (f"No {label} visits remembered{window}."
+                    + self._in_progress_note(label, camera_arg))
 
         clauses = []
         for e in events[:10]:
@@ -982,6 +983,7 @@ class CameraTools:
                 f"[#{e.id}] {span} on camera {e.camera_id}{plate_bit}"
                 + (" (photo kept)" if e.has_evidence else "")
             )
+        live_note = self._in_progress_note(label, camera_arg)
         summary = (f"I remember {len(events)} {label} visit(s)"
                    f"{self._window_phrase(start, end)}: " + "; ".join(clauses) + ".")
 
@@ -991,6 +993,7 @@ class CameraTools:
         # extra read and turns "I saw someone at 16:25" into something the
         # operator can actually check.
         await self._attach_evidence_frames(events)
+        summary += live_note
 
         # Face-match the evidence for person questions (best-effort, capped).
         if label == "person" and bool(args.get("identify_faces", True)):
@@ -998,6 +1001,36 @@ class CameraTools:
             if names:
                 summary += " Recognised: " + ", ".join(sorted(names)) + "."
         return summary
+
+    def _in_progress_note(self, label: str, camera_arg) -> str:
+        """A visit enters the store only when it ENDS, so history alone answers
+        'did anyone come today?' with a straight no while the person is
+        literally standing on camera. Seen in the field: the operator walked in
+        to test, asked, and was denied — the visit was still being written.
+        Cross-check the live Tier-0 ring and say so.
+        """
+        try:
+            cam_filter = None
+            if camera_arg not in (None, "", "all", "__any__"):
+                cam_filter = str(camera_arg)
+            events = self._ctx.recent_events(
+                camera_id=cam_filter, window_seconds=45.0)
+        except Exception:
+            return ""            # the note is a bonus; history stays the answer
+        cams: list[str] = []
+        for ev in events or ():
+            if getattr(ev, "adapter", None) != "tier0":
+                continue
+            tracks = (getattr(ev, "raw", None) or {}).get("tracks") or []
+            if any(str(t.get("label") or "").strip().lower() == label
+                   for t in tracks if isinstance(t, dict)):
+                cam = str(getattr(ev, "camera_id", "") or "")
+                if cam and cam not in cams:
+                    cams.append(cam)
+        if not cams:
+            return ""
+        return (f" And right now a {label} IS on {', '.join(sorted(cams))} — "
+                f"that visit is still in progress and enters history when it ends.")
 
     async def _attach_evidence_frames(self, events, cap: int = 3) -> None:
         """Publish up to ``cap`` remembered best-frames onto this turn.


### PR DESCRIPTION
… stop

the backstop starving the pipeline

Field report, verified in the logs: alarm armed, operator tested it by talking to the agent, ring came >30 seconds after the person did — 'yielded 4 cycles' immediately followed by the trigger, all of them 'via poll'.

Two causes.

The interactive yield deferred the WHOLE poll, including the Tier-0 check. That check is a ring-buffer read — microseconds, no model touched — so deferring it bought the user's turn nothing and cost the alarm up to ~20s. Now only the inference yields (same 4-cycle bound as before); the Tier-0 read runs every cycle, conversation or not.

The backstop's own full-frame inference was part of the problem it existed to solve. It burns seconds of the same CPU detect-pipeline needs, every cycle, and the live logs show the consequence: the moment a person appeared, Tier-0's frame latency blew its budget (1.32s vs 0.50s), the load shedder cut its detector regions 8 -> 2, and the pipeline went half-blind exactly when it mattered — that first visit produced no tracks, no bus events, and no record in the events store at all. The alarm then had nothing to ring on except its own slow poll. So while Tier-0 is verifiably alive for a camera — ANY record within the freshness window counts, gate audits of non-events included, since they prove the pipeline is up and watching — the backstop runs on a 15s throttle instead of every cycle. Silence stays ambiguous (quiet scene and dead pipeline look identical), so with no Tier-0 records the backstop keeps its full cadence unchanged.

The trade, stated plainly: an object Tier-0 is blind to on an alive camera now waits up to ~15s + inference for the backstop instead of ~5s, in exchange for sub-cycle rings on everything Tier-0 sees (the second visit in the same logs DID ring via tier0 — first live confirmation of that path) and for not sabotaging Tier-0's detection at the worst moment.

Five new tests, each verified by sabotage: re-gating the Tier-0 check behind the yield, removing the throttle, demanding tracks for liveness, and making the yield unbounded each fail their test; the throttled/unthrottled split and the bounded yield are pinned separately.