### PR TITLE
fix(camera-agent): let the demo's camera roster follow OpenNVR instea…

### DIFF
--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1279,26 +1279,92 @@
       }catch(err){ addMsg("Request failed: "+err.message,"sys"); setStatus("Error","error"); }
       finally{ $("askBtn").disabled=false; setAvatar("idle"); }
     }
-    async function loadCameras(){ try{ const r=await fetch("/cameras"); if(!r.ok)return;
+    // ── the camera roster: a live view, not a boot snapshot ─────────────
+    // This used to run exactly ONCE, at page load, and the /updates socket
+    // carries tasks, monitors, reports, events and alarms but NOT cameras.
+    // So a camera added in OpenNVR never showed up until someone reloaded,
+    // and a deleted one kept its strip tile forever (stuck on "no frame")
+    // and stayed pickable in the history/alarm/watch/task selects — you
+    // could arm an alarm on a camera that no longer exists. The agent
+    // already reconciles its own roster against OpenNVR on a ~30s cadence
+    // (_sync_camera_roster); the page now follows it.
+    //
+    // Rebuild only when the roster actually CHANGED. The signature covers
+    // id AND role, because the pickers render the role. Rebuilding blindly
+    // every 30s would recreate every strip <img>, flashing the tiles and
+    // throwing away frames that were just fetched.
+    let _rosterSig=null, _rosterWired=false, _rosterBusy=false;
+    async function loadCameras(){
+      // Wired before the fetch, not after it: a /cameras that fails at boot
+      // (agent still starting, token not yet accepted) must not cost the
+      // page its retry timer forever.
+      if(!_rosterWired){ _rosterWired=true; wireRosterOnce(); }
+      // The 30s timer, the visibilitychange handler and useLocalCamera() can
+      // all ask at once; one in flight is enough.
+      if(_rosterBusy) return;
+      _rosterBusy=true;
+      try{ const r=await fetch("/cameras"); if(!r.ok)return;
       const cams=((await r.json()).cameras||[]);
+      const sig=JSON.stringify(cams.map(c=>[c.camera_id,String(c.role||"").trim()]));
+      if(sig===_rosterSig) return;                      // nothing moved
+      _rosterSig=sig;
+      renderCamChecks(cams);
+      renderCamSelects(cams);
+      buildCamStrip(cams);
+    }catch{} finally{ _rosterBusy=false; } }
+    // The "All cameras / cam1 / cam2…" row that scopes a chat question.
+    // Every label carrying a .cam-cb is ours to replace — including the
+    // ad-hoc one useLocalCamera() appends, which would otherwise survive
+    // as a duplicate once /cameras starts reporting that device.
+    function renderCamChecks(cams){
+      const old=[...camboxEl.querySelectorAll(".cam-cb")];
+      const ticked=new Set(old.filter(c=>c.checked).map(c=>c.value));
+      for(const cb of old) (cb.closest("label")||cb).remove();
       for(const cam of cams){ const lab=document.createElement("label");
-        const role=(cam.role||"").trim(); const txt=role&&role!=="(no role configured)"?`${cam.camera_id} · ${role.slice(0,28)}`:cam.camera_id;
+        const role=String(cam.role||"").trim(); const txt=role&&role!=="(no role configured)"?`${cam.camera_id} · ${role.slice(0,28)}`:cam.camera_id;
         // DOM + textContent: camera ids/roles are server-configured strings.
         const cb=document.createElement("input"); cb.type="checkbox"; cb.className="cam-cb"; cb.value=cam.camera_id;
+        cb.checked=ticked.has(cam.camera_id);           // keep the operator's scope
         lab.appendChild(cb); lab.appendChild(document.createTextNode(" "+txt)); camboxEl.appendChild(lab); }
-      const all=$("cam-all"), cbs=()=>[...document.querySelectorAll(".cam-cb")];
-      all.addEventListener("change",()=>{ if(all.checked) cbs().forEach(c=>{c.checked=false;}); });
-      camboxEl.addEventListener("change",(e)=>{ if(e.target.classList.contains("cam-cb")&&e.target.checked) all.checked=false;
-        if(!cbs().some(c=>c.checked)) all.checked=true; });
-      buildCamStrip(cams);
-      // History filter + the alarm/watch/task camera pickers share the roster.
-      for(const sel of [$("histCam"), $("alarmCam"), $("watchCam"), $("taskCam")]){
+      const all=$("cam-all");
+      if(all && ![...camboxEl.querySelectorAll(".cam-cb")].some(c=>c.checked)) all.checked=true; }
+    // History filter + the alarm/watch/task camera pickers share the roster.
+    // Each keeps its own static first option ("all cameras" / "Any camera")
+    // and, where the camera is still present, the operator's choice.
+    function renderCamSelects(cams){
+      const hist=$("histCam");
+      for(const sel of [hist, $("alarmCam"), $("watchCam"), $("taskCam")]){
         if(!sel) continue;
+        const was=sel.value;
+        while(sel.options.length>1) sel.remove(1);
         for(const cam of cams){ const o=document.createElement("option");
           o.value=cam.camera_id;
           o.textContent=cam.camera_id+(cam.role?(" · "+String(cam.role).slice(0,22)):"");
-          sel.appendChild(o); } }
-    }catch{} }
+          sel.appendChild(o); }
+        // A camera that went away falls back to the static option rather
+        // than silently arming/filtering on a stale id.
+        sel.value=[...sel.options].some(o=>o.value===was)?was:sel.options[0].value;
+        // The history picker is a live FILTER, not just a form field: the
+        // list under it was fetched for the camera that just disappeared.
+        // Assigning .value fires no change event, so the reload has to be
+        // asked for, or the card reads "all cameras" over one camera's rows.
+        if(sel===hist && sel.value!==was) loadHistory(); } }
+    // Listeners and timers that must exist exactly once, however many
+    // times the roster is rebuilt underneath them.
+    function wireRosterOnce(){
+      const all=$("cam-all"), cbs=()=>[...document.querySelectorAll(".cam-cb")];
+      if(all) all.addEventListener("change",()=>{ if(all.checked) cbs().forEach(c=>{c.checked=false;}); });
+      // Delegated: the checkboxes themselves are replaced on every rebuild.
+      camboxEl.addEventListener("change",(e)=>{ if(!e.target.classList.contains("cam-cb")) return;
+        if(e.target.checked && all) all.checked=false;
+        if(all && !cbs().some(c=>c.checked)) all.checked=true; });
+      // Follow the agent's own reconcile cadence, and only while someone is
+      // looking — a hidden tab has nothing to re-render.
+      setInterval(()=>{ if(document.visibilityState==="visible") loadCameras(); },30000);
+      document.addEventListener("visibilitychange",()=>{ if(document.visibilityState==="visible") loadCameras(); });
+      // The strip's own frame poll: one timer for the page's lifetime, not
+      // one more every time buildCamStrip() runs.
+      setInterval(()=>{ if(document.visibilityState==="visible" && !window._camScreenCam) refreshCamStrip(); },6000); }
 
     // ── what can set off an alarm/watch: the detector's real vocabulary ─
     // Fills the shared <datalist> behind every target input, so operators
