### PR TITLE
fix(webrtc): make ICE host advertisement survive container recreates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -413,6 +413,26 @@ DEFAULT_ADMIN_LAST_NAME=Administrator
 # Manual nginx bind IP (auto-set by start.sh - only override if auto-detection is wrong).
 #NGINX_BIND_HOST=0.0.0.0
 
+# The address(es) MediaMTX advertises as WebRTC ICE host candidates, and the
+# base URL browsers use to reach this server. Both are auto-detected and
+# written here by start.sh - set them by hand only when auto-detection is
+# wrong (behind NAT, or a multi-NIC host where the wrong NIC wins).
+#
+# Why they matter: MediaMTX runs on the Docker bridge, so left to itself it
+# can only advertise 127.0.0.1 and 172.28.0.x - neither of which a LAN
+# browser can route to. With no usable candidate, ICE never completes, every
+# WHEP session dies on a 10s timeout, and Live View silently falls back to
+# HLS (working, but seconds of latency instead of sub-second).
+#
+# You normally do NOT need to set these: the backend keeps its own DB-backed
+# list, re-applies it to MediaMTX on every MediaMTX start, and learns the
+# address browsers actually reach it on - so a recreated container or a new
+# DHCP lease repairs itself. These are the first-boot seed.
+#
+# MEDIAMTX_WEBRTC_HOSTS takes a comma-separated list for multi-NIC or VPN.
+#MEDIAMTX_WEBRTC_HOSTS=192.168.1.100
+#MEDIAMTX_PUBLIC_URL=https://192.168.1.100
+
 # WebRTC ICE media port (UDP + TCP), published on NGINX_BIND_HOST.
 #
 # Leave this unset and the launcher probes for a bindable port at startup,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -498,6 +498,12 @@ services:
       - MEDIAMTX_EXTERNAL_BASE_URL=${MEDIAMTX_PUBLIC_URL:-https://localhost}/webrtc
       - MEDIAMTX_EXTERNAL_HLS_URL=${MEDIAMTX_PUBLIC_URL:-https://localhost}/hls
       - MEDIAMTX_EXTERNAL_PLAYBACK_URL=${MEDIAMTX_PUBLIC_URL:-https://localhost}/playback
+      # Seed for the ICE hosts MediaMTX advertises. The backend owns the
+      # authoritative list (DB-backed, learned from the address browsers
+      # actually reach) and re-pushes it on every MediaMTX start, so this is
+      # only a first-boot hint — unlike MTX_WEBRTCADDITIONALHOSTS on the
+      # mediamtx service, losing it no longer breaks live WebRTC.
+      - MEDIAMTX_WEBRTC_HOSTS=${MEDIAMTX_WEBRTC_HOSTS:-}
       - KAI_C_URL=http://127.0.0.1:8100
       # ONVIF discovery auto-detection: inside this bridge container the only
       # visible network is the compose bridge, so the launchers export the

--- a/nginx/opennvr.conf
+++ b/nginx/opennvr.conf
@@ -192,6 +192,14 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-Host  $host;
 
+        # The address the client actually connected to on THIS host, taken
+        # from nginx's own listening socket. The backend feeds it to
+        # MediaMTX's webrtcAdditionalHosts so WebRTC ICE advertises an
+        # address the browser can demonstrably reach, and so a DHCP move
+        # repairs itself. Deliberately $server_addr and NOT $host: $host is
+        # client-controlled, and would be a config-injection vector.
+        proxy_set_header X-Server-Addr     $server_addr;
+
         # WebSocket upgrade — the inference-event stream, the audit
         # live-tail, and any future SSE/WS endpoint will need this.
         proxy_set_header Upgrade           $http_upgrade;

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -177,6 +177,14 @@ class Settings(BaseSettings):
     mediamtx_admin_token: str | None = None
     mediamtx_auto_provision: bool = True  # Enable/disable auto-provisioning on startup
 
+    # Seed for the ICE host addresses MediaMTX advertises to browsers
+    # (``webrtcAdditionalHosts``). Comma-separated. This is only a seed: the
+    # authoritative list lives in the DB and is learned from the address
+    # browsers actually reach this server on. See
+    # services/webrtc_ice_host_service.py for why the env var alone is not
+    # enough (it is baked in at container-create time and silently lost).
+    mediamtx_webrtc_hosts: str = ""
+
     # Default recording segment length (seconds) the backend sends to MediaMTX
     # when provisioning a camera that has no explicit value of its own. Env var:
     # RECORDING_SEGMENT_SECONDS. Default 60 (1-minute clips) to match the

--- a/server/routers/mediamtx_admin.py
+++ b/server/routers/mediamtx_admin.py
@@ -416,6 +416,21 @@ async def mediamtx_startup_hook(
             await _apply_stored_ice_to_mediamtx()
         except Exception as e:
             mediamtx_logger.warning(f"Could not apply stored WebRTC ICE servers: {e}")
+        # Re-advertise the ICE host addresses. MediaMTX gathers only its own
+        # container interfaces (127.0.0.1 + the Docker bridge), neither of
+        # which a LAN browser can route to, so without this every WHEP session
+        # dies on a 10s ICE timeout and the UI silently falls back to HLS.
+        # Doing it here — on every MediaMTX start — is what makes it survive a
+        # `docker compose up -d` that recreates the container with an empty
+        # MTX_WEBRTCADDITIONALHOSTS.
+        try:
+            from core.database import SessionLocal
+            from services.webrtc_ice_host_service import WebRTCIceHostService
+
+            with SessionLocal() as db:
+                await WebRTCIceHostService.apply_to_mediamtx(db)
+        except Exception as e:
+            mediamtx_logger.warning(f"Could not apply WebRTC ICE hosts: {e}")
 
     # Start background task
     asyncio.create_task(run_auto_provision())

--- a/server/routers/streams.py
+++ b/server/routers/streams.py
@@ -27,7 +27,7 @@ Security Architecture:
 - MediaMTX validates tokens via JWKS endpoint
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from core.auth import get_current_active_user
@@ -249,11 +249,38 @@ async def get_hls_url(
     }
 
 
+async def _learn_ice_host(request: Request | None, db: Session) -> None:
+    """Teach MediaMTX the address this request arrived on, if it is new.
+
+    ``X-Server-Addr`` is set by nginx from ``$server_addr`` — its own listening
+    socket — so it describes this host, not anything the client chose. It is
+    honored only from a trusted proxy peer; the client-controlled ``Host``
+    header is deliberately never used here, since it would let any caller
+    inject arbitrary values into MediaMTX's advertised candidates.
+    """
+    if request is None:
+        return
+    try:
+        from services.webrtc_ice_host_service import WebRTCIceHostService
+
+        peer = request.client.host if request.client else ""
+        if not WebRTCIceHostService.is_trusted_proxy(peer):
+            return
+        addr = (request.headers.get("x-server-addr") or "").strip()
+        if addr:
+            await WebRTCIceHostService.learn(db, addr)
+    except Exception:
+        # Advertising is an optimization for live view; a failure here must
+        # never cost the caller its token and URLs.
+        pass
+
+
 @router.get("/{camera_id}/info")
 async def get_stream_info(
     camera_id: int,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
+    request: Request = None,
 ):
     """
     Get comprehensive stream information and JWT token for a camera.
@@ -261,6 +288,13 @@ async def get_stream_info(
     Returns all stream URLs and a single token valid for all protocols.
     """
     camera = _check_camera_permission(db, camera_id, current_user)
+
+    # Every WHEP attempt is preceded by this call, so it is where we learn the
+    # address the browser actually reached us on and make sure MediaMTX
+    # advertises it as an ICE candidate. Without it MediaMTX offers only its
+    # own container addresses and live WebRTC fails silently into HLS.
+    # Best-effort: never let this break the stream info response.
+    await _learn_ice_host(request, db)
 
     stream_name = _build_stream_name(
         settings.mediamtx_stream_prefix, camera_id, camera.ip_address

--- a/server/services/mediamtx_admin_service.py
+++ b/server/services/mediamtx_admin_service.py
@@ -415,6 +415,33 @@ class MediaMtxAdminService:
         except Exception as e:
             return {"status": "error", "message": f"Request failed: {e!s}"}
 
+    @staticmethod
+    async def set_webrtc_additional_hosts(hosts: list[str]) -> dict[str, Any]:
+        """Set the ICE host addresses MediaMTX advertises (``webrtcAdditionalHosts``).
+
+        Same shape and rationale as ``set_webrtc_ice_servers`` above: the field
+        is in READ_ONLY_INFRASTRUCTURE_FIELDS so the generic admin PATCH cannot
+        reach it, but OpenNVR owns it, so this dedicated method patches it
+        directly. PATCH (not set) so env-supplied global config survives.
+
+        Called from the MediaMTX startup hook on every MediaMTX start, which is
+        what makes the value survive a container recreate — see
+        services/webrtc_ice_host_service.py.
+        """
+        if not MediaMtxAdminService.is_configured():
+            return {"status": "no_admin_api"}
+        url = MediaMtxAdminService._base() + "/config/global/patch"
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.patch(
+                    url,
+                    json={"webrtcAdditionalHosts": hosts},
+                    headers=MediaMtxAdminService._headers(),
+                )
+            return MediaMtxAdminService._to_result("global", resp)
+        except Exception as e:
+            return {"status": "error", "message": f"Request failed: {e!s}"}
+
     # === PATH DEFAULTS ===
 
     @staticmethod

--- a/server/services/webrtc_ice_host_service.py
+++ b/server/services/webrtc_ice_host_service.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+The addresses MediaMTX advertises as WebRTC ICE host candidates.
+
+Why this exists: MediaMTX runs on the Docker bridge, so ``webrtcIPsFromInterfaces``
+can only ever gather the container's own addresses (``127.0.0.1`` and
+``172.28.0.x``). A LAN browser cannot route to either, so unless something tells
+MediaMTX the host's real address, the SDP answer carries no reachable candidate,
+ICE never completes, and the UI silently falls back to HLS.
+
+``MEDIAMTX_WEBRTC_HOSTS`` was that "something", but it is baked into the
+container at *create* time, so any ``docker compose up -d`` run without
+``start.sh``'s exports wiped it and broke live WebRTC with no error anywhere.
+
+So the value lives in the database instead and is pushed to MediaMTX at
+runtime, from the ``runOnInit`` startup hook that fires on every MediaMTX
+start. Two consequences:
+
+* Recreating the container no longer matters — the hook re-applies within
+  seconds regardless of what the container's environment says.
+* The set can be *learned*. ``learn()`` records the address a browser actually
+  reached this server on, so a DHCP move repairs itself on the next page load.
+
+Storage is its own ``SecuritySetting`` row rather than a field inside the
+``webrtc`` row: ``PUT /webrtc/settings`` rewrites that row from a Pydantic
+model, which would silently drop any key the schema does not declare and throw
+away everything learned here.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+
+from core.client_ip import _in_nets, _internal_nets, _parse_cidrs
+from core.config import settings
+from models import SecuritySetting
+
+logger = logging.getLogger(__name__)
+
+SETTING_KEY = "webrtc_ice_hosts"
+
+# Bounded so a host that legitimately changes address over months cannot grow
+# the advertised candidate list without limit — every extra host is another
+# candidate in every SDP answer, and ICE checks them all.
+MAX_HOSTS = 8
+
+
+class WebRTCIceHostService:
+    """Owns ``webrtcAdditionalHosts``: what MediaMTX advertises to browsers."""
+
+    # ---- validation -------------------------------------------------
+
+    @staticmethod
+    def is_advertisable(addr: str) -> bool:
+        """Whether ``addr`` is worth advertising as an ICE host candidate.
+
+        Rejects anything a browser on another machine could not use, and
+        anything that would merely re-advertise what MediaMTX already gathers
+        for itself: loopback, link-local, multicast, unspecified, and the
+        Docker bridge networks (``internal_service_cidrs``, which pins the
+        compose subnets).
+        """
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return False
+        if (
+            ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_unspecified
+            or ip.is_reserved
+        ):
+            return False
+        # The bridge addresses are exactly what MediaMTX already offers and the
+        # browser already cannot reach — re-adding them is pure noise.
+        return not _in_nets(addr, _internal_nets())
+
+    @staticmethod
+    def is_trusted_proxy(peer: str) -> bool:
+        """Whether ``peer`` (the socket peer) may set ``X-Server-Addr``.
+
+        Same trust model as ``core.client_ip``: a header describing the
+        network is believed only from the reverse proxy, never from an
+        arbitrary client.
+        """
+        return bool(peer) and _in_nets(peer, _parse_cidrs(settings.trusted_proxy_cidrs))
+
+    # ---- storage ----------------------------------------------------
+
+    @staticmethod
+    def load(db) -> list[str]:
+        row = (
+            db.query(SecuritySetting).filter(SecuritySetting.key == SETTING_KEY).first()
+        )
+        if not row:
+            return []
+        try:
+            val = json.loads(row.json_value or "[]")
+        except Exception:
+            return []
+        return [h for h in val if isinstance(h, str)] if isinstance(val, list) else []
+
+    @staticmethod
+    def store(db, hosts: list[str]) -> None:
+        row = (
+            db.query(SecuritySetting).filter(SecuritySetting.key == SETTING_KEY).first()
+        )
+        payload = json.dumps(hosts)
+        if row:
+            row.json_value = payload
+        else:
+            db.add(SecuritySetting(key=SETTING_KEY, json_value=payload))
+        db.commit()
+
+    # ---- resolution -------------------------------------------------
+
+    @classmethod
+    def resolve(cls, db) -> list[str]:
+        """The hosts to advertise: everything learned, then the env seed.
+
+        The environment value is a *seed*, not an override — it is what
+        ``start.sh`` detected, which is right on a fresh install and stale
+        after the host moves. Learned addresses come first so the most
+        recently observed one is preferred.
+        """
+        hosts = cls.load(db)
+        seed = (getattr(settings, "mediamtx_webrtc_hosts", "") or "").strip()
+        for part in seed.split(","):
+            part = part.strip()
+            if part and part not in hosts and cls.is_advertisable(part):
+                hosts.append(part)
+        return hosts[:MAX_HOSTS]
+
+    # ---- application ------------------------------------------------
+
+    @classmethod
+    async def apply_to_mediamtx(cls, db) -> bool:
+        """Push the resolved host list to MediaMTX. Returns True if applied."""
+        from services.mediamtx_admin_service import MediaMtxAdminService
+
+        hosts = cls.resolve(db)
+        if not hosts:
+            # The failure this whole module exists to prevent, made loud: with
+            # no advertisable host every WHEP session dies on a 10s ICE
+            # timeout and the UI quietly degrades to HLS.
+            logger.warning(
+                "No WebRTC ICE host to advertise — MediaMTX will offer only "
+                "container-local candidates and live WebRTC will fail (HLS "
+                "still works). Set MEDIAMTX_WEBRTC_HOSTS in .env, or open Live "
+                "View once so the address can be learned."
+            )
+            return False
+        result = await MediaMtxAdminService.set_webrtc_additional_hosts(hosts)
+        if result.get("status") == "ok":
+            logger.info("Applied WebRTC ICE hosts to MediaMTX: %s", hosts)
+            return True
+        logger.warning("Could not apply WebRTC ICE hosts %s: %s", hosts, result)
+        return False
+
+    @classmethod
+    async def learn(cls, db, addr: str) -> bool:
+        """Record an address a browser genuinely reached this server on.
+
+        No-op unless ``addr`` is advertisable and new. On a new address the
+        list is persisted and pushed to MediaMTX immediately, so the repair
+        takes effect for the WHEP request that follows this one.
+        """
+        if not cls.is_advertisable(addr):
+            return False
+        hosts = cls.load(db)
+        if addr in hosts:
+            return False
+        # Most recent first, oldest evicted — a host that moves repeatedly
+        # keeps working without the list growing forever.
+        hosts = [addr] + [h for h in hosts if h != addr]
+        cls.store(db, hosts[:MAX_HOSTS])
+        logger.info("Learned new WebRTC ICE host %s", addr)
+        await cls.apply_to_mediamtx(db)
+        return True

--- a/server/tests/test_webrtc_ice_hosts.py
+++ b/server/tests/test_webrtc_ice_hosts.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""
+Tests for the WebRTC ICE host advertisement (``webrtcAdditionalHosts``).
+
+The bug these pin: MediaMTX on the Docker bridge can only gather 127.0.0.1 and
+172.28.0.x as ICE candidates. Neither is routable from a LAN browser, so with
+nothing else advertised every WHEP session dies on a 10s ICE timeout and Live
+View silently degrades to HLS. ``MEDIAMTX_WEBRTC_HOSTS`` used to be the only
+source and was baked in at container-create time, so a bare
+``docker compose up -d`` wiped it.
+
+Coverage:
+
+* ``is_advertisable`` rejects everything a browser could not use — crucially
+  the Docker bridge addresses, which are exactly what MediaMTX already offers.
+* ``is_trusted_proxy`` gates ``X-Server-Addr`` so a client cannot inject
+  arbitrary hosts into MediaMTX's config.
+* ``resolve`` seed order: learned values first, env as fallback seed, capped.
+* ``learn`` persists, dedupes, evicts oldest, and pushes to MediaMTX.
+* ``apply_to_mediamtx`` warns rather than silently doing nothing when there is
+  no advertisable host — the silence is what hid the original bug.
+
+    cd server && pytest tests/test_webrtc_ice_hosts.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+try:
+    from cryptography.fernet import Fernet
+
+    os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+except Exception:  # pragma: no cover - cryptography is a hard dep in practice
+    pass
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+
+# A sibling test stubs core.logging_config via sys.modules.setdefault; drop it
+# so we import the real module and get every logger our imports expect.
+sys.modules.pop("core.logging_config", None)
+
+from core.config import settings  # noqa: E402
+from services.mediamtx_admin_service import MediaMtxAdminService  # noqa: E402
+from services.webrtc_ice_host_service import (  # noqa: E402
+    MAX_HOSTS,
+    SETTING_KEY,
+    WebRTCIceHostService,
+)
+
+# ---------------------------------------------------------------- fake DB
+
+
+class _FakeRow:
+    def __init__(self, key: str, json_value: str) -> None:
+        self.key = key
+        self.json_value = json_value
+
+
+class _FakeQuery:
+    def __init__(self, rows: dict[str, _FakeRow]) -> None:
+        self._rows = rows
+        self._key: str | None = None
+
+    def filter(self, criterion):
+        # The service always filters SecuritySetting.key == <literal>.
+        self._key = criterion.right.value
+        return self
+
+    def first(self):
+        return self._rows.get(self._key)
+
+
+class FakeDB:
+    """Just enough Session surface for load/store."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, _FakeRow] = {}
+        self.commits = 0
+
+    def query(self, _model):
+        return _FakeQuery(self.rows)
+
+    def add(self, row) -> None:
+        self.rows[row.key] = row
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    # test helper
+    def stored(self) -> list[str]:
+        row = self.rows.get(SETTING_KEY)
+        return json.loads(row.json_value) if row else []
+
+
+@pytest.fixture
+def db() -> FakeDB:
+    return FakeDB()
+
+
+# ------------------------------------------------------------- validation
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "127.0.0.1",  # container loopback — MediaMTX already offers this
+        "172.28.0.2",  # the Docker bridge — the address that broke live view
+        "169.254.10.1",  # link-local
+        "0.0.0.0",
+        "224.0.0.1",  # multicast
+        "not-an-ip",
+        "",
+        "192.168.31.67:8189",  # port suffix is not an address
+    ],
+)
+def test_rejects_unusable_ice_hosts(addr: str) -> None:
+    assert WebRTCIceHostService.is_advertisable(addr) is False
+
+
+@pytest.mark.parametrize("addr", ["192.168.31.67", "10.20.30.40", "49.43.161.182"])
+def test_accepts_routable_ice_hosts(addr: str) -> None:
+    assert WebRTCIceHostService.is_advertisable(addr) is True
+
+
+def test_bridge_peer_may_set_the_header_but_a_lan_client_may_not() -> None:
+    # nginx reaches the backend from the pinned Docker subnet.
+    assert WebRTCIceHostService.is_trusted_proxy("172.28.0.8") is True
+    assert WebRTCIceHostService.is_trusted_proxy("127.0.0.1") is True
+    # A browser connecting directly must never be able to inject a host.
+    assert WebRTCIceHostService.is_trusted_proxy("192.168.31.50") is False
+    assert WebRTCIceHostService.is_trusted_proxy("") is False
+
+
+# -------------------------------------------------------------- resolve
+
+
+def test_resolve_prefers_learned_over_env_seed(db: FakeDB, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "mediamtx_webrtc_hosts", "10.0.0.5", raising=False)
+    WebRTCIceHostService.store(db, ["192.168.31.67"])
+
+    # Learned first, seed appended — a stale env value cannot mask the address
+    # we have actually observed working.
+    assert WebRTCIceHostService.resolve(db) == ["192.168.31.67", "10.0.0.5"]
+
+
+def test_resolve_dedupes_and_drops_unusable_seed(db: FakeDB, monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings,
+        "mediamtx_webrtc_hosts",
+        "192.168.31.67, 172.28.0.2 , , 127.0.0.1",
+        raising=False,
+    )
+    WebRTCIceHostService.store(db, ["192.168.31.67"])
+
+    # The duplicate collapses; the bridge and loopback seeds are filtered out.
+    assert WebRTCIceHostService.resolve(db) == ["192.168.31.67"]
+
+
+def test_resolve_is_empty_when_nothing_is_known(db: FakeDB, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "mediamtx_webrtc_hosts", "", raising=False)
+    assert WebRTCIceHostService.resolve(db) == []
+
+
+# ---------------------------------------------------------------- learn
+
+
+@pytest.mark.asyncio
+async def test_learn_records_and_pushes_a_new_address(db: FakeDB, monkeypatch) -> None:
+    pushed: list[list[str]] = []
+
+    async def _fake_push(hosts):
+        pushed.append(hosts)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        MediaMtxAdminService, "set_webrtc_additional_hosts", _fake_push, raising=False
+    )
+    monkeypatch.setattr(settings, "mediamtx_webrtc_hosts", "", raising=False)
+
+    assert await WebRTCIceHostService.learn(db, "192.168.31.67") is True
+    assert db.stored() == ["192.168.31.67"]
+    assert pushed == [["192.168.31.67"]]
+
+
+@pytest.mark.asyncio
+async def test_learn_is_a_noop_for_a_known_address(db: FakeDB, monkeypatch) -> None:
+    called = False
+
+    async def _fake_push(hosts):
+        nonlocal called
+        called = True
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        MediaMtxAdminService, "set_webrtc_additional_hosts", _fake_push, raising=False
+    )
+    WebRTCIceHostService.store(db, ["192.168.31.67"])
+    before = db.commits
+
+    assert await WebRTCIceHostService.learn(db, "192.168.31.67") is False
+    # No write and no MediaMTX call on the steady-state path — this runs on
+    # every stream-info request.
+    assert db.commits == before
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_learn_refuses_an_unusable_address(db: FakeDB) -> None:
+    assert await WebRTCIceHostService.learn(db, "172.28.0.2") is False
+    assert await WebRTCIceHostService.learn(db, "evil.example") is False
+    assert db.stored() == []
+
+
+@pytest.mark.asyncio
+async def test_learn_keeps_newest_first_and_evicts_oldest(
+    db: FakeDB, monkeypatch
+) -> None:
+    async def _fake_push(hosts):
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        MediaMtxAdminService, "set_webrtc_additional_hosts", _fake_push, raising=False
+    )
+    monkeypatch.setattr(settings, "mediamtx_webrtc_hosts", "", raising=False)
+
+    for i in range(MAX_HOSTS + 3):
+        await WebRTCIceHostService.learn(db, f"10.0.0.{i + 1}")
+
+    stored = db.stored()
+    assert len(stored) == MAX_HOSTS
+    # Most recently seen wins; a host that moves repeatedly keeps working.
+    assert stored[0] == f"10.0.0.{MAX_HOSTS + 3}"
+    assert "10.0.0.1" not in stored
+
+
+# ------------------------------------------------------------ application
+
+
+@pytest.mark.asyncio
+async def test_apply_warns_instead_of_failing_silently(
+    db: FakeDB, monkeypatch, caplog
+) -> None:
+    monkeypatch.setattr(settings, "mediamtx_webrtc_hosts", "", raising=False)
+
+    with caplog.at_level("WARNING"):
+        assert await WebRTCIceHostService.apply_to_mediamtx(db) is False
+
+    # The original bug was invisible; an empty list must say so out loud.
+    assert any("No WebRTC ICE host" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_apply_pushes_the_resolved_list(db: FakeDB, monkeypatch) -> None:
+    pushed: list[list[str]] = []
+
+    async def _fake_push(hosts):
+        pushed.append(hosts)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        MediaMtxAdminService, "set_webrtc_additional_hosts", _fake_push, raising=False
+    )
+    monkeypatch.setattr(settings, "mediamtx_webrtc_hosts", "10.0.0.5", raising=False)
+    WebRTCIceHostService.store(db, ["192.168.31.67"])
+
+    assert await WebRTCIceHostService.apply_to_mediamtx(db) is True
+    assert pushed == [["192.168.31.67", "10.0.0.5"]]

--- a/start.sh
+++ b/start.sh
@@ -540,8 +540,8 @@ configure_nginx_bind_host() {
         local single_host
         single_host=$(detect_lan_ip 2>/dev/null || echo "")
         if [ -n "$single_host" ]; then
-            export MEDIAMTX_PUBLIC_URL="https://${single_host}"
-            export MEDIAMTX_WEBRTC_HOSTS="${single_host}"
+            set_env_var MEDIAMTX_PUBLIC_URL "https://${single_host}"
+            set_env_var MEDIAMTX_WEBRTC_HOSTS "${single_host}"
             # ISSUE-6 v9: propagate to cert SAN — see dual-declared
             # branch for the rationale.
             if [ -z "$(get_env_var OPENNVR_HOST_IP 2>/dev/null)" ]; then
@@ -575,8 +575,8 @@ configure_nginx_bind_host() {
         # emits HTTPS URLs through nginx. MEDIAMTX_WEBRTC_HOSTS →
         # mediamtx advertises ICE candidates the LAN browser can
         # reach for the UDP/8189 media path.
-        export MEDIAMTX_PUBLIC_URL="https://${mgmt_ip}"
-        export MEDIAMTX_WEBRTC_HOSTS="${mgmt_ip}"
+        set_env_var MEDIAMTX_PUBLIC_URL "https://${mgmt_ip}"
+        set_env_var MEDIAMTX_WEBRTC_HOSTS "${mgmt_ip}"
         # ISSUE-6 v9: propagate the IP to the cert init containers
         # so the TLS cert SAN list includes the IP browsers will
         # actually visit. Without this, the cert is generated with
@@ -622,8 +622,8 @@ configure_nginx_bind_host() {
     local fallback_host
     fallback_host=$(detect_lan_ip 2>/dev/null || echo "")
     if [ -n "$fallback_host" ]; then
-        export MEDIAMTX_PUBLIC_URL="https://${fallback_host}"
-        export MEDIAMTX_WEBRTC_HOSTS="${fallback_host}"
+        set_env_var MEDIAMTX_PUBLIC_URL "https://${fallback_host}"
+        set_env_var MEDIAMTX_WEBRTC_HOSTS "${fallback_host}"
         if [ -z "$(get_env_var OPENNVR_HOST_IP 2>/dev/null)" ]; then
             export OPENNVR_HOST_IP="${fallback_host}"
         fi
@@ -679,6 +679,24 @@ write_env_var() {
     else
         echo "${key}=${value}" >> "$file"
     fi
+}
+
+# export + persist in one step.
+#
+# Values detected from the host topology (the LAN IP browsers reach us on)
+# used to be exported only, so they lived just in this script's process. Any
+# `docker compose up -d` that recreated a container without them baked an
+# empty value in — which silently killed live WebRTC, because MediaMTX then
+# advertises only its own Docker-bridge address as an ICE candidate. Writing
+# them to .env makes every compose entry point see the same value.
+#
+# Always overwrites: these are DETECTED, so a host whose LAN IP changed must
+# refresh rather than keep a stale value. Operator-set values are read via
+# get_env_var by the callers before they decide, so they are not clobbered.
+set_env_var() {
+    local key="$1" value="$2"
+    export "${key}=${value}"
+    write_env_var "$key" "$value"
 }
 
 prompt_nic_topology() {
@@ -741,8 +759,8 @@ prompt_nic_topology() {
             # cert SAN includes the LAN IP — see dual-declared
             # branch for the rationale.
             if [ -n "$lan_hint" ]; then
-                export MEDIAMTX_PUBLIC_URL="https://${lan_hint}"
-                export MEDIAMTX_WEBRTC_HOSTS="${lan_hint}"
+                set_env_var MEDIAMTX_PUBLIC_URL "https://${lan_hint}"
+                set_env_var MEDIAMTX_WEBRTC_HOSTS "${lan_hint}"
                 if [ -z "$(get_env_var OPENNVR_HOST_IP 2>/dev/null)" ]; then
                     export OPENNVR_HOST_IP="${lan_hint}"
                 fi
@@ -794,8 +812,8 @@ prompt_nic_topology() {
             # https://localhost for the browser-facing stream URLs and
             # advertises no reachable WebRTC ICE host — live view
             # broken until a restart nobody knows they need.
-            export MEDIAMTX_PUBLIC_URL="https://${mgmt_ip}"
-            export MEDIAMTX_WEBRTC_HOSTS="${mgmt_ip}"
+            set_env_var MEDIAMTX_PUBLIC_URL "https://${mgmt_ip}"
+            set_env_var MEDIAMTX_WEBRTC_HOSTS "${mgmt_ip}"
             if [ -z "$(get_env_var OPENNVR_HOST_IP 2>/dev/null)" ]; then
                 export OPENNVR_HOST_IP="${mgmt_ip}"
             fi


### PR DESCRIPTION
MediaMTX on the Docker bridge can only gather its own interfaces as ICE candidates (127.0.0.1 and 172.28.0.x), neither routable from a LAN browser. The one thing that told it the host's real address, MEDIAMTX_WEBRTC_HOSTS, was only ever exported by start.sh -- never written to .env. Docker bakes env at container-create time, so live WebRTC worked after ./start.sh up and died the moment anything recreated the mediamtx container from a plain shell. There was no error: the UI falls back to HLS and keeps playing, so the only symptom was latency.

Confirmed from a chrome://webrtc-internals dump: the answer SDP carried only 127.0.0.1, 172.28.0.2 and a NAT-mapped srflx, no LAN address. With zero reachable candidates the browser fails ICE 0.5ms after setRemoteDescription while MediaMTX waits out its full 10s handshake timeout.

Pinning the IP in .env fixes today and still fails silently on a DHCP move, so the value is now applied at runtime and re-learned instead of baked in:

* New WebRTCIceHostService owns the list, stored in its own SecuritySetting row. Not a field on WebRTCSettings: PUT /webrtc/settings rewrites that row from the Pydantic model and would silently drop the learned hosts.
* set_webrtc_additional_hosts patches webrtcAdditionalHosts, mirroring the existing set_webrtc_ice_servers. Called from the MediaMTX startup hook, which runOnInit fires on every MediaMTX start -- so a recreate now self-repairs within seconds regardless of the container's env.
* nginx passes X-Server-Addr ($server_addr, its own listening socket) and the stream-info endpoint learns it, so a changed host address is picked up on the next Live View load. Deliberately not the Host header, which is client-controlled and would let a caller inject arbitrary candidates; the header is honored only from a trusted proxy peer.
* start.sh gains set_env_var (export + persist) so detected values reach .env and every compose entry point sees them. Always overwrites, since a detected value must refresh rather than go stale.
* An empty resolved list now logs a warning instead of failing silently -- that silence is what hid this for as long as it did.

start.ps1 is untouched: it has no NIC-topology detection at all, so there is nothing to mirror. The runtime path above covers Windows anyway.

Adds 21 tests: validation, Host-injection rejection, seed order, eviction, and the empty-list warning.

Fixes #347