### PR TITLE
fix(player): render anamorphic streams at their true aspect (fixes #354)

### DIFF
--- a/app/src/components/PlaybackConsole.tsx
+++ b/app/src/components/PlaybackConsole.tsx
@@ -38,6 +38,10 @@ import {
   Radio,
 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
+import { displayAspect, isStretched } from '../lib/aspect'
+import type { AspectOverride } from '../lib/aspect'
+import { useVideoSize } from '../hooks/useVideoAspect'
+import { AspectFrame } from './VideoPlayer'
 import { loadHls, warmHls } from '../lib/loadHls'
 import { useCameraSegments } from '../lib/queries'
 import { localDayEnd, localDayStart } from '../lib/time'
@@ -62,6 +66,10 @@ interface PlaybackConsoleProps {
   /** YYYY-MM-DD */
   date: string
   onClose: () => void
+  /** Per-camera display-aspect override; recordings are stored exactly as the
+      camera sent them, so an anamorphic stream plays back squished without it
+      (issue #354). Omitted for a deleted camera — detection still applies. */
+  displayAspectOverride?: AspectOverride | null
 }
 
 // Zoom presets (visible span in ms) — mirrors the "1 Day / …" control.
@@ -98,7 +106,13 @@ const sameSegs = (a: Seg[], b: Seg[]) =>
   a.length === b.length &&
   a.every((s, i) => s.startMs === b[i].startMs && s.endMs === b[i].endMs)
 
-export function PlaybackConsole({ cameraId, cameraName, date, onClose }: PlaybackConsoleProps) {
+export function PlaybackConsole({
+  cameraId,
+  cameraName,
+  date,
+  onClose,
+  displayAspectOverride,
+}: PlaybackConsoleProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const hlsRef = useRef<Hls | null>(null)
@@ -109,6 +123,15 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
   useEffect(() => {
     warmHls()
   }, [])
+  // A clip's coded size is not always the size it should be shown at — see
+  // lib/aspect.ts. MediaMTX records the camera's bytes untouched, so a 1080N
+  // recording is 960x1080 exactly like the live stream it came from.
+  const videoSize = useVideoSize(videoRef)
+  const videoAspect = useMemo(
+    () => displayAspect(videoSize?.width, videoSize?.height, displayAspectOverride),
+    [videoSize?.width, videoSize?.height, displayAspectOverride]
+  )
+  const stretched = isStretched(videoSize?.width, videoSize?.height, videoAspect)
   const sessionIdRef = useRef<string | null>(null)
   // Guards against out-of-order async loads: only the latest load token wins.
   const loadTokenRef = useRef(0)
@@ -698,10 +721,14 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
         </div>
 
         {/* Video */}
+        {/* Size container so AspectFrame's 100cqw resolves to this box's width.
+            Both branches have a definite height — aspect-video derives one from
+            the width, flex-1 min-h-0 takes one from the column. */}
         <div
           className={`relative bg-black flex items-center justify-center ${
             isFullscreen ? 'flex-1 min-h-0' : 'aspect-video'
           }`}
+          style={{ containerType: 'size' }}
         >
           {error ? (
             <div className="text-center p-8">
@@ -710,13 +737,15 @@ export function PlaybackConsole({ cameraId, cameraName, date, onClose }: Playbac
             </div>
           ) : (
             <>
-              <video
-                ref={videoRef}
-                className="w-full h-full object-contain"
-                playsInline
-                crossOrigin="anonymous"
-                onClick={togglePlay}
-              />
+              <AspectFrame aspect={videoAspect}>
+                <video
+                  ref={videoRef}
+                  className={`block w-full h-full ${stretched ? 'object-fill' : 'object-contain'}`}
+                  playsInline
+                  crossOrigin="anonymous"
+                  onClick={togglePlay}
+                />
+              </AspectFrame>
               {(loading || buffering) && !livePrompt && (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/30 pointer-events-none">
                   <Loader2 size={40} className="animate-spin text-[var(--accent)]" />

--- a/app/src/components/SyncPlaybackTile.tsx
+++ b/app/src/components/SyncPlaybackTile.tsx
@@ -16,10 +16,14 @@
  * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type Hls from 'hls.js'
 import { CameraOff, Loader2, Radio, AlertCircle, Volume2 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
+import { displayAspect, isStretched } from '../lib/aspect'
+import type { AspectOverride } from '../lib/aspect'
+import { useVideoSize } from '../hooks/useVideoAspect'
+import { AspectFrame } from './VideoPlayer'
 import { loadHls } from '../lib/loadHls'
 import type { TimelineSegment } from './PlaybackTimeline'
 
@@ -38,6 +42,8 @@ interface SyncPlaybackTileProps {
   /** Highlighted tile (audio focus). */
   active: boolean
   onActivate: () => void
+  /** Per-camera display-aspect override — see lib/aspect.ts (issue #354). */
+  displayAspectOverride?: AspectOverride | null
 }
 
 type TileStatus = 'idle' | 'loading' | 'ok' | 'gap' | 'live' | 'error'
@@ -63,6 +69,7 @@ export function SyncPlaybackTile({
   muted,
   active,
   onActivate,
+  displayAspectOverride,
 }: SyncPlaybackTileProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const hlsRef = useRef<Hls | null>(null)
@@ -362,16 +369,34 @@ export function SyncPlaybackTile({
     }
   }, [teardownMedia])
 
+  // Coded size of the loaded clip vs. the aspect it should be shown at.
+  const videoSize = useVideoSize(videoRef)
+  const videoAspect = useMemo(
+    () => displayAspect(videoSize?.width, videoSize?.height, displayAspectOverride),
+    [videoSize?.width, videoSize?.height, displayAspectOverride]
+  )
+  const stretched = isStretched(videoSize?.width, videoSize?.height, videoAspect)
+
   const showSpinner = status === 'loading' || (status === 'ok' && buffering)
 
   return (
     <div
       onClick={onActivate}
-      className={`relative bg-black overflow-hidden cursor-pointer aspect-video lg:aspect-auto border ${
+      className={`relative bg-black overflow-hidden cursor-pointer flex items-center justify-center aspect-video lg:aspect-auto border ${
         active ? 'border-[var(--accent)]' : 'border-[var(--border)]'
       }`}
+      style={{ containerType: 'size' }}
     >
-      <video ref={videoRef} className="w-full h-full object-contain" playsInline crossOrigin="anonymous" />
+      {/* The clip carries the camera's coded size, which for an anamorphic
+          stream is not the size to show it at — see lib/aspect.ts (#354). */}
+      <AspectFrame aspect={videoAspect}>
+        <video
+          ref={videoRef}
+          className={`block w-full h-full ${stretched ? 'object-fill' : 'object-contain'}`}
+          playsInline
+          crossOrigin="anonymous"
+        />
+      </AspectFrame>
 
       {/* Name chip */}
       <div className="absolute top-1 left-1 flex items-center gap-1 max-w-[85%] px-1.5 py-0.5 bg-black/60 text-white text-[10px] leading-tight">

--- a/app/src/components/VideoPlayer/AspectFrame.tsx
+++ b/app/src/components/VideoPlayer/AspectFrame.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 OpenNVR
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { ReactNode } from 'react'
+
+/**
+ * A box of the given DISPLAY aspect, centred in its parent and never
+ * overflowing it — the frame an anamorphic stream gets stretched into.
+ *
+ * The parent must be a size container (`containerType: 'size'`) with a
+ * definite height: `100cqw` is the parent's width, so
+ * `height = min(100%, 100cqw / aspect)` is the tallest the box can be while
+ * still fitting horizontally, and `aspect-ratio` then derives the width.
+ *
+ * `aspect` is null until the stream's metadata lands, in which case the box
+ * simply fills the parent and the video inside stays on object-contain.
+ */
+export function AspectFrame({
+  aspect,
+  className = '',
+  children,
+}: {
+  aspect: number | null
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <div
+      className={`relative ${className}`}
+      style={
+        aspect
+          ? { height: `min(100%, calc(100cqw / ${aspect}))`, aspectRatio: String(aspect) }
+          : { width: '100%', height: '100%' }
+      }
+    >
+      {children}
+    </div>
+  )
+}

--- a/app/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/app/src/components/VideoPlayer/VideoPlayer.tsx
@@ -23,10 +23,14 @@ import {
   useState,
   useImperativeHandle,
   useCallback,
+  useMemo,
 } from 'react'
 import { apiService } from '../../lib/apiService'
 import type Hls from 'hls.js'
 import { loadHls } from '../../lib/loadHls'
+import { displayAspect, isStretched, snapshotSize } from '../../lib/aspect'
+import type { AspectOverride } from '../../lib/aspect'
+import { useVideoSize } from '../../hooks/useVideoAspect'
 import { VideoControls } from './VideoControls'
 import { AlertCircle } from 'lucide-react'
 
@@ -74,6 +78,9 @@ export interface VideoPlayerProps {
   /** Extra overlay rendered inside the player (e.g. the PTZ pad) — kept
       inside so it stays visible when the player element goes fullscreen */
   overlay?: React.ReactNode
+  /** Operator's per-camera display-aspect override ('auto' | 'native' | 'W:H').
+      Absent or 'auto' runs the detection in lib/aspect.ts (issue #354). */
+  displayAspectOverride?: AspectOverride | null
 }
 
 export interface VideoPlayerHandle {
@@ -107,6 +114,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       onTogglePtz,
       ptzActive = false,
       overlay,
+      displayAspectOverride,
     },
     ref
   ) {
@@ -158,9 +166,9 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const onAuthExpiredRef = useRef(onAuthExpired)
     onAuthExpiredRef.current = onAuthExpired
     const [isReconnecting, setIsReconnecting] = useState(false)
-    // Real aspect ratio of the incoming stream (width/height), read from the
-    // video metadata. null until known (or after the source is torn down).
-    const [videoAspect, setVideoAspect] = useState<number | null>(null)
+    // Coded frame size of the incoming stream, read from the video metadata.
+    // null until known (or after the source is torn down).
+    const videoSize = useVideoSize(videoRef)
     // Title chip fades to half opacity after a few seconds so it stops
     // competing with the camera's burned-in OSD; tile hover restores it
     // purely via CSS (group-hover), so there are no re-renders on hover.
@@ -171,6 +179,43 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     }, [])
 
     const isLive = mode === 'live'
+
+    // The aspect the picture is DISPLAYED at, which is not always the aspect it
+    // is CODED at: a Dahua-family "1080N" stream is 960x1080 for a 16:9 scene
+    // and declares no SAR to correct from. Every box below sizes off this —
+    // never off videoWidth/videoHeight directly. See lib/aspect.ts.
+    const videoAspect = useMemo(
+      () => displayAspect(videoSize?.width, videoSize?.height, displayAspectOverride),
+      [videoSize?.width, videoSize?.height, displayAspectOverride]
+    )
+    // True only when the two disagree, i.e. the frame has to be stretched
+    // rather than letterboxed. Drives object-fit on the <video> below.
+    const stretched = isStretched(videoSize?.width, videoSize?.height, videoAspect)
+
+    /** JPEG of the current frame at the CORRECTED width. An anamorphic stream
+        has to be un-squished in the export too, or the saved file looks nothing
+        like the tile it was taken from; drawImage's explicit destination rect
+        does the stretch. null when no frame is capturable — callers report why. */
+    const captureSnapshot = useCallback((): string | null => {
+      const el = videoRef.current
+      if (!el || el.readyState < 2) return null
+      const codedW = el.videoWidth || el.clientWidth
+      const codedH = el.videoHeight || el.clientHeight
+      if (!codedW || !codedH) return null
+      const aspect = displayAspect(codedW, codedH, displayAspectOverride)
+      const { width, height } = snapshotSize(codedW, codedH, aspect)
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return null
+      try {
+        ctx.drawImage(el, 0, 0, width, height)
+      } catch {
+        return null
+      }
+      return canvas.toDataURL('image/jpeg', 0.92)
+    }, [displayAspectOverride])
 
     // Determine available stream types
     const availableStreamTypes: Array<'webrtc' | 'hls'> = []
@@ -189,24 +234,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         pause: () => {
           if (videoRef.current) videoRef.current.pause()
         },
-        snapshot: () => {
-          const el = videoRef.current
-          if (!el || el.readyState < 2) return null
-          const w = el.videoWidth || el.clientWidth
-          const h = el.videoHeight || el.clientHeight
-          if (!w || !h) return null
-          const canvas = document.createElement('canvas')
-          canvas.width = w
-          canvas.height = h
-          const ctx = canvas.getContext('2d')
-          if (!ctx) return null
-          try {
-            ctx.drawImage(el, 0, 0, w, h)
-          } catch {
-            return null
-          }
-          return canvas.toDataURL('image/jpeg', 0.92)
-        },
+        snapshot: captureSnapshot,
         requestFullscreen: () => {
           if (containerRef.current) {
             const fn =
@@ -221,7 +249,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           if (isLive) setStreamType(type)
         },
       }),
-      [isLive]
+      [isLive, captureSnapshot]
     )
 
     // Cleanup function
@@ -835,26 +863,6 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       }
     }, [])
 
-    // Track the stream's true aspect ratio. 'resize' fires when the decoded
-    // frame size changes mid-stream (e.g. adaptive HLS level switch); 'emptied'
-    // resets it when the source is torn down.
-    useEffect(() => {
-      const el = videoRef.current
-      if (!el) return
-      const update = () => {
-        setVideoAspect(el.videoWidth && el.videoHeight ? el.videoWidth / el.videoHeight : null)
-      }
-      update()
-      el.addEventListener('loadedmetadata', update)
-      el.addEventListener('resize', update)
-      el.addEventListener('emptied', update)
-      return () => {
-        el.removeEventListener('loadedmetadata', update)
-        el.removeEventListener('resize', update)
-        el.removeEventListener('emptied', update)
-      }
-    }, [])
-
     // Fullscreen change listener
     useEffect(() => {
       const onFullscreenChange = () => {
@@ -930,28 +938,13 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         console.warn('[VideoPlayer] Snapshot failed: Video not ready, readyState:', el.readyState)
         return
       }
-      const w = el.videoWidth || el.clientWidth
-      const h = el.videoHeight || el.clientHeight
-      if (!w || !h) {
-        console.warn('[VideoPlayer] Snapshot failed: Invalid dimensions', w, h)
+      const dataUrl = captureSnapshot()
+      if (!dataUrl) {
+        console.warn('[VideoPlayer] Snapshot failed: no frame could be captured')
         return
       }
-      const canvas = document.createElement('canvas')
-      canvas.width = w
-      canvas.height = h
-      const ctx = canvas.getContext('2d')
-      if (!ctx) {
-        console.warn('[VideoPlayer] Snapshot failed: Could not get canvas context')
-        return
-      }
-      try {
-        ctx.drawImage(el, 0, 0, w, h)
-        const dataUrl = canvas.toDataURL('image/jpeg', 0.92)
-        console.log('[VideoPlayer] Snapshot captured, length:', dataUrl.length)
-        onSnapshot?.(dataUrl)
-      } catch (err) {
-        console.error('[VideoPlayer] Snapshot failed:', err)
-      }
+      console.log('[VideoPlayer] Snapshot captured, length:', dataUrl.length)
+      onSnapshot?.(dataUrl)
     }
     const restartStream = () => {
       cleanup()
@@ -1072,11 +1065,15 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           style={videoAspect ? { aspectRatio: String(videoAspect) } : { width: '100%' }}
         >
 
-        {/* Video element — the feed box already matches its aspect ratio,
-            so object-contain leaves no internal bars once metadata is known */}
+        {/* Video element. The feed box already carries the stream's DISPLAY
+            aspect, so object-fill stretches an anamorphic frame across it with
+            nothing cropped — exactly what the DVR's own client does, and a
+            no-op whenever the coded and display aspects agree. object-contain
+            until metadata lands, when the box has no aspect of its own yet and
+            fill would smear the frame across the whole tile. */}
         <video
           ref={videoRef}
-          className="block w-full h-full object-contain"
+          className={`block w-full h-full ${stretched ? 'object-fill' : 'object-contain'}`}
           playsInline
           muted={isMuted}
           autoPlay={autoPlay}

--- a/app/src/components/VideoPlayer/index.ts
+++ b/app/src/components/VideoPlayer/index.ts
@@ -18,5 +18,6 @@
 
 export { VideoPlayer } from './VideoPlayer'
 export type { VideoPlayerProps, VideoPlayerHandle, VideoPlayerMode, StreamType } from './VideoPlayer'
+export { AspectFrame } from './AspectFrame'
 export { VideoControls } from './VideoControls'
 export type { VideoControlsProps } from './VideoControls'

--- a/app/src/hooks/useVideoAspect.ts
+++ b/app/src/hooks/useVideoAspect.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 OpenNVR
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useEffect, useState } from 'react'
+import type { RefObject } from 'react'
+
+export interface VideoSize {
+  width: number
+  height: number
+}
+
+/**
+ * Coded frame size of the media in `ref`, tracked across source changes.
+ *
+ * 'loadedmetadata' is the first point the size is known; 'resize' fires when
+ * the decoded size changes mid-stream (an HLS level switch, or a camera
+ * re-negotiating); 'emptied' clears it when the source is torn down, so a
+ * stale aspect never outlives the stream that produced it.
+ *
+ * Note this is the CODED size — for an anamorphic stream it is NOT the size
+ * the frame should be displayed at. Feed it through `displayAspect()`.
+ */
+export function useVideoSize(ref: RefObject<HTMLVideoElement | null>): VideoSize | null {
+  const [size, setSize] = useState<VideoSize | null>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const update = () => {
+      setSize(
+        el.videoWidth && el.videoHeight
+          ? { width: el.videoWidth, height: el.videoHeight }
+          : null
+      )
+    }
+    update()
+    el.addEventListener('loadedmetadata', update)
+    el.addEventListener('resize', update)
+    el.addEventListener('emptied', update)
+    return () => {
+      el.removeEventListener('loadedmetadata', update)
+      el.removeEventListener('resize', update)
+      el.removeEventListener('emptied', update)
+    }
+  }, [ref])
+
+  return size
+}

--- a/app/src/lib/aspect.ts
+++ b/app/src/lib/aspect.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 OpenNVR
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Display-aspect correction for anamorphic camera streams (issue #354).
+ *
+ * Some encoders deliberately squash a dimension and expect the player to
+ * stretch it back. Dahua-family DVRs (CP Plus "1080N") encode a 16:9 scene
+ * as 960x1080 — half the horizontal resolution — and their own client
+ * hardcodes the 2x stretch. The bitstream carries NO sample aspect ratio in
+ * the SPS VUI, so a standards-compliant player has nothing to correct from
+ * and renders a narrow near-portrait strip.
+ *
+ * A camera that DOES declare a correct SAR is a related but separate case:
+ * it renders fine over HLS and still squished over WebRTC, because Chrome's
+ * WebRTC pipeline reports the coded size and drops the VUI aspect ratio.
+ * Nothing in the browser exposes that difference — catching it needs the
+ * backend to measure the source and hand the answer down, which is not wired
+ * up yet. The operator override covers those cameras in the meantime.
+ *
+ * Resolution order, most specific first:
+ *   1. operator override on the camera row  ('native' | 'W:H')
+ *   2. known anamorphic mode table          (encoders that declare nothing)
+ *   3. the coded aspect                     (every normal camera, untouched)
+ */
+
+/**
+ * Per-camera operator override. 'auto' (or null/undefined) runs the
+ * resolution order above; 'native' pins the coded aspect and disables the
+ * correction entirely — the escape hatch for a camera the table gets wrong.
+ * Anything else is a `width:height` ratio.
+ */
+export type AspectOverride = 'auto' | 'native' | (string & {})
+
+/**
+ * Encoder modes that squash a dimension and signal no SAR/DAR at all.
+ *
+ * Matched on the EXACT coded size, never on a ratio: a genuinely portrait
+ * corridor-mode camera (1080x1920) or a 1:1 fisheye must be left alone, and
+ * a ratio test would "correct" both into garbage.
+ */
+const ANAMORPHIC: ReadonlyArray<{ w: number; h: number; dar: number }> = [
+  { w: 960, h: 1080, dar: 16 / 9 }, // Dahua / CP Plus "1080N"
+  { w: 640, h: 720, dar: 16 / 9 }, // Dahua "720N"
+  { w: 960, h: 576, dar: 4 / 3 }, // "960H" PAL
+  { w: 960, h: 480, dar: 4 / 3 }, // "960H" NTSC
+  { w: 704, h: 576, dar: 4 / 3 }, // D1 PAL
+  { w: 704, h: 480, dar: 4 / 3 }, // D1 NTSC
+]
+
+/**
+ * Parse a display aspect ratio. Accepts "16:9", "4/3", or a bare decimal
+ * ("1.777"), which is what ffprobe and the settings field between them can
+ * produce. Returns null for anything unusable, so a bad stored value degrades
+ * to "no correction" rather than a NaN layout.
+ */
+export function parseRatio(value: string | number | null | undefined): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) && value > 0 ? value : null
+  if (!value) return null
+  const text = value.trim()
+  const pair = text.match(/^(\d+(?:\.\d+)?)\s*[:/]\s*(\d+(?:\.\d+)?)$/)
+  if (pair) {
+    const w = Number(pair[1])
+    const h = Number(pair[2])
+    return h > 0 && w > 0 ? w / h : null
+  }
+  const scalar = Number(text)
+  return Number.isFinite(scalar) && scalar > 0 ? scalar : null
+}
+
+/**
+ * The aspect ratio (width/height) the frame should be RENDERED at.
+ *
+ * Returns null while the coded size is unknown — callers keep their
+ * "no metadata yet" layout in that case rather than guessing.
+ */
+export function displayAspect(
+  codedWidth: number | null | undefined,
+  codedHeight: number | null | undefined,
+  override?: AspectOverride | null,
+): number | null {
+  if (!codedWidth || !codedHeight) return null
+  const native = codedWidth / codedHeight
+
+  if (override && override !== 'auto') {
+    if (override === 'native') return native
+    return parseRatio(override) ?? native
+  }
+
+  const known = ANAMORPHIC.find((m) => m.w === codedWidth && m.h === codedHeight)
+  return known ? known.dar : native
+}
+
+/**
+ * True when the frame must be STRETCHED (object-fit: fill) rather than
+ * letterboxed — i.e. the display aspect differs from the coded one.
+ *
+ * The 1% tolerance keeps float noise from flipping an ordinary camera into
+ * fill mode, where a rounding error would show as a barely-visible smear.
+ */
+export function isStretched(
+  codedWidth: number | null | undefined,
+  codedHeight: number | null | undefined,
+  effective: number | null,
+): boolean {
+  if (!codedWidth || !codedHeight || !effective) return false
+  return Math.abs(codedWidth / codedHeight - effective) / effective > 0.01
+}
+
+/**
+ * Canvas size for a snapshot or export of an anamorphic frame: keep every
+ * coded scanline and widen to the display aspect, so the saved image matches
+ * the tile it was taken from. 960x1080 at 16:9 -> 1920x1080.
+ */
+export function snapshotSize(
+  codedWidth: number,
+  codedHeight: number,
+  effective: number | null,
+): { width: number; height: number } {
+  if (!isStretched(codedWidth, codedHeight, effective)) {
+    return { width: codedWidth, height: codedHeight }
+  }
+  return { width: Math.max(1, Math.round(codedHeight * effective!)), height: codedHeight }
+}
+
+/** Presets for the per-camera setting; 'custom' reveals a free-form W:H field. */
+export const ASPECT_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: 'auto', label: 'Auto (detect)' },
+  { value: 'native', label: 'Native (as encoded)' },
+  { value: '16:9', label: '16:9 (widescreen)' },
+  { value: '4:3', label: '4:3 (standard)' },
+  { value: 'custom', label: 'Custom…' },
+]
+
+/** True when `value` needs the free-form field rather than a preset. */
+export function isCustomAspect(value: string | null | undefined): boolean {
+  if (!value || value === 'auto' || value === 'native') return false
+  return value !== '16:9' && value !== '4:3'
+}

--- a/app/src/lib/queries.ts
+++ b/app/src/lib/queries.ts
@@ -20,8 +20,10 @@
 // these instead of calling apiService in a useEffect, so concurrent mounts
 // share one request and one cache entry.
 
+import { useMemo } from 'react'
 import { QueryClient, keepPreviousData, useQueries, useQuery } from '@tanstack/react-query'
 import { apiService } from './apiService'
+import type { AspectOverride } from './aspect'
 import { todayLocalKey } from './time'
 
 export const queryClient = new QueryClient({
@@ -51,6 +53,14 @@ export type CameraItem = {
   /** Observed recording health: 'recording' | 'stalled' | 'never' | 'off'. */
   recording_state?: string | null
   last_recording_at?: string | null
+  /** Operator's display-aspect override; null means auto-detect (#354). */
+  display_aspect_ratio?: AspectOverride | null
+}
+
+/** What a video surface needs to render a camera at the right shape. A named
+ *  type so the props can be spread at every call site as one unit. */
+export type CameraAspect = {
+  displayAspectOverride?: AspectOverride | null
 }
 
 export type CameraListResp = { cameras: CameraItem[]; total: number }
@@ -92,6 +102,25 @@ export function useCameras(
     // this the table would blank out and remount on every keystroke pause.
     placeholderData: keepPreviousData,
   })
+}
+
+/**
+ * Per-camera display-aspect settings, keyed by camera id, for surfaces that
+ * show video but only know a camera_id (playback, sync playback).
+ *
+ * active_only:false because a paused camera's recordings are still played
+ * back, and they need the same correction. A missing entry is not a problem:
+ * it means "auto", and the known-mode detection in lib/aspect.ts still runs.
+ */
+export function useCameraAspects(): Record<number, CameraAspect> {
+  const { data } = useCameras({ limit: 200, active_only: false })
+  return useMemo(() => {
+    const out: Record<number, CameraAspect> = {}
+    for (const c of data?.cameras ?? []) {
+      out[c.id] = { displayAspectOverride: c.display_aspect_ratio ?? null }
+    }
+    return out
+  }, [data])
 }
 
 /**

--- a/app/src/views/Cameras.tsx
+++ b/app/src/views/Cameras.tsx
@@ -30,6 +30,7 @@ import type { BadgeVariant } from '../components/ui'
 import { AddCameraDialog } from '../components/AddCameraDialog'
 import { QrScanner } from '../components/QrScanner'
 import { parseCameraQr } from '../lib/cameraQr'
+import { ASPECT_OPTIONS, isCustomAspect } from '../lib/aspect'
 import { parseRtspUrl, rtspPortFromUrl, syncCameraIdentity } from '../lib/cameraIdentity'
 import type { IdentityField } from '../lib/cameraIdentity'
 import { formatDuration } from '../lib/time'
@@ -61,6 +62,8 @@ type Camera = {
   password?: string | null
   rtsp_url?: string | null
   substream_url?: string | null
+  /** Display-only aspect override; null = auto-detect. See lib/aspect.ts. */
+  display_aspect_ratio?: string | null
   location?: string | null
   vlan?: string | null
   status?: string | null
@@ -88,6 +91,23 @@ type Camera = {
   assignments?: CameraAssignment[] | null
 }
 
+/** Which preset the stored display-aspect value corresponds to. A stored
+ *  ratio that isn't one of the presets lands on 'custom'. */
+function aspectChoiceOf(stored: string | null | undefined): string {
+  if (!stored) return 'auto'
+  if (isCustomAspect(stored)) return 'custom'
+  return stored
+}
+
+/** The value to persist: null means "auto", which is how the API and the DB
+ *  both spell "no override". */
+function aspectValueOf(form: CameraForm): string | null {
+  const choice = form.display_aspect_choice || 'auto'
+  if (choice === 'auto') return null
+  if (choice === 'custom') return form.display_aspect_custom?.trim() || null
+  return choice
+}
+
 // Form-side assignment row: labels edited as a comma-separated string.
 type AssignmentRow = { skill: string; labels: string }
 
@@ -100,6 +120,10 @@ type CameraForm = {
   password?: string
   rtsp_url?: string
   substream_url?: string
+  /** Preset key: 'auto' | 'native' | '16:9' | '4:3' | 'custom'. */
+  display_aspect_choice?: string
+  /** Free-form "W:H", only meaningful while display_aspect_choice is 'custom'. */
+  display_aspect_custom?: string
   location?: string
   vlan?: string
   status?: string
@@ -207,6 +231,8 @@ export function Cameras() {
     password: '',
     rtsp_url: '',
     substream_url: '',
+    display_aspect_choice: 'auto',
+    display_aspect_custom: '',
     location: '',
     vlan: '',
     status: 'unknown',
@@ -222,6 +248,8 @@ export function Cameras() {
     password: '',
     rtsp_url: '',
     substream_url: '',
+    display_aspect_choice: 'auto',
+    display_aspect_custom: '',
     location: '',
     vlan: '',
     status: 'unknown',
@@ -356,6 +384,7 @@ export function Cameras() {
         ...(form.password ? { password: form.password } : {}),
         rtsp_url: form.rtsp_url || null,
         substream_url: form.substream_url || null,
+        display_aspect_ratio: aspectValueOf(form),
         location: form.location || null,
         vlan: form.vlan || null,
         status: form.status || undefined,
@@ -473,6 +502,10 @@ export function Cameras() {
       password: '',
       rtsp_url: c.rtsp_url || '',
       substream_url: c.substream_url || '',
+      display_aspect_choice: aspectChoiceOf(c.display_aspect_ratio),
+      display_aspect_custom: isCustomAspect(c.display_aspect_ratio)
+        ? (c.display_aspect_ratio as string)
+        : '',
       location: c.location || '',
       vlan: c.vlan || '',
       status: c.status || 'unknown',
@@ -826,6 +859,36 @@ export function Cameras() {
             )}
             <Field label="Substream URL">
               <input className={EDIT_INPUT} value={form.substream_url || ''} onChange={(e) => setForm({ ...form, substream_url: e.target.value })} placeholder="Optional low-res feed for the camera agent's live view" />
+            </Field>
+
+            {/* Display only — it never re-encodes and never re-provisions the
+                stream. Auto covers encoders that squash the picture and signal
+                no aspect ratio (Dahua/CP Plus "1080N" = 960x1080 for a 16:9
+                scene); Native is the escape hatch if detection guesses wrong. */}
+            <Field label="Display aspect ratio">
+              <div className="space-y-1">
+                <select
+                  className={EDIT_INPUT}
+                  value={form.display_aspect_choice || 'auto'}
+                  onChange={(e) => setForm({ ...form, display_aspect_choice: e.target.value })}
+                >
+                  {ASPECT_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>{o.label}</option>
+                  ))}
+                </select>
+                {form.display_aspect_choice === 'custom' && (
+                  <input
+                    className={EDIT_INPUT}
+                    value={form.display_aspect_custom || ''}
+                    onChange={(e) => setForm({ ...form, display_aspect_custom: e.target.value })}
+                    placeholder="e.g. 16:9"
+                  />
+                )}
+                <p className="text-xs text-[var(--muted)]">
+                  How OpenNVR shows this camera. Display only — recordings are
+                  stored exactly as the camera sends them.
+                </p>
+              </div>
             </Field>
 
             <Field label="Assignments">

--- a/app/src/views/LiveView.tsx
+++ b/app/src/views/LiveView.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
 import { apiService } from '../lib/apiService'
 import { rebaseToCurrentOrigin } from '../lib/streamUrl'
 import { VideoPlayer, type VideoPlayerHandle } from '../components/VideoPlayer'
+import type { AspectOverride } from '../lib/aspect'
 import { QrScanner } from '../components/QrScanner'
 import { AddCameraDialog } from '../components/AddCameraDialog'
 import { useFullscreen } from '../hooks/useFullscreen'
@@ -203,7 +204,7 @@ export function LiveView() {
   const { toggle: toggleFs, isFullscreen } = useFullscreen(gridRef as React.RefObject<HTMLDivElement>)
   // FS toolbar visibility — toggled by the bottom-center handle button
   const [fsToolbarVisible, setFsToolbarVisible] = useState(false)
-  const [availableCameras, setAvailableCameras] = useState<Array<{id: number, name: string, live_online?: boolean | null}>>([])
+  const [availableCameras, setAvailableCameras] = useState<Array<{id: number, name: string, live_online?: boolean | null, display_aspect_ratio?: AspectOverride | null}>>([])
   
   // Camera display order - array of camera IDs in display sequence
   // This determines which camera appears in which tile position
@@ -273,7 +274,14 @@ export function LiveView() {
       // transitions, so without this the overlay waits for the camera to
       // change state — which, for one that is simply still offline, never
       // happens, and the tile just shows a dead player.
-      const cameraList = cameras.map((cam: any) => ({ id: cam.id, name: cam.name, live_online: cam.live_online }))
+      const cameraList = cameras.map((cam: any) => ({
+        id: cam.id,
+        name: cam.name,
+        live_online: cam.live_online,
+        // The display-aspect override rides along so the tile can render an
+        // anamorphic stream at its true shape — see lib/aspect.ts (#354).
+        display_aspect_ratio: cam.display_aspect_ratio,
+      }))
       setAvailableCameras(cameraList)
       
       // Update display order: add new cameras, remove deleted ones
@@ -654,7 +662,7 @@ function Tile({
   canManage = false
 }: { 
   index: number
-  availableCameras: Array<{id: number, name: string, live_online?: boolean | null}>
+  availableCameras: Array<{id: number, name: string, live_online?: boolean | null, display_aspect_ratio?: AspectOverride | null}>
   assignedCameraId?: number | null
   onCameraSelected?: (cameraId: number) => void
   onCameraAdded?: () => void
@@ -737,6 +745,7 @@ function Tile({
 
   const hasLink = !!urls?.whep || !!urls?.hls
   const displayName = cameraName || `Camera ${cameraId || index + 1}`
+  const assignedCamera = availableCameras.find((c) => c.id === assignedCameraId)
   
   const handleSnapshot = (dataUrl: string) => {
     const a = document.createElement('a')
@@ -770,8 +779,8 @@ function Tile({
         {!hasLink && cameraId && <div className="absolute right-2 top-2 z-20 text-[10px] uppercase tracking-wide bg-black/60 px-1 py-0.5">NO LINK</div>}
 
         {/* Absolute so the <video>'s intrinsic size (e.g. a 1:1 stream) can't
-            stretch the box taller than 16:9 — the box height comes only from
-            aspect-video, and object-contain letter/pillarboxes the stream. */}
+            stretch this box — the player sizes itself to the stream's DISPLAY
+            aspect inside it and letter/pillarboxes against the panel bg. */}
         <div className="absolute inset-0">
           {hasLink ? (
             <VideoPlayer
@@ -787,6 +796,7 @@ function Tile({
               autoPlay
               muted
               onSnapshot={handleSnapshot}
+              displayAspectOverride={assignedCamera?.display_aspect_ratio}
               onTogglePtz={() => setPtzOpen((s) => !s)}
               ptzActive={ptzOpen}
               overlay={ptzOpen && cameraId ? (

--- a/app/src/views/PlaybackView.tsx
+++ b/app/src/views/PlaybackView.tsx
@@ -21,7 +21,7 @@ import { Link } from 'react-router-dom'
 import { apiService } from '../lib/apiService'
 import { useAuth } from '../auth/AuthContext'
 import { api } from '../lib/api'
-import { useRecordingsByDate } from '../lib/queries'
+import { useCameraAspects, useRecordingsByDate } from '../lib/queries'
 import { formatDuration } from '../lib/time'
 import {
   Calendar,
@@ -94,6 +94,9 @@ interface CloudUploadStatus {
 export function PlaybackView() {
   const { token, loading: authLoading, user } = useAuth()
   const { showError, showSuccess } = useSnackbar()
+  // Recordings hold the camera's coded frames untouched, so an anamorphic
+  // camera needs the same correction here as in Live View (#354).
+  const cameraAspects = useCameraAspects()
 
   // Data states
   const [cameras, setCameras] = useState<CameraWithRecordings[]>([])
@@ -581,6 +584,7 @@ export function PlaybackView() {
           cameraName={consoleTarget.cameraName}
           date={consoleTarget.date}
           onClose={closePlayer}
+          {...(cameraAspects[consoleTarget.cameraId] ?? {})}
         />
       )}
 

--- a/app/src/views/SyncPlayback.tsx
+++ b/app/src/views/SyncPlayback.tsx
@@ -38,7 +38,7 @@ import {
   Video,
 } from 'lucide-react'
 import { warmHls } from '../lib/loadHls'
-import { useRecordingsByDate, useSegmentsForCameras } from '../lib/queries'
+import { useCameraAspects, useRecordingsByDate, useSegmentsForCameras } from '../lib/queries'
 import { localDayEnd, localDayStart, todayLocalKey } from '../lib/time'
 import { useSnackbar } from '../components/Snackbar'
 import { RecordingCalendar } from '../components/RecordingCalendar'
@@ -120,6 +120,8 @@ function formatDateLong(date: string) {
 export function SyncPlayback() {
   const { showError } = useSnackbar()
   const stageRef = useRef<HTMLDivElement>(null)
+  // Per-camera display-aspect settings for the grid tiles (#354).
+  const cameraAspects = useCameraAspects()
 
   // Download the hls.js chunk while the overview request is in flight — the
   // tiles will need it the moment segments land.
@@ -557,6 +559,7 @@ export function SyncPlayback() {
                 muted={muted || cam.camera_id !== activeId}
                 active={cam.camera_id === activeId}
                 onActivate={() => setActiveId(cam.camera_id)}
+                {...(cameraAspects[cam.camera_id] ?? {})}
               />
             ))
           )}

--- a/app/src/views/apps/GeometryEditor.tsx
+++ b/app/src/views/apps/GeometryEditor.tsx
@@ -18,6 +18,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiService } from '../../lib/apiService'
+import { displayAspect } from '../../lib/aspect'
+import type { AspectOverride } from '../../lib/aspect'
 import { Button } from '../../components/ui'
 
 type Pt = [number, number]
@@ -25,7 +27,11 @@ type Dir = 'both' | 'a_to_b' | 'b_to_a'
 type Tripwire = { a: Pt; b: Pt; count_direction: Dir }
 type PerCam = Record<string, Pt[] | Tripwire>
 
-type Camera = { id: number | string; name?: string }
+type Camera = {
+  id: number | string
+  name?: string
+  display_aspect_ratio?: AspectOverride | null
+}
 
 // Parse whatever is currently stored (JSON string or object) into the
 // per-camera map; tolerate junk by starting empty rather than throwing.
@@ -98,6 +104,12 @@ export function GeometryEditor({
   }, [cam, perCam, cameras])
 
   const snap = useSnapshotUrl(cam || null)
+  // Natural size of the still. The snapshot comes off the camera at its CODED
+  // size, so a 1080N frame arrives 960x1080 — see lib/aspect.ts (#354).
+  const [snapDims, setSnapDims] = useState<{ w: number; h: number } | null>(null)
+  useEffect(() => {
+    setSnapDims(null)
+  }, [snap.data])
   const svgRef = useRef<SVGSVGElement | null>(null)
   const [drag, setDrag] = useState<number | 'a' | 'b' | null>(null)
 
@@ -151,14 +163,24 @@ export function GeometryEditor({
     write(next)
   }
 
-  // The SVG uses a 160×90 (16:9) viewBox with the container locked to
-  // aspect-ratio 16/9, so x and y scale equally — circles stay round and
-  // strokes uniform. Crucially, `<polygon points>` needs UNITLESS
-  // numbers (percentages are invalid there and render nothing — the bug
-  // the first draft had); viewBox coords fix that. VW/VH map normalized
-  // 0–1 into that space.
-  const VW = 160
+  // Draw surface aspect. It must match the still's DISPLAY aspect, not the
+  // container's old hard-coded 16:9: the overlay's normalized 0–1 coordinates
+  // span the whole box, so if the image doesn't span exactly the same box
+  // every point an operator places lands somewhere else in the frame the
+  // pipeline processes. Falls back to 16:9 until the still loads.
+  const camOverride = cameras.find((c) => String(c.id) === cam)
+  const drawAspect =
+    displayAspect(snapDims?.w, snapDims?.h, camOverride?.display_aspect_ratio) ?? 16 / 9
+
+  // The SVG viewBox is VH tall and VW wide, with the container locked to the
+  // same aspect, so x and y scale equally — circles stay round and strokes
+  // uniform. Deriving VW from drawAspect is what preserves that for a camera
+  // that isn't 16:9. Crucially, `<polygon points>` needs UNITLESS numbers
+  // (percentages are invalid there and render nothing — the bug the first
+  // draft had); viewBox coords fix that. VW/VH map normalized 0–1 into that
+  // space.
   const VH = 90
+  const VW = Math.round(VH * drawAspect)
   const vx = (n: number) => n * VW
   const vy = (n: number) => n * VH
 
@@ -201,9 +223,23 @@ export function GeometryEditor({
       </div>
 
       {/* Draw surface: snapshot (or grid) + SVG overlay */}
-      <div className="relative w-full rounded border border-[var(--border)] overflow-hidden bg-[var(--bg-2)]" style={{ aspectRatio: '16 / 9' }}>
+      <div className="relative w-full rounded border border-[var(--border)] overflow-hidden bg-[var(--bg-2)]" style={{ aspectRatio: String(drawAspect) }}>
         {snap.data ? (
-          <img src={snap.data} alt="camera still" className="absolute inset-0 w-full h-full object-cover" draggable={false} />
+          /* object-fill, not object-cover: cover crops a still whose aspect
+             differs from the box, and the cropped-away band is frame the
+             operator would then be unable to draw on (and would mis-map). */
+          <img
+            src={snap.data}
+            alt="camera still"
+            className="absolute inset-0 w-full h-full object-fill"
+            draggable={false}
+            onLoad={(e) =>
+              setSnapDims({
+                w: e.currentTarget.naturalWidth,
+                h: e.currentTarget.naturalHeight,
+              })
+            }
+          />
         ) : (
           <div className="absolute inset-0" style={{
             backgroundImage:

--- a/server/migrations/versions/d5b39f61ac04_add_camera_display_aspect.py
+++ b/server/migrations/versions/d5b39f61ac04_add_camera_display_aspect.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""add camera display aspect
+
+Adds an optional per-camera ``display_aspect_ratio`` to ``cameras`` (#354).
+
+Some encoders squash a dimension and expect the player to stretch it back:
+a Dahua-family "1080N" channel sends a 16:9 scene as 960x1080. The bitstream
+declares no sample aspect ratio, so OpenNVR's passthrough pipeline has nothing
+to correct from and the picture renders as a narrow strip.
+
+Detection of the known modes lives in the UI and needs no stored value; this
+column is the operator's override for the cameras it doesn't recognise, and
+always wins over it.
+
+Nullable, no default: existing rows keep NULL, which means "detect".
+
+Revision ID: d5b39f61ac04
+Revises: bb88cc99dd00
+Create Date: 2026-08-29 19:10:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5b39f61ac04"
+down_revision: str | None = "bb88cc99dd00"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cameras",
+        sa.Column(
+            "display_aspect_ratio",
+            sa.String(length=16),
+            nullable=True,
+            comment=(
+                'Operator display-aspect override: NULL (detect), "native", '
+                'or a "W:H" ratio. Display only — never re-provisions a stream.'
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("cameras", "display_aspect_ratio")

--- a/server/models.py
+++ b/server/models.py
@@ -227,6 +227,15 @@ class Camera(Base):
     # vendor default — covers cameras whose substream path isn't a known
     # Hikvision/Dahua convention.
     substream_url = Column(String(500), nullable=True)
+    # How the UI should DISPLAY this camera's picture: NULL (auto-detect),
+    # "native", or a "W:H" ratio. Purely a rendering hint — it never reaches
+    # MediaMTX and never re-provisions a path. Exists because Dahua-family
+    # DVRs (CP Plus "1080N" = 960x1080 for a 16:9 scene) encode anamorphically
+    # and signal no aspect ratio at all, so a passthrough player has nothing
+    # to correct from. NULL means "detect", which the UI resolves against a
+    # table of known anamorphic encoder modes. Nullable so the additive column
+    # self-heal can add it to old create_all databases.
+    display_aspect_ratio = Column(String(16), nullable=True)
     is_active = Column(Boolean, default=True)
     # Tombstone for irreversible soft delete. NULL = live (active or paused);
     # set = camera is in the bin: hidden from every normal list, not editable,

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -22,6 +22,7 @@ Defines the structure of data exchanged between the API and clients.
 import html
 import ipaddress
 import os
+import re
 from datetime import datetime
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -89,6 +90,8 @@ class CameraBase(BaseModel):
     rtsp_url: str | None = Field(None, max_length=500)
     # Optional low-res secondary RTSP profile for the camera-agent live view.
     substream_url: str | None = Field(None, max_length=500)
+    # Display-only aspect hint; see _validate_display_aspect.
+    display_aspect_ratio: str | None = Field(None, max_length=16)
     location: str | None = Field(None, max_length=200)
     vlan: str | None = Field(None, max_length=50)
     status: str | None = Field("unknown", max_length=20)
@@ -113,6 +116,11 @@ class CameraBase(BaseModel):
         if v:
             return html.escape(v)
         return v
+
+    @field_validator("display_aspect_ratio")
+    @classmethod
+    def validate_display_aspect(cls, v: str | None) -> str | None:
+        return _validate_display_aspect(v)
 
     @field_validator("rtsp_url", "substream_url")
     @classmethod
@@ -408,6 +416,31 @@ def _validate_assignments(
     return v
 
 
+_DISPLAY_ASPECT_RE = re.compile(r"^\d{1,5}(?:\.\d{1,3})?[:/]\d{1,5}(?:\.\d{1,3})?$")
+
+
+def _validate_display_aspect(v: str | None) -> str | None:
+    """Shared display-aspect rules: NULL/"auto" mean detect, else "native"
+    or a "W:H" ratio. Normalizing the empty and "auto" spellings to None here
+    means the DB has exactly one representation of "no override" (issue #354).
+    """
+    if v is None:
+        return None
+    s = v.strip().lower()
+    if s in ("", "auto"):
+        return None
+    if s == "native":
+        return s
+    if not _DISPLAY_ASPECT_RE.match(s):
+        raise ValueError(
+            'display aspect must be "auto", "native" or a "W:H" ratio (e.g. "16:9")'
+        )
+    w, h = (float(part) for part in s.replace("/", ":").split(":"))
+    if w <= 0 or h <= 0:
+        raise ValueError("display aspect ratio parts must be positive")
+    return s
+
+
 class CameraUpdate(BaseModel):
     """Schema for updating a camera."""
 
@@ -419,6 +452,8 @@ class CameraUpdate(BaseModel):
     password: str | None = Field(None, max_length=255)
     rtsp_url: str | None = Field(None, max_length=500)
     substream_url: str | None = Field(None, max_length=500)
+    # Display-only aspect hint; "auto"/"" normalize to None (auto-detect).
+    display_aspect_ratio: str | None = Field(None, max_length=16)
     location: str | None = Field(None, max_length=200)
     vlan: str | None = Field(None, max_length=50)
     status: str | None = Field(None, max_length=20)
@@ -426,6 +461,11 @@ class CameraUpdate(BaseModel):
     # Per-camera capability assignment (see CameraAssignment). Send the FULL
     # list each time — this replaces, it does not merge. [] clears.
     assignments: list[CameraAssignment] | None = None
+
+    @field_validator("display_aspect_ratio")
+    @classmethod
+    def validate_display_aspect(cls, v: str | None) -> str | None:
+        return _validate_display_aspect(v)
 
     @field_validator("assignments")
     @classmethod

--- a/server/services/camera_service.py
+++ b/server/services/camera_service.py
@@ -73,6 +73,7 @@ class CameraService:
                     password=camera_create.password,
                     rtsp_url=camera_create.rtsp_url,
                     substream_url=camera_create.substream_url,
+                    display_aspect_ratio=camera_create.display_aspect_ratio,
                     location=camera_create.location,
                     vlan=camera_create.vlan,
                     status=camera_create.status or "unknown",

--- a/server/tests/test_camera_edit_reprovision.py
+++ b/server/tests/test_camera_edit_reprovision.py
@@ -232,6 +232,7 @@ def _full_form(cam, **overrides) -> dict:
         "username": cam.username,
         "rtsp_url": cam.rtsp_url,
         "substream_url": cam.substream_url,
+        "display_aspect_ratio": cam.display_aspect_ratio,
         "is_active": cam.is_active,
     }
     body.update(overrides)
@@ -335,6 +336,54 @@ def test_port_only_change_does_not_reprovision(env):
         f"/api/v1/cameras/{cam.id}", json=_full_form(cam, port=8554), headers=_auth()
     )
     assert resp.status_code == 200, resp.text
+    assert env.calls == []
+
+
+def test_display_aspect_change_does_not_reprovision(env):
+    """The display aspect is a rendering hint the browser applies — it never
+    reaches MediaMTX. Bouncing the stream to change how a tile is shaped would
+    drop every viewer for nothing (issue #354)."""
+    cam = env.make_camera()
+    resp = env.client.put(
+        f"/api/v1/cameras/{cam.id}",
+        json=_full_form(cam, display_aspect_ratio="16:9"),
+        headers=_auth(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert env.calls == []
+    assert resp.json()["stream_action"] in (None, "none")
+
+    env.db.expire_all()
+    assert env.db.get(Camera, cam.id).display_aspect_ratio == "16:9"
+
+
+def test_display_aspect_auto_is_stored_as_null(env):
+    """"auto" and "" are spellings of "no override"; the DB keeps exactly one
+    representation of it so the frontend never has to test for three."""
+    cam = env.make_camera()
+    env.client.put(
+        f"/api/v1/cameras/{cam.id}",
+        json=_full_form(cam, display_aspect_ratio="16:9"),
+        headers=_auth(),
+    )
+    resp = env.client.put(
+        f"/api/v1/cameras/{cam.id}",
+        json=_full_form(cam, display_aspect_ratio="auto"),
+        headers=_auth(),
+    )
+    assert resp.status_code == 200, resp.text
+    env.db.expire_all()
+    assert env.db.get(Camera, cam.id).display_aspect_ratio is None
+
+
+def test_display_aspect_rejects_junk(env):
+    cam = env.make_camera()
+    resp = env.client.put(
+        f"/api/v1/cameras/{cam.id}",
+        json=_full_form(cam, display_aspect_ratio="1080N"),
+        headers=_auth(),
+    )
+    assert resp.status_code == 422, resp.text
     assert env.calls == []
 
 


### PR DESCRIPTION
CP Plus / Dahua DVRs in "1080N" mode send a 16:9 scene as 960x1080 and expect the player to stretch it back, but signal no sample aspect ratio in the SPS VUI. OpenNVR's live path is pure passthrough, so the browser reports 960x1080, VideoPlayer sized the feed box from that, and every tile rendered a narrow near-portrait strip. Recordings, snapshots and the zone editor were squished identically, because MediaMTX records the same bytes.

lib/aspect.ts resolves the aspect a frame should be DISPLAYED at: an operator override on the camera row, else a table of known anamorphic encoder modes, else the coded aspect. The table matches on exact coded size, never on a ratio, so a corridor-mode camera (1080x1920) or a 1:1 fisheye is left alone. Where the two aspects disagree the video switches from object-contain to object-fill, which scales the axes independently — all 1080 scanlines kept, nothing cropped, which is what the DVR's own UI does.

Applied to live tiles, PlaybackConsole, SyncPlaybackTile and snapshots (a 960x1080 grab now exports 1920x1080). The metadata listener and the centred feed box are extracted to useVideoSize/AspectFrame, and VideoPlayer's two divergent snapshot paths collapse into one.

GeometryEditor was a correctness bug of the same shape: it locked the draw surface to 16:9 with object-cover, so a 960x1080 still was cropped and every normalized point an operator placed mapped to a different pixel than the pipeline processes. It now sizes to the still's display aspect with object-fill, and derives the viewBox width from it so handles stay round.

Camera.display_aspect_ratio is display-only: "auto"/"" normalize to NULL, and it is deliberately absent from the re-provision diff so saving it never bounces a stream.

Not covered: exported clips stream raw MediaMTX bytes and stay anamorphic; correcting those needs a server-side remux. Cameras that DO declare a SAR still render squished over WebRTC (Chrome reports the coded size and drops the VUI) — catching those needs the backend to measure the source, which the core image can't do today as it ships without ffmpeg. The override covers them meanwhile.