### PR TITLE
feat(detect-pipeline): export the decode config a camera is actually …

### DIFF
--- a/detect-pipeline/detect_pipeline/metrics.py
+++ b/detect-pipeline/detect_pipeline/metrics.py
@@ -20,6 +20,7 @@ pipeline/gate core stays metric-free and unit-testable. Names follow
     gate_suppressions_total{camera,reason}             counter
     gate_shadow_would_suppress_total{camera}           counter
     tier0_frame_latency_seconds{camera}                histogram
+    tier0_decode_config{camera,skip,threads,fast,hwaccel,idle}  info (always 1)
 
 Derived KPIs (compute in Prometheus/Grafana or the benchmark harness):
 motion-gate ratio = skipped / (runs + skipped); expensive-call reduction =
@@ -111,6 +112,25 @@ class Metrics:
         with self._lock:
             for store in (self._counters, self._gauges, self._hist):
                 for key in [k for k in store if pair in k[1]]:
+                    store.pop(key, None)
+                    removed += 1
+        return removed
+
+    def drop_series(self, name: str, label: str, value: str) -> int:
+        """Remove every series of ONE metric carrying ``label=value``.
+
+        Narrower than ``drop_label``, and it exists for info-metrics: their
+        payload lives in the LABELS, so re-emitting after a config change
+        mints a second series instead of updating the first. Both would then
+        render — one describing a decode config that no longer exists —
+        which is worse than not exporting the config at all. Callers
+        drop-then-set to keep exactly one series per camera.
+        """
+        pair = (label, value)
+        removed = 0
+        with self._lock:
+            for store in (self._counters, self._gauges, self._hist):
+                for key in [k for k in store if k[0] == name and pair in k[1]]:
                     store.pop(key, None)
                     removed += 1
         return removed
