### PR TITLE
fix(camera-agent): stop the camera widget serialising cameras, and te…

### DIFF
--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1394,14 +1394,41 @@
         t.querySelector(".ct-x").addEventListener("click",(e)=>{ e.stopPropagation(); openCamScreen(cam.camera_id); });
         strip.appendChild(t); }
       refreshCamStrip(); setInterval(()=>{ if(document.visibilityState==="visible" && !window._camScreenCam) refreshCamStrip(); },6000); }
+    // Strip refresh. Each /frame miss is a fresh ffmpeg that waits for the
+    // camera's next KEYFRAME (1-4s on long-GOP H.265 OEM cameras), so this
+    // used to be a strictly sequential await loop: with four cameras the
+    // last tile updated ~6s after the first, and the 6s interval then
+    // overlapped the next cycle — two loops racing, double the ffmpegs.
+    //
+    // Fetching several cameras at once is what the server was BUILT for:
+    // context.get_frame takes a PER-CAMERA lock precisely so different
+    // cameras "proceed in parallel on their own locks" while callers on the
+    // same camera coalesce onto one fetch. The old loop defeated that
+    // design. Bounded to a few lanes rather than Promise.all over the whole
+    // fleet — a 24-camera site should not open 24 RTSP sessions at once —
+    // and an in-flight guard means a slow cycle delays the next instead of
+    // stacking on top of it. No cache, lock or coalescing behaviour changes.
+    const _STRIP_LANES = 4;
+    let _stripBusy = false;
     async function refreshCamStrip(){
-      if(!authReady())return;
-      for(const t of document.querySelectorAll(".camtile")){ const cam=t.dataset.cam;
-        const img=t.querySelector("img"), off=t.querySelector(".ct-off");
-        try{ const r=await fetch("/frame/"+encodeURIComponent(cam)+"?t="+Date.now());
-          if(!r.ok) throw new Error();
-          setBlobSrc(img,await r.blob()); img.hidden=false; off.hidden=true;
-        }catch{ img.hidden=true; off.hidden=false; } } }
+      if(!authReady() || _stripBusy) return;
+      _stripBusy = true;
+      try{
+        const tiles=[...document.querySelectorAll(".camtile")];
+        let next=0;
+        const lane=async()=>{ while(next<tiles.length) await _refreshTile(tiles[next++]); };
+        await Promise.all(
+          Array.from({length: Math.min(_STRIP_LANES, tiles.length)}, lane)
+        );
+      } finally { _stripBusy = false; }
+    }
+    async function _refreshTile(t){
+      const cam=t.dataset.cam;
+      const img=t.querySelector("img"), off=t.querySelector(".ct-off");
+      try{ const r=await fetch("/frame/"+encodeURIComponent(cam)+"?t="+Date.now());
+        if(!r.ok) throw new Error();
+        setBlobSrc(img,await r.blob()); img.hidden=false; off.hidden=true;
+      }catch{ img.hidden=true; off.hidden=false; } }
     // One blob URL per <img>: revoke the previous BEFORE assigning — onload
     // revocation leaks when a new src lands before the old one loaded.
     function setBlobSrc(img,blob){ if(img.dataset.blobUrl) URL.revokeObjectURL(img.dataset.blobUrl);
@@ -1525,6 +1552,28 @@
     function stopPlayback(){ _playback=false; const v=$("camVideo"); if(!v) return;
       try{ v.pause(); }catch{} v.removeAttribute("src"); v.load(); v.hidden=true;
       document.querySelectorAll(".rec-seg.on").forEach(el=>el.classList.remove("on")); }
+    // A stream that DIES after connecting was invisible: nothing watched the
+    // connection, so _pc stayed non-null (which gates the 1 fps still-poller
+    // OFF), the last decoded frame stayed on screen, and the caption still
+    // read "Live · real-time stream". A MediaMTX restart or a network blip
+    // therefore showed a FROZEN picture under a green LIVE pill — the player
+    // claiming live while showing the past. Tear the session down instead:
+    // _pc goes null so stills resume within a second, and the caption says
+    // what is true. Named (not an inline closure) so it is directly callable
+    // from a test — the drop path is otherwise unreachable without a real
+    // WHEP peer.
+    function handleWebrtcState(pc){
+      if(_pc!==pc) return;                          // already superseded
+      if(!["failed","disconnected","closed"].includes(pc.connectionState)) return;
+      const cam=window._camScreenCam;
+      stopWebrtc();                                 // clears _pc → stills resume
+      if(cam && !_revTs && !_playback){
+        const n=$("camTnote");
+        if(n) n.textContent="Live preview — up to 1 frame/s (real-time stream dropped)";
+        const im=$("camImg"); if(im) im.hidden=false;
+        refreshPlayerLive();                        // don't wait for the tick
+      }
+    }
     function stopWebrtc(){
       if(_pc){ try{ _pc.close(); }catch{} _pc=null; }
       if(_whepResource){ fetch(_whepResource,{method:"DELETE"}).catch(()=>{}); _whepResource=null; }
@@ -1545,6 +1594,15 @@
       try{
         const pc=new RTCPeerConnection({iceServers:[{urls:["stun:stun.l.google.com:19302"]}]});
         _pc=pc;
+        // A stream that DIES after connecting was invisible: nothing watched
+        // the connection, so _pc stayed non-null (which gates the 1 fps
+        // still-poller off), the last decoded frame stayed on screen, and
+        // the caption still read "Live · real-time stream". A MediaMTX
+        // restart or a network blip therefore showed a FROZEN picture under
+        // a green LIVE pill — the player claiming live while showing the
+        // past. Tear the session down instead: _pc goes null, the stills
+        // resume within a second, and the caption says what is true.
+        pc.onconnectionstatechange=()=>handleWebrtcState(pc);
         pc.addTransceiver("video",{direction:"recvonly"});
         pc.addTransceiver("audio",{direction:"recvonly"});
         const gotTrack=new Promise((res)=>{ pc.ontrack=(ev)=>{ const [stream]=ev.streams;

--- a/examples/camera-agent/tests/test_demo_skills_ui.py
+++ b/examples/camera-agent/tests/test_demo_skills_ui.py
@@ -333,3 +333,59 @@ def test_live_video_pauses_when_tab_hidden(script: str) -> None:
     assert re.search(r"document\.hidden[\s\S]{0,200}goLive\(\)", script), (
         "returning to a live camera screen should re-establish the stream"
     )
+
+
+# ── camera widget: strip concurrency + honest WebRTC drop ──────────────
+
+def _demo_html() -> str:
+    from pathlib import Path
+    return (Path(__file__).resolve().parents[1] / "demo" / "index.html").read_text()
+
+
+def test_camera_strip_refreshes_cameras_concurrently():
+    """The strip must not serialise cameras.
+
+    Every /frame miss is a fresh ffmpeg waiting for the camera's next
+    KEYFRAME (1-4s on long-GOP OEM cameras). Awaiting them one at a time
+    made the last tile land ~N x that behind the first, and the server was
+    built for the opposite: context.get_frame takes a PER-CAMERA lock so
+    different cameras proceed in parallel while callers on the SAME camera
+    coalesce. Measured in-browser at 4 cameras x 1.2s: 4809ms -> 1211ms.
+    """
+    html = _demo_html()
+    assert "_STRIP_LANES" in html
+    assert "Promise.all(" in html[html.index("async function refreshCamStrip"):]
+    # The old shape: a for-loop awaiting each tile inline.
+    body = html[html.index("async function refreshCamStrip"):]
+    body = body[:body.index("async function _refreshTile")]
+    assert "for(const t of document.querySelectorAll" not in body
+
+
+def test_camera_strip_cycles_cannot_overlap():
+    """A refresh slower than the 6s interval used to stack a second cycle on
+    top of the first — two loops racing, double the ffmpeg processes.
+    Measured in-browser: 11 fetches for 4 cameras, now 4."""
+    html = _demo_html()
+    assert "_stripBusy" in html
+    body = html[html.index("async function refreshCamStrip"):]
+    assert "if(!authReady() || _stripBusy) return;" in body
+    assert "finally { _stripBusy = false; }" in body
+
+
+def test_a_dropped_webrtc_stream_stops_claiming_to_be_live():
+    """A WHEP session dying after connect was invisible: _pc stayed non-null
+    (gating the still-poller OFF) and the caption still said 'real-time
+    stream', so the player showed a FROZEN frame under a green LIVE pill.
+    """
+    html = _demo_html()
+    assert "function handleWebrtcState" in html
+    assert "pc.onconnectionstatechange=()=>handleWebrtcState(pc);" in html
+    fn = html[html.index("function handleWebrtcState"):]
+    fn = fn[:fn.index("function stopWebrtc")]
+    # Only real terminal states act — a healthy transition must be a no-op.
+    assert '["failed","disconnected","closed"]' in fn
+    # It must clear the session (stills resume) AND correct the caption.
+    assert "stopWebrtc();" in fn
+    assert "real-time stream dropped" in fn
+    # And it must ignore a peer that has already been superseded.
+    assert "if(_pc!==pc) return;" in fn


### PR DESCRIPTION
…ll the truth when a live stream drops

Camera-agent demo only — OpenNVR playback/recording untouched. Neither change removes an optimization; the first one finally USES one.

Strip refresh was a strictly sequential await loop over the tiles. Every /frame miss is a fresh ffmpeg that waits for the camera's next KEYFRAME (1-4s on the long-GOP H.265 OEM cameras the fetch code already calls out), so with four cameras the last tile landed ~5s behind the first — and since that exceeded the 6s interval, the next cycle stacked on top, racing two loops and doubling the ffmpeg processes.

The server was built for the opposite: context.get_frame takes a PER-CAMERA lock precisely so different cameras 'proceed in parallel on their own locks' while callers on the SAME camera coalesce onto one fetch. The loop defeated that design. Now a few bounded lanes (4, not Promise.all over the whole fleet — a 24-camera site must not open 24 RTSP sessions at once) plus an in-flight guard. Cache TTL, per-camera locks and coalescing are unchanged. Measured in-browser at four cameras x 1.2s per grab: 4809ms -> 1211ms per full refresh, and 11 -> 4 fetches when a slow cycle meets the next tick.

A WHEP session that DIED after connecting was invisible. Nothing watched the connection, so _pc stayed non-null — which is exactly what gates the 1 fps still-poller OFF — the last decoded frame stayed on screen, and the caption still read 'Live · real-time stream'. A MediaMTX restart or a network blip showed a FROZEN picture under a green LIVE pill: the player claiming live while showing the past. handleWebrtcState() now tears the session down on failed/disconnected/closed, so stills resume within a second and the caption says the stream dropped. Named rather than inline so the drop path is reachable from a test without a real WHEP peer; healthy transitions and superseded peers are both no-ops.

All three guards verified by sabotage: restoring the sequential loop, widening the terminal-state filter, and removing the in-flight guard each fail exactly their test. Agent suite 760 passed, 7 skipped.