### PR TITLE
feat(core): GET /api/v1/skills — the registry as an index (RFC-0002 P…

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -79,6 +79,7 @@ from routers import (
     recordings,
     roles,
     security,
+    skills as skills_router,
     streams,
     suricata_logs,
     suricata_stream,
@@ -750,6 +751,9 @@ app.include_router(ai_models.router, prefix=settings.api_prefix)
 app.include_router(ai_model_management.router, prefix=settings.api_prefix)
 app.include_router(ai_detection_results.router, prefix=settings.api_prefix)
 app.include_router(apps.router, prefix=settings.api_prefix)
+# RFC-0002 Phase 1: the skills registry — index over adapters, apps,
+# assignments (Phase 2) and health. GET /api/v1/skills.
+app.include_router(skills_router.router, prefix=settings.api_prefix)
 app.include_router(cloud_providers.router, prefix=settings.api_prefix)
 app.include_router(cloud_inference.router, prefix=settings.api_prefix)
 app.include_router(compliance.router, prefix=settings.api_prefix)

--- a/server/routers/skills.py
+++ b/server/routers/skills.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 OpenNVR
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""RFC-0002 Phase 1: ``GET /api/v1/skills`` — the registry as an index.
+
+The derivation itself lives in ``services/skills_registry.py`` (pure);
+this router owns fetching the inputs and a short TTL cache so the view
+stays cheap enough to poll from UIs without turning KAI-C probes into
+load. The cache is per-process and advisory — 15s of staleness on an
+*index* is fine; anything needing fresher truth (the enable gate, the
+infer path) already talks to the source directly, which is exactly the
+index-never-broker rule (decision 1).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from core.auth import get_current_active_user
+from core.database import get_db
+from core.logging_config import main_logger
+from models import InstalledApp, User
+from routers.ai_models import _load_tasks_registry
+from services.kai_c_service import get_kai_c_service
+from services.skills_registry import derive_skills
+
+router = APIRouter(prefix="/skills", tags=["skills"])
+
+_CACHE_TTL_SECONDS = 15.0
+_cache: dict[str, Any] = {"at": 0.0, "health": None, "caps": None}
+
+
+async def _kai_c_view() -> tuple[Optional[dict], Optional[dict]]:
+    """(adapters_health, adapters_caps) from KAI-C, each None on failure,
+    TTL-cached together. Failures are logged once per fetch, not raised —
+    the registry reports an unreachable source instead of 500ing."""
+    now = time.monotonic()
+    if now - _cache["at"] < _CACHE_TTL_SECONDS:
+        return _cache["health"], _cache["caps"]
+    service = get_kai_c_service()
+    health: Optional[dict] = None
+    caps: Optional[dict] = None
+    try:
+        raw = await service.check_kai_c_health()
+        if raw.get("kai_c_status") == "ok" and isinstance(raw.get("adapters"), dict):
+            health = raw["adapters"]
+    except Exception:  # noqa: BLE001
+        main_logger.debug("skills registry: adapter health fetch failed",
+                          exc_info=True)
+    try:
+        raw = await service.get_capabilities()
+        if isinstance(raw.get("adapters"), dict):
+            caps = raw["adapters"]
+    except Exception:  # noqa: BLE001
+        main_logger.debug("skills registry: capabilities fetch failed",
+                          exc_info=True)
+    _cache.update({"at": now, "health": health, "caps": caps})
+    return health, caps
+
+
+@router.get("")
+async def list_skills(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Every skill the platform knows, with live status — RFC-0002
+    decision 2's view over the four sources. Consumers: the camera
+    agent's skills panel, the App Catalog, and anything else that today
+    reinvents this derivation privately."""
+    health, caps = await _kai_c_view()
+    apps_rows = db.query(InstalledApp).all()
+    return derive_skills(
+        tasks_registry=_load_tasks_registry(),
+        adapters_health=health,
+        adapters_caps=caps,
+        apps_rows=apps_rows,
+    )

--- a/server/services/skills_registry.py
+++ b/server/services/skills_registry.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 OpenNVR
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""RFC-0002 Phase 1: the skills registry — an index, never a broker.
+
+One derivation, live at request time, over the four sources decision 2
+names: the KAI-C adapter registry, the App Catalog's installed
+manifests, the assignment table (Phase 2 — reported honestly as
+not-yet-implemented), and health. Nothing here proxies an inference,
+holds a queue, or owns state: delete this module and every producer
+and consumer keeps working — you only lose the *view*.
+
+Status vocabulary (RFC-0002 lifecycle):
+
+* adapter-provided skills: ``available`` (a healthy provider exists),
+  ``degraded`` (providers exist, none currently healthy — or the
+  adapter registry itself is unreachable, which is reported as itself,
+  never dressed up; issue #344's lesson), ``missing-dependency`` (no
+  registered provider at all).
+* app-provided skills: ``dormant`` (installed, not enabled),
+  ``active`` (enabled and recently seen healthy), ``degraded``
+  (enabled but unreachable or stale).
+
+``active``/``dormant`` for adapter skills needs the camera-assignment
+table and arrives with Phase 2; each adapter entry carries
+``assignments: None`` until then rather than a guess.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Optional
+
+#: An enabled app whose last_seen is older than this is degraded even if
+#: its stored status column still says "ok" — the column only updates on
+#: re-registration; recency is the real signal.
+APP_STALE_AFTER = timedelta(minutes=10)
+
+#: Domain events per provider. Mirrors the KAI-C normaliser map
+#: (kai-c/kai_c/domain_events.py) and the App SDK alert dispatcher —
+#: both contracted in docs/EVENT_CONTRACTS.md. Keep the three in step:
+#: growing the normaliser map without this view makes the registry lie
+#: by omission.
+ADAPTER_DOMAIN_EVENTS: dict[str, list[str]] = {
+    "fast_plate_ocr": ["plate.recognized.v1"],
+}
+APP_DOMAIN_EVENTS: list[str] = ["alert.fired.v1"]
+
+
+def _healthy_adapters(adapters_health: Optional[dict]) -> Optional[set[str]]:
+    """Names of adapters KAI-C reports healthy; None = registry unknown."""
+    if not isinstance(adapters_health, dict):
+        return None
+    return {
+        name for name, entry in adapters_health.items()
+        if isinstance(entry, dict) and entry.get("status") == "ok"
+    }
+
+
+def _tasks_by_adapter(adapters_caps: Optional[dict]) -> Optional[dict[str, set[str]]]:
+    """adapter name -> lowercased advertised task set; None = caps unknown."""
+    if not isinstance(adapters_caps, dict):
+        return None
+    out: dict[str, set[str]] = {}
+    for name, entry in adapters_caps.items():
+        caps = (entry or {}).get("capabilities") if isinstance(entry, dict) else None
+        tasks = caps.get("tasks_advertised") if isinstance(caps, dict) else None
+        out[name] = {
+            t.lower() for t in tasks if isinstance(t, str)
+        } if isinstance(tasks, list) else set()
+    return out
+
+
+def _adapter_skill(entry: Any, *,
+                   registered: Optional[set[str]],
+                   healthy: Optional[set[str]],
+                   advertised: Optional[dict[str, set[str]]]) -> dict[str, Any]:
+    """One taxonomy task (server/config/tasks.yml TaskEntry) → one entry."""
+    names = {entry.task.lower()} | {a.lower() for a in entry.aliases}
+
+    if advertised is not None:
+        # Real signal: adapters that actually advertise this task.
+        providers = sorted(
+            name for name, tasks in advertised.items() if tasks & names)
+    elif registered is not None:
+        # Capabilities fetch failed but the registry answered: fall back
+        # to the editorial mapping intersected with what is registered.
+        providers = sorted(
+            set(entry.suggested_adapters) & registered)
+    else:
+        providers = []
+
+    if registered is None:
+        status, reason = "degraded", "adapter registry unreachable"
+    elif not providers:
+        status, reason = "missing-dependency", (
+            "no registered adapter provides this task")
+    elif healthy and set(providers) & healthy:
+        status, reason = "available", None
+    else:
+        status, reason = "degraded", "no healthy provider"
+
+    publishes: list[str] = []
+    for p in providers:
+        publishes.extend(ADAPTER_DOMAIN_EVENTS.get(p, []))
+
+    return {
+        "id": entry.task,
+        "name": entry.label,
+        "provider": {"kind": "adapter", "providers": providers},
+        "status": status,
+        "reason": reason,
+        "publishes": sorted(set(publishes)),
+        "config": {},                     # adapters carry no operator params here
+        "assignments": None,              # Phase 2: the camera-assignment table
+        "agent_skill": entry.agent_skill,
+        "suggested_adapters": list(entry.suggested_adapters),
+        "suggested_apps": list(entry.suggested_apps),
+    }
+
+
+def _app_status(row: Any, now: datetime) -> tuple[str, Optional[str]]:
+    if not row.enabled:
+        return "dormant", "installed but not enabled"
+    if row.status == "unreachable":
+        return "degraded", "app unreachable at last contact"
+    last_seen = row.last_seen
+    if last_seen is not None and last_seen.tzinfo is None:
+        last_seen = last_seen.replace(tzinfo=timezone.utc)
+    if last_seen is None or now - last_seen > APP_STALE_AFTER:
+        return "degraded", "no recent contact from app"
+    return "active", None
+
+
+def _app_skill(row: Any, now: datetime) -> dict[str, Any]:
+    status, reason = _app_status(row, now)
+    manifest = row.manifest_json if isinstance(row.manifest_json, dict) else {}
+    params = manifest.get("params") or []
+    return {
+        "id": f"app:{row.id}",
+        "name": row.name,
+        "provider": {"kind": "app", "providers": [row.id]},
+        "status": status,
+        "reason": reason,
+        "publishes": list(APP_DOMAIN_EVENTS),
+        "config": {
+            "params": [
+                p.get("name") for p in params
+                if isinstance(p, dict) and p.get("name")
+            ],
+        },
+        "assignments": None,              # Phase 2
+        "agent_skill": None,
+        "suggested_adapters": [],
+        "suggested_apps": [],
+    }
+
+
+def derive_skills(
+    *,
+    tasks_registry: Iterable[Any],
+    adapters_health: Optional[dict],
+    adapters_caps: Optional[dict],
+    apps_rows: Iterable[Any],
+    now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """The whole view, from already-fetched inputs. Pure: no I/O, no
+    state — the router owns fetching (and caching) the inputs.
+
+    ``adapters_health`` / ``adapters_caps`` are the raw KAI-C
+    ``/adapters/health`` adapters map and ``/capabilities`` adapters
+    map, or None when that fetch failed — the distinction is preserved
+    into per-skill status and the ``sources`` block instead of being
+    smoothed over.
+    """
+    now = now or datetime.now(timezone.utc)
+    registered = (
+        set(adapters_health.keys()) if isinstance(adapters_health, dict)
+        else None
+    )
+    healthy = _healthy_adapters(adapters_health)
+    advertised = _tasks_by_adapter(adapters_caps)
+
+    skills = [
+        _adapter_skill(
+            e, registered=registered, healthy=healthy, advertised=advertised)
+        for e in tasks_registry
+    ]
+    skills.extend(_app_skill(row, now) for row in apps_rows)
+
+    return {
+        "skills": skills,
+        "sources": {
+            "adapter_registry": "ok" if registered is not None else "unreachable",
+            "adapter_capabilities": "ok" if advertised is not None else "unavailable",
+            "app_catalog": "ok",
+            "assignments": {"implemented": False, "phase": 2},
+        },
+        "generated_at": now.replace(microsecond=0).isoformat(),
+    }

--- a/server/tests/test_skills_registry.py
+++ b/server/tests/test_skills_registry.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""RFC-0002 Phase 1: the skills registry derivation.
+
+``derive_skills`` is pure — inputs in, view out — so the whole status
+matrix is testable without KAI-C, a DB, or FastAPI. What these tests
+pin is the honesty rules: status from real signals (a healthy provider
+actually advertising the task), an unreachable source reported as
+itself rather than smoothed into a guess (issue #344's lesson), and
+the not-yet-implemented assignment source declared, not faked.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+from cryptography.fernet import Fernet
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# routers.ai_models (imported by the taxonomy round-trip test) pulls in
+# core.config, whose Settings() needs these — same bootstrap as the
+# other suites.
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_skills_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+from services.skills_registry import (  # noqa: E402
+    APP_STALE_AFTER,
+    derive_skills,
+)
+
+NOW = datetime(2026, 8, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@dataclass
+class Task:
+    """Duck-typed stand-in for routers.ai_models.TaskEntry."""
+    task: str
+    label: str = ""
+    agent_skill: str | None = None
+    aliases: list[str] = field(default_factory=list)
+    suggested_adapters: list[str] = field(default_factory=list)
+    suggested_apps: list[str] = field(default_factory=list)
+
+
+def _app_row(app_id="license-plate-recognition", *, enabled=True, status="ok",
+             last_seen=NOW - timedelta(seconds=30), manifest=None):
+    return SimpleNamespace(
+        id=app_id, name=app_id, enabled=enabled, status=status,
+        last_seen=last_seen,
+        manifest_json=manifest if manifest is not None else {
+            "params": [{"name": "poll_interval_seconds"}, {"name": "watchlist"}],
+        },
+    )
+
+
+def _skill(view, skill_id):
+    matches = [s for s in view["skills"] if s["id"] == skill_id]
+    assert matches, f"{skill_id} not in view: {[s['id'] for s in view['skills']]}"
+    return matches[0]
+
+
+HEALTH = {
+    "yolov8": {"status": "ok", "url": "http://yolov8:9002"},
+    "fast_plate_ocr": {"status": "error", "url": "http://lpr:9004",
+                       "message": "connect timeout"},
+}
+CAPS = {
+    "yolov8": {"capabilities": {"tasks_advertised": ["object_detection"]}},
+    "fast_plate_ocr": {"capabilities": {
+        "tasks_advertised": ["license_plate_recognition"]}},
+}
+
+
+def test_available_needs_a_healthy_advertising_provider():
+    view = derive_skills(
+        tasks_registry=[Task("object_detection")],
+        adapters_health=HEALTH, adapters_caps=CAPS, apps_rows=[], now=NOW)
+    s = _skill(view, "object_detection")
+    assert s["status"] == "available" and s["reason"] is None
+    assert s["provider"] == {"kind": "adapter", "providers": ["yolov8"]}
+
+
+def test_unhealthy_provider_is_degraded_not_available():
+    # fast_plate_ocr is registered and advertises the task — but its
+    # health probe failed. Process-up is not the signal (issue #344).
+    view = derive_skills(
+        tasks_registry=[Task("license_plate_recognition")],
+        adapters_health=HEALTH, adapters_caps=CAPS, apps_rows=[], now=NOW)
+    s = _skill(view, "license_plate_recognition")
+    assert s["status"] == "degraded"
+    assert s["reason"] == "no healthy provider"
+    # And the normaliser mirror still names what a provider would publish.
+    assert s["publishes"] == ["plate.recognized.v1"]
+
+
+def test_no_provider_at_all_is_missing_dependency():
+    view = derive_skills(
+        tasks_registry=[Task("face_recognition",
+                             suggested_adapters=["insightface"],
+                             suggested_apps=["smart-doorbell"])],
+        adapters_health=HEALTH, adapters_caps=CAPS, apps_rows=[], now=NOW)
+    s = _skill(view, "face_recognition")
+    assert s["status"] == "missing-dependency"
+    # The on-ramp fields ride the registry (the agent's private
+    # suggested_apps derivation becomes a registry field — RFC Phase 1).
+    assert s["suggested_adapters"] == ["insightface"]
+    assert s["suggested_apps"] == ["smart-doorbell"]
+
+
+def test_alias_advertisement_counts_as_providing():
+    caps = {"yolov8": {"capabilities": {"tasks_advertised": ["Object-Det"]}}}
+    view = derive_skills(
+        tasks_registry=[Task("object_detection", aliases=["object-det"])],
+        adapters_health={"yolov8": {"status": "ok"}},
+        adapters_caps=caps, apps_rows=[], now=NOW)
+    assert _skill(view, "object_detection")["status"] == "available"
+
+
+def test_caps_fetch_down_falls_back_to_editorial_mapping():
+    view = derive_skills(
+        tasks_registry=[Task("object_detection",
+                             suggested_adapters=["yolov8"])],
+        adapters_health={"yolov8": {"status": "ok"}},
+        adapters_caps=None, apps_rows=[], now=NOW)
+    s = _skill(view, "object_detection")
+    assert s["status"] == "available"
+    assert s["provider"]["providers"] == ["yolov8"]
+    assert view["sources"]["adapter_capabilities"] == "unavailable"
+
+
+def test_registry_unreachable_is_reported_not_guessed():
+    view = derive_skills(
+        tasks_registry=[Task("object_detection")],
+        adapters_health=None, adapters_caps=None, apps_rows=[], now=NOW)
+    s = _skill(view, "object_detection")
+    assert s["status"] == "degraded"
+    assert s["reason"] == "adapter registry unreachable"
+    assert view["sources"]["adapter_registry"] == "unreachable"
+
+
+def test_app_lifecycle_dormant_active_degraded():
+    rows = [
+        _app_row("a-dormant", enabled=False),
+        _app_row("a-active"),
+        _app_row("a-unreachable", status="unreachable"),
+        _app_row("a-stale",
+                 last_seen=NOW - APP_STALE_AFTER - timedelta(seconds=1)),
+        _app_row("a-never-seen", last_seen=None),
+    ]
+    view = derive_skills(tasks_registry=[], adapters_health={},
+                         adapters_caps={}, apps_rows=rows, now=NOW)
+    assert _skill(view, "app:a-dormant")["status"] == "dormant"
+    assert _skill(view, "app:a-active")["status"] == "active"
+    assert _skill(view, "app:a-unreachable")["status"] == "degraded"
+    assert _skill(view, "app:a-stale")["status"] == "degraded"
+    assert _skill(view, "app:a-never-seen")["status"] == "degraded"
+
+
+def test_app_entry_shape():
+    view = derive_skills(tasks_registry=[], adapters_health={},
+                         adapters_caps={}, apps_rows=[_app_row()], now=NOW)
+    s = _skill(view, "app:license-plate-recognition")
+    assert s["provider"] == {"kind": "app",
+                             "providers": ["license-plate-recognition"]}
+    assert s["publishes"] == ["alert.fired.v1"]
+    assert s["config"]["params"] == ["poll_interval_seconds", "watchlist"]
+
+
+def test_naive_last_seen_is_treated_as_utc():
+    # SQLite (and some drivers) hand back naive datetimes; a naive-vs-
+    # aware comparison must not crash the whole view.
+    row = _app_row("a-naive",
+                   last_seen=(NOW - timedelta(seconds=30)).replace(tzinfo=None))
+    view = derive_skills(tasks_registry=[], adapters_health={},
+                         adapters_caps={}, apps_rows=[row], now=NOW)
+    assert _skill(view, "app:a-naive")["status"] == "active"
+
+
+def test_assignments_source_is_declared_not_faked():
+    view = derive_skills(tasks_registry=[], adapters_health={},
+                         adapters_caps={}, apps_rows=[], now=NOW)
+    assert view["sources"]["assignments"] == {"implemented": False, "phase": 2}
+
+
+def test_real_tasks_yml_derives_without_error():
+    # The wired inputs: the actual curated taxonomy file must flow
+    # through the derivation (guards a tasks.yml field rename breaking
+    # the endpoint at runtime rather than in CI).
+    from routers.ai_models import _load_tasks_registry
+    view = derive_skills(
+        tasks_registry=_load_tasks_registry(),
+        adapters_health=HEALTH, adapters_caps=CAPS, apps_rows=[], now=NOW)
+    assert len(view["skills"]) >= 5
+    assert all(s["status"] in {
+        "available", "degraded", "missing-dependency"} for s in view["skills"])


### PR DESCRIPTION
…hase 1)

One derivation over the four sources decision 2 names: KAI-C adapter registry, App Catalog manifests, the assignment table (Phase 2 — reported as {implemented: false} rather than faked), and health. An index, never a broker: nothing proxies, queues, or owns state; delete the module and every producer/consumer keeps working.

- services/skills_registry.py: pure derive_skills(inputs) -> view. Adapter-provided skills come from the curated taxonomy (server/config/tasks.yml): providers = adapters whose LIVE tasks_advertised matches canonical name or alias; when the capabilities fetch is down, fall back to the editorial suggested_adapters intersected with what is actually registered. Status from real signals (issue #344's lesson): available needs a healthy advertising provider; registered-but-unhealthy is degraded with a reason; nothing registered is missing-dependency; KAI-C unreachable is reported as itself ('adapter registry unreachable'), never smoothed into a guess. App-provided skills map the RFC lifecycle: dormant (installed, not enabled), active (enabled + seen within 10 min), degraded (unreachable or stale). Every entry carries publishes (mirroring the KAI-C normaliser map + the SDK alert dispatcher — both contracted in EVENT_CONTRACTS.md), the config surface, and the suggested_adapters/suggested_apps on-ramp — the field the agent's private derivation becomes.
- routers/skills.py: GET /api/v1/skills behind the normal user auth; 15s TTL cache on the KAI-C probes so UIs can poll the index without turning it into adapter load. Source failures degrade the view, never 500 it.
- main.py: router wired under the api prefix.
- test_skills_registry.py (11 tests): the status matrix, alias matching, editorial fallback, unreachable-registry honesty, the app lifecycle including naive-datetime last_seen from SQLite, the declared-not-faked assignments source, and a round-trip through the real tasks.yml so a taxonomy field rename fails in CI, not at runtime.

Sabotage-verified: dropping the health gate fails the degraded test; dropping naive-datetime handling fails the SQLite test. Full server suite 888 passed; the one failure is the known environmental test_orphan_aging (passes in CI, fails in this sandbox on clean main).

Next in Phase 1 (separate commits): the agent's skills panel consumes this endpoint; agent contract parity (needs PR #346's conformance allowlist merged first).