### PR TITLE
docs: RFC-0002 Phase 0 — event contracts, CI-enforced

### DIFF
--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -1,0 +1,214 @@
+# OpenNVR Event Contracts
+
+Status: **normative** (RFC-0002 Phase 0). Every subject a first-party
+app or service publishes or subscribes to on the bus MUST appear in
+this document — CI enforces that (`server/tests/test_event_contracts.py`).
+
+This document is the answer to "what can I subscribe to, and what will
+I get?" — without reading any producer's source code. RFC-0002
+decision 3: contracts come before the registry, because a registry
+that indexes unversioned, producer-shaped events indexes drift.
+
+## The envelope
+
+Every **domain event** (the `opennvr.events.*` tree, defined below)
+carries these fields at the top level of a JSON object. Producers MUST
+set all of them; consumers MUST tolerate extra fields (additive-only
+rule, next section).
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | string | Unique per event. `evt_` + 12 hex chars. |
+| `schema` | string | The versioned schema name, e.g. `plate.recognized.v1`. Redundant with the subject on purpose — payloads get stored, forwarded, and read without their subject. |
+| `correlation_id` | string \| null | Joins the event to the KAI-C audit trail and to every other event in the same causal chain (alert → inference → adapter audit line). Thread it, never mint a new one mid-chain. |
+| `camera_id` | string | The camera this event is about. |
+| `ts` | string | ISO-8601 UTC wall-clock time of the *observation* (not of publish). Monotonic clocks never appear in contracts — see the `wall_ts` lesson in `detect_pipeline/bus.py`. |
+| `producer` | string | Who published: `tier1-dispatch`, `kai-c`, `core`, or `app:<name>`. Consumers MUST NOT branch on it (that is the whole point); it exists for audit and debugging. |
+| `payload` | object | The schema-specific body, defined per event below. |
+
+## Subject naming
+
+```
+opennvr.events.<domain>.<event>.v<N>.<camera_id>
+```
+
+* `<domain>.<event>` — noun.verb-in-past-tense: `plate.recognized`,
+  `visit.recorded`. The domain is the *subject matter* (plate, visit,
+  detection, alert), never the producer or the adapter.
+* `.v<N>` — major version, part of the subject so a v2 can run beside
+  v1 during migration and subscribers pick explicitly.
+* `.<camera_id>` — last token, so `opennvr.events.plate.recognized.v1.>`
+  subscribes to all cameras and `...v1.cam-front` to one.
+
+### Versioning: additive-only
+
+Within a version, changes may only **add** optional fields. Renaming,
+removing, retyping, or changing the meaning of an existing field
+requires `v<N+1>` — published in parallel until consumers migrate,
+then the old version is retired in a minor release with notice.
+Consumers MUST ignore unknown fields (`extra="ignore"` in Pydantic
+terms). This is the same rule KAI-C's `InferenceCompletedEvent`
+already follows; it is now the rule everywhere.
+
+## The two trees: domain events vs adapter completions
+
+Two event families exist on the bus, on purpose:
+
+1. **Adapter completions** — `opennvr.inference.<adapter>.<camera_id>.completed`
+   (and `.gate`). Published by KAI-C after every successful infer call
+   and by Tier-0 for its own frames. Shaped by the *adapter's*
+   response. These are **plumbing**: correct for consumers that care
+   about the inference machinery itself (metrics, audit, the
+   inference-listener example). They are versioned by the adapter's
+   own schema field (`opennvr.tier0.v1`) and are NOT the surface apps
+   should build business logic on.
+
+2. **Domain events** — `opennvr.events.<domain>.<event>.v<N>.<camera_id>`.
+   Producer-independent, envelope-carrying, versioned by contract.
+   **This is the surface for apps.**
+
+### The split decision (RFC-0002 Phase 0, decided)
+
+Tier-1 dispatch results land today on adapter-shaped subjects only.
+The decided rule: **the completion publish site also emits the domain
+event** — a thin normaliser at the source, not a new service.
+Concretely, KAI-C's `_publish_inference_completed` consults a small
+static map (adapter name → domain schema + payload extractor) and,
+when the adapter has a domain mapping, publishes the domain event
+right after the completion. Both events carry the same
+`correlation_id`.
+
+Why this over the alternatives considered:
+
+* *A standalone normaliser service* is a new moving part whose only
+  job is to re-publish; on a platform that runs on one box, that is
+  cost without isolation benefit.
+* *Domain schema riding inside the completion payload* leaves
+  subscribers needing to know adapter subjects — which fails Phase
+  0's acceptance test ("a subscriber can consume plates without
+  knowing which producer fired them").
+
+The map lives in KAI-C beside the publisher, is part of this contract
+(the table below), and growing it is a docs-reviewed change:
+
+| Adapter | Domain event emitted |
+|---|---|
+| `fast_plate_ocr` | `plate.recognized.v1` |
+
+## Contracted events (v1)
+
+What already flows, now with names. Payload field tables list required
+fields; producers may add optional ones under the additive-only rule.
+
+### `detection.observed.v1`
+
+Subject: `opennvr.events.detection.observed.v1.<camera_id>`
+Producer: Tier-0 (`detect-pipeline`).
+
+One event per published Tier-0 frame result that contains at least one
+track. This is the domain rendering of the existing
+`opennvr.inference.tier0.<camera_id>.completed` / `opennvr.tier0.v1`
+payload — that adapter-tree subject continues unchanged for plumbing
+consumers.
+
+`payload`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `frame` | object | `{w, h}` in pixels — lets consumers normalise boxes. |
+| `calibrating` | bool | Tier-0 still calibrating; treat tracks as provisional. |
+| `tracks` | array | Same track shape as `opennvr.tier0.v1` (`id`, `label`, `conf`, `bbox`, motion fields). Normative source: `detect_pipeline/bus.py::build_payload`. |
+
+### `visit.recorded.v1`
+
+Subject: `opennvr.events.visit.recorded.v1.<camera_id>`
+Producer: core (timeline ingestion), at the moment a finished visit
+row is persisted (`services/timeline_service.py::record_track_visit`).
+
+Today visits are DB rows only; this contract puts the fact on the bus
+so apps stop polling the timeline API for "something happened".
+
+`payload`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `event_id` | int | The timeline row id — join key for the REST API. |
+| `label` | string | Track label (`person`, `car`, ...). |
+| `started_at` / `ended_at` | string | ISO-8601 UTC visit bounds. |
+| `evidence_path` | string \| null | Best-frame evidence reference, resolvable via the evidence API (not a raw filesystem path promise). |
+
+### `plate.recognized.v1`
+
+Subject: `opennvr.events.plate.recognized.v1.<camera_id>`
+Producer: the KAI-C normaliser (see the split decision) — regardless
+of whether the OCR was initiated by Tier-1 dispatch or by core's
+enrichment during the transition.
+
+One event per **accepted** OCR read (a plate was actually extracted —
+empty/failed reads do not fire).
+
+`payload`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `plate_text` | string | The normalised read, uppercase, no separators. |
+| `confidence` | number \| null | Adapter-reported confidence for the read, when available. |
+| `vehicle_label` | string \| null | Upstream detection label (`car`/`truck`/`bus`) when the chain knows it. |
+| `event_id` | int \| null | Timeline visit row this read enriches, when initiated from a visit. |
+
+#### Producer convergence (Phase 0 exit criterion)
+
+Two callers currently initiate plate OCR: core's
+`services/plate_enrichment.py` (per persisted vehicle visit) and
+Tier-1 dispatch (per escalated track, best-frame). Convergence:
+
+1. The normaliser ships first — both initiators immediately produce
+   the same `plate.recognized.v1`, because the event fires at KAI-C,
+   the one place both paths already meet. Nothing breaks on installs
+   where Tier-1 routes are disabled.
+2. Core's enrichment then becomes a *consumer*: it subscribes to
+   `plate.recognized.v1` and writes `plate_text` onto the matching
+   visit row. Its own OCR call is demoted to fallback for events the
+   dispatch path did not cover, and retires with Phase 4 (one OCR per
+   visit, dispatch-initiated, best-frame).
+
+Accept: a subscriber consumes plates without knowing which producer
+fired them.
+
+### `alert.fired.v1`
+
+Subject: `opennvr.events.alert.fired.v1.<camera_id>`
+Producer: `app:<name>` via the App SDK's NATS alert dispatcher.
+
+The existing wire shape (`opennvr_app_sdk/alerts.py::Alert.to_wire`:
+`alert_id`, `fired_at`, `title`, `description`, `severity`, `source`,
+`camera_id`, `correlation_id`, `evidence`, `tags`) **is** the v1
+payload — it already satisfies the envelope's spirit and every
+first-party app publishes it.
+
+Transition note: apps publish today on
+`opennvr.alerts.{source.kind}.{source.name}.{camera_id}`. That tree
+remains supported as the *plumbing* address (subscribers filtering by
+which app fired, e.g. the alerts-subscriber example). The SDK
+dispatcher dual-publishes to the domain subject so consumers that
+only care "an alert fired on this camera" stop encoding app names in
+subscriptions. New consumers use the domain subject.
+
+## Out of contract (deliberately)
+
+* `opennvr.inference.>` payload internals beyond what each adapter's
+  own schema field declares — plumbing, versioned per producer.
+* Recording, playback, and media subjects — explicitly out of
+  RFC-0002 scope; nothing in this phase touches them.
+* Agent/UI websocket traffic — not bus events.
+
+## Checklist for adding an event
+
+1. Add the schema table here, under a `v1` heading, with subject and
+   producer.
+2. Envelope fields all present; payload additive-only from day one.
+3. If a Tier-1 adapter produces it, add the adapter → domain row to
+   the normaliser map table.
+4. CI (`test_event_contracts.py`) will fail any first-party publish or
+   subscribe on an `opennvr.events.*` subject that this document does
+   not list — that failure is the review prompt, not an obstacle.