@@ -1380,8 +1446,18 @@
     // tap = PEEK (the agent drops the camera's current frame into the
     // chat with an Open link) · ⤢ / name = the camera's own screen.
     const _camRoles={};
-    function buildCamStrip(cams){ const strip=$("camstrip"); if(!strip||!cams.length) return;
+    function buildCamStrip(cams){ const strip=$("camstrip"); if(!strip) return;
+      // Every tile holds an object URL for the frame it is showing. Dropping
+      // the elements does NOT free those — the browser keeps each blob alive
+      // until it is revoked — so the last roster's frames must be released
+      // before the strip is thrown away, or a site that adds and removes
+      // cameras leaks a JPEG per tile per rebuild.
+      for(const img of strip.querySelectorAll("img[data-blob-url]")) URL.revokeObjectURL(img.dataset.blobUrl);
       strip.innerHTML="";
+      // An empty roster clears the strip rather than leaving the old tiles
+      // standing: "no cameras" is an answer, not a reason to keep stale ones.
+      for(const k of Object.keys(_camRoles)) delete _camRoles[k];
+      if(!cams.length) return;
       for(const cam of cams){ _camRoles[cam.camera_id]=(cam.role||"").trim();
         const t=document.createElement("div"); t.className="camtile"; t.dataset.cam=cam.camera_id;
         t.title="Tap to peek — the agent shows this camera in the chat";
@@ -1393,7 +1469,17 @@
         t.querySelector(".ct-nm span").addEventListener("click",()=>openCamScreen(cam.camera_id));
         t.querySelector(".ct-x").addEventListener("click",(e)=>{ e.stopPropagation(); openCamScreen(cam.camera_id); });
         strip.appendChild(t); }
-      refreshCamStrip(); setInterval(()=>{ if(document.visibilityState==="visible" && !window._camScreenCam) refreshCamStrip(); },6000); }
+      // The 6s frame poll is started once, in wireRosterOnce() — starting it
+      // here would add another timer on every rebuild.
+      //
+      // Prime the new tiles now, but NOT while the operator is on a camera's
+      // own screen: the strip is hidden behind it, and every /frame miss is
+      // a fresh ffmpeg waiting for that camera's next keyframe. A roster
+      // change would otherwise spawn one per camera in the fleet for a strip
+      // nobody can see, on top of the live stream the screen is already
+      // pulling. closeCamScreen() calls refreshCamStrip() on the way back,
+      // and the 6s tick covers the rest — nothing is lost by waiting.
+      if(!window._camScreenCam) refreshCamStrip(); }
     // Strip refresh. Each /frame miss is a fresh ffmpeg that waits for the
     // camera's next KEYFRAME (1-4s on long-GOP H.265 OEM cameras), so this
     // used to be a strictly sequential await loop: with four cameras the
