### PR TITLE
feat(agent): contract parity — the flagship becomes visible to its pl…

### DIFF
--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -3051,6 +3051,7 @@ class CameraAgentRuntime:
         # else kaic_api_key, else the INTERNAL_API_KEY env var.
         self.app_registry: AppRegistryClient | None = None
         self.skills_registry: SkillsRegistryClient | None = None
+        self._registry_key: str = ""
         if cfg.opennvr_api_url:
             import os
 
@@ -3070,6 +3071,8 @@ class CameraAgentRuntime:
             self.skills_registry = SkillsRegistryClient(
                 base_url=cfg.opennvr_api_url, api_key=app_key,
             )
+            # Kept for contract-parity self-registration (RFC-0002 gap 8).
+            self._registry_key = app_key
             logger.info(
                 "app door enabled: reading installed apps from %s "
                 "(read-only — the agent never enables/disables/configures)",
@@ -4544,7 +4547,80 @@ class CameraAgentRuntime:
             except asyncio.TimeoutError:
                 pass
 
+    def contract_state(self) -> dict[str, Any]:
+        """The ``GET /state`` payload (RFC-0002 contract parity): coarse
+        live state in the same spirit as SDK apps' StateView payloads —
+        identity-level facts, no controls, no media. Everything here is
+        already visible on /health or the skills panel; /state is the
+        CONTRACT-shaped door to it."""
+        try:
+            skills = self.skills_payload()
+        except Exception:  # noqa: BLE001 — state must never 500 the probe
+            skills = []
+        return {
+            "cameras": [cam.camera_id for cam in self.cfg.cameras],
+            "monitors": len(getattr(self.monitors, "_monitors", {}) or {}),
+            "skills": {
+                "enabled": sum(1 for s in skills if s.get("enabled")),
+                "total": len(skills),
+            },
+            "llm_model": self.cfg.llm_model,
+            "llm_error": getattr(self, "last_llm_error", None),
+            "vision_error": getattr(self.tools, "last_vision_error", None),
+        }
+
+    async def register_with_app_catalog(self) -> bool:
+        """RFC-0002 gap 8: self-register with the App Catalog on boot, the
+        way every SDK app does (POST /api/v1/apps/register, best-effort).
+        Never raises; False = not registered (unwired, unreachable, or
+        rejected) and the agent runs exactly as before — registration
+        makes the platform SEE the agent, it gates nothing.
+        """
+        base = self.cfg.opennvr_api_url
+        if not base:
+            return False
+        import socket
+
+        scheme = "https" if self.cfg.tls_certfile else "http"
+        own_url = (
+            self.cfg.agent_public_url
+            or f"{scheme}://{socket.gethostname()}:{self.cfg.port}"
+        ).rstrip("/")
+        payload = {"url": own_url, "manifest": agent_manifest()}
+        headers: dict[str, str] = {}
+        if self._registry_key:
+            # Both header shapes, same reason as the SDK: one configured
+            # key must work whether the operator provisioned the internal
+            # service key or a user token.
+            headers["X-Internal-Api-Key"] = self._registry_key
+            headers["Authorization"] = f"Bearer {self._registry_key}"
+        try:
+            async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
+                resp = await client.post(
+                    f"{base.rstrip('/')}/api/v1/apps/register",
+                    json=payload, headers=headers,
+                )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "app-catalog self-registration rejected: HTTP %d %s",
+                    resp.status_code, resp.text[:200])
+                return False
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "app-catalog self-registration failed: %s — continuing "
+                "without the registry", exc)
+            return False
+        logger.info("registered with the App Catalog as %s", own_url)
+        return True
+
     async def startup(self) -> None:
