### PR TITLE
feat(agent): the skills panel consumes the platform registry (RFC-000…

### DIFF
--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -1025,3 +1025,103 @@ class OpennvrRecordingsClient(_ReusableClientMixin):
         except Exception as exc:
             logger.warning("streams: info proxy failed: %s", exc)
             return 502, {"error": "OpenNVR server unreachable"}
+
+
+class SkillsRegistryClient(_ReusableClientMixin):
+    """Cached view of the platform skills registry (RFC-0002 Phase 1).
+
+    ``GET {base}/api/v1/internal/camera-agent/skills`` with the same
+    ``X-Internal-Api-Key`` the events store uses. This replaces the
+    agent's PRIVATE derivations for the platform-owned facts on the
+    skills panel: whether a skill's backing capability has a healthy
+    provider, and which adapters/apps to suggest when it doesn't (the
+    ``suggested_apps`` on-ramp is a registry field now, so every
+    consumer renders the same truth).
+
+    ADVISORY, like :class:`KaicCapabilitiesClient`: :meth:`refresh`
+    never raises; unreachable → cached ``None`` = unknown (negative-
+    cached per TTL), and callers fall back to their previous private
+    derivation instead of greying anything out. The agent-local halves
+    of the panel (advertised tools, config gating) never come from
+    here — they are process state only the agent knows.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str = "",
+        ttl_seconds: float = 60.0,
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._api_key = api_key
+        self._ttl = ttl_seconds
+        self._timeout = timeout_seconds
+        self._fetched_at: float | None = None
+        self._skills: list[dict[str, Any]] | None = None   # None = unknown
+
+    @property
+    def skills_cached(self) -> list[dict[str, Any]] | None:
+        """Last-known registry entries (``None`` = unknown/unreachable)."""
+        return self._skills
+
+    def availability_by_agent_skill(self) -> dict[str, bool] | None:
+        """agent-skill id -> "a healthy provider exists", from the last
+        refresh. Only skills the registry maps (``agent_skill`` set on a
+        taxonomy entry) appear; ``None`` = registry unknown. A skill
+        with several backing entries is available if ANY is."""
+        if self._skills is None:
+            return None
+        out: dict[str, bool] = {}
+        for entry in self._skills:
+            sid = entry.get("agent_skill")
+            if not sid:
+                continue
+            out[sid] = out.get(sid, False) or entry.get("status") == "available"
+        return out
+
+    def suggestions_by_agent_skill(self) -> dict[str, dict[str, list[str]]]:
+        """agent-skill id -> {"adapters": [...], "apps": [...]} unioned
+        across that skill's backing registry entries. Empty dict when the
+        registry is unknown — callers keep their private fallback."""
+        if self._skills is None:
+            return {}
+        out: dict[str, dict[str, list[str]]] = {}
+        for entry in self._skills:
+            sid = entry.get("agent_skill")
+            if not sid:
+                continue
+            slot = out.setdefault(sid, {"adapters": [], "apps": []})
+            for key, field in (("adapters", "suggested_adapters"),
+                               ("apps", "suggested_apps")):
+                for name in entry.get(field) or []:
+                    if name not in slot[key]:
+                        slot[key].append(name)
+        return out
+
+    async def refresh(self) -> list[dict[str, Any]] | None:
+        """Fetch (at most once per TTL) the registry view. Never raises."""
+        now = time.monotonic()
+        if self._fetched_at is not None and now - self._fetched_at < self._ttl:
+            return self._skills
+        self._fetched_at = now   # stamp first: negative-cache failures
+        try:
+            headers = (
+                {"X-Internal-Api-Key": self._api_key} if self._api_key else {}
+            )
+            resp = await self._client().get(
+                f"{self._base}/api/v1/internal/camera-agent/skills",
+                headers=headers,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            skills = data.get("skills") if isinstance(data, dict) else None
+            self._skills = list(skills) if isinstance(skills, list) else None
+        except Exception as exc:
+            logger.debug(
+                "skills registry fetch failed (%s); panel falls back to "
+                "private derivation", exc,
+            )
+            self._skills = None
+        return self._skills

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -60,6 +60,7 @@ from adapter_clients import (
     OpennvrAuthClient,
     OpennvrRecordingsClient,
     PiperClient,
+    SkillsRegistryClient,
     SyntheticDetectionClient,
     WhisperClient,
 )
@@ -3049,6 +3050,7 @@ class CameraAgentRuntime:
         # deployment INTERNAL_API_KEY the infer path uses: opennvr_api_key,
         # else kaic_api_key, else the INTERNAL_API_KEY env var.
         self.app_registry: AppRegistryClient | None = None
+        self.skills_registry: SkillsRegistryClient | None = None
         if cfg.opennvr_api_url:
             import os
 
@@ -3058,6 +3060,14 @@ class CameraAgentRuntime:
                 or os.environ.get("INTERNAL_API_KEY", "")
             )
             self.app_registry = AppRegistryClient(
+                base_url=cfg.opennvr_api_url, api_key=app_key,
+            )
+            # RFC-0002 Phase 1: the platform skills registry replaces the
+            # agent's private derivations for platform-owned panel facts
+            # (backing availability, the suggested_adapters/apps on-ramp).
+            # Advisory like every registry client here: unreachable →
+            # None → skills_payload falls back to the private derivation.
+            self.skills_registry = SkillsRegistryClient(
                 base_url=cfg.opennvr_api_url, api_key=app_key,
             )
             logger.info(
@@ -3442,6 +3452,15 @@ class CameraAgentRuntime:
         skill reports ``tasks_available: true`` — i.e. exactly the previous
         config-based behavior, never a spuriously greyed-out tool."""
         live_tasks = self.kaic_capabilities.tasks_advertised   # None = unknown
+        # RFC-0002 Phase 1: platform-owned facts come from the skills
+        # registry when it answered (availability includes provider
+        # HEALTH, which the raw tasks_advertised union never saw), with
+        # the private derivations kept as the fallback chain:
+        # registry → KAI-C capabilities → config-based (never grey out
+        # on "unknown"). None/{} = registry unknown.
+        reg = self.skills_registry
+        reg_available = reg.availability_by_agent_skill() if reg else None
+        reg_suggestions = reg.suggestions_by_agent_skill() if reg else {}
         advertised = {t["function"]["name"] for t in self.tool_definitions}
         allow = None if self.cfg.enabled_tools is None else set(self.cfg.enabled_tools)
         # The events skill's caption names what is ACTUALLY wired — it has
@@ -3479,12 +3498,17 @@ class CameraAgentRuntime:
             # missing backend must still read as not-enabled in the panel.)
             enabled = (primary in advertised) and req_met
             backing = _SKILL_BACKING_TASKS.get(sid, [])
-            # Live availability from the tasks_advertised intersection. Unknown
-            # (KAI-C unreachable) or nothing to back → don't grey anything out.
-            tasks_available = (
-                live_tasks is None or not backing
-                or bool(set(backing) & live_tasks)
-            )
+            # Live availability: the platform registry's verdict when it
+            # has one for this skill (it factors provider health), else
+            # the tasks_advertised intersection. Unknown (both sources
+            # unreachable) or nothing to back → don't grey anything out.
+            if reg_available is not None and sid in reg_available:
+                tasks_available = reg_available[sid]
+            else:
+                tasks_available = (
+                    live_tasks is None or not backing
+                    or bool(set(backing) & live_tasks)
+                )
             # Tool-level honesty: a skill card bundles several tools, and the
             # old panel only reflected the PRIMARY one — "Look back at recent
             # events" showed on while search_history (the tool the user's
@@ -3515,7 +3539,14 @@ class CameraAgentRuntime:
             # action behind OpenNVR's permission gate. Additive: not-greyed
             # skills omit both fields.
             if not tasks_available:
-                entry["suggested_adapters"] = _SKILL_SUGGESTED_ADAPTERS.get(sid, [])
+                # On-ramp guidance: the registry's fields when it answered
+                # (RFC-0002: suggested_apps is a registry field so every
+                # consumer renders the same guidance), else the private
+                # editorial maps.
+                reg_sugg = reg_suggestions.get(sid)
+                entry["suggested_adapters"] = (
+                    reg_sugg["adapters"] if reg_sugg
+                    else _SKILL_SUGGESTED_ADAPTERS.get(sid, []))
                 entry["enable_url"] = (
                     f"{self.cfg.opennvr_ui_url.rstrip('/')}/ai-adapters"
                     if self.cfg.opennvr_ui_url else None
@@ -3525,7 +3556,9 @@ class CameraAgentRuntime:
                 # when we know the main UI's base URL, deep-link the App
                 # Catalog. Guide-only — no install POST; the operator
                 # installs from the catalog behind OpenNVR's permission gate.
-                entry["suggested_apps"] = _SKILL_SUGGESTED_APPS.get(sid, [])
+                entry["suggested_apps"] = (
+                    reg_sugg["apps"] if reg_sugg
+                    else _SKILL_SUGGESTED_APPS.get(sid, []))
                 entry["app_enable_url"] = (
                     f"{self.cfg.opennvr_ui_url.rstrip('/')}/app-catalog"
                     if self.cfg.opennvr_ui_url else None
@@ -4681,6 +4714,8 @@ class CameraAgentRuntime:
             closers.append(self.recordings.aclose())
         if self.app_registry:
             closers.append(self.app_registry.aclose())
+        if self.skills_registry:
+            closers.append(self.skills_registry.aclose())
         await asyncio.gather(*closers, return_exceptions=True)
 
     # ── System prompt construction ────────────────────────────────
@@ -5416,6 +5451,8 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         await runtime.kaic_capabilities.refresh()
         if runtime.app_registry is not None:
             await runtime.app_registry.list_apps()   # 60s TTL; never raises
+        if runtime.skills_registry is not None:
+            await runtime.skills_registry.refresh()  # 60s TTL; never raises
         return {"skills": runtime.skills_payload()}
 
     @app.get("/hardware")

--- a/examples/camera-agent/tests/test_skills_registry_consumption.py
+++ b/examples/camera-agent/tests/test_skills_registry_consumption.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RFC-0002 Phase 1: the skills panel consumes the PLATFORM registry.
+
+The rule under test is the fallback chain for platform-owned facts:
+registry verdict (includes provider health) → KAI-C tasks_advertised
+→ config-based, never greying anything out on "unknown". And the
+on-ramp fields (suggested_adapters / suggested_apps) come from the
+registry when it answered — so every consumer renders the same
+guidance — else the private editorial maps.
+
+Agent-LOCAL facts (advertised tools, config gating, enabled state)
+must be untouched by anything the registry says.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from adapter_clients import SkillsRegistryClient
+from camera_agent import (
+    _SKILL_SUGGESTED_ADAPTERS,
+    AppConfig,
+    CameraAgentRuntime,
+)
+from context import CameraSpec
+
+
+def _runtime() -> CameraAgentRuntime:
+    cfg = AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+        cameras=[CameraSpec(camera_id="cam1", frame_url="http://x/1.jpg",
+                            role="front door")],
+    )
+    return CameraAgentRuntime(cfg)
+
+
+class _StubRegistry:
+    """Stands in for SkillsRegistryClient on the runtime."""
+
+    def __init__(self, skills):
+        self._skills = skills
+
+    def availability_by_agent_skill(self):
+        return SkillsRegistryClient.availability_by_agent_skill(self)
+
+    def suggestions_by_agent_skill(self):
+        return SkillsRegistryClient.suggestions_by_agent_skill(self)
+
+
+def _entry(agent_skill, status, *, adapters=(), apps=()):
+    return {
+        "id": f"task-for-{agent_skill}-{status}", "agent_skill": agent_skill,
+        "status": status,
+        "suggested_adapters": list(adapters), "suggested_apps": list(apps),
+    }
+
+
+def _by_id(runtime):
+    return {s["id"]: s for s in runtime.skills_payload()}
+
+
+def test_registry_verdict_wins_over_tasks_advertised():
+    rt = _runtime()
+    # KAI-C never fetched (None = unknown) → old behavior said available.
+    assert rt.kaic_capabilities.tasks_advertised is None
+    # Registry answered: the 'count' skill's backing task is degraded
+    # (registered adapter, failing health probe — the #344 shape).
+    rt.skills_registry = _StubRegistry([_entry("count", "degraded")])
+    assert _by_id(rt)["count"]["tasks_available"] is False
+    # And a healthy verdict reads available even with KAI-C caps unknown.
+    rt.skills_registry = _StubRegistry([_entry("count", "available")])
+    assert _by_id(rt)["count"]["tasks_available"] is True
+
+
+def test_any_available_backing_entry_wins():
+    rt = _runtime()
+    rt.skills_registry = _StubRegistry([
+        _entry("count", "degraded"),
+        _entry("count", "available"),
+    ])
+    assert _by_id(rt)["count"]["tasks_available"] is True
+
+
+def test_unknown_registry_falls_back_to_private_derivation():
+    rt = _runtime()
+    rt.skills_registry = None            # unwired
+    before = _by_id(rt)
+    class _Unknown:
+        def availability_by_agent_skill(self):
+            return None
+        def suggestions_by_agent_skill(self):
+            return {}
+    rt.skills_registry = _Unknown()      # wired but unreachable
+    after = _by_id(rt)
+    for sid in before:
+        assert before[sid]["tasks_available"] == after[sid]["tasks_available"], (
+            f"{sid}: an unreachable registry changed the panel")
+
+
+def test_skill_absent_from_registry_uses_old_derivation():
+    rt = _runtime()
+    # Registry knows about 'count' only; 'see' keeps the old rule
+    # (KAI-C unknown → not greyed out).
+    rt.skills_registry = _StubRegistry([_entry("count", "available")])
+    assert _by_id(rt)["see"]["tasks_available"] is True
+
+
+def test_suggestions_come_from_registry_when_greyed_out():
+    rt = _runtime()
+    rt.skills_registry = _StubRegistry([
+        _entry("faces", "missing-dependency",
+               adapters=["insightface"], apps=["smart-doorbell"]),
+    ])
+    s = _by_id(rt)["faces"]
+    assert s["tasks_available"] is False
+    assert s["suggested_adapters"] == ["insightface"]
+    assert s["suggested_apps"] == ["smart-doorbell"]
+
+
+def test_suggestions_fall_back_to_editorial_maps():
+    rt = _runtime()
+
+    class _DegradedNoSuggestions:
+        def availability_by_agent_skill(self):
+            return {"faces": False}
+        def suggestions_by_agent_skill(self):
+            return {}
+    rt.skills_registry = _DegradedNoSuggestions()
+    s = _by_id(rt)["faces"]
+    assert s["tasks_available"] is False
+    assert s["suggested_adapters"] == _SKILL_SUGGESTED_ADAPTERS.get("faces", [])
+
+
+def test_registry_never_touches_agent_local_state():
+    rt = _runtime()
+    baseline = _by_id(rt)
+    rt.skills_registry = _StubRegistry(
+        [_entry(sid, "available") for sid in baseline])
+    after = _by_id(rt)
+    for sid in baseline:
+        for field in ("enabled", "available", "tools"):
+            assert baseline[sid].get(field) == after[sid].get(field), (
+                f"{sid}.{field}: platform registry leaked into agent-local "
+                "state (it may only steer tasks_available + suggestions)")
+
+
+def test_client_parses_and_negative_caches():
+    calls = {"n": 0}
+
+    class _Resp:
+        def __init__(self, payload):
+            self._p = payload
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return self._p
+
+    client = SkillsRegistryClient(base_url="http://core", api_key="k",
+                                  ttl_seconds=60.0)
+
+    class _Http:
+        async def get(self, url, headers=None):
+            calls["n"] += 1
+            assert url.endswith("/api/v1/internal/camera-agent/skills")
+            assert headers == {"X-Internal-Api-Key": "k"}
+            return _Resp({"skills": [_entry("count", "available")]})
+    client._http = _Http()
+
+    got = asyncio.run(client.refresh())
+    assert got and got[0]["agent_skill"] == "count"
+    assert client.availability_by_agent_skill() == {"count": True}
+    # TTL: a second refresh inside the window must not re-fetch.
+    asyncio.run(client.refresh())
+    assert calls["n"] == 1
+
+
+def test_client_failure_is_unknown_not_crash():
+    client = SkillsRegistryClient(base_url="http://core", api_key="k")
+
+    class _Boom:
+        async def get(self, url, headers=None):
+            raise RuntimeError("down")
+    client._http = _Boom()
+    assert asyncio.run(client.refresh()) is None
+    assert client.availability_by_agent_skill() is None
+    assert client.suggestions_by_agent_skill() == {}

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -421,3 +421,27 @@ async def internal_recording_frame(
         content=jpeg, media_type="image/jpeg",
         headers={"Cache-Control": "max-age=86400"},
     )
+
+
+@router.get("/skills", dependencies=[Depends(_require_internal_key)])
+async def internal_skills_registry(db: Session = Depends(get_db)):
+    """RFC-0002 Phase 1: the skills-registry view, on the internal door.
+
+    Same derivation (and same TTL-cached KAI-C probes) as the operator's
+    ``GET /api/v1/skills`` — this route exists because the camera agent
+    is a service authenticating with ``X-Internal-Api-Key``, not a user
+    with a JWT. One view, two doors; the derivation stays in
+    ``services/skills_registry.py`` so they can never drift.
+    """
+    from models import InstalledApp
+    from routers.ai_models import _load_tasks_registry
+    from routers.skills import _kai_c_view
+    from services.skills_registry import derive_skills
+
+    health, caps = await _kai_c_view()
+    return derive_skills(
+        tasks_registry=_load_tasks_registry(),
+        adapters_health=health,
+        adapters_caps=caps,
+        apps_rows=db.query(InstalledApp).all(),
+    )

--- a/server/tests/test_skills_registry.py
+++ b/server/tests/test_skills_registry.py
@@ -202,3 +202,22 @@ def test_real_tasks_yml_derives_without_error():
     assert len(view["skills"]) >= 5
     assert all(s["status"] in {
         "available", "degraded", "missing-dependency"} for s in view["skills"])
+
+
+def test_internal_agent_door_serves_the_same_view():
+    # RFC-0002 Phase 1: the camera agent (a service with an internal
+    # key, not a user with a JWT) gets the registry on the internal
+    # router. Presence + auth-gating checked here; the derivation
+    # itself is the same function tested above, so the two doors
+    # cannot drift.
+    from routers.internal_camera_agent import router as internal_router
+    routes = {r.path: r for r in internal_router.routes}
+    path = "/internal/camera-agent/skills"
+    assert path in routes, "internal skills route is gone"
+    deps = [
+        d.dependency.__name__
+        for d in routes[path].dependencies
+        if getattr(d, "dependency", None)
+    ]
+    assert "_require_internal_key" in deps, (
+        "internal skills route lost its X-Internal-Api-Key gate")


### PR DESCRIPTION
…2 Phase 1)

The agent's panel derived platform facts privately — the KAI-C tasks_advertised union for availability, editorial maps for the suggested adapters/apps on-ramp. Both now come from the skills registry when it answers, so every consumer renders the same truth and availability finally includes provider HEALTH (a registered adapter with a failing probe reads degraded, not available — the issue #344 shape the old union could not see).

- server/routers/internal_camera_agent.py: GET /internal/camera-agent/skills — the same derive_skills view on the internal door, because the agent is a service with an X-Internal-Api-Key, not a user with a JWT. One derivation, two doors; they cannot drift.
- adapter_clients.py: SkillsRegistryClient, mirroring the KaicCapabilitiesClient discipline exactly — 60s TTL, negative caching, refresh() never raises, unreachable → None = unknown. Helpers reduce entries to per-agent-skill availability and unioned suggestions.
- camera_agent.py: constructed beside the AppRegistryClient (same opennvr_api_url + key chain), refreshed by the /skills handler, closed at shutdown. skills_payload's fallback chain, in order: registry verdict → tasks_advertised intersection → config-based; unknown at every level still never greys a skill out. Suggested adapters/apps prefer the registry's fields, else the editorial maps. Agent-LOCAL facts (advertised tools, enabled_tools gating, enable state) are untouched by anything the registry says.
- tests: 9 agent-side (verdict-wins, any-available-entry-wins, unknown-falls-back, absent-skill-keeps-old-rule, suggestions from registry and fallback, agent-local-state isolation, client TTL + parse + failure paths) + a server-side guard that the internal route exists and keeps its internal-key gate.

Sabotage-verified: short-circuiting the registry verdict fails 3 tests. Camera-agent suite 810 passed; server suite 889 passed (plus the known environmental test_orphan_aging, which passes in CI).