### PR TITLE
feat(observability): per-camera Tier-0 detail and the events flow, on…

### DIFF
--- a/app/src/views/AIAdapters.tsx
+++ b/app/src/views/AIAdapters.tsx
@@ -761,7 +761,29 @@ type Tier0MetricsResp = {
     detector_runs: number
     skipped_no_motion: number
     skipped_calibrating: number
+    skipped_stationary?: number
     motion_gate_ratio: number | null
+  }
+  cameras?: Array<{
+    camera: string
+    up: boolean
+    fps: number | null
+    target_fps: number | null
+    frame_age_s: number | null
+    regions_budget: number | null
+    regions_configured: number | null
+    shedding: boolean
+    regions_capped_total: number
+    tracks_active: number
+    visits_posted: number
+    visits_dropped: number
+    mainstream_fallback: boolean
+  }>
+  events_flow?: {
+    bus_events_published: number
+    visits_posted: number
+    visits_dropped: number
+    sink_errors: number
   }
   gate?: { escalations: number; suppressions: number; shadow_would_suppress: number }
   tier1?: {
@@ -967,6 +989,77 @@ function ComputeGatedPanel() {
           <StatTile label="Frames" value={(f?.total ?? 0).toLocaleString()}
             sub={`${(f?.detector_runs ?? 0).toLocaleString()} ran the detector`} />
         </div>
+
+        {/* Per-camera detail — the fleet aggregate hides exactly the camera
+            that is struggling. "Regions 3/8 · shedding" is the load-shedder
+            protecting the stream by detecting less; "main stream" flags the
+            5x-decode-cost misconfiguration the operator can actually fix. */}
+        {(d.cameras?.length ?? 0) > 0 && (
+          <div className="border border-[var(--border)] rounded bg-[var(--bg-2)] p-3 overflow-x-auto">
+            <div className="text-[11px] uppercase tracking-wider text-[var(--text-dim)] mb-2 font-mono">
+              Cameras
+            </div>
+            <table className="w-full font-mono text-xs">
+              <thead>
+                <tr className="text-[var(--text-dim)] text-left">
+                  <th className="pr-4 pb-1 font-normal">camera</th>
+                  <th className="pr-4 pb-1 font-normal">fps</th>
+                  <th className="pr-4 pb-1 font-normal">frame age</th>
+                  <th className="pr-4 pb-1 font-normal">regions</th>
+                  <th className="pr-4 pb-1 font-normal">tracks</th>
+                  <th className="pr-4 pb-1 font-normal">visits</th>
+                  <th className="pb-1 font-normal">flags</th>
+                </tr>
+              </thead>
+              <tbody>
+                {d.cameras!.map((c) => {
+                  const fpsLow = c.fps != null && c.target_fps != null && c.target_fps > 0 && c.fps / c.target_fps < 0.9
+                  return (
+                    <tr key={c.camera} className="border-t border-[var(--border)]">
+                      <td className="pr-4 py-1">
+                        <span className={c.up ? '' : 'text-red-400'}>{c.camera}{c.up ? '' : ' (down)'}</span>
+                      </td>
+                      <td className={`pr-4 py-1 tabular-nums ${fpsLow ? 'text-amber-400' : ''}`}>
+                        {c.fps ?? '—'}{c.target_fps != null ? ` / ${c.target_fps}` : ''}
+                      </td>
+                      <td className="pr-4 py-1 tabular-nums">
+                        {c.frame_age_s != null ? `${c.frame_age_s}s` : '—'}
+                      </td>
+                      <td className={`pr-4 py-1 tabular-nums ${c.shedding ? 'text-amber-400' : ''}`}>
+                        {c.regions_budget ?? '—'}{c.regions_configured != null ? ` / ${c.regions_configured}` : ''}
+                        {c.shedding ? ' · shedding' : ''}
+                      </td>
+                      <td className="pr-4 py-1 tabular-nums">{c.tracks_active}</td>
+                      <td className={`pr-4 py-1 tabular-nums ${c.visits_dropped > 0 ? 'text-amber-400' : ''}`}>
+                        {c.visits_posted.toLocaleString()}
+                        {c.visits_dropped > 0 ? ` (+${c.visits_dropped} dropped)` : ''}
+                      </td>
+                      <td className="py-1">
+                        {c.mainstream_fallback && <Badge variant="warning">main stream</Badge>}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Outputs leaving the pipeline — detections becoming NATS events (what
+            alarms and apps consume) and finished visits becoming history rows.
+            Zero here while detections climb is "detected but nobody was told". */}
+        {d.events_flow && (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            <StatTile label="Bus events" value={d.events_flow.bus_events_published.toLocaleString()}
+              sub="published to NATS (alarms, apps)" />
+            <StatTile label="Visits posted" value={d.events_flow.visits_posted.toLocaleString()}
+              sub="written to history" />
+            <StatTile label="Visits dropped" value={d.events_flow.visits_dropped.toLocaleString()}
+              sub="lost before history" warn={d.events_flow.visits_dropped > 0} />
+            <StatTile label="Sink errors" value={d.events_flow.sink_errors.toLocaleString()}
+              sub="event-store write failures" warn={d.events_flow.sink_errors > 0} />
+          </div>
+        )}
 
         {/* Detector model — speed + output volume, the aspects you A/B two models on */}
         {d.detector && (

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -534,6 +534,13 @@ class CameraWorker:
             "tier0_regions_budget", float(budget.current),
             {"camera": self.spec.camera_id},
         )
+        # The budget gauge alone is unreadable on a dashboard — "3" is only
+        # meaningful against what was configured. Export the ceiling once so
+        # the UI can render "3 / 8" and flag a shed camera at a glance.
+        _metrics.gauge(
+            "tier0_regions_configured", float(budget.configured),
+            {"camera": self.spec.camera_id},
+        )
         prev_seq: int | None = None
         win_t0 = time.monotonic()
         win_n = 0

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -775,3 +775,36 @@ def test_pinned_cv_threads_are_never_retuned():
     finally:
         svc.os.cpu_count = original
         sys.modules.pop("cv2", None)
+
+
+def test_worker_exports_the_region_ceiling_beside_the_budget(monkeypatch):
+    """The budget gauge alone is unreadable on a dashboard — "3" means nothing
+    without the ceiling it is being held under. The worker must export both,
+    per camera, so the UI can render "3 / 8" and flag a shed camera."""
+    import detect_pipeline.motion as motion_mod
+    from detect_pipeline.metrics import metrics as _m
+
+    real_detect = motion_mod.MotionDetector.detect
+
+    def fake_detect(self, luma):
+        real_detect(self, luma)
+        self.calibrating = False
+        return [(80, 60, 160, 200)]
+
+    monkeypatch.setattr(motion_mod.MotionDetector, "detect", fake_detect)
+
+    worker = CameraWorker(
+        _spec("cam-gauges"), _FakeSink(),
+        detector=_MotionAllDetector(), frame_source=_FramesSource(2),
+    )
+    worker.start()
+    for _ in range(50):
+        text = _m.render()
+        if 'tier0_regions_configured{camera="cam-gauges"}' in text:
+            break
+        time.sleep(0.02)
+    worker.stop()
+
+    text = _m.render()
+    assert 'tier0_regions_budget{camera="cam-gauges"}' in text
+    assert 'tier0_regions_configured{camera="cam-gauges"}' in text

--- a/server/services/tier0_metrics.py
+++ b/server/services/tier0_metrics.py
@@ -101,6 +101,15 @@ def _sums_grouped_by(samples: list[Sample], name: str, label: str) -> dict[str, 
     return out
 
 
+def _by_camera(samples: list[Sample], name: str) -> dict[str, float]:
+    """Latest value of a per-camera family, keyed by camera label."""
+    out: dict[str, float] = {}
+    for s in samples:
+        if s.name == name and "camera" in s.labels:
+            out[s.labels["camera"]] = s.value
+    return out
+
+
 def _dominant_label(samples: list[Sample], name: str, label: str) -> str | None:
     """The label value carrying the most weight (e.g. the active detector model)."""
     grouped = _sums_grouped_by(samples, name, label)
@@ -149,6 +158,7 @@ def reduce_metrics(samples: list[Sample]) -> dict[str, Any]:
     runs = _sum(samples, "tier0_detector_runs_total")
     skipped_motion = _sum_by_label(samples, "tier0_detector_skipped_total", "reason", "no_motion")
     skipped_calib = _sum_by_label(samples, "tier0_detector_skipped_total", "reason", "calibrating")
+    skipped_stationary = _sum(samples, "tier0_stationary_skipped_total")
     denom = runs + skipped_motion  # calibrating frames aren't a gate decision
     motion_gate_ratio = (skipped_motion / denom) if denom > 0 else None
 
@@ -192,6 +202,45 @@ def reduce_metrics(samples: list[Sample]) -> dict[str, Any]:
            if s.name == "tier0_target_fps" and "camera" in s.labels}
     ratios = {c: proc[c] / tgt[c] for c in proc if tgt.get(c, 0) > 0}
     worst_cam = min(ratios, key=ratios.get) if ratios else None
+    # Per-camera detail — the fleet aggregate hides exactly the signals that
+    # matter when ONE camera is struggling. Every one of these earned its
+    # place in a live debugging session: the region budget pinned below its
+    # ceiling is the load-shedding signature (the pipeline is protecting the
+    # stream by detecting less); frame age says whether frames are fresh;
+    # visits dropped and a main-stream fallback are misconfigurations the
+    # operator can actually fix.
+    frame_age = _by_camera(samples, "tier0_frame_age_seconds")
+    budget_now = _by_camera(samples, "tier0_regions_budget")
+    budget_cfg = _by_camera(samples, "tier0_regions_configured")
+    tracks_act = _by_camera(samples, "tier0_tracks_active")
+    mainstream = _by_camera(samples, "tier0_mainstream_fallback")
+    visits_ok = _by_camera(samples, "tier0_visits_posted_total")
+    visits_drop = _by_camera(samples, "tier0_visits_dropped_total")
+    capped = _by_camera(samples, "tier0_regions_capped_total")
+    up_by_cam = _by_camera(samples, "tier0_worker_up")
+    all_cams = sorted(set(proc) | set(tgt) | set(up_by_cam) | set(frame_age))
+    cameras = []
+    for cam in all_cams:
+        b = budget_now.get(cam)
+        c = budget_cfg.get(cam)
+        cameras.append({
+            "camera": cam,
+            "up": bool(up_by_cam.get(cam, 0) >= 1.0),
+            "fps": round(proc[cam], 2) if cam in proc else None,
+            "target_fps": round(tgt[cam], 2) if cam in tgt else None,
+            "frame_age_s": round(frame_age[cam], 2) if cam in frame_age else None,
+            "regions_budget": None if b is None else int(b),
+            "regions_configured": None if c is None else int(c),
+            # Shedding = the budget is currently held below its ceiling.
+            # Only claimable when BOTH numbers exist; absence is not evidence.
+            "shedding": (b is not None and c is not None and b < c),
+            "regions_capped_total": int(capped.get(cam, 0)),
+            "tracks_active": int(tracks_act.get(cam, 0)),
+            "visits_posted": int(visits_ok.get(cam, 0)),
+            "visits_dropped": int(visits_drop.get(cam, 0)),
+            "mainstream_fallback": bool(mainstream.get(cam, 0) >= 1.0),
+        })
+
     health = {
         "workers_up": workers_up,
         "workers_total": len([c for c in worker_cams if c is not None]),
@@ -236,7 +285,20 @@ def reduce_metrics(samples: list[Sample]) -> dict[str, Any]:
             "detector_runs": int(runs),
             "skipped_no_motion": int(skipped_motion),
             "skipped_calibrating": int(skipped_calib),
+            "skipped_stationary": int(skipped_stationary),
             "motion_gate_ratio": motion_gate_ratio,
+        },
+        "cameras": cameras,
+        # The pipeline's outputs actually LEAVING it: detections become NATS
+        # events (what alarms and apps consume) and finished visits become
+        # events-store rows (what history answers from). Zero here while
+        # detections climb is the "detected but nobody was told" failure —
+        # observed live, and invisible until these were surfaced.
+        "events_flow": {
+            "bus_events_published": int(_sum(samples, "tier0_events_published_total")),
+            "visits_posted": int(_sum(samples, "tier0_visits_posted_total")),
+            "visits_dropped": int(_sum(samples, "tier0_visits_dropped_total")),
+            "sink_errors": int(_sum(samples, "tier0_sink_errors_total")),
         },
         "gate": {
             "escalations": int(escalations),

--- a/server/tests/test_tier0_metrics.py
+++ b/server/tests/test_tier0_metrics.py
@@ -271,3 +271,84 @@ def test_promotion_handles_no_data_gracefully():
                            shadow_since_iso=None)
     assert p == {"override": None, "shadow_since": None, "shadow_days": None,
                  "would_save_ratio": None, "ready": False}
+
+
+# ── per-camera detail + events flow ──────────────────────────────────
+# Every series here earned its place in a live debugging session: the region
+# budget pinned below its ceiling is the load-shedding signature, and zero
+# bus events while detections climb is the "detected but nobody was told"
+# failure. The fleet aggregate hides exactly the camera that is struggling.
+
+PER_CAMERA_TEXT = """
+tier0_worker_up{camera="cam1"} 1
+tier0_worker_up{camera="cam2"} 1
+tier0_processing_fps{camera="cam1"} 1.96
+tier0_processing_fps{camera="cam2"} 5.0
+tier0_target_fps{camera="cam1"} 2
+tier0_target_fps{camera="cam2"} 5
+tier0_frame_age_seconds{camera="cam1"} 0.15
+tier0_frame_age_seconds{camera="cam2"} 0.4
+tier0_regions_budget{camera="cam1"} 3
+tier0_regions_configured{camera="cam1"} 8
+tier0_regions_budget{camera="cam2"} 8
+tier0_regions_configured{camera="cam2"} 8
+tier0_regions_capped_total{camera="cam1"} 415
+tier0_tracks_active{camera="cam1"} 2
+tier0_mainstream_fallback{camera="cam1"} 1
+tier0_visits_posted_total{camera="cam1"} 7
+tier0_visits_dropped_total{camera="cam1"} 1
+tier0_events_published_total{camera="cam1"} 292
+tier0_sink_errors_total{camera="cam1"} 3
+tier0_stationary_skipped_total{camera="cam1"} 44
+tier0_frames_total{camera="cam1"} 1000
+"""
+
+
+def test_per_camera_rows_surface_the_struggling_camera():
+    r = reduce_metrics(parse_prometheus_text(PER_CAMERA_TEXT))
+    cams = {c["camera"]: c for c in r["cameras"]}
+    assert set(cams) == {"cam1", "cam2"}
+
+    c1 = cams["cam1"]
+    assert c1["up"] is True
+    assert c1["fps"] == 1.96 and c1["target_fps"] == 2
+    assert c1["frame_age_s"] == 0.15
+    # The load-shedding signature: budget held below its ceiling.
+    assert c1["regions_budget"] == 3 and c1["regions_configured"] == 8
+    assert c1["shedding"] is True
+    assert c1["regions_capped_total"] == 415
+    assert c1["tracks_active"] == 2
+    assert c1["visits_posted"] == 7 and c1["visits_dropped"] == 1
+    assert c1["mainstream_fallback"] is True
+
+    c2 = cams["cam2"]
+    assert c2["shedding"] is False
+    assert c2["mainstream_fallback"] is False
+
+
+def test_shedding_needs_both_numbers_absence_is_not_evidence():
+    """A pipeline predating the configured gauge must not be labelled as
+    shedding (or as healthy) off a missing number."""
+    text = 'tier0_worker_up{camera="cam1"} 1\ntier0_regions_budget{camera="cam1"} 3\n'
+    r = reduce_metrics(parse_prometheus_text(text))
+    row = r["cameras"][0]
+    assert row["regions_budget"] == 3
+    assert row["regions_configured"] is None
+    assert row["shedding"] is False
+
+
+def test_events_flow_rollup():
+    r = reduce_metrics(parse_prometheus_text(PER_CAMERA_TEXT))
+    assert r["events_flow"] == {
+        "bus_events_published": 292,
+        "visits_posted": 7,
+        "visits_dropped": 1,
+        "sink_errors": 3,
+    }
+    assert r["frames"]["skipped_stationary"] == 44
+
+
+def test_no_cameras_yields_empty_list_not_a_crash():
+    r = reduce_metrics(parse_prometheus_text("tier0_frames_total 5\n"))
+    assert r["cameras"] == []
+    assert r["events_flow"]["bus_events_published"] == 0


### PR DESCRIPTION
… the AI page

"We have to make the metrics and display them in OpenNVR — motion gating, detections, VLM inferences, latencies." The inventory found most of it already built: the pipeline exports 33 series, every adapter exports the SDK's infer/latency/queue series (VLM included), KAI-C rolls the fleet up, and the AI Adapters page renders adapters AND a Tier-0 panel with motion gating, detections by class, stage latencies, and gate decisions.

What was missing was 18 pipeline series the server parser never read — and they are precisely the ones a live debugging session needed and could not see in the UI:

* Per-camera table: fps vs target, frame age, region budget vs its ceiling ("3 / 8 · shedding" is the load shedder protecting the stream by detecting less — invisible in any fleet aggregate), active tracks, visits posted/dropped, worker up, and a "main stream" badge for the 5x-decode-cost misconfiguration the operator can actually fix.
* Events flow: bus events published (what alarms and apps consume) and visits posted/dropped/sink errors (what history answers from). Zero here while detections climb is the "detected but nobody was told" failure — observed live, invisible until now.
* frames.skipped_stationary joins the motion-gating story.

The pipeline grows one gauge to make the table readable: tier0_regions_configured beside tier0_regions_budget, because "3" means nothing without the ceiling it is being held under. Shedding is only claimed when BOTH numbers exist — a pipeline predating the gauge is not labelled off a missing value.

Tests: pipeline (real CameraWorker exports both gauges; 362 pass), server (per-camera rows, the shedding signature, absence-is-not-evidence, events flow, empty fleet; 17 pass), frontend typechecks clean (the one tsc error in the repo pre-exists on main, in a file this change does not touch). Sabotage-verified: dropping the new gauge fails the worker test; forcing shedding=false fails the parser test.