+        # Contract parity (RFC-0002 gap 8): make the platform see the
+        # flagship. Fire-and-forget so a slow core never delays boot.
+        if self.cfg.opennvr_api_url:
+            asyncio.create_task(
+                self.register_with_app_catalog(),
+                name="camera-agent-app-catalog-register",
+            )
         if self.cfg.nats_inference_url:
             self._subscriber_task = asyncio.create_task(
                 run_event_subscriber(
@@ -4968,8 +5044,39 @@ def build_pipeline_task(runtime: CameraAgentRuntime, transport: Any) -> Any:
 # ── FastAPI app + WebSocket entry point ────────────────────────────
 
 
+AGENT_VERSION = "1.0.0"
+
+
+def agent_manifest() -> dict[str, Any]:
+    """RFC-0002 gap 8 (contract parity): the flagship app's identity, in
+    the same shape every SDK app serves. AppManifest is an identity
+    dataclass, not a base class — the agent still doesn't ride
+    Detector/FrameApp/AlertSubscriber (that debt stays on the SDK-rule
+    conformance allowlist); what changes is that the App Catalog and the
+    skills registry can finally SEE it.
+
+    ``requires_tasks`` is empty on purpose: every capability degrades
+    gracefully (that's the agent's whole design), so nothing is a hard
+    requirement the catalog should warn about.
+    """
+    from opennvr_app_sdk import AppManifest
+
+    return AppManifest(
+        id="camera-agent",
+        name="OpenNVR Agent",
+        version=AGENT_VERSION,
+        category="assistant",
+        summary=(
+            "Conversational monitoring agent: looks at cameras, answers "
+            "questions, runs watch monitors, and relays app alerts. Every "
+            "capability degrades gracefully when its backend is absent."
+        ),
+        requires_tasks=[],
+    ).to_dict()
+
+
 def build_app(runtime: CameraAgentRuntime) -> FastAPI:
-    app = FastAPI(title="OpenNVR camera-agent", version="1.0.0")
+    app = FastAPI(title="OpenNVR camera-agent", version=AGENT_VERSION)
 
     @app.on_event("startup")
     async def _startup() -> None:
@@ -4985,7 +5092,11 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
     # ranks: viewer < operator < admin. The PAGE SHELL stays open (it
     # renders the login overlay); every data/action endpoint is gated.
     _TIER_RANK = {"viewer": 0, "operator": 1, "admin": 2}
-    _OPEN_PATHS = {"/health", "/auth/login", "/auth/refresh", "/agent"}
+    # /manifest and /state are the RFC-0002 contract surface: core's App
+    # Catalog probes them without an OpenNVR bearer (same trust story as
+    # /health — identity + coarse live state, no controls, no media).
+    _OPEN_PATHS = {"/health", "/manifest", "/state",
+                   "/auth/login", "/auth/refresh", "/agent"}
 
     def _user_tier(user: dict[str, Any]) -> str:
         if user.get("is_superuser"):
@@ -5118,6 +5229,19 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             "llm_error": getattr(runtime, "last_llm_error", None),
             "history": getattr(runtime, "events_client", None) is not None,
         }
+
+    # ── RFC-0002 contract parity (gap 8) ───────────────────────────
+    # The two contract routes every SDK app serves, so the App Catalog's
+    # status probe and the skills registry's app-manifest source finally
+    # see the flagship. Same trust level as /health (open paths).
+
+    @app.get("/manifest")
+    async def _manifest() -> dict[str, Any]:
+        return agent_manifest()
+
+    @app.get("/state")
+    async def _state() -> dict[str, Any]:
+        return runtime.contract_state()
 
     @app.get("/demo", response_class=HTMLResponse)
     async def _demo() -> HTMLResponse:

--- a/examples/camera-agent/tests/test_contract_parity.py
+++ b/examples/camera-agent/tests/test_contract_parity.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RFC-0002 gap 8 — agent contract parity.
+
+The flagship app becomes visible to its own platform: it serves the
+same ``/manifest`` and ``/state`` contract routes every SDK app serves,
+and self-registers with the App Catalog on boot. Pinned here:
+
+* the two routes exist, answer without auth (same trust level as
+  ``/health`` — the catalog's probe carries no OpenNVR bearer), and
+  return the contracted shapes;
+* the manifest is the SDK ``AppManifest`` shape with the agent's fixed
+  identity (id ``camera-agent``);
+* registration is best-effort and never raises — unwired, unreachable,
+  and rejected all mean "runs exactly as before";
+* registration POSTs the same body shape the SDK posts
+  (``{url, manifest}`` to ``/api/v1/apps/register``).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from camera_agent import (
+    AppConfig,
+    CameraAgentRuntime,
+    agent_manifest,
+    build_app,
+)
+from context import CameraSpec
+
+
+def _cfg(**kw) -> AppConfig:
+    return AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+        cameras=[CameraSpec(camera_id="cam1", frame_url="http://x/1.jpg",
+                            role="front door")],
+        **kw,
+    )
+
+
+def test_manifest_is_the_sdk_shape_with_fixed_identity():
+    m = agent_manifest()
+    assert m["id"] == "camera-agent"
+    assert m["category"] == "assistant"
+    # The registry upserts by manifest id — a drifting id would register
+    # a SECOND app instead of updating the first.
+    assert set(m) >= {"id", "name", "version", "category", "summary",
+                      "requires_tasks", "params", "emits"}
+    assert m["requires_tasks"] == []
+
+
+def test_contract_routes_exist_and_are_open():
+    runtime = CameraAgentRuntime(_cfg(auth_mode="opennvr",
+                                      opennvr_api_url="http://core:8000"))
+    app = build_app(runtime)
+    with TestClient(app) as client:
+        man = client.get("/manifest")
+        assert man.status_code == 200
+        assert man.json()["id"] == "camera-agent"
+        state = client.get("/state")
+        assert state.status_code == 200
+        body = state.json()
+        assert body["cameras"] == ["cam1"]
+        assert set(body["skills"]) == {"enabled", "total"}
+        assert "llm_error" in body and "vision_error" in body
+
+
+def test_state_never_500s_when_skills_derivation_breaks():
+    runtime = CameraAgentRuntime(_cfg())
+
+    def boom():
+        raise RuntimeError("panel bug")
+    runtime.skills_payload = boom  # type: ignore[assignment]
+    body = runtime.contract_state()
+    assert body["skills"] == {"enabled": 0, "total": 0}
+
+
+def test_registration_posts_the_sdk_body_shape(monkeypatch):
+    runtime = CameraAgentRuntime(_cfg(
+        opennvr_api_url="http://core:8000",
+        opennvr_api_key="sekrit",
+        agent_public_url="https://agent.lan:9100",
+    ))
+    seen = {}
+
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+    class _Client:
+        def __init__(self, **kw):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, url, json=None, headers=None):
+            seen.update(url=url, json=json, headers=headers)
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    assert asyncio.run(runtime.register_with_app_catalog()) is True
+    assert seen["url"] == "http://core:8000/api/v1/apps/register"
+    assert seen["json"]["url"] == "https://agent.lan:9100"
+    assert seen["json"]["manifest"]["id"] == "camera-agent"
+    # Both header shapes, like the SDK: one key, either credential kind.
+    assert seen["headers"]["X-Internal-Api-Key"] == "sekrit"
+    assert seen["headers"]["Authorization"] == "Bearer sekrit"
+
+
+@pytest.mark.parametrize("failure", ["transport", "rejected"])
+def test_registration_failure_is_false_never_raise(monkeypatch, failure):
+    runtime = CameraAgentRuntime(_cfg(opennvr_api_url="http://core:8000"))
+
+    class _Resp:
+        status_code = 403
+        text = "no"
+
+    class _Client:
+        def __init__(self, **kw):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, url, json=None, headers=None):
+            if failure == "transport":
+                raise httpx.ConnectError("down")
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    assert asyncio.run(runtime.register_with_app_catalog()) is False
+
+
+def test_registration_unwired_is_a_clean_no():
+    runtime = CameraAgentRuntime(_cfg())      # no opennvr_api_url
+    assert asyncio.run(runtime.register_with_app_catalog()) is False
+
+
+def test_default_registration_url_scheme_follows_tls(monkeypatch):
+    import socket
+    monkeypatch.setattr(socket, "gethostname", lambda: "agent-host")
+    seen = {}
+
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+    class _Client:
+        def __init__(self, **kw):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, url, json=None, headers=None):
+            seen.update(json=json)
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    rt = CameraAgentRuntime(_cfg(opennvr_api_url="http://core:8000"))
+    asyncio.run(rt.register_with_app_catalog())
+    assert seen["json"]["url"] == "http://agent-host:9100"
+
+    rt = CameraAgentRuntime(_cfg(opennvr_api_url="http://core:8000",
+                                 tls_certfile="/certs/a.pem",
+                                 tls_keyfile="/certs/a.key"))
+    asyncio.run(rt.register_with_app_catalog())
+    assert seen["json"]["url"] == "https://agent-host:9100"


