### PR TITLE
fix(camera-agent): stop a two-second network blip demoting the camera…

### DIFF
--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1686,9 +1686,48 @@
     // what is true. Named (not an inline closure) so it is directly callable
     // from a test — the drop path is otherwise unreachable without a real
     // WHEP peer.
+    // 'disconnected' is NOT 'failed'. Per the WebRTC spec ICE can recover
+    // from 'disconnected' on its own — a Wi-Fi roam, a brief reroute or a
+    // few lost packets flip a healthy session to it for a second or two and
+    // then back to 'connected'. The first version of this handler treated
+    // all three states as terminal, and because the teardown DELETEs the
+    // WHEP resource and the agent (unlike the OpenNVR Live view) never
+    // retries, a two-second blip demoted the camera screen to 1 fps stills
+    // until the operator left the screen and came back. Give ICE the same
+    // grace the core player gives it, and only then fall back.
+    //
+    // The caption still refuses to lie during the wait: media really has
+    // stopped, so it says "reconnecting…" rather than "real-time stream",
+    // and goes back when the session recovers.
+    const _WHEP_GRACE_MS=5000;
+    let _whepGrace=null;
+    function _clearWhepGrace(){ if(_whepGrace){ clearTimeout(_whepGrace); _whepGrace=null; } }
+    // Only paint the player's caption while the live view is what's on
+    // screen — a scrub into review or a recorded segment owns it instead.
+    function _setLiveNote(txt){
+      if(!window._camScreenCam || _revTs || _playback) return;
+      const n=$("camTnote"); if(n) n.textContent=txt; }
     function handleWebrtcState(pc){
       if(_pc!==pc) return;                          // already superseded
-      if(!["failed","disconnected","closed"].includes(pc.connectionState)) return;
+      const st=pc.connectionState;
+      if(st==="connected"){                         // first connect, or recovered
+        _clearWhepGrace();
+        _setLiveNote("Live · real-time stream · marks = detections · drag to review");
+        return; }
+      if(st==="disconnected"){
+        _setLiveNote("Live · real-time stream · reconnecting…");
+        // One clock per outage: a second 'disconnected' without an
+        // intervening 'connected' must not keep pushing the deadline out.
+        if(!_whepGrace) _whepGrace=setTimeout(()=>{
+          _whepGrace=null;
+          if(_pc===pc && pc.connectionState!=="connected") whepDropped(pc);
+        },_WHEP_GRACE_MS);
+        return; }
+      if(st==="failed"||st==="closed") whepDropped(pc);   // terminal, no waiting
+    }
+    // Giving up on WebRTC: back to honest stills, and say so.
+    function whepDropped(pc){
+      if(_pc!==pc) return;
       const cam=window._camScreenCam;
       stopWebrtc();                                 // clears _pc → stills resume
       if(cam && !_revTs && !_playback){
@@ -1699,6 +1738,9 @@
       }
     }
     function stopWebrtc(){
+      // Leaving the camera screen mid-blip must not leave a timer that wakes
+      // 5s later and stomps the caption of whatever is on screen by then.
+      _clearWhepGrace();
       if(_pc){ try{ _pc.close(); }catch{} _pc=null; }
       if(_whepResource){ fetch(_whepResource,{method:"DELETE"}).catch(()=>{}); _whepResource=null; }
       // Hide the video surface too — leaving it visible stacks a dead

--- a/examples/camera-agent/tests/test_demo_skills_ui.py
+++ b/examples/camera-agent/tests/test_demo_skills_ui.py
@@ -382,10 +382,70 @@ def test_a_dropped_webrtc_stream_stops_claiming_to_be_live():
     assert "pc.onconnectionstatechange=()=>handleWebrtcState(pc);" in html
     fn = html[html.index("function handleWebrtcState"):]
     fn = fn[:fn.index("function stopWebrtc")]
-    # Only real terminal states act — a healthy transition must be a no-op.
-    assert '["failed","disconnected","closed"]' in fn
+    # 'failed' and 'closed' are terminal and act at once. 'disconnected' is
+    # NOT — see test_a_transient_ice_blip_does_not_demote_to_stills.
+    assert 'st==="failed"||st==="closed"' in fn
     # It must clear the session (stills resume) AND correct the caption.
     assert "stopWebrtc();" in fn
     assert "real-time stream dropped" in fn
     # And it must ignore a peer that has already been superseded.
     assert "if(_pc!==pc) return;" in fn
+
+
+def test_a_transient_ice_blip_does_not_demote_to_stills():
+    """'disconnected' is not 'failed'.
+
+    ICE recovers from 'disconnected' on its own — a Wi-Fi roam or a brief
+    reroute trips it for a second or two. Treating it as terminal tore down
+    the WHEP session (DELETEing the resource), and because the agent never
+    retries, a two-second blip left the operator on 1 fps stills until they
+    left the camera screen and came back. The core player (app/src/
+    components/VideoPlayer/VideoPlayer.tsx) gives ICE a 5s grace; the agent
+    now matches it.
+    """
+    html = _demo_html()
+    fn = html[html.index("function handleWebrtcState"):html.index("function whepDropped")]
+    assert 'st==="disconnected"' in fn
+    # The load-bearing assertion: everything the blip branch does BEFORE it
+    # arms the timer must be non-destructive. Slicing to the timer (rather
+    # than checking the whole function) is what makes this fail when someone
+    # reintroduces an inline teardown — the timer below it would still be
+    # present, just unreachable, so a bare "is setTimeout there?" check would
+    # happily pass. The condition is matched loosely so an added clause
+    # doesn't slip past the guard.
+    m = re.search(r'st==="disconnected"[^{]*\{(.*?)if\(!_whepGrace\)', fn, re.S)
+    assert m, "the disconnected branch no longer arms the grace timer"
+    inline = m.group(1)
+    assert "whepDropped" not in inline, "a blip tears the session down inline again"
+    assert "stopWebrtc" not in inline, "a blip tears the session down inline again"
+    # One clock per outage: repeated 'disconnected' must not extend the wait.
+    assert "if(!_whepGrace) _whepGrace=setTimeout(" in fn
+    # The timer only gives up if the peer is STILL not connected, and is
+    # still the current one.
+    assert '_pc===pc && pc.connectionState!=="connected"' in fn
+    # Recovery cancels the clock and restores the honest caption.
+    assert 'st==="connected"' in fn
+    assert "_clearWhepGrace();" in fn
+    assert "real-time stream · marks" in fn
+
+
+def test_the_caption_tells_the_truth_during_a_blip():
+    """Media really has stopped during the grace window, so the player must
+    not keep claiming 'real-time stream' — that was the original bug, just
+    for 5s instead of forever."""
+    html = _demo_html()
+    fn = html[html.index("function handleWebrtcState"):html.index("function whepDropped")]
+    assert "reconnecting…" in fn
+    # And the note is only painted when the LIVE view actually owns the
+    # caption — not over a scrub into review or a recorded segment.
+    helper = html[html.index("function _setLiveNote"):html.index("function handleWebrtcState")]
+    assert "if(!window._camScreenCam || _revTs || _playback) return;" in helper
+
+
+def test_leaving_the_camera_screen_cancels_a_pending_grace_timer():
+    """Otherwise the timer wakes 5s later and stomps the caption of whatever
+    the operator is looking at by then."""
+    html = _demo_html()
+    fn = html[html.index("function stopWebrtc"):]
+    fn = fn[:fn.index("// The same WebRTC")]
+    assert "_clearWhepGrace();" in fn


### PR DESCRIPTION
… screen to stills

'disconnected' is not 'failed'. Per the WebRTC spec ICE can recover from 'disconnected' on its own — a Wi-Fi roam, a brief reroute or a burst of lost packets flips a healthy session to it for a second or two and then back to 'connected'. The handler added in #337 lumped all three terminal- looking states together, and because its teardown DELETEs the WHEP resource and the agent (unlike the OpenNVR Live view) never retries, a transient blip left the operator on 1 fps stills until they backed out of the camera screen and re-entered.

So #337 traded a frozen frame under a green LIVE pill for an over-eager fallback. This keeps the honesty and drops the over-eagerness, matching what the core player already does — app/src/components/VideoPlayer/ VideoPlayer.tsx gives ICE a 5s grace on 'disconnected' and acts at once only on 'failed'/'closed'. The agent now behaves the same way:

  * 'disconnected' arms a single 5s timer instead of tearing down. One clock per outage — a second 'disconnected' without an intervening 'connected' must not keep pushing the deadline out — and the timer re-checks that the peer is still current AND still not connected before giving up;
  * 'connected' cancels the timer and restores the caption, so a recovered session costs nothing;
  * 'failed'/'closed' stay immediately terminal, unchanged;
  * stopWebrtc() clears any pending timer, so leaving the camera screen mid-blip cannot leave a wake-up that stomps the caption of whatever is on screen 5s later.

The caption still refuses to lie during the wait. Media really has stopped, so it reads "Live · real-time stream · reconnecting…" rather than claiming a real-time stream — the original bug would otherwise just be back for 5s instead of forever — and _setLiveNote() only paints when the live view actually owns the caption, never over a scrub into review or a recorded segment.

Verified in jsdom with a fake RTCPeerConnection, so tryWebrtcLive() really runs and _pc really points at the peer being driven: 16/16 checks pass — a blip holds the session open and restores the caption on recovery with zero WHEP DELETEs, a real outage still gives up after the grace and resumes 1 fps stills, 'failed' still tears down immediately with no wait, and leaving mid-blip leaves no late timer. The same harness scores 7 failures against current main, all of them the blip path; the terminal- outage and 'failed' checks pass on both, which is the evidence that #337's fix is preserved rather than reverted.

Each of the 9 static guards was checked by sabotage. The first attempt had a hole worth recording: a guard that only asked "is the setTimeout there?" passed while an inline teardown was reintroduced above it, because the timer was still present, merely unreachable. The guard now slices the branch at the timer and asserts nothing destructive precedes it, and that sabotage fails correctly.

Agent-side only. WHEP is the shared live transport — server/services/ stream_service.py, server/routers/streams.py, mediamtx.docker.yml and the core Live view — and none of it is touched here; the agent is only a client of it. No playback, recording or server-side change.

Full agent suite 784 passed, 7 skipped. Camera screen rendered at 1280px and 390px: no layout change.