--- a/kai-c/kai_c/domain_events.py
+++ b/kai-c/kai_c/domain_events.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RFC-0002 Phase 0 normaliser: adapter completions → domain events.
+
+``docs/EVENT_CONTRACTS.md`` (the normative source) decided that the
+completion publish site also emits the producer-independent domain
+event — a thin normaliser at the source, not a new service. KAI-C is
+that site: every plate OCR call, whether initiated by Tier-1 dispatch
+or by core's visit enrichment, already meets here, so publishing the
+domain event here is what makes "a subscriber can consume plates
+without knowing which producer fired them" literally true.
+
+The map is deliberately static and small. Growing it is a
+docs-reviewed change: add the adapter → domain row to the contracts
+doc table first, then here.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional, Tuple
+
+logger = logging.getLogger("kai-c.domain_events")
+
+#: ``producer`` envelope field. Audit/debugging only — the contract
+#: forbids consumers branching on it.
+DOMAIN_EVENT_PRODUCER = "kai-c"
+
+#: (subject, envelope) ready to publish, or None for "no domain event
+#: for this completion" (not an error — most completions have none).
+Normalised = Optional[Tuple[str, Dict[str, Any]]]
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _envelope(
+    schema: str,
+    *,
+    camera_id: str,
+    correlation_id: Optional[str],
+    payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    """The EVENT_CONTRACTS.md envelope. Every field, every time."""
+    return {
+        "id": "evt_" + uuid.uuid4().hex[:12],
+        "schema": schema,
+        "correlation_id": correlation_id,
+        "camera_id": camera_id,
+        "ts": _utcnow_iso(),
+        "producer": DOMAIN_EVENT_PRODUCER,
+        "payload": payload,
+    }
+
+
+def _normalise_fast_plate_ocr(
+    result: Dict[str, Any],
+    *,
+    camera_id: str,
+    correlation_id: Optional[str],
+    event_id: Optional[int],
+) -> Normalised:
+    """``fast_plate_ocr`` completion → ``plate.recognized.v1``.
+
+    Fires only for **accepted** reads (the contract): honours the
+    adapter's own ``accepted`` verdict when present and requires a
+    non-empty ``plate_text``. Normalisation (uppercase, no separators,
+    capped) mirrors core's ``plate_enrichment.extract_plate`` so the
+    bus and the timeline column can never disagree about the text.
+    """
+    if result.get("accepted") is False:
+        return None
+    text = result.get("plate_text")
+    if not isinstance(text, str):
+        return None
+    text = "".join(text.split()).upper()[:32]
+    if not text:
+        return None
+    confidence = result.get("confidence")
+    if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+        confidence = None
+    payload: Dict[str, Any] = {
+        "plate_text": text,
+        "confidence": confidence,
+        # The chain's upstream detection label. The initiators that know
+        # it don't currently thread it through the infer payload; the
+        # field is contracted optional so it can arrive additively.
+        "vehicle_label": None,
+        "event_id": event_id,
+    }
+    subject = f"opennvr.events.plate.recognized.v1.{camera_id}"
+    return subject, _envelope(
+        "plate.recognized.v1",
+        camera_id=camera_id,
+        correlation_id=correlation_id,
+        payload=payload,
+    )
+
+
+#: adapter name → normaliser. Mirrors the table in EVENT_CONTRACTS.md.
+NORMALISERS: Dict[str, Callable[..., Normalised]] = {
+    "fast_plate_ocr": _normalise_fast_plate_ocr,
+}
+
+
+def normalise_completion(
+    adapter_name: str,
+    result: Any,
+    *,
+    camera_id: Optional[str],
+    correlation_id: Optional[str] = None,
+    event_id: Optional[int] = None,
+) -> Normalised:
+    """Domain event for one successful completion, or None.
+
+    None is the common case: no normaliser for this adapter, no
+    camera_id (a domain event without its camera is uncontractable —
+    conformance probes land here), or the normaliser judged the result
+    not domain-worthy (e.g. a rejected OCR read). Never raises.
+    """
+    fn = NORMALISERS.get(adapter_name)
+    if fn is None:
+        return None
+    if not camera_id:
+        logger.debug(
+            "domain event skipped for %s: no camera_id [correlation_id=%s]",
+            adapter_name, correlation_id,
+        )
+        return None
+    if not isinstance(result, dict):
+        return None
+    try:
+        return fn(
+            result,
+            camera_id=camera_id,
+            correlation_id=correlation_id,
+            event_id=event_id,
+        )
+    except Exception:  # noqa: BLE001 — normalisation must never hurt the caller
+        logger.warning(
+            "domain-event normalisation failed for %s [correlation_id=%s]",
+            adapter_name, correlation_id, exc_info=True,
+        )
+        return None

--- a/kai-c/kai_c/nats_publisher.py
+++ b/kai-c/kai_c/nats_publisher.py
@@ -203,6 +203,41 @@ class NatsPublisher:
             self._client = None
             return False
 
+    async def publish_domain_event(self, subject: str, envelope: dict) -> bool:
+        """Publish one RFC-0002 domain event (``opennvr.events.*``).
+
+        Same never-raise, best-effort semantics as
+        ``publish_inference_completed`` and the same counters — a
+        domain event lost to a bus outage is surfaced by
+        ``failed_count`` on /metrics exactly like a lost completion.
+        """
+        if not self.enabled:
+            return False
+        try:
+            await self._ensure_connected()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "NATS domain publish skipped (connect failure): %s "
+                "[subject=%s]", exc, subject,
+            )
+            self.failed_count += 1
+            return False
+        import json
+
+        payload = json.dumps(envelope).encode("utf-8")
+        try:
+            await self._client.publish(subject, payload)
+            self.published_count += 1
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "NATS domain publish to %r failed: %s [correlation_id=%s]",
+                subject, exc, envelope.get("correlation_id"),
+            )
+            self.failed_count += 1
+            self._client = None
+            return False
+
     # ── Internals ──────────────────────────────────────────────────
 
     async def _ensure_connected(self) -> None:

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -45,6 +45,7 @@ from fastapi import Header
 from kai_c.audit import AuditEventType, AuditStore, new_correlation_id
 from kai_c.connector import KaiConnector
 from kai_c.correlation import CORRELATION_ID_HEADER, CorrelationIdMiddleware