### PR DESCRIPTION
…atform

RFC-0002 gap 8, Phase 1's last task: the camera agent now serves the same contract surface every SDK app serves and self-registers with the App Catalog — so the registry's app-manifest source (decision 2) and the catalog finally SEE the platform's most important app. Contract parity only, exactly as scoped: no base-class rewrite, no behavior change to any existing capability.

- agent_manifest(): the SDK AppManifest shape (AppManifest is an identity dataclass, not a base class) with fixed id 'camera-agent', category 'assistant', requires_tasks=[] on purpose — every agent capability degrades gracefully, so nothing is a hard requirement the catalog should warn about.
- GET /manifest and GET /state on the agent's existing FastAPI. /state = coarse contract-shaped live state (cameras, monitor count, skills enabled/total, llm_error/vision_error — all already visible via /health or the panel); it never 500s, even if the skills derivation breaks. Both routes join /health in the auth middleware's open set: core's catalog probe carries no OpenNVR bearer, and the routes expose identity + coarse state, no controls, no media.
- register_with_app_catalog(): boot-time POST /api/v1/apps/register, the SDK's exact body shape ({url, manifest}) and dual auth headers (one configured key works as either credential kind). URL is agent_public_url when set, else scheme(hostname):port with the scheme following TLS config. Best-effort and fire-and-forget from startup(): unwired, unreachable, and rejected all mean the agent runs exactly as before — registration makes the platform see the agent, it gates nothing.

NOTE on the conformance allowlist (PR #346, still open): the SDK-rule test defines conformance as extending an SDK base, which this commit deliberately does not do — so camera-agent STAYS allowlisted there. Once #346 lands, the allowlist comment should be updated to say the remaining debt is base-class adoption only; gap 8's visibility debt is retired here.

Tests (8): manifest identity/shape, routes open under auth_mode= opennvr, state-never-500s, registration body/headers, failure paths return False and never raise (sabotage-verified: re-raising fails the transport test), unwired no-op, TLS-follows-scheme URL derivation. Camera-agent suite: 818 passed.