### PR TITLE
fix(detect-pipeline): evidence crops carry context, not just the box

### DIFF
--- a/detect-pipeline/detect_pipeline/tracking.py
+++ b/detect-pipeline/detect_pipeline/tracking.py
@@ -143,13 +143,25 @@ def _coverage(inner: Box, outer: Box) -> float:
     return inter / area
 
 
-def _crop_bgr(bgr, box: Box):
-    """Clamp ``box`` to the frame and return a copied BGR crop, or None if empty."""
+def _crop_bgr(bgr, box: Box, margin: float = 0.25):
+    """Crop ``box`` plus a context margin, clamped to the frame; None if empty.
+
+    The margin is the point. This crop becomes the visit's stored EVIDENCE —
+    the photo the operator is shown when they ask "who came today?" — and the
+    bare detection box is the least legible framing of it. Field case: a
+    person leaned over a desk camera, the highest-scoring box of the visit
+    was their hands, and the evidence photo was a 163x187 crop of knuckles
+    with zero surroundings. A quarter of the box's size on every side keeps
+    the subject dominant while showing enough scene to tell WHERE they were
+    and what they were near — which is what evidence is for.
+    """
     h, w = bgr.shape[:2]
-    x1 = max(0, min(int(box[0]), w - 1))
-    y1 = max(0, min(int(box[1]), h - 1))
-    x2 = max(x1 + 1, min(int(box[2]), w))
-    y2 = max(y1 + 1, min(int(box[3]), h))
+    mx = int((int(box[2]) - int(box[0])) * margin)
+    my = int((int(box[3]) - int(box[1])) * margin)
+    x1 = max(0, min(int(box[0]) - mx, w - 1))
+    y1 = max(0, min(int(box[1]) - my, h - 1))
+    x2 = max(x1 + 1, min(int(box[2]) + mx, w))
+    y2 = max(y1 + 1, min(int(box[3]) + my, h))
     crop = bgr[y1:y2, x1:x2]
     return crop.copy() if crop.size else None
 

--- a/detect-pipeline/test/test_tracking.py
+++ b/detect-pipeline/test/test_tracking.py
@@ -107,3 +107,48 @@ def test_best_frame_tracked_per_object():
     tracks = tk.update([Detection("person", (100, 100, 160, 300), 0.80)])  # +0.20 score
     assert tracks[0].best is not None
     assert tracks[0].best.score == 0.80     # best updated to the higher-scoring frame
+
+
+# ── evidence crops carry context ───────────────────────────────────────
+
+
+def test_best_crop_includes_context_around_the_box():
+    """The crop becomes the visit's stored evidence — the photo the operator
+    sees for "who came today?". The bare detection box is the least legible
+    framing of it: field case, a person leaned over a desk camera and the
+    evidence was a 163x187 crop of their knuckles with zero surroundings."""
+    import numpy as np
+    from detect_pipeline.tracking import _crop_bgr
+
+    frame = np.zeros((1080, 1920, 3), np.uint8)
+    crop = _crop_bgr(frame, (800, 400, 1000, 700))       # 200x300 box mid-frame
+    h, w = crop.shape[:2]
+    assert w > 200 and h > 300, f"no context added: got {w}x{h}"
+    assert w == 200 + 2 * 50 and h == 300 + 2 * 75, (
+        f"expected a quarter-box margin per side, got {w}x{h}")
+
+
+def test_best_crop_margin_clamps_at_the_frame_edge():
+    """A box in a corner cannot borrow context that does not exist — the crop
+    clamps to the frame instead of failing or wrapping."""
+    import numpy as np
+    from detect_pipeline.tracking import _crop_bgr
+
+    frame = np.zeros((480, 640, 3), np.uint8)
+    crop = _crop_bgr(frame, (0, 0, 100, 100))
+    h, w = crop.shape[:2]
+    assert (w, h) == (125, 125), f"corner crop should clamp to 125x125, got {w}x{h}"
+
+    crop = _crop_bgr(frame, (540, 380, 640, 480))        # bottom-right corner
+    h, w = crop.shape[:2]
+    assert (w, h) == (125, 125), f"corner crop should clamp, got {w}x{h}"
+
+
+def test_best_crop_of_a_full_frame_box_is_the_frame():
+    """margin cannot push past the frame however large the box."""
+    import numpy as np
+    from detect_pipeline.tracking import _crop_bgr
+
+    frame = np.zeros((480, 640, 3), np.uint8)
+    crop = _crop_bgr(frame, (0, 0, 640, 480))
+    assert crop.shape[:2] == (480, 640)


### PR DESCRIPTION
Field case: a person leaned over a desk camera, the highest-scoring frame of the 3.5-second visit was a close-up of their hands, and the stored evidence — the photo the operator is shown for "who came today?" — was a 163x187 crop of knuckles with zero surroundings.

Best-frame SELECTION was not the fix: every candidate frame of that visit was a close-up, so no scoring rule picks a good one. The crop itself was the problem — the bare detection box is the least legible framing of whatever won. Cut a quarter of the box's size extra on every side, clamped to the frame: the subject stays dominant, and the photo shows where they were and what they were near, which is what evidence is for.

The margin also reaches every other best_crop consumer — the /best_frame endpoint and the Tier-1 dispatch — where context helps rather than hurts (a VLM describing a scene, a face model searching within the crop).

Pinned by tests for the margin, the corner clamp, and the full-frame box; removing the margin fails the first.