### PR TITLE
feat(camera-agent): collapse the History card, and stop its work when…

### DIFF
--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -729,7 +729,7 @@
           <div id="eventsList"><div class="empty-note">Nothing yet — alarm rings, watch hits, and app alerts land here.</div></div>
         </div>
         <div class="card" id="historyCard" hidden>
-          <div class="cardhead"><h2>History</h2><button class="addbtn" id="histRefresh" type="button" title="Refresh remembered visits" aria-label="Refresh history">↻</button></div>
+          <div class="cardhead"><h2>History</h2><span class="headbtns"><button class="addbtn" id="histRefresh" type="button" title="Refresh remembered visits" aria-label="Refresh history">↻</button><button class="addbtn" id="histToggle" type="button" title="Collapse / expand" aria-label="Toggle history">▾</button></span></div>
           <div class="skillhint">Visits the NVR remembers, with the photo it kept. Tap 💬 to ask about one.</div>
           <div class="histfilters">
             <select id="histLabel" aria-label="What to look for">
@@ -1324,6 +1324,34 @@
     // Thumbnails are fetched with fetch() (which carries the bearer token)
     // into object URLs — a bare <img src> would arrive without auth.
     let _histUrls=[];
+    // ── History collapse ────────────────────────────────────────────
+    // The card that grows most (up to 30 visits, each with a photo) was the
+    // only rail card you could not fold away — Activity and Hardware both
+    // collapse. Same sessionStorage + glyph pattern as Activity; the hint,
+    // the filters and the list fold together so a collapsed card is just
+    // its title bar.
+    const _histCollapsed=()=>sessionStorage.getItem("histCollapsed")==="1";
+    function applyHistCollapse(){
+      const c=_histCollapsed(), card=$("historyCard"); if(!card) return;
+      for(const el of [card.querySelector(".skillhint"),
+                       card.querySelector(".histfilters"), $("histList")]){
+        if(el) el.hidden=c;
+      }
+      const b=$("histToggle"); if(b) b.textContent=c?"▸":"▾";
+      // Refresh is meaningless while nothing is shown, and a disabled
+      // control that still looks live invites a click that does nothing.
+      const r=$("histRefresh"); if(r) r.hidden=c;
+    }
+    (function(){ const b=$("histToggle"); if(!b) return;
+      b.addEventListener("click",()=>{
+        sessionStorage.setItem("histCollapsed", _histCollapsed()?"0":"1");
+        applyHistCollapse();
+        // Expanding re-loads: while collapsed the evidence photos are
+        // deliberately never fetched, so the list would otherwise unfold
+        // showing rows with permanently blank thumbnails.
+        if(!_histCollapsed()) loadHistory();
+      }); })();
+
     async function loadHistory(){ if(!authReady()) return;
       const card=$("historyCard"), list=$("histList"); if(!card||!list) return;
       let d; try{ d=await (await fetch("/history?label="+encodeURIComponent(($("histLabel")||{}).value||"")
@@ -1333,8 +1361,14 @@
       const htab=$("mtabHistory");
       if(!d || d.available===false){ card.hidden=true; if(htab) htab.hidden=true; return; }
       card.hidden=false; if(htab) htab.hidden=false;
+      applyHistCollapse();
       for(const u of _histUrls) URL.revokeObjectURL(u); _histUrls=[];
       list.innerHTML="";
+      // Collapsed: the availability check above still ran (one cheap JSON
+      // call, and it decides whether the card and its phone tab exist at
+      // all), but building rows nobody can see — and firing up to 30
+      // authenticated evidence-photo fetches for them — is pure waste.
+      if(_histCollapsed()) return;
       if(d.ok===false){ list.innerHTML='<div class="empty-note">Couldn’t reach the history store just now.</div>'; return; }
       const rows=d.events||[];
       if(!rows.length){ list.innerHTML='<div class="empty-note">No remembered visits in this window.</div>'; return; }

--- a/examples/camera-agent/tests/test_demo_history_ui.py
+++ b/examples/camera-agent/tests/test_demo_history_ui.py
@@ -170,3 +170,39 @@ def test_demo_has_suggestion_chips_and_health_dot():
     assert 'id="healthDot"' in _HTML
     assert "pollHealth" in _HTML
     assert "vision_error" in _HTML
+
+
+# ── History collapse ───────────────────────────────────────────────────
+
+def test_history_card_can_be_collapsed_like_the_others():
+    # Activity and Hardware both fold; History — the card that grows most,
+    # up to 30 visits each with a photo — was the only one that could not.
+    assert 'id="histToggle"' in _HTML
+    assert "applyHistCollapse" in _HTML
+    # Same session-scoped persistence + glyph convention as Activity.
+    assert 'sessionStorage.setItem("histCollapsed"' in _HTML
+    assert 'sessionStorage.getItem("histCollapsed")' in _HTML
+
+
+def test_collapsed_history_skips_the_evidence_photo_fetches():
+    """Collapsing must stop the work, not just hide it.
+
+    Each visible visit fires its own authenticated evidence fetch, so a
+    30-row card is 30 requests per refresh. The availability call above the
+    guard still runs (it decides whether the card and its phone tab exist),
+    but nothing below it should build rows nobody can see.
+    """
+    body = _HTML[_HTML.index("async function loadHistory"):]
+    guard = body.index("if(_histCollapsed()) return;")
+    first_thumb_fetch = body.index('fetch("/history/"')
+    assert guard < first_thumb_fetch, (
+        "the collapsed-return must come BEFORE the per-visit evidence fetches"
+    )
+
+
+def test_expanding_history_reloads_so_thumbs_are_not_blank():
+    # Because the photos are skipped while collapsed, unfolding without a
+    # reload would show rows with permanently empty thumbnails.
+    toggle = _HTML[_HTML.index('const b=$("histToggle")'):]
+    toggle = toggle[:toggle.index("async function loadHistory")]
+    assert "loadHistory()" in toggle


### PR DESCRIPTION
… folded

History was the only rail card that could not be folded away — Activity and Hardware both collapse — and it is the one that grows most: up to 30 visits, each a row with a photo. On a busy day it pushed Skills and Hardware far below the fold with no way to get them back.

Same pattern as Activity: a ▾/▸ toggle in the card head, collapsed state in sessionStorage so it survives a reload without becoming a permanent preference. The hint, the filter row and the list fold together, so a collapsed card is just its title bar (436px -> 64px with four visits). The refresh button hides with them — a live-looking control that can only act on hidden content invites a click that does nothing.

Collapsing stops the WORK, not just the view: each visible visit fires its own authenticated evidence-photo fetch, so the guard sits above that loop (measured: 3 visits = 3 fetches per refresh expanded, 0 collapsed — a 30-row card saves 30 requests every refresh). The availability call above the guard still runs, because it decides whether the card and its phone tab exist at all. Expanding re-loads, since photos skipped while folded would otherwise unfold as permanently blank thumbnails.

Guard verified by sabotage: removing the early return fails its test. Agent suite 757 passed, 7 skipped.