### PR TITLE
fix: stop the platform hiding its own AI failures (issue #344 + the C…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -476,6 +476,15 @@ services:
       - MEDIAMTX_HLS_URL=http://mediamtx:8888
       - MEDIAMTX_RTSP_URL=rtsp://mediamtx:8554
       - MEDIAMTX_RTSPS_URL=rtsps://mediamtx:8322
+      # Where the app's "Compute-gated inference" panel reads the Tier-0
+      # detect-pipeline's Prometheus /metrics. The server's config default
+      # is localhost:9109, which is correct only when server and pipeline
+      # share a host — inside this container it is the CORE's own loopback,
+      # so without this line the panel says "not reachable" on every
+      # compose install regardless of the pipeline's actual health.
+      # Follows DETECT_METRICS_PORT (0 disables exposition on the pipeline;
+      # the server treats a :0 URL as "disabled", not "unreachable").
+      - DETECT_PIPELINE_METRICS_URL=http://detect-pipeline:${DETECT_METRICS_PORT:-9109}
       # Tier-0 tap selection (auto | sub | main) + the hardware-decode
       # signal 'auto' keys off — same DETECT_HWACCEL the detect-pipeline
       # container gets, so both sides agree on what the hardware can do.

--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -614,7 +614,20 @@ class OllamaClient(_ReusableClientMixin):
         resp = await self._client().post(self._url, json=body, headers=headers)
         if "think" in body and getattr(resp, "status_code", 200) >= 400:
             # Some Ollama versions / non-thinking models reject the ``think``
-            # field. Retry once without it rather than failing the turn.
+            # field. Retry once without it rather than failing the turn — but
+            # READ THE BODY FIRST. This used to fire on any 4xx, so a missing
+            # model ("model 'x' not found, try pulling it first", HTTP 404)
+            # burned the retry on a request doomed to the same 404 and logged
+            # a misleading "rejected with think=..." line (issue #344's box).
+            # A think rejection names the field; a missing model says "not
+            # found". Only the former is worth a second request.
+            err_text = ""
+            try:
+                err_text = (resp.text or "").lower()
+            except Exception:  # pragma: no cover - defensive
+                pass
+            if "not found" in err_text and "think" not in err_text:
+                resp.raise_for_status()
             logger.info("ollama: request rejected with think=%s; retrying without it", body["think"])
             body.pop("think", None)
             resp = await self._client().post(self._url, json=body, headers=headers)

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import httpx
 import yaml
 from fastapi import FastAPI, Request, WebSocket
 from fastapi.responses import HTMLResponse, JSONResponse, Response
@@ -2972,6 +2973,14 @@ class CameraAgentRuntime:
     def __init__(self, cfg: AppConfig) -> None:
         self.cfg = cfg
 
+        # The last LLM failure, for /health and the demo's header dot — None
+        # while the brain answers. Issue #344: Ollama crash-looped for three
+        # days while the dot glowed green and every question said only
+        # "assistant failed"; this is the field that would have said why.
+        # Set/cleared ONLY by the turn loop (real questions), never by
+        # boot-time prewarm, whose transient failures are not a verdict.
+        self.last_llm_error: str | None = None
+
         self.context = CameraContext(
             cameras=cfg.cameras,
             frame_cache_ttl_seconds=cfg.frame_cache_ttl_seconds,
@@ -5069,6 +5078,9 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             # failure reason (None = last look succeeded or none ran yet) and
             # whether the events store (History) is wired.
             "vision_error": getattr(runtime.tools, "last_vision_error", None),
+            # The last LLM failure from a real turn (None = answering).
+            # Issue #344: the brain crash-looped for days behind a green dot.
+            "llm_error": getattr(runtime, "last_llm_error", None),
             "history": getattr(runtime, "events_client", None) is not None,
         }
 
@@ -5791,6 +5803,11 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             # racing thumbnail fetch may have overwritten the cache seed,
             # and the chat must show the frame the answer was ABOUT.
             frames = _frames_for(runtime)
+        except LLMTurnError as exc:
+            # The diagnosis IS the message (issue #344): "model X not found,
+            # try pulling it first" must reach the operator, not the log.
+            logger.error("ask: %s", exc)
+            return JSONResponse({"error": str(exc)}, status_code=502)
         except Exception:
             logger.exception("ask: turn failed")
             return JSONResponse({"error": "assistant failed"}, status_code=502)
@@ -5974,6 +5991,9 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 return JSONResponse({"transcript": transcript, "reply": "",
                                      "audio_b64": None, "timings_ms": timings,
                                      "cancelled": True})
+            except LLMTurnError as exc:
+                logger.error("converse: %s", exc)
+                return JSONResponse({"error": str(exc)}, status_code=502)
             except Exception:
                 logger.exception("converse: LLM turn failed")
                 return JSONResponse({"error": "assistant failed"}, status_code=502)
@@ -6519,6 +6539,57 @@ def _pick_camera(text: str, cameras: list[str], preferred: str | None = None) ->
     return cameras[0]
 
 
+class LLMTurnError(RuntimeError):
+    """The LLM leg of a turn failed, with a message worth SHOWING.
+
+    Issue #344's shape: httpx raised, the generic handler said "assistant
+    failed", and the one line that named the fix — Ollama's own error body,
+    literally "model not found, try pulling it first" — was thrown away.
+    Handlers turn this into a 502 whose ``error`` is the diagnosis, and the
+    same text lands in ``runtime.last_llm_error`` for /health.
+    """
+
+
+async def _chat_or_explain(runtime: "CameraAgentRuntime", **kw: Any) -> dict[str, Any]:
+    """One LLM call that either succeeds (clearing ``last_llm_error``) or
+    raises :class:`LLMTurnError` carrying a human-usable reason.
+
+    The URL in the message is the one the AGENT dials — on a compose install
+    that is ``host.docker.internal:11434``, and naming it is what turns
+    "assistant failed" into "go start Ollama on the host"."""
+    where = (runtime.cfg.llm_base_url or runtime.cfg.ollama_url
+             if runtime.cfg.llm_provider.strip().lower() == "openai"
+             else runtime.cfg.ollama_url)
+    try:
+        response = await runtime.ollama.chat(**kw)
+    except httpx.HTTPStatusError as exc:
+        # The body is the diagnosis ("model X not found, try pulling it
+        # first") — keep it. Cap it: error pages can be arbitrarily long.
+        body = ""
+        try:
+            body = (exc.response.text or "").strip()[:300]
+        except Exception:  # pragma: no cover - defensive
+            pass
+        msg = (f"LLM at {where} answered HTTP "
+               f"{exc.response.status_code}: {body or 'no detail'}")
+        runtime.last_llm_error = msg
+        raise LLMTurnError(msg) from exc
+    except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+        msg = (f"LLM unreachable at {where} ({exc.__class__.__name__}) — "
+               f"is the runtime (e.g. Ollama) running and reachable from "
+               f"the agent?")
+        runtime.last_llm_error = msg
+        raise LLMTurnError(msg) from exc
+    except httpx.TimeoutException as exc:
+        msg = f"LLM at {where} timed out ({exc.__class__.__name__})"
+        runtime.last_llm_error = msg
+        raise LLMTurnError(msg) from exc
+    # Answers clear the flag — the dot goes green again on the next /health
+    # poll, no separate probe, no extra traffic.
+    runtime.last_llm_error = None
+    return response
+
+
 async def _run_conversation_turn(
     runtime: "CameraAgentRuntime",
     history: list[dict[str, str]],
@@ -6582,7 +6653,8 @@ async def _run_conversation_turn(
     #                        gets the real detection/caption instead of "Sorry".
     for iteration in range(max_iterations):
         _llm_t0 = time.perf_counter()
-        response = await runtime.ollama.chat(
+        response = await _chat_or_explain(
+            runtime,
             messages=messages,
             tools=tools,
             temperature=runtime.cfg.llm_temperature,

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1412,7 +1412,14 @@
     // /health is an open path, so the dot works even behind the login.
     async function pollHealth(){ const d=$("healthDot"); if(!d) return;
       try{ const h=await (await fetch("/health")).json();
-        if(h.vision_error){ d.className="hdot warn";
+        // LLM first: a dead brain outranks a degraded eye — with it down,
+        // EVERY question fails, so the dot goes red, not amber. The title
+        // carries the server's actual reason ("model X not found — pull
+        // it", "unreachable at host.docker.internal:11434"), because a
+        // red dot with no diagnosis is how issue #344 took three people.
+        if(h.llm_error){ d.className="hdot down";
+          d.title="LLM failing: "+h.llm_error; }
+        else if(h.vision_error){ d.className="hdot warn";
           d.title="Vision degraded: "+h.vision_error; }
         else { d.className="hdot ok"; d.title="Agent healthy"; }
       }catch{ d.className="hdot down"; d.title="Agent unreachable"; } }

--- a/examples/camera-agent/tests/test_llm_error_surfacing.py
+++ b/examples/camera-agent/tests/test_llm_error_surfacing.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Issue #344's real lesson: the agent's brain (Ollama) crash-looped for
+three days while the health dot glowed green and every question returned a
+bare "assistant failed" — and when the model was missing, Ollama's own 404
+body LITERALLY contained the fix ("model 'x' not found, try pulling it
+first") and the agent threw it away.
+
+These pin the surfacing that replaces that:
+
+* an LLM connect failure → 502 whose error NAMES the URL, and /health
+  carries the same text as ``llm_error``;
+* an LLM HTTP failure → the response BODY (the diagnosis) is kept;
+* a successful turn CLEARS ``llm_error`` — green means answering again;
+* non-LLM turn failures keep the old generic 502 (no behaviour change);
+* the think=False retry reads the error body first: a missing model is
+  not a think rejection, and must not burn the retry on a doomed request;
+* the demo's header dot treats llm_error as red-with-reason, above the
+  amber vision_error.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+import camera_agent as ca
+from camera_agent import AppConfig, CameraAgentRuntime, build_app
+from context import CameraSpec
+
+
+def _runtime():
+    cfg = AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t", text_mode=True,
+        synthetic_detection=True,
+        cameras=[CameraSpec(camera_id="front_door", frame_url="synth:people=2",
+                            role="door")],
+    )
+    return CameraAgentRuntime(cfg)
+
+
+class _DeadOllama:
+    """The LLM leg of issue #344: connection refused, every time."""
+    async def chat(self, **kw):
+        raise httpx.ConnectError("All connection attempts failed")
+
+    async def aclose(self):
+        return None
+
+
+class _Http404Ollama:
+    """Ollama answering but the model is missing — its body IS the fix."""
+    def __init__(self, body: str):
+        self._body = body
+
+    async def chat(self, **kw):
+        req = httpx.Request("POST", "http://host.docker.internal:11434/api/chat")
+        resp = httpx.Response(404, request=req, text=self._body)
+        raise httpx.HTTPStatusError("404", request=req, response=resp)
+
+    async def aclose(self):
+        return None
+
+
+class _AnsweringOllama:
+    async def chat(self, **kw):
+        return {"message": {"content": "All quiet.", "tool_calls": []}}
+
+    async def aclose(self):
+        return None
+
+
+# ── connect failure: the 502 explains, /health carries it ───────────────
+
+def test_unreachable_llm_names_the_url_in_the_502():
+    rt = _runtime()
+    rt.ollama = _DeadOllama()
+    client = TestClient(build_app(rt))
+    r = client.post("/ask", json={"text": "anyone at the door?"})
+    assert r.status_code == 502
+    err = r.json()["error"]
+    assert "unreachable" in err
+    assert rt.cfg.ollama_url in err           # the address the AGENT dials
+    assert err != "assistant failed"          # the old, useless message
+
+
+def test_llm_failure_reaches_health_as_llm_error():
+    rt = _runtime()
+    rt.ollama = _DeadOllama()
+    client = TestClient(build_app(rt))
+    client.post("/ask", json={"text": "hello"})
+    h = client.get("/health").json()
+    assert h["llm_error"] is not None
+    assert "unreachable" in h["llm_error"]
+
+
+# ── HTTP failure: the body is the diagnosis, keep it ────────────────────
+
+def test_http_error_keeps_ollamas_own_diagnosis():
+    rt = _runtime()
+    body = json.dumps({"error": "model \"qwen2.5:3b\" not found, "
+                                "try pulling it first"})
+    rt.ollama = _Http404Ollama(body)
+    client = TestClient(build_app(rt))
+    r = client.post("/ask", json={"text": "hello"})
+    assert r.status_code == 502
+    assert "try pulling it first" in r.json()["error"]
+    assert "404" in r.json()["error"]
+    h = client.get("/health").json()
+    assert "try pulling it first" in h["llm_error"]
+
+
+def test_http_error_body_is_capped():
+    # An error page can be arbitrarily long; llm_error must not become one.
+    rt = _runtime()
+    rt.ollama = _Http404Ollama("x" * 10_000)
+    client = TestClient(build_app(rt))
+    r = client.post("/ask", json={"text": "hello"})
+    assert len(r.json()["error"]) < 500
+
+
+# ── recovery: success clears the flag ───────────────────────────────────
+
+def test_a_successful_turn_clears_llm_error():
+    rt = _runtime()
+    rt.ollama = _DeadOllama()
+    client = TestClient(build_app(rt))
+    client.post("/ask", json={"text": "hello"})
+    assert client.get("/health").json()["llm_error"] is not None
+    rt.ollama = _AnsweringOllama()            # Ollama came back
+    r = client.post("/ask", json={"text": "hello again"})
+    assert r.status_code == 200
+    assert client.get("/health").json()["llm_error"] is None
+
+
+def test_healthy_boot_reports_no_llm_error():
+    rt = _runtime()
+    h = TestClient(build_app(rt)).get("/health").json()
+    assert h["llm_error"] is None
+
+
+# ── non-LLM failures keep the old generic message ───────────────────────
+
+def test_non_llm_failures_still_say_assistant_failed(monkeypatch):
+    rt = _runtime()
+    rt.ollama = _AnsweringOllama()
+
+    async def _boom(*a, **k):
+        raise RuntimeError("something unrelated")
+    monkeypatch.setattr(ca, "_run_conversation_turn", _boom)
+    client = TestClient(build_app(rt))
+    r = client.post("/ask", json={"text": "hello"})
+    assert r.status_code == 502
+    assert r.json()["error"] == "assistant failed"
+    # And it must NOT masquerade as an LLM problem.
+    assert client.get("/health").json()["llm_error"] is None
+
+
+# ── the think retry reads the body before burning its one retry ─────────
+
+def _ollama_client_with(status: int, body: str, calls: list):
+    from adapter_clients import OllamaClient
+    c = OllamaClient(url="http://x:11434", token="", model="m", think=False)
+
+    class _Resp:
+        status_code = status
+        text = body
+
+        def raise_for_status(self):
+            if status >= 400:
+                req = httpx.Request("POST", "http://x:11434/api/chat")
+                raise httpx.HTTPStatusError(
+                    str(status), request=req,
+                    response=httpx.Response(status, request=req, text=body))
+
+        def json(self):
+            return {"message": {"content": "ok"}}
+
+    class _C:
+        async def post(self, url, **kw):
+            # Copy: the client pops "think" from this dict IN PLACE for the
+            # retry, and a stored reference would retroactively lose the key.
+            calls.append(dict(kw.get("json", {})))
+            return _Resp()
+
+    c._client = lambda: _C()
+    return c
+
+
+def test_missing_model_is_not_mistaken_for_a_think_rejection():
+    """Issue #344's box: a 404 'model not found' fired the think retry —
+    one extra doomed request and a misleading log line."""
+    calls: list = []
+    c = _ollama_client_with(
+        404, '{"error":"model \\"qwen2.5:3b\\" not found, try pulling it first"}',
+        calls)
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(c.chat(messages=[{"role": "user", "content": "hi"}]))
+    assert len(calls) == 1, "a missing model must not burn the think retry"
+
+
+def test_a_real_think_rejection_still_retries_without_it():
+    calls: list = []
+    c = _ollama_client_with(400, '{"error":"this model does not support think"}',
+                            calls)
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(c.chat(messages=[{"role": "user", "content": "hi"}]))
+    assert len(calls) == 2, "a think rejection keeps its retry"
+    assert "think" in calls[0] and "think" not in calls[1]
+
+
+# ── demo: the header dot puts the brain above the eye ───────────────────
+
+_HTML = (Path(__file__).resolve().parents[1] / "demo" / "index.html").read_text()
+
+
+def test_demo_health_dot_shows_llm_error_red_and_first():
+    fn = _HTML[_HTML.index("async function pollHealth"):]
+    fn = fn[:fn.index("// ── History card")]
+    assert "h.llm_error" in fn
+    # Red (down), not amber: with the brain gone EVERY question fails.
+    llm = fn[fn.index("h.llm_error"):]
+    assert 'className="hdot down"' in llm[:200]
+    # And it outranks vision_error: checked first.
+    assert fn.index("h.llm_error") < fn.index("h.vision_error")
+    assert "LLM failing:" in fn

--- a/server/services/tier0_metrics.py
+++ b/server/services/tier0_metrics.py
@@ -361,7 +361,11 @@ async def get_tier0_metrics() -> dict[str, Any]:
     unreachable — a normal state (gate off / pipeline not deployed), not an error.
     """
     base = (settings.detect_pipeline_metrics_url or "").rstrip("/")
-    if not base:
+    # ``:0`` is DETECT_METRICS_PORT=0 flowing through the compose URL
+    # (docker-compose.yml builds it as http://detect-pipeline:${PORT}):
+    # the operator disabled exposition on the pipeline, so report
+    # "disabled" — probing port 0 would misreport it as "unreachable".
+    if not base or base.endswith(":0"):
         return {"available": False, "reason": "disabled"}
     url = f"{base}/metrics"
     try:

--- a/server/tests/test_tier0_metrics.py
+++ b/server/tests/test_tier0_metrics.py
@@ -192,6 +192,33 @@ def test_get_tier0_metrics_disabled_config(monkeypatch):
     assert out == {"available": False, "reason": "disabled"}
 
 
+def test_get_tier0_metrics_port_zero_is_disabled_not_unreachable(monkeypatch):
+    # DETECT_METRICS_PORT=0 disables exposition on the pipeline; compose
+    # builds the URL as http://detect-pipeline:${PORT}, so the server sees
+    # ":0". That is the operator saying OFF — probing it would misreport
+    # a deliberate choice as a fault.
+    from services import tier0_metrics as mod
+    monkeypatch.setattr(mod.settings, "detect_pipeline_metrics_url",
+                        "http://detect-pipeline:0", raising=False)
+    out = asyncio.run(get_tier0_metrics())
+    assert out == {"available": False, "reason": "disabled"}
+
+
+def test_compose_wires_core_to_the_detect_pipeline_metrics():
+    """The bug this guards: the config default is http://localhost:9109,
+    which inside the core container is core's OWN loopback — the panel
+    read "not reachable" on every compose install regardless of the
+    pipeline's actual health, because compose never overrode it. (No
+    commit in history ever set DETECT_PIPELINE_METRICS_URL before this.)
+    """
+    compose = (REPO_ROOT / "docker-compose.yml").read_text()
+    assert ("DETECT_PIPELINE_METRICS_URL=http://detect-pipeline:"
+            "${DETECT_METRICS_PORT:-9109}") in compose, (
+        "the core service no longer tells the server where the "
+        "detect-pipeline's /metrics lives — the Compute-gated panel "
+        "will read 'not reachable' on every Docker install")
+
+
 def test_nan_and_inf_values_are_dropped_not_crashing():
     # float() accepts NaN/+Inf; they must be filtered so int() casts can't blow up.
     text = "\n".join([


### PR DESCRIPTION
…ompute-gated panel)

Two surfacing bugs, found in the same week, with the same shape: the truth existed and nothing showed it.

1. THE COMPUTE-GATED PANEL LIED ON EVERY DOCKER INSTALL. The server reads the detect-pipeline's /metrics from detect_pipeline_metrics_url, whose config default is http://localhost:9109 — correct only when server and pipeline share a host. Inside the core container that is core's OWN loopback, and no commit in history ever set DETECT_PIPELINE_METRICS_URL in compose (git log -S comes back empty). So the panel said "the detect-pipeline is not reachable" on every compose install, regardless of the pipeline's actual health — observed on a box whose pipeline was Up 2 days (healthy) with four workers decoding.

   docker-compose.yml now wires the core to http://detect-pipeline:${DETECT_METRICS_PORT:-9109}. It follows DETECT_METRICS_PORT, and the server treats a resulting ":0" URL (operator disabled exposition) as "disabled", not "unreachable" — probing port 0 would misreport a deliberate choice as a fault.

2. THE AGENT SWALLOWED ITS OWN DIAGNOSIS (issue #344). Ollama crash-looped for three days behind a green health dot; every question returned a bare "assistant failed" 502. When the model was missing, Ollama's 404 body literally contained the fix — "model 'x' not found, try pulling it first" — and raise_for_status() threw it away. Diagnosis took three people and a debugging thread; it should have been one glance.

   The turn loop's LLM call now goes through _chat_or_explain:

   * connect/timeout failures raise LLMTurnError naming the URL the agent actually dials (host.docker.internal:11434 on a compose install — naming it is what turns "assistant failed" into "go start Ollama");
   * HTTP failures keep the response body (capped at 300 chars — error pages can be arbitrarily long);
   * the same text lands in runtime.last_llm_error, served by /health as llm_error — set by real turns only, never by boot-time prewarm, and CLEARED by the next successful turn, so recovery is visible without any extra probe or traffic;
   * /ask and /converse return the diagnosis as the 502's error; all other failures keep the old generic message unchanged;
   * the demo's header dot shows llm_error red-with-reason, above the amber vision_error — with the brain gone, every question fails.

   Also: the think=False retry fired on ANY 4xx, so the missing model
   burned its one retry on a doomed request and logged a misleading
   "rejected with think=..." line. It now reads the error body first: a
   think rejection names the field; "not found" is not one.

Tests: 12 added — connect failure names the URL, HTTP failure keeps the body (and caps it), success clears, non-LLM failures stay generic, the think retry distinguishes missing-model from think-rejection (a stored request dict had to be copied: the client pops "think" in place), the demo dot ranks llm above vision, compose wiring guarded, and port-0 is "disabled". All 11 sabotage checks fail their own guard and no other. Agent suite 801 passed / 7 skipped; server tier0 suite 22/22. Compose YAML parses; demo JS parses.

Pre-existing and NOT touched here: server's
test_reconciler_identity.py::test_orphan_aging_removes_fully_aged_tree fails deterministically on clean main before this change.

No change to playback, recording, or any pipeline behaviour — every edit is error REPORTING, plus one compose env line.