+from kai_c.domain_events import normalise_completion
 from kai_c.events import InferenceCompletedEvent
 from kai_c.nats_publisher import NatsPublisher
 from kai_c.registry import AdapterRegistry
@@ -1225,6 +1226,7 @@ async def _publish_inference_completed(
     correlation_id: str,
     latency_ms: int,
     body: Dict[str, Any],
+    event_id: Optional[int] = None,
 ) -> None:
     """Build an ``InferenceCompletedEvent`` from the response body the
     adapter returned and publish it on NATS. Shared by HTTP and WS
@@ -1286,6 +1288,21 @@ async def _publish_inference_completed(
         )
         return
     await publisher.publish_inference_completed(event)
+
+    # RFC-0002 Phase 0: the completion publish site also emits the
+    # domain event (EVENT_CONTRACTS.md, "the split decision"). The
+    # normaliser returns None for the common no-domain-mapping case
+    # and never raises; publish is the same best-effort as above.
+    normalised = normalise_completion(
+        adapter_name,
+        body.get("result"),
+        camera_id=camera_id,
+        correlation_id=correlation_id,
+        event_id=event_id,
+    )
+    if normalised is not None:
+        subject, envelope = normalised
+        await publisher.publish_domain_event(subject, envelope)
 
 
 @app.post("/api/v1/adapters/refresh", dependencies=[Depends(require_internal_api_key)])
@@ -1368,6 +1385,11 @@ async def v1_infer(
         # delay the HTTP response. (Peer review H1 — earlier we
         # ``await``ed the publish which could add up to 5 s of
         # latency on the first request after a NATS outage.)
+        # ``event_id`` is an optional client reference (the timeline row
+        # an initiator wants this inference joined back to — see
+        # EVENT_CONTRACTS.md, plate.recognized.v1). Plucked like
+        # camera_id: a top-level request param, echoed never interpreted.
+        raw_event_id = payload.get("event_id") if isinstance(payload, dict) else None
         asyncio.create_task(_publish_inference_completed(
             adapter_name=adapter_name,
             adapter=adapter,
@@ -1375,6 +1397,9 @@ async def v1_infer(
             correlation_id=correlation_id,
             latency_ms=latency_ms,
             body=body,
+            event_id=raw_event_id
+            if isinstance(raw_event_id, int) and not isinstance(raw_event_id, bool)
+            else None,
         ))
         return body
 

--- a/kai-c/test/test_domain_events.py
+++ b/kai-c/test/test_domain_events.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RFC-0002 Phase 0 normaliser: completions → domain events.
+
+The contract under test is docs/EVENT_CONTRACTS.md: subject shape
+(camera last), the full envelope every time, accepted-reads-only for
+plate.recognized.v1, and normalise-never-raises. The publisher-side
+guarantee (best-effort, counted, never raises upward) is covered by
+test_nats_publisher.py; here we add only the domain-publish method's
+happy path and disabled short-circuit.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kai_c.domain_events import NORMALISERS, normalise_completion
+from kai_c.nats_publisher import NatsPublisher
+
+PLATE_RESULT = {"accepted": True, "plate_text": "abc 1234", "confidence": 0.91}
+
+
+# ── normalise_completion: mapping + skip cases ─────────────────────
+
+
+def test_fast_plate_ocr_maps_to_plate_recognized_v1():
+    out = normalise_completion(
+        "fast_plate_ocr", PLATE_RESULT,
+        camera_id="cam-front", correlation_id="corr-1", event_id=42,
+    )
+    assert out is not None
+    subject, env = out
+    assert subject == "opennvr.events.plate.recognized.v1.cam-front"
+    # The envelope: every field, every time (EVENT_CONTRACTS.md).
+    assert env["schema"] == "plate.recognized.v1"
+    assert env["correlation_id"] == "corr-1"
+    assert env["camera_id"] == "cam-front"
+    assert env["producer"] == "kai-c"
+    assert env["id"].startswith("evt_") and len(env["id"]) == 16
+    assert env["ts"].endswith("+00:00")
+    assert env["payload"] == {
+        "plate_text": "ABC1234",       # normalised: upper, no spaces
+        "confidence": 0.91,
+        "vehicle_label": None,
+        "event_id": 42,
+    }
+
+
+def test_unmapped_adapter_produces_no_domain_event():
+    assert normalise_completion(
+        "yolov8", {"detections": []}, camera_id="cam-1",
+    ) is None
+
+
+def test_no_camera_id_skips_a_domain_event_needs_its_camera():
+    assert normalise_completion(
+        "fast_plate_ocr", PLATE_RESULT, camera_id=None,
+    ) is None
+    assert normalise_completion(
+        "fast_plate_ocr", PLATE_RESULT, camera_id="",
+    ) is None
+
+
+@pytest.mark.parametrize("result", [
+    {"accepted": False, "plate_text": "ABC1234"},   # adapter's own verdict
+    {"plate_text": ""},                              # empty read
+    {"plate_text": "   "},                           # whitespace-only
+    {"plate_text": 1234},                            # wrong type
+    {},                                              # nothing at all
+    "not-a-dict",                                    # malformed body
+    None,
+])
+def test_only_accepted_reads_fire(result):
+    assert normalise_completion(
+        "fast_plate_ocr", result, camera_id="cam-1",
+    ) is None
+
+
+def test_confidence_only_when_numeric():
+    for raw, expected in [(0.5, 0.5), (1, 1), ("high", None), (True, None), (None, None)]:
+        out = normalise_completion(
+            "fast_plate_ocr",
+            {"plate_text": "XYZ", "confidence": raw},
+            camera_id="cam-1",
+        )
+        assert out is not None
+        assert out[1]["payload"]["confidence"] == expected
+
+
+def test_normalise_never_raises():
+    # A normaliser bug must not hurt the infer path. Break the mapped
+    # normaliser and confirm the wrapper swallows it.
+    def boom(*a, **k):
+        raise RuntimeError("normaliser bug")
+    original = NORMALISERS["fast_plate_ocr"]
+    NORMALISERS["fast_plate_ocr"] = boom
+    try:
+        assert normalise_completion(
+            "fast_plate_ocr", PLATE_RESULT, camera_id="cam-1",
+        ) is None
+    finally:
+        NORMALISERS["fast_plate_ocr"] = original
+
+
+# ── publish_domain_event: same best-effort semantics ───────────────
+
+
+def _publisher_with_fake_client() -> tuple[NatsPublisher, AsyncMock]:
+    pub = NatsPublisher(
+        url="nats://127.0.0.1:4222", token=None, sovereignty_mode="local_only")
+    client = MagicMock()
+    client.publish = AsyncMock()
+    pub._client = client
+    return pub, client
+
+
+@pytest.mark.asyncio
+async def test_publish_domain_event_publishes_json_envelope():
+    pub, client = _publisher_with_fake_client()
+    subject, env = normalise_completion(
+        "fast_plate_ocr", PLATE_RESULT, camera_id="cam-1",
+    )
+    assert await pub.publish_domain_event(subject, env) is True
+    (sent_subject, sent_payload), _ = client.publish.call_args
+    assert sent_subject == subject
+    import json
+    assert json.loads(sent_payload.decode()) == env
+    assert pub.published_count == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_domain_event_disabled_short_circuits():
+    pub = NatsPublisher(url=None, token=None, sovereignty_mode="local_only")
+    assert await pub.publish_domain_event("opennvr.events.x.y.v1.c", {}) is False
+
+
+@pytest.mark.asyncio
+async def test_publish_domain_event_failure_counts_never_raises():
+    pub, client = _publisher_with_fake_client()
+    client.publish = AsyncMock(side_effect=RuntimeError("bus down"))
+    assert await pub.publish_domain_event(
+        "opennvr.events.plate.recognized.v1.cam-1", {"correlation_id": "c"},
+    ) is False
+    assert pub.failed_count == 1
+    assert pub._client is None  # forced rebuild on next call

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -334,6 +334,11 @@ class Settings(BaseSettings):
     # PR-C: OCR the best frame of vehicle visits (fast_plate_ocr via KAI-C)
     # and store plate_text on the event row. Best-effort; off = rows only.
     events_plate_enrichment: bool = True
+    # RFC-0002 Phase 0: NATS URL for core's domain-event consumers
+    # (plate.recognized.v1 today). Compose sets NATS_URL=nats://nats:4222;
+    # empty disables consumption (enrichment's synchronous fallback still
+    # writes plate_text).
+    nats_url: str = ""
 
     @field_validator("trusted_proxy_cidrs", "internal_service_cidrs")
     @classmethod

--- a/server/main.py
+++ b/server/main.py
@@ -526,6 +526,20 @@ async def lifespan(app: FastAPI):
 
     asyncio.create_task(background_recording_reconciler())
 
+    # RFC-0002 Phase 0: consume plate.recognized.v1 from the bus and write
+    # plate_text onto timeline rows — producer-independent (EVENT_CONTRACTS.md
+    # convergence). No NATS_URL / no nats-py degrades to the enrichment
+    # fallback's synchronous writes; the loop itself never raises.
+    async def background_plate_event_consumer():
+        try:
+            from services.plate_event_consumer import run_consumer_loop
+
+            await run_consumer_loop()
+        except Exception as e:
+            main_logger.error(f"Plate event consumer failed: {e}", exc_info=True)
+
+    asyncio.create_task(background_plate_event_consumer())
+
     # Start camera connectivity reconciler — safety net for the MediaMTX
     # runOnReady/runOnNotReady hooks (catches missed hooks and restarts of
     # either process). The loop delays its first pass internally so startup

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
     "python-dotenv>=1.0.0",
+    "nats-py>=2.6",
     "python-jose>=3.3.0",
     "python-multipart>=0.0.6",
     "PyYAML>=6.0.3",

--- a/server/services/plate_enrichment.py
+++ b/server/services/plate_enrichment.py
@@ -106,9 +106,15 @@ async def enrich_event_plate(event_id: int) -> None:
         # camera_id threaded through so KAI-C's audit row and NATS subject
         # attribute this OCR call to the right camera (same convention as
         # process_inference's governed path).
+        # camera_id and event_id thread through KAI-C untouched: camera_id
+        # attributes the audit row + NATS subjects, event_id joins the
+        # resulting plate.recognized.v1 back to this timeline row (RFC-0002
+        # Phase 0 — this call is now the *fallback* producer; the write can
+        # arrive via the bus consumer or the synchronous path below,
+        # whichever lands first).
         payload = build_infer_payload(
             task=PLATE_TASK, jpeg_bytes=jpeg,
-            params={"camera_id": str(row.camera_id)},
+            params={"camera_id": str(row.camera_id), "event_id": int(row.id)},
         )
         try:
             async with _OCR_CONCURRENCY:

--- a/server/services/plate_event_consumer.py
+++ b/server/services/plate_event_consumer.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 OpenNVR
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""RFC-0002 Phase 0: core consumes ``plate.recognized.v1`` from the bus.
+
+Producer convergence (EVENT_CONTRACTS.md): KAI-C's normaliser emits one
+domain event per accepted OCR read regardless of who initiated the call.
+This consumer is core's side of the deal — the timeline's ``plate_text``
+column is written from the *contract event*, so core no longer cares
+whether its own enrichment fallback or Tier-1 dispatch ran the OCR.
+
+Wiring: ``run_consumer_loop`` is a lifespan background task. It is
+best-effort by design — no NATS URL configured, nats-py missing, or the
+broker being down degrades to "rows are written by the enrichment
+fallback's synchronous path only", exactly the pre-RFC behaviour.
+Both writers write the same normalised text, and both skip rows whose
+``plate_text`` is already set, so delivery order and redelivery are
+harmless.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+SUBJECT = "opennvr.events.plate.recognized.v1.>"
+
+#: Reconnect cadence after a connect/subscribe failure. Deliberately slow —
+#: a down bus should cost one warning line a minute, not a hot loop.
+_RETRY_SECONDS = 60.0
+
+
+def apply_plate_event(envelope: object) -> str:
+    """Apply one ``plate.recognized.v1`` envelope to the timeline.
+
+    Pure-decision core of the consumer, unit-testable without a bus.
+    Returns a status token (logged, asserted in tests):
+
+    * ``"applied"``      — wrote ``plate_text`` onto the referenced row.
+    * ``"already-set"``  — row already enriched (fallback raced us, or a
+      redelivery); left untouched.
+    * ``"no-event-id"``  — event carries no timeline reference (e.g. a
+      dispatch-initiated read; joining those is Phase 4's job).
+    * ``"no-plate"`` / ``"malformed"`` — nothing usable in the payload.
+    * ``"not-found"``    — referenced row does not exist (deleted, or a
+      foreign initiator's reference); nothing to do.
+    """
+    if not isinstance(envelope, dict):
+        return "malformed"
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        return "malformed"
+    plate = payload.get("plate_text")
+    if not isinstance(plate, str) or not plate.strip():
+        return "no-plate"
+    event_id = payload.get("event_id")
+    if not isinstance(event_id, int) or isinstance(event_id, bool):
+        return "no-event-id"
+
+    from core.database import SessionLocal
+    from models import TimelineEvent
+
+    db = SessionLocal()
+    try:
+        row = (
+            db.query(TimelineEvent)
+            .filter(TimelineEvent.id == event_id)
+            .first()
+        )
+        if row is None:
+            return "not-found"
+        if row.plate_text:
+            return "already-set"
+        row.plate_text = plate.strip()[:32]
+        db.commit()
+        logger.info(
+            "plate event applied: event %s -> %s [correlation_id=%s]",
+            event_id, row.plate_text, envelope.get("correlation_id"),
+        )
+        return "applied"
+    finally:
+        db.close()
+
+
+async def _handle_message(msg) -> None:
+    """One bus message → one ``apply_plate_event``. Never raises — a bad
+    message is a debug line, not a dead subscription."""
+    try:
+        envelope = json.loads(msg.data.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        logger.debug("plate consumer: undecodable message on %s", msg.subject)
+        return
+    try:
+        status = await asyncio.to_thread(apply_plate_event, envelope)
+        if status not in ("applied", "already-set", "no-event-id"):
+            logger.debug("plate consumer: %s for %s", status, msg.subject)
+    except Exception:  # noqa: BLE001
+        logger.warning("plate consumer: apply failed", exc_info=True)
+
+
+async def run_consumer_loop() -> None:
+    """Subscribe to ``plate.recognized.v1`` and keep the subscription
+    alive for the process lifetime. Returns immediately when no NATS URL
+    is configured; retries (slowly) on every other failure."""
+    from core.config import settings
+
+    url = (getattr(settings, "nats_url", "") or "").strip()
+    if not url:
+        logger.info(
+            "plate event consumer disabled (no NATS_URL) — plate_text is "
+            "written by the enrichment fallback only")
+        return
+    try:
+        import nats
+    except ImportError:
+        logger.warning(
+            "plate event consumer disabled: nats-py not installed")
+        return
+
+    while True:
+        try:
+            client = await nats.connect(url, connect_timeout=5)
+            sub = await client.subscribe(SUBJECT, cb=_handle_message)
+            logger.info("plate event consumer subscribed to %s", SUBJECT)
+            try:
+                # nats-py reconnects transparently; this just parks the
+                # task until cancellation (shutdown) unwinds us.
+                await asyncio.Event().wait()
+            finally:
+                try:
+                    await sub.unsubscribe()
+                    await client.drain()
+                except Exception:  # noqa: BLE001
+                    pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "plate event consumer: connect/subscribe failed (%s); "
+                "retrying in %.0fs", exc, _RETRY_SECONDS)
+            await asyncio.sleep(_RETRY_SECONDS)

--- a/server/tests/test_event_contracts.py
+++ b/server/tests/test_event_contracts.py
@@ -32,6 +32,16 @@ CONTRACTS = REPO_ROOT / "docs" / "EVENT_CONTRACTS.md"
 # Where first-party bus traffic can originate.
 SCANNED_TREES = ("server", "kai-c", "detect-pipeline", "examples", "sdk")
 
+# Test directories are exempt from the scans: expected-value literals in
+# tests legitimately hard-code cameras and invent throwaway subjects.
+# Subjects that matter live in producers and consumers — source files.
+_TEST_DIR_PARTS = frozenset({"test", "tests"})
+
+
+def _is_test_file(path: Path) -> bool:
+    return bool(_TEST_DIR_PARTS.intersection(path.parts))
+
+
 # A contracted name as it appears in code AND in the doc:
 # opennvr.events.<domain>.<event>.v<N>
 SUBJECT_RE = re.compile(r"opennvr\.events\.([a-z_]+)\.([a-z_]+)\.v(\d+)")
@@ -61,6 +71,8 @@ def _schemas_used_in_code() -> dict[str, set[str]]:
         if not root.is_dir():
             continue
         for src in root.rglob("*.py"):
+            if _is_test_file(src.relative_to(REPO_ROOT)):
+                continue
             try:
                 text = src.read_text(encoding="utf-8")
             except (UnicodeDecodeError, OSError):
@@ -113,6 +125,8 @@ def test_camera_id_is_the_last_subject_token_in_code():
         if not root.is_dir():
             continue
         for src in root.rglob("*.py"):
+            if _is_test_file(src.relative_to(REPO_ROOT)):
+                continue
             try:
                 text = src.read_text(encoding="utf-8")
             except (UnicodeDecodeError, OSError):

--- a/server/tests/test_event_contracts.py
+++ b/server/tests/test_event_contracts.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""RFC-0002 Phase 0: the event-contracts doc is CI-enforced, not advisory.
+
+Two directions, one ratchet:
+
+* Any ``opennvr.events.*`` subject a first-party source file mentions
+  MUST be contracted in ``docs/EVENT_CONTRACTS.md``. Publishing (or
+  subscribing to) a domain event nobody wrote down is exactly the
+  drift RFC-0002 decision 3 exists to stop — the failure message is
+  the review prompt.
+* The doc itself must keep contracting the v1 set that Phase 0 named,
+  so a careless edit can't silently un-contract an event that
+  consumers already rely on (contracts are retired by version, with
+  notice — never by deletion).
+
+The scan is string-literal level on purpose: subjects are built with
+f-strings whose static prefix still contains ``opennvr.events.<domain>.
+<event>.v<N>`` (the camera_id is the only runtime token, and it is the
+last token by contract), so a source regex catches every real use
+without importing anything.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS = REPO_ROOT / "docs" / "EVENT_CONTRACTS.md"
+
+# Where first-party bus traffic can originate.
+SCANNED_TREES = ("server", "kai-c", "detect-pipeline", "examples", "sdk")
+
+# A contracted name as it appears in code AND in the doc:
+# opennvr.events.<domain>.<event>.v<N>
+SUBJECT_RE = re.compile(r"opennvr\.events\.([a-z_]+)\.([a-z_]+)\.v(\d+)")
+
+# The Phase 0 baseline — the doc may grow, never silently shrink.
+BASELINE_V1 = frozenset({
+    "detection.observed.v1",
+    "visit.recorded.v1",
+    "plate.recognized.v1",
+    "alert.fired.v1",
+})
+
+
+def _contracted_schemas() -> set[str]:
+    text = CONTRACTS.read_text(encoding="utf-8")
+    return {
+        f"{m.group(1)}.{m.group(2)}.v{m.group(3)}"
+        for m in SUBJECT_RE.finditer(text)
+    }
+
+
+def _schemas_used_in_code() -> dict[str, set[str]]:
+    """schema -> set of files (repo-relative) that mention it."""
+    used: dict[str, set[str]] = {}
+    for tree in SCANNED_TREES:
+        root = REPO_ROOT / tree
+        if not root.is_dir():
+            continue
+        for src in root.rglob("*.py"):
+            try:
+                text = src.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for m in SUBJECT_RE.finditer(text):
+                schema = f"{m.group(1)}.{m.group(2)}.v{m.group(3)}"
+                used.setdefault(schema, set()).add(
+                    str(src.relative_to(REPO_ROOT)))
+    return used
+
+
+def test_contracts_doc_exists_and_holds_the_baseline():
+    assert CONTRACTS.is_file(), (
+        "docs/EVENT_CONTRACTS.md is gone — the domain-event surface has "
+        "no normative definition. Contracts are retired by version with "
+        "notice, never by deleting the doc (RFC-0002 Phase 0).")
+    contracted = _contracted_schemas()
+    missing = BASELINE_V1 - contracted
+    assert not missing, (
+        f"EVENT_CONTRACTS.md no longer defines {sorted(missing)} — v1 "
+        "contracts consumers rely on cannot be silently un-contracted; "
+        "supersede with a v2 and a migration note instead")
+
+
+def test_every_domain_subject_in_code_is_contracted():
+    contracted = _contracted_schemas()
+    offenders = {
+        schema: sorted(files)
+        for schema, files in _schemas_used_in_code().items()
+        if schema not in contracted
+    }
+    assert not offenders, (
+        "uncontracted opennvr.events.* subject(s) in first-party code: "
+        f"{offenders}. Add the schema to docs/EVENT_CONTRACTS.md (subject, "
+        "producer, payload table, additive-only) before shipping the "
+        "producer or consumer — that doc is what lets a subscriber build "
+        "on the event without reading your source.")
+
+
+def test_camera_id_is_the_last_subject_token_in_code():
+    # The contract puts <camera_id> last so wildcard subscriptions work
+    # (`opennvr.events.<domain>.<event>.v1.>`). A literal that continues
+    # past the version with a fixed token (anything but a format field,
+    # wildcard, or quote-end) is breaking that shape.
+    bad: list[str] = []
+    tail_re = re.compile(
+        r"opennvr\.events\.[a-z_]+\.[a-z_]+\.v\d+\.(?![>{*\"'])")
+    for tree in SCANNED_TREES:
+        root = REPO_ROOT / tree
+        if not root.is_dir():
+            continue
+        for src in root.rglob("*.py"):
+            try:
+                text = src.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for m in tail_re.finditer(text):
+                line = text[:m.start()].count("\n") + 1
+                bad.append(f"{src.relative_to(REPO_ROOT)}:{line}")
+    assert not bad, (
+        f"hard-coded token after the version segment at {bad} — the "
+        "camera_id must be the final, runtime-substituted subject token "
+        "(f-string field or wildcard), or per-camera wildcards break")

--- a/server/tests/test_plate_event_consumer.py
+++ b/server/tests/test_plate_event_consumer.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""RFC-0002 Phase 0: core consumes ``plate.recognized.v1``.
+
+``apply_plate_event`` is the decision core: envelope in, one status
+token out, with the timeline row as the only side effect. These tests
+pin the contract behaviours that make the two writers (bus consumer +
+enrichment's synchronous fallback) safe to run together: never
+overwrite an enriched row, ignore events that carry no timeline
+reference, and treat malformed input as a no-op — never an exception.
+
+Also pinned here: the enrichment fallback now threads ``event_id``
+into its infer payload, because that reference is what lets the domain
+event join back to the row at all.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_pec_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.database as cdb  # noqa: E402
+import models  # noqa: E402
+from services.plate_event_consumer import apply_plate_event  # noqa: E402
+
+
+def _envelope(event_id, plate="ABC1234", **overrides):
+    env = {
+        "id": "evt_0123456789ab",
+        "schema": "plate.recognized.v1",
+        "correlation_id": "corr-1",
+        "camera_id": "3",
+        "ts": "2026-08-29T10:00:00+00:00",
+        "producer": "kai-c",
+        "payload": {
+            "plate_text": plate,
+            "confidence": 0.9,
+            "vehicle_label": None,
+            "event_id": event_id,
+        },
+    }
+    env.update(overrides)
+    return env
+
+
+@pytest.fixture()
+def db(monkeypatch):
+    # Some suites pop core.* / models from sys.modules and leave docker
+    # hostnames in the env; apply_plate_event's lazy imports would then
+    # re-execute core.config's Settings() and trip its trust-zone
+    # validator. Pin the modules this file already imported so the lazy
+    # imports resolve to THESE objects (and this fixture's patches).
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    monkeypatch.setitem(sys.modules, "models", models)
+    eng = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    models.Base.metadata.create_all(eng)
+    SessionLocal = sessionmaker(bind=eng)
+    monkeypatch.setattr(cdb, "SessionLocal", SessionLocal)
+    s = SessionLocal()
+    role = models.Role(name="admin")
+    s.add(role)
+    s.commit()
+    user = models.User(username="u", email="u@x", hashed_password="x",
+                       role_id=role.id)
+    s.add(user)
+    s.commit()
+    cam = models.Camera(name="c", ip_address="10.0.0.5", owner_id=user.id)
+    s.add(cam)
+    s.commit()
+    row = models.TimelineEvent(
+        camera_id=cam.id, source="tier0", event_type="track", label="car",
+        started_at=datetime(2026, 8, 29, 9, 59, tzinfo=timezone.utc),
+    )
+    s.add(row)
+    s.commit()
+    row_id = row.id
+    s.close()
+    yield SessionLocal, row_id
+
+
+def _plate_of(SessionLocal, row_id):
+    s = SessionLocal()
+    try:
+        return s.get(models.TimelineEvent, row_id).plate_text
+    finally:
+        s.close()
+
+
+def test_applies_plate_to_referenced_row(db):
+    SessionLocal, row_id = db
+    assert apply_plate_event(_envelope(row_id)) == "applied"
+    assert _plate_of(SessionLocal, row_id) == "ABC1234"
+
+
+def test_never_overwrites_an_enriched_row(db):
+    SessionLocal, row_id = db
+    assert apply_plate_event(_envelope(row_id)) == "applied"
+    # Redelivery / fallback race with a DIFFERENT read: first write wins.
+    assert apply_plate_event(_envelope(row_id, plate="ZZZ999")) == "already-set"
+    assert _plate_of(SessionLocal, row_id) == "ABC1234"
+
+
+def test_missing_row_is_a_noop(db):
+    _, row_id = db
+    assert apply_plate_event(_envelope(row_id + 999)) == "not-found"
+
+
+def test_dispatch_initiated_events_without_event_id_are_deferred(db):
+    # Tier-1 dispatch doesn't reference a timeline row yet — joining
+    # those is Phase 4. Until then the consumer must leave them alone.
+    for missing in (None, "42", 3.5, True):
+        assert apply_plate_event(_envelope(missing)) == "no-event-id"
+
+
+def test_malformed_envelopes_never_raise(db):
+    _, row_id = db
+    assert apply_plate_event(None) == "malformed"
+    assert apply_plate_event("junk") == "malformed"
+    assert apply_plate_event({"payload": "junk"}) == "malformed"
+    assert apply_plate_event(_envelope(row_id, plate="")) == "no-plate"
+    assert apply_plate_event(_envelope(row_id, plate=None)) == "no-plate"
+
+
+def test_plate_is_trimmed_and_capped(db):
+    SessionLocal, row_id = db
+    assert apply_plate_event(_envelope(row_id, plate="  " + "A" * 40)) == "applied"
+    assert _plate_of(SessionLocal, row_id) == "A" * 32
+
+
+def test_enrichment_fallback_threads_event_id():
+    # The join key: enrichment's infer payload must carry the row id so
+    # KAI-C's normaliser can put it in the domain event. String-level on
+    # the source (the function does live HTTP; its request-building isn't
+    # separable without refactoring it — deliberately out of scope here).
+    src = (_HERE / "services" / "plate_enrichment.py").read_text()
+    assert '"event_id": int(row.id)' in src, (
+        "plate_enrichment no longer sends event_id with its OCR call — "
+        "the plate.recognized.v1 it triggers can't be joined back to the "
+        "visit row, so the bus consumer becomes a no-op for the fallback "
+        "path (RFC-0002 Phase 0 convergence)")


### PR DESCRIPTION
docs/EVENT_CONTRACTS.md is the normative answer to 'what can I subscribe to and what will I get' without reading producer source:

- Envelope: id, schema, correlation_id, camera_id, ts (wall-clock, ISO-8601 — the detect_pipeline/bus.py monotonic-ts lesson made a rule), producer (audit-only, consumers must not branch on it), payload. Additive-only within a version; breaking changes get v<N+1> published in parallel.
- Subject grammar: opennvr.events.<domain>.<event>.v<N>.<camera_id>, camera last so per-camera wildcards work.
- Two trees, on purpose: opennvr.inference.* stays as plumbing (adapter-shaped, per-producer versioning); opennvr.events.* is the app surface.
- The Phase 0 split decision, decided: the completion publish site (KAI-C's _publish_inference_completed) also emits the domain event via a small static adapter→domain map — a normaliser at the source, not a new service and not domain-schema-inside-completion (both alternatives argued in the doc). Map starts with fast_plate_ocr → plate.recognized.v1.
- v1 payload tables for what already flows: detection.observed (tier0 payload), visit.recorded (timeline visit rows, put on the bus), plate.recognized (with the producer-convergence plan: the normaliser makes both initiators emit the same event on day one, core's enrichment then demotes to consumer+fallback), alert.fired (Alert.to_wire IS v1; SDK dual-publishes during transition).

server/tests/test_event_contracts.py enforces it (3 tests):
- baseline: the doc exists and keeps contracting the v1 set — contracts retire by version, never by deletion or edit.
- every opennvr.events.* subject mentioned in first-party code (server, kai-c, detect-pipeline, examples, sdk) is contracted in the doc — the failure message is the review prompt.
- nothing hard-codes a token after the version segment, so camera_id stays the final runtime token and wildcards keep working.

Sabotage-verified: an uncontracted subject in an example fails the scan; a hard-coded camera in a literal fails the shape test; renaming plate.recognized.v1 in the doc fails the baseline; deleting the doc fails two tests. All restored, 3 passed.