@@ -1427,7 +1513,11 @@
       const img=t.querySelector("img"), off=t.querySelector(".ct-off");
       try{ const r=await fetch("/frame/"+encodeURIComponent(cam)+"?t="+Date.now());
         if(!r.ok) throw new Error();
-        setBlobSrc(img,await r.blob()); img.hidden=false; off.hidden=true;
+        const blob=await r.blob();
+        // A roster rebuild can land mid-fetch. Painting a detached tile
+        // would mint a blob URL nothing can ever revoke — drop the frame.
+        if(!t.isConnected) return;
+        setBlobSrc(img,blob); img.hidden=false; off.hidden=true;
       }catch{ img.hidden=true; off.hidden=false; } }
     // One blob URL per <img>: revoke the previous BEFORE assigning — onload
     // revocation leaks when a new src lands before the old one loaded.
@@ -1896,6 +1986,10 @@
             lab.innerHTML=`<input type="checkbox" class="cam-cb" value="${cam.camera_id}" checked> ${cam.camera_id} · this machine`;
             camboxEl.appendChild(lab); }
           const all=$("cam-all"); if(all) all.checked=false;
+          // Pull the roster now instead of waiting up to 30s: the rebuild
+          // replaces the ad-hoc label above and gives the new camera its
+          // strip tile and its entry in the history/alarm/watch/task pickers.
+          loadCameras();
           setStatus(`Using this machine's camera (${added.map(c=>c.camera_id).join(", ")}). Ask a question!`,"ok");
         }
       }catch(err){ setStatus("Could not access a local camera: "+err.message,"error"); }