@@ -343,6 +363,56 @@ def record_worker_state(camera_id: str, up: bool, *, target_fps: float | None = 
     metrics.gauge("tier0_worker_up", 1.0 if up else 0.0, {"camera": camera_id})
     if target_fps is not None:
         metrics.gauge("tier0_target_fps", float(target_fps), {"camera": camera_id})
+
+
+def record_decode_config(
+    camera_id: str,
+    *,
+    skip: str,
+    threads: int,
+    fast: bool,
+    hwaccel: str,
+    idle: str | None,
+) -> None:
+    """Export the decode configuration this camera is ACTUALLY running under.
+
+    Every other decode saving is measurable — ``tier0_decode_idle`` says
+    whether a camera is in cheap keyframe-only mode right now,
+    ``tier0_regions_budget`` says where the shedder settled — but the static
+    dials that shape the dominant cost (decode) were only ever logged at
+    worker start. From a dashboard there was no way to answer "is this camera
+    really running noref on 2 threads, or did a typo fall back?", and the
+    fallbacks are deliberately silent: an invalid DECODE_SKIP degrades to a
+    safe default (see run.py), and hwaccel downgrades to CPU when the device
+    is unusable. That is exactly the state worth seeing — a camera whose
+    config says ``vaapi`` while its decode says ``cpu`` is the difference
+    between ~0.3 and ~2 cores, and #306 shipped a decode token that no
+    dashboard could have contradicted.
+
+    Prometheus info-metric convention: the value is always 1 and the payload
+    is the label set, so it joins onto the numeric series in a query —
+    e.g. ``tier0_process_cpu_percent * on(camera) group_left(skip,hwaccel)
+    tier0_decode_config``.
+
+    ``hwaccel`` must be the EFFECTIVE backend (after any downgrade), not the
+    requested one — reporting the request would re-hide the fallback this
+    metric exists to reveal.
+    """
+    labels = {
+        "camera": camera_id,
+        "skip": str(skip or "none"),
+        "threads": str(int(threads)),
+        "fast": "true" if fast else "false",
+        "hwaccel": str(hwaccel or "cpu"),
+        # "off" rather than an empty label: an absent value reads as "unknown"
+        # in a query, and adaptive decode being OFF is a definite answer.
+        "idle": str(idle or "off"),
+    }
+    # Drop-then-set: a worker restarting under changed config (reconcile, an
+    # edited .env, an hwaccel downgrade on the second attempt) must REPLACE
+    # its series, never accumulate a second one describing the old world.
+    metrics.drop_series("tier0_decode_config", "camera", camera_id)
+    metrics.gauge("tier0_decode_config", 1.0, labels)
 
 
 def record_worker_restart(camera_id: str) -> None:

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -40,6 +40,7 @@ from .metrics import (
     record_frame,
     record_gate,
     record_processing_fps,
+    record_decode_config,
     record_mainstream_fallback,
     record_published,
     record_sink_error,
@@ -484,6 +485,18 @@ class CameraWorker:
         # the README's "why is my CPU high" section can point at it.
         mainstream = (w or 0) * (h or 0) > 1280 * 720
         record_mainstream_fallback(self.spec.camera_id, mainstream)
+        # Publish the decode dials this camera actually opened with. Emitted
+        # HERE — after the source opened — so the hwaccel label carries the
+        # EFFECTIVE backend (resolve_hwaccel may have downgraded to CPU),
+        # which is the discrepancy the metric exists to surface.
+        record_decode_config(
+            self.spec.camera_id,
+            skip=self.decode_skip,
+            threads=self.decode_threads,
+            fast=self.fast_decode,
+            hwaccel=self._effective_hwaccel().value,
+            idle=self.decode_idle,
+        )
         if mainstream:
             log.warning(
                 "tier0 %s: decoding a %dx%d stream — this looks like a MAIN "

--- a/detect-pipeline/test/test_metrics.py
+++ b/detect-pipeline/test/test_metrics.py
@@ -291,3 +291,118 @@ def test_track_population_gauge_shows_what_the_cap_counts():
     assert m.metrics.value("tier0_tracks_active", cam) == 2.0
     assert m.metrics.value("tier0_tracks_population", cam) == 7.0
     m.metrics.reset()
+
+
+# ── tier0_decode_config: the static decode dials, made scrapeable ──────
+#
+# Every DYNAMIC decode saving already had a metric (tier0_decode_idle,
+# tier0_regions_budget). The static dials that shape the dominant cost —
+# skip token, decoder threads, fast-decode, effective hwaccel — were only
+# logged at worker start, so no dashboard could contradict a silent
+# fallback. #306 shipped an invalid skip token; nothing exported would
+# have shown it.
+
+def _decode_labels(m: Metrics, camera: str = "cam1") -> dict:
+    """The one tier0_decode_config series for a camera, as a label dict."""
+    found = [
+        dict(key[1]) for key in m._gauges
+        if key[0] == "tier0_decode_config" and ("camera", camera) in key[1]
+    ]
+    assert len(found) <= 1, f"expected at most one series, got {found}"
+    return found[0] if found else {}
+
+
+def test_decode_config_exports_the_effective_dials(monkeypatch):
+    from detect_pipeline import metrics as mod
+
+    m = Metrics()
+    monkeypatch.setattr(mod, "metrics", m)
+    mod.record_decode_config(
+        "cam1", skip="nonref", threads=2, fast=False, hwaccel="cpu", idle="nokey",
+    )
+    labels = _decode_labels(m)
+    assert labels == {
+        "camera": "cam1", "skip": "nonref", "threads": "2",
+        "fast": "false", "hwaccel": "cpu", "idle": "nokey",
+    }
+    # Info-metric convention: the value carries nothing, the labels do.
+    assert m.value("tier0_decode_config", labels) == 1.0
+
+
+def test_decode_config_replaces_its_series_when_config_changes(monkeypatch):
+    # The bug this guards: an info-metric's payload is its LABELS, so a
+    # worker restarting under changed config would mint a SECOND series and
+    # /metrics would render two answers — one describing a decode config
+    # that no longer exists.
+    from detect_pipeline import metrics as mod
+
+    m = Metrics()
+    monkeypatch.setattr(mod, "metrics", m)
+    mod.record_decode_config(
+        "cam1", skip="nonref", threads=2, fast=False, hwaccel="vaapi", idle="nokey",
+    )
+    # Second open: the GPU turned out unusable and decode fell back to CPU.
+    mod.record_decode_config(
+        "cam1", skip="nonref", threads=2, fast=False, hwaccel="cpu", idle="nokey",
+    )
+    series = [k for k in m._gauges if k[0] == "tier0_decode_config"]
+    assert len(series) == 1, "config change must replace, never accumulate"
+    assert _decode_labels(m)["hwaccel"] == "cpu"
+
+
+def test_decode_config_is_per_camera(monkeypatch):
+    from detect_pipeline import metrics as mod
+
+    m = Metrics()
+    monkeypatch.setattr(mod, "metrics", m)
+    mod.record_decode_config(
+        "cam1", skip="nonref", threads=2, fast=False, hwaccel="cpu", idle="nokey",
+    )
+    mod.record_decode_config(
+        "cam2", skip="nokey", threads=4, fast=True, hwaccel="vaapi", idle=None,
+    )
+    assert _decode_labels(m, "cam1")["skip"] == "nonref"
+    cam2 = _decode_labels(m, "cam2")
+    assert cam2["skip"] == "nokey" and cam2["threads"] == "4"
+    assert cam2["fast"] == "true"
+    # Adaptive decode OFF is a definite answer, not an absent label.
+    assert cam2["idle"] == "off"
+
+
+def test_decode_config_renders_in_prometheus_text(monkeypatch):
+    from detect_pipeline import metrics as mod
+
+    m = Metrics()
+    monkeypatch.setattr(mod, "metrics", m)
+    mod.record_decode_config(
+        "cam1", skip="noref", threads=2, fast=False, hwaccel="cpu", idle="nokey",
+    )
+    text = m.render()
+    assert "tier0_decode_config{" in text
+    assert 'skip="noref"' in text and 'hwaccel="cpu"' in text
+
+
+def test_forget_camera_still_clears_the_config_series(monkeypatch):
+    # A deleted camera must not keep describing a decode config forever —
+    # the same staleness drop_label() was introduced for.
+    from detect_pipeline import metrics as mod
+
+    m = Metrics()
+    monkeypatch.setattr(mod, "metrics", m)
+    mod.record_decode_config(
+        "cam1", skip="nonref", threads=2, fast=False, hwaccel="cpu", idle="nokey",
+    )
+    mod.forget_camera("cam1")
+    assert _decode_labels(m) == {}
+
+
+def test_drop_series_only_touches_the_named_metric():
+    m = Metrics()
+    m.gauge("tier0_decode_config", 1.0, {"camera": "cam1", "skip": "nonref"})
+    m.gauge("tier0_worker_up", 1.0, {"camera": "cam1"})
+    m.inc("tier0_frames_total", {"camera": "cam1"})
+    assert m.drop_series("tier0_decode_config", "camera", "cam1") == 1
+    # Neighbours on the same camera survive — that is the whole point of the
+    # narrower helper next to drop_label().
+    assert m.value("tier0_worker_up", {"camera": "cam1"}) == 1.0
+    assert m.value("tier0_frames_total", {"camera": "cam1"}) == 1.0

--- a/detect-pipeline/test/test_service.py
+++ b/detect-pipeline/test/test_service.py
@@ -808,3 +808,60 @@ def test_worker_exports_the_region_ceiling_beside_the_budget(monkeypatch):
     text = _m.render()
     assert 'tier0_regions_budget{camera="cam-gauges"}' in text
     assert 'tier0_regions_configured{camera="cam-gauges"}' in text
+
+
+# ── tier0_decode_config carries the EFFECTIVE decode backend ───────────
+
+def test_decode_config_metric_reports_the_hwaccel_actually_used(monkeypatch):
+    """A camera configured for GPU decode that silently fell back to CPU must
+    say ``cpu`` on /metrics.
+
+    This is the whole reason the metric exists: resolve_hwaccel() downgrades
+    to CPU when the device is unusable (missing render node, no driver), and
+    the only previous evidence was one WARNING line at worker start. An
+    operator watching a dashboard would see the configured intent, not the
+    ~5x-more-expensive reality. Reporting ``self.hwaccel`` (the REQUEST)
+    instead of the resolved backend re-hides exactly that.
+    """
+    import detect_pipeline.motion as motion_mod
+    import detect_pipeline.service as service_mod
+    from detect_pipeline.ffmpeg_presets import HwAccel
+    from detect_pipeline.metrics import metrics
+
+    real_detect = motion_mod.MotionDetector.detect
+
+    def fake_detect(self, luma):
+        real_detect(self, luma)
+        self.calibrating = False
+        return [(80, 60, 160, 200)]
+
+    monkeypatch.setattr(motion_mod.MotionDetector, "detect", fake_detect)
+    # The GPU the operator asked for is unusable here.
+    monkeypatch.setattr(
+        service_mod, "resolve_hwaccel",
+        lambda requested, device=None: (HwAccel.CPU, "no render node"),
+    )
+    metrics.drop_series("tier0_decode_config", "camera", "cam-gpu")
+
+    sink = _FakeSink()
+    worker = CameraWorker(
+        _spec("cam-gpu"), sink,
+        detector=_MotionAllDetector(), frame_source=_FramesSource(2),
+        hwaccel="vaapi",
+    )
+    worker.start()
+    for _ in range(50):
+        if sink.events:
+            break
+        time.sleep(0.02)
+    worker.stop()
+
+    series = [
+        dict(key[1]) for key in metrics._gauges
+        if key[0] == "tier0_decode_config" and ("camera", "cam-gpu") in key[1]
+    ]
+    assert len(series) == 1, "exactly one decode-config series per camera"
+    assert series[0]["hwaccel"] == "cpu", (
+        "the metric must report the EFFECTIVE backend after a downgrade — "
+        "reporting the requested 'vaapi' hides the fallback it exists to show"
+    )

--- a/docs/DETECT_CPU.md
+++ b/docs/DETECT_CPU.md
@@ -110,6 +110,38 @@ reconstructing pixels at all); it's research-grade and noted on the
 [roadmap](ROADMAP.md) horizon, not needed while the dials above still leave
 headroom.
 
+## Verifying what a camera is actually doing
+
+Every dial above is exported, so a dashboard can answer "is this camera
+really running what I configured?" without reading container logs:
+
+| Signal | Metric |
+|---|---|
+| The static decode dials in force | `tier0_decode_config{camera,skip,threads,fast,hwaccel,idle}` |
+| Currently in cheap keyframe-only mode? | `tier0_decode_idle{camera}` (1 = idle) |
+| Adaptive decode flapping? | `tier0_decode_mode_changes_total{camera}` |
+| Decoding a main stream by mistake | `tier0_mainstream_fallback{camera}` |
+| Detector work avoided by the motion gate | `tier0_detector_skipped_total{camera,reason}` |
+| Detector work avoided by stationary gating | `tier0_stationary_skipped_total{camera}` |
+| Where the load shedder settled | `tier0_regions_budget` vs `tier0_regions_configured` |
+| What it all cost | `tier0_process_cpu_percent`, `tier0_frame_latency_seconds` |
+
+`tier0_decode_config` is a Prometheus info-metric — its value is always 1
+and the payload is the labels, so it joins onto the numeric series:
+
+```promql
+tier0_process_cpu_percent
+  * on(camera) group_left(skip, hwaccel) tier0_decode_config
+```
+
+It reports the **effective** backend, not the requested one. A camera
+configured for `vaapi` whose GPU turned out unusable reports
+`hwaccel="cpu"` — that downgrade is silent apart from one startup warning,
+and it is the difference between ~0.3 and ~2 cores. The same applies to an
+invalid `DETECT_DECODE_SKIP`, which degrades to a safe default rather than
+refusing to start. OpenNVR's own AI page shows this per camera beside the
+load signals.
+
 ## If your detect container is still hot, in order
 
 1. Is a camera decoding its main stream? (`tier0_mainstream_fallback` on

--- a/server/services/tier0_metrics.py
+++ b/server/services/tier0_metrics.py
@@ -110,6 +110,36 @@ def _by_camera(samples: list[Sample], name: str) -> dict[str, float]:
     return out
 
 
+def _labels_by_camera(samples: list[Sample], name: str) -> dict[str, dict]:
+    """Label sets of an info-metric family, keyed by camera.
+
+    Info-metrics (value always 1) carry their payload in the LABELS, so
+    ``_by_camera`` — which keeps the value — reads nothing useful from them.
+    """
+    out: dict[str, dict] = {}
+    for s in samples:
+        if s.name == name and "camera" in s.labels:
+            out[s.labels["camera"]] = dict(s.labels)
+    return out
+
+
+def _decode_row(labels: dict | None) -> dict | None:
+    """Shape one camera's decode config for the API, or None if unreported."""
+    if not labels:
+        return None
+    try:
+        threads = int(labels.get("threads", "0"))
+    except ValueError:                      # a malformed scrape is not a crash
+        threads = 0
+    return {
+        "skip": labels.get("skip") or "none",
+        "threads": threads,
+        "fast": labels.get("fast") == "true",
+        "hwaccel": labels.get("hwaccel") or "cpu",
+        "idle": labels.get("idle") or "off",
+    }
+
+
 def _dominant_label(samples: list[Sample], name: str, label: str) -> str | None:
     """The label value carrying the most weight (e.g. the active detector model)."""
     grouped = _sums_grouped_by(samples, name, label)
@@ -218,6 +248,10 @@ def reduce_metrics(samples: list[Sample]) -> dict[str, Any]:
     visits_drop = _by_camera(samples, "tier0_visits_dropped_total")
     capped = _by_camera(samples, "tier0_regions_capped_total")
     up_by_cam = _by_camera(samples, "tier0_worker_up")
+    # The decode dials this camera actually opened with. Sits next to the
+    # struggling-camera signals on purpose: "cam3 is shedding" and "cam3 is
+    # decoding on the CPU with skip=none" is one answer, not two lookups.
+    decode_cfg = _labels_by_camera(samples, "tier0_decode_config")
     all_cams = sorted(set(proc) | set(tgt) | set(up_by_cam) | set(frame_age))
     cameras = []
     for cam in all_cams:
@@ -239,6 +273,10 @@ def reduce_metrics(samples: list[Sample]) -> dict[str, Any]:
             "visits_posted": int(visits_ok.get(cam, 0)),
             "visits_dropped": int(visits_drop.get(cam, 0)),
             "mainstream_fallback": bool(mainstream.get(cam, 0) >= 1.0),
+            # None when the pipeline predates the metric — an older
+            # detect-pipeline image against a newer core must render as
+            # "unknown", never as a fabricated default config.
+            "decode": _decode_row(decode_cfg.get(cam)),
         })
 
     health = {

--- a/server/tests/test_tier0_metrics.py
+++ b/server/tests/test_tier0_metrics.py
@@ -352,3 +352,44 @@ def test_no_cameras_yields_empty_list_not_a_crash():
     r = reduce_metrics(parse_prometheus_text("tier0_frames_total 5\n"))
     assert r["cameras"] == []
     assert r["events_flow"]["bus_events_published"] == 0
+
+
+# ── per-camera decode config (tier0_decode_config info-metric) ─────────
+
+def test_camera_row_carries_the_decode_config():
+    """The dials that shape decode cost land next to the struggling-camera
+    signals, so "cam1 is shedding" and "cam1 decodes on CPU with skip=none"
+    are one answer rather than two lookups."""
+    text = (
+        'tier0_worker_up{camera="cam1"} 1\n'
+        'tier0_decode_config{camera="cam1",skip="nonref",threads="2",'
+        'fast="false",hwaccel="vaapi",idle="nokey"} 1\n'
+    )
+    snap = reduce_metrics(parse_prometheus_text(text))
+    (cam,) = snap["cameras"]
+    assert cam["decode"] == {
+        "skip": "nonref", "threads": 2, "fast": False,
+        "hwaccel": "vaapi", "idle": "nokey",
+    }
+
+
+def test_missing_decode_config_reads_as_unknown_not_a_default():
+    """An older detect-pipeline image against a newer core reports nothing
+    here. None is the honest answer — inventing 'cpu/none' would put a
+    fabricated config on the page and send an operator chasing a dial that
+    was never set."""
+    snap = reduce_metrics(parse_prometheus_text('tier0_worker_up{camera="cam1"} 1\n'))
+    (cam,) = snap["cameras"]
+    assert cam["decode"] is None
+
+
+def test_decode_config_survives_a_malformed_thread_count():
+    text = (
+        'tier0_worker_up{camera="cam1"} 1\n'
+        'tier0_decode_config{camera="cam1",skip="noref",threads="oops",'
+        'fast="true",hwaccel="cpu",idle="off"} 1\n'
+    )
+    snap = reduce_metrics(parse_prometheus_text(text))
+    (cam,) = snap["cameras"]
+    assert cam["decode"]["threads"] == 0        # degraded, not a 500
+    assert cam["decode"]["fast"] is True


### PR DESCRIPTION
…running

Every DYNAMIC decode saving was already measurable — tier0_decode_idle says whether a camera is in cheap keyframe-only mode right now, tier0_regions_budget says where the load shedder settled — but the STATIC dials that shape the dominant cost were only logged at worker start. From a dashboard there was no way to answer 'is this camera really running noref on 2 threads, or did something fall back?', and the fallbacks are deliberately silent by design: an invalid DETECT_DECODE_SKIP degrades to a safe default rather than refusing to boot, and hwaccel downgrades to CPU when the device is unusable — the difference between ~0.3 and ~2 cores. #306 shipped a decode token no dashboard could have contradicted.

New Prometheus info-metric (value always 1, payload in the labels, so it joins onto the numeric series):

    tier0_decode_config{camera,skip,threads,fast,hwaccel,idle} 1

Emitted after the source opens, so hwaccel carries the EFFECTIVE backend — reporting the request would re-hide the fallback the metric exists to reveal. Two hazards handled: info-metric label churn (a worker restarting under changed config would mint a SECOND series and render two answers, so a narrower drop_series() drop-then-sets exactly one series per camera), and staleness (forget_camera already clears it with the rest).

The server's AI page carries it per camera beside the load signals — 'cam3 is shedding' and 'cam3 decodes on CPU with skip=none' is one answer, not two lookups. A pipeline predating the metric renders as null, never a fabricated default config.

Both semantic rules verified by sabotage: reporting the requested hwaccel and dropping the drop-then-set each fail exactly their test. docs/DETECT_CPU.md gains a dial→metric table and the join query.

detect-pipeline 370 passed; server tier0-metrics 20 passed.