--- a/examples/camera-agent/tests/test_demo_roster_refresh.py
+++ b/examples/camera-agent/tests/test_demo_roster_refresh.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The demo page's camera roster must be a live view, not a boot snapshot.
+
+``loadCameras()`` used to run exactly once, at page load, and the /updates
+socket carries tasks, monitors, reports, events and alarms but NOT cameras.
+So:
+
+* a camera ADDED in OpenNVR never appeared until someone reloaded the page;
+* a camera DELETED in OpenNVR kept its strip tile forever (stuck on "no
+  frame") and stayed selectable in the history, alarm, watch and task
+  pickers — you could arm an alarm on a camera that no longer exists.
+
+The agent already reconciles its own roster against OpenNVR on a ~30s
+cadence (``_sync_camera_roster``); these guards pin the page to the same
+cadence, and pin the four things a re-runnable ``loadCameras()`` has to get
+right that a run-once one never had to: rebuild only on a real change,
+release the frames it drops, keep the operator's selections, and never
+stack a second listener or timer.
+
+Same house style as the other demo-UI guards: ``demo/index.html`` is
+vanilla no-build JS with no node/jsdom in the test env, so these are
+whitespace-tolerant static assertions on the inline script.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_DEMO = Path(__file__).resolve().parent.parent / "demo" / "index.html"
+
+
+@pytest.fixture(scope="module")
+def script() -> str:
+    html = _DEMO.read_text(encoding="utf-8")
+    scripts = re.findall(r"<script\b[^>]*>(.*?)</script>", html, re.S | re.I)
+    assert scripts, "demo/index.html has no inline <script> block"
+    return "\n".join(scripts)
+
+
+def _fn(script: str, name: str) -> str:
+    """The source of one top-level ``function name(``, to its dedented close."""
+    start = script.index(f"function {name}(")
+    depth, i = 0, script.index("{", start)
+    for j in range(i, len(script)):
+        if script[j] == "{":
+            depth += 1
+        elif script[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return script[start:j + 1]
+    raise AssertionError(f"unbalanced braces in {name}")
+
+
+# ── the roster is polled at all ────────────────────────────────────────
+
+def test_roster_is_refetched_on_the_agents_reconcile_cadence(script: str) -> None:
+    wire = _fn(script, "wireRosterOnce")
+    assert re.search(r"setInterval\(.*loadCameras\(\).*?,\s*30000\)", wire, re.S), \
+        "no periodic /cameras poll — the roster is a boot snapshot again"
+    assert 'document.visibilityState==="visible"' in wire, \
+        "a hidden tab should not poll the roster"
+
+
+def test_returning_to_the_tab_refreshes_the_roster(script: str) -> None:
+    # 30s of staleness is fine while nobody is looking; it is not fine the
+    # moment the operator comes back to the tab.
+    wire = _fn(script, "wireRosterOnce")
+    assert 'addEventListener("visibilitychange"' in wire
+    assert "loadCameras()" in wire[wire.index("visibilitychange"):]
+
+
+def test_a_failed_first_load_still_leaves_a_retry_timer(script: str) -> None:
+    # Wiring after the fetch meant a /cameras that 401s or 503s at boot
+    # (agent still starting) cost the page its retry timer for good.
+    fn = _fn(script, "loadCameras")
+    assert fn.index("wireRosterOnce()") < fn.index('fetch("/cameras")'), \
+        "the poll must be armed before the first fetch can fail"
+
+
+def test_the_roster_poll_is_armed_exactly_once(script: str) -> None:
+    fn = _fn(script, "loadCameras")
+    assert "if(!_rosterWired){ _rosterWired=true; wireRosterOnce(); }" in fn, \
+        "every loadCameras() call would add another 30s timer"
+
+
+# ── rebuild only when something actually moved ─────────────────────────
+
+def test_an_unchanged_roster_does_not_rebuild_the_ui(script: str) -> None:
+    """Rebuilding recreates every strip <img>. Doing that on each poll would
+    flash all tiles and throw away frames fetched seconds earlier."""
+    fn = _fn(script, "loadCameras")
+    assert "const sig=JSON.stringify(" in fn
+    assert "if(sig===_rosterSig) return;" in fn
+    # The signature must cover the role too — the pickers render it, so a
+    # rename that keeps the id still has to redraw.
+    sig = fn[fn.index("const sig="):fn.index("if(sig===_rosterSig)")]
+    assert "camera_id" in sig and "role" in sig
+
+
+# ── what a rebuild must preserve ───────────────────────────────────────
+
+def test_rebuild_keeps_the_operators_camera_scope(script: str) -> None:
+    fn = _fn(script, "renderCamChecks")
+    assert "filter(c=>c.checked)" in fn, "ticked boxes are not read before the wipe"
+    assert "cb.checked=ticked.has(cam.camera_id)" in fn, \
+        "a rebuild would silently widen a scoped question to every camera"
+
+
+def test_rebuild_keeps_a_still_present_picker_choice(script: str) -> None:
+    fn = _fn(script, "renderCamSelects")
+    assert "const was=sel.value;" in fn
+    assert "sel.value=[...sel.options].some(o=>o.value===was)?was:" in fn, \
+        "the history/alarm/watch/task pickers reset themselves on every rebuild"
+
+
+def test_a_deleted_camera_leaves_the_pickers(script: str) -> None:
+    """The bug with teeth: cam1/cam2/cam3 deleted in OpenNVR stayed armable."""
+    fn = _fn(script, "renderCamSelects")
+    # Options are replaced, but the static first one ("all cameras" / "Any
+    # camera") is markup, not roster — it must survive.
+    assert "while(sel.options.length>1) sel.remove(1);" in fn
+    # And a vanished selection falls back to that static option rather than
+    # sitting on a stale id.
+    assert "sel.options[0].value" in fn
+
+
+def test_the_checkbox_row_replaces_only_its_own_labels(script: str) -> None:
+    # "All cameras" is static markup inside #cambox; wiping the container
+    # would delete it.
+    fn = _fn(script, "renderCamChecks")
+    assert 'camboxEl.innerHTML=""' not in fn
+    assert 'camboxEl.querySelectorAll(".cam-cb")' in fn
+    # useLocalCamera() appends its own .cam-cb label outside this function;
+    # it has to be swept too, or it survives as a duplicate once /cameras
+    # starts reporting that device.
+    assert 'cb.closest("label")' in fn
+
+
+# ── what a rebuild must release / must not stack ───────────────────────
+
+def test_strip_rebuild_revokes_the_frames_it_drops(script: str) -> None:
+    """A blob URL outlives the <img> that held it until it is revoked, so a
+    site that adds and removes cameras would leak a JPEG per tile per
+    rebuild. Unreachable before this change (the strip was never rebuilt)."""
+    fn = _fn(script, "buildCamStrip")
+    revoke = fn.index("URL.revokeObjectURL")
+    assert revoke < fn.index('strip.innerHTML=""'), \
+        "the tiles are dropped before their object URLs are released"
+    assert "img[data-blob-url]" in fn[:revoke + 200]
+
+
+def test_an_empty_roster_clears_the_strip(script: str) -> None:
+    # The old guard bailed out before the wipe, so deleting the last camera
+    # left its tile standing.
+    fn = _fn(script, "buildCamStrip")
+    assert 'if(!strip) return;' in fn
+    assert fn.index('strip.innerHTML=""') < fn.index("if(!cams.length) return;"), \
+        "an empty roster must clear the strip, not leave stale tiles"
+
+
+def test_the_frame_poll_timer_is_not_restarted_per_rebuild(script: str) -> None:
+    fn = _fn(script, "buildCamStrip")
+    assert "setInterval" not in fn, \
+        "each rebuild would add another 6s frame poll, multiplying ffmpegs"
+    assert re.search(r"setInterval\(.*refreshCamStrip\(\).*?,\s*6000\)",
+                     _fn(script, "wireRosterOnce"), re.S)
+
+
+def test_a_rebuild_behind_the_camera_screen_fetches_no_frames(script: str) -> None:
+    """The CPU guard. The strip is hidden while a camera's own screen is up,
+    and every /frame miss is a fresh ffmpeg waiting for that camera's next
+    keyframe. Priming the tiles on a roster change would spawn one per
+    camera in the fleet for a strip nobody can see — on top of the live
+    stream the screen is already pulling. closeCamScreen() refreshes on the
+    way back, so the wait costs nothing."""
+    fn = _fn(script, "buildCamStrip")
+    assert "if(!window._camScreenCam) refreshCamStrip();" in fn, \
+        "a roster change behind the camera screen would fetch the whole fleet"
+    assert "refreshCamStrip()" in _fn(script, "closeCamScreen"), \
+        "nothing refills the strip when the operator comes back"
+
+
+def test_overlapping_roster_requests_collapse_to_one(script: str) -> None:
+    # The 30s timer, visibilitychange and useLocalCamera() can all fire at
+    # once; a hidden/shown tab should not queue a burst of /cameras.
+    fn = _fn(script, "loadCameras")
+    assert "if(_rosterBusy) return;" in fn
+    assert "finally{ _rosterBusy=false; }" in fn
+
+
+def test_a_forced_history_filter_reload_follows_the_picker(script: str) -> None:
+    """Assigning .value fires no change event, so resetting the history
+    filter to "all cameras" left the card showing the deleted camera's rows
+    under a picker that claimed otherwise."""
+    fn = _fn(script, "renderCamSelects")
+    assert "if(sel===hist && sel.value!==was) loadHistory();" in fn
+    # Only the history picker drives a fetch — the alarm/watch/task ones are
+    # form fields, and reloading on those would be pointless work.
+    assert fn.count("loadHistory()") == 1
+
+
+def test_roster_listeners_are_not_stacked_per_rebuild(script: str) -> None:
+    """The cam-all / cambox change handlers used to be attached inside
+    loadCameras(); re-running it would fire them N times per click."""
+    for name in ("loadCameras", "renderCamChecks", "renderCamSelects"):
+        assert "addEventListener" not in _fn(script, name), name
+    wire = _fn(script, "wireRosterOnce")
+    assert 'all.addEventListener("change"' in wire
+    assert 'camboxEl.addEventListener("change"' in wire
+
+
+def test_a_tile_detached_mid_fetch_is_not_painted(script: str) -> None:
+    """A rebuild can land while a /frame is in flight; painting the old tile
+    mints a blob URL nothing can ever revoke."""
+    fn = _fn(script, "_refreshTile")
+    assert "if(!t.isConnected) return;" in fn
+    assert fn.index("if(!t.isConnected) return;") < fn.index("setBlobSrc(img,blob)")
+
+
+# ── the local-camera path joins the roster ─────────────────────────────
+
+def test_adding_this_machines_camera_refreshes_the_roster(script: str) -> None:
+    fn = _fn(script, "useLocalCamera")
+    assert "loadCameras();" in fn, \
+        "a local camera would wait up to 30s for its tile and picker entries"


### PR DESCRIPTION
…d of freezing at page load

loadCameras() ran exactly once, at page load, and the /updates socket carries tasks, monitors, reports, events and alarms but NOT cameras. So the page's idea of the fleet was a boot snapshot:

  * a camera ADDED in OpenNVR never appeared until someone reloaded;
  * a camera DELETED in OpenNVR kept its strip tile forever, stuck on "no frame", and stayed selectable in the history, alarm, watch and task pickers — you could arm an alarm on a camera that no longer exists, and the reported "cam1/cam2/cam3 are gone but still listed" was exactly this.

The agent already reconciles its own roster against OpenNVR every ~30s (_sync_camera_roster); the page now follows the same cadence, and also refetches the moment a hidden tab comes back.

Making a run-once function re-runnable is most of the change:

  * rebuild only when the roster really moved (id+role signature) — rebuilding blindly every 30s would recreate every strip <img>, flashing the tiles and discarding frames fetched seconds earlier;
  * revoke the object URL of every tile the rebuild drops. A blob URL outlives the <img> that held it until revoked, so add/remove churn would leak a JPEG per tile per rebuild (unreachable before this change — nothing ever rebuilt the strip);
  * keep the operator's ticked cameras and picker choices across a rebuild, and fall back to the static "all cameras" option when the selected camera is the one that went away, rather than filtering or arming on a stale id. The history picker drives a FETCH, so a forced fallback reloads the list too — assigning .value fires no change event, and the card would otherwise read "all cameras" over one deleted camera's rows;
  * attach the cam-all / cambox change listeners and both timers exactly once. The 6s frame poll used to be started inside buildCamStrip(), which was harmless only because buildCamStrip ran once — every rebuild would have added another poll, multiplying ffmpegs;
  * collapse overlapping roster requests (the 30s timer, visibilitychange and useLocalCamera() can all ask at once) onto one in flight;
  * skip painting a tile that a rebuild detached mid-fetch, which would mint a blob URL nothing can revoke;
  * clear the strip on an empty roster instead of bailing out before the wipe and leaving the last camera's tile standing;
  * pull the roster immediately after "use this machine's camera" so the new device gets its tile and picker entries now, not in 30s.

CPU: the only new recurring work is one GET /cameras every 30s while the tab is visible. That route is a pure in-memory list comprehension over runtime.cfg.cameras — it contacts no camera and touches no disk. Because a rebuild is gated on a real roster change, 30 steady-state polls issue ZERO extra /frame fetches and add zero timers (measured in jsdom). The strip's 6s poll moved rather than multiplied: one 30s timer and one 6s timer for the page's life.

It is a net reduction in two places. A rebuild that lands while the operator is on a camera's own screen no longer primes the hidden strip — that would have fetched a frame per camera in the fleet, each miss a fresh ffmpeg waiting for a keyframe, on top of the live stream the screen is already pulling (measured: 11 frame fetches → 0; closeCamScreen() refreshes on the way back). And dead tiles stop being polled at all: with cam1-3 deleted out of four, main today issues 4 /frame requests every 6s forever, 3 of them to cameras that no longer exist (~30 wasted requests a minute until reload); this branch issues 1. Those wasted ones were cheap 404s — get_frame raises LookupError before any ffmpeg spawns — so the saving is request overhead, not decode.

Verified in jsdom against a stubbed backend, driving boot → unchanged poll → add → delete → empty: 25/25 checks pass on this tree (0 blob URLs live at the end, exactly one 6s and one 30s timer), and the same harness scores 15 failures against the pre-fix tree — duplicated checkbox rows and picker options on every re-run, five stacked 6s polls, 14 leaked blob URLs, deleted cameras never leaving. Rendered at 1280px and 390px: no layout change. Each of the 16 new static guards was checked by sabotage — breaking it fails that guard and no other. Full agent suite 778 passed, 7 skipped.

No change to playback, recording, or any server-side path.