### PR TITLE
feat(apps): the /apps/{id}/ui surface convention — LPR gets its dashb…

### DIFF
--- a/app/src/services/appsService.ts
+++ b/app/src/services/appsService.ts
@@ -32,6 +32,11 @@ export const appsService = {
   updateAppConfig: (id: string, config: Record<string, any>) =>
     api.put(`/api/v1/apps/${id}/config`, config),
   getAppStatus: (id: string) => api.get(`/api/v1/apps/${id}/status`),
+  // RFC-0002 Phase 4 app-surface convention: the app's self-contained
+  // HTML dashboard, proxied off its contract port. Rendered in a
+  // sandboxed iframe by AppView; refetched on an interval (the page is
+  // a static snapshot, not an app).
+  getAppUi: (id: string) => api.get(`/api/v1/apps/${id}/ui`, { responseType: 'text' }),
 
   // Opt-in one-click install: the agent GUIDES the operator, the backend
   // enforces opt-in + RBAC. install/uninstall 403 when APPS_INSTALL_ENABLED is

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -67,6 +67,9 @@ export type AppManifest = {
   // Declarative operator actions (SDK Action.to_dict()) — generic forms
   // POSTed through the server's user-JWT-only proxy.
   actions?: ManifestAction[]
+  // RFC-0002 Phase 4: the app serves an HTML dashboard at /ui on its
+  // contract port; AppView renders it via core's proxy, sandboxed.
+  has_ui?: boolean
 }
 
 export type ManifestAction = {

--- a/app/src/views/AppView.tsx
+++ b/app/src/views/AppView.tsx
@@ -69,6 +69,23 @@ function useLiveStatus(appId: string, enabled: boolean) {
   })
 }
 
+// RFC-0002 Phase 4 app-surface convention: the app's self-contained HTML
+// dashboard through core's JWT-gated proxy. The page is a static snapshot
+// (no scripts — rendered sandboxed), so we refetch on an interval instead
+// of letting the page self-refresh.
+function useAppUi(appId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ['app-ui', appId],
+    queryFn: async () => {
+      const { data } = await apiService.getAppUi(appId)
+      return typeof data === 'string' ? data : ''
+    },
+    enabled,
+    retry: 0,
+    refetchInterval: enabled ? 15000 : false,
+  })
+}
+
 function useCapabilities() {
   return useQuery({
     queryKey: ['kai-c-capabilities'],
@@ -102,6 +119,8 @@ export function AppView() {
     return set
   }, [caps.data])
 
+  const hasUi = Boolean(app?.manifest?.has_ui)
+  const appUi = useAppUi(appId, hasUi && Boolean(app?.enabled))
   const requires = asStringList(app?.manifest?.requires_tasks)
   const missing = requires.filter((t) => !availableTasks.has(t))
   const stateSchema = Array.isArray(app?.manifest?.state_schema) ? app!.manifest!.state_schema! : []
@@ -226,6 +245,33 @@ export function AppView() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         {/* ── Live dashboard ─────────────────────────────────────── */}
         <div className="lg:col-span-2 space-y-4">
+          {hasUi && app.enabled && (
+            <Card>
+              <CardHeader>
+                <CardTitle>App dashboard</CardTitle>
+                <span className="ml-auto text-xs text-[var(--text-dim)]">
+                  served by the app · refreshes every 15s
+                </span>
+              </CardHeader>
+              <CardContent>
+                {appUi.isError ? (
+                  <div className="text-sm text-[var(--text-dim)]">
+                    The app's dashboard is unreachable right now.
+                  </div>
+                ) : (
+                  <iframe
+                    title={`${app.name} dashboard`}
+                    // No scripts, no navigation, no same-origin: the page
+                    // is app-authored HTML — render it inert.
+                    sandbox=""
+                    srcDoc={appUi.data ?? ''}
+                    className="w-full rounded-md border border-[var(--border)] bg-white"
+                    style={{ height: 360 }}
+                  />
+                )}
+              </CardContent>
+            </Card>
+          )}
           <Card>
             <CardHeader>
               <Activity size={16} className="text-[var(--text-dim)]" />

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -94,6 +94,7 @@ MANIFEST = AppManifest(
         AlertType("plate_expected", severity="low"),
         AlertType("plate_watchlist", severity="high"),
     ],
+    has_ui=True,   # GET /ui dashboard, proxied at /api/v1/apps/{id}/ui
     state_schema=[
         StateView(name="allowlist_size", label="Allowlist",
                   kind="metric", path="allowlist_size"),
@@ -348,6 +349,61 @@ class PlateAlerter(Detector):
             "denylist_size": len(self._watchlists[1]),
             "recent": list(self._recent),
         }
+
+    def ui_html(self) -> str:
+        """The app dashboard (RFC-0002 Phase 4 app-surface convention):
+        ONE self-contained, static HTML document — no scripts (core's
+        catalog renders it in a sandboxed iframe and refetches on an
+        interval, so the page is a snapshot, not an app)."""
+        import html as _html
+
+        snap = self.state_snapshot()
+        allow, deny = self._watchlists
+        rows = []
+        for item in reversed(list(self._recent)[-12:]):
+            level = str(item.get("level", "info"))
+            color = {"high": "#e5484d", "low": "#46a758"}.get(level, "#8b8d98")
+            age_min = max(0, int((time.time() - item.get("time", 0)) / 60))
+            rows.append(
+                f"<tr><td style='color:{color};font-weight:600'>"
+                f"{_html.escape(str(item.get('message', '')))}</td>"
+                f"<td>{_html.escape(level)}</td><td>{age_min}m ago</td></tr>"
+            )
+        table = (
+            "<table><tr><th>Read</th><th>Severity</th><th>When</th></tr>"
+            + "".join(rows) + "</table>" if rows
+            else "<p class='dim'>No plate reads yet.</p>"
+        )
+        scope = snap.get("cameras") or []
+        scope_line = (
+            ", ".join(_html.escape(c) for c in scope)
+            if scope else "all cameras (no assignment restriction)"
+        )
+        return f"""<title>License Plate Recognition</title>
+<style>
+ body {{ font: 14px system-ui, sans-serif; margin: 1.2rem; color: #1a1a1a;
+        background: #fafafa; }}
+ h1 {{ font-size: 1.1rem; margin: 0 0 .2rem }}
+ .dim {{ color: #6b6f76 }}
+ .stats {{ display: flex; gap: 1.5rem; margin: .8rem 0 }}
+ .stats b {{ font-size: 1.3rem; display: block }}
+ table {{ border-collapse: collapse; width: 100% }}
+ th, td {{ text-align: left; padding: .3rem .6rem;
+          border-bottom: 1px solid #e0e0e0; font-size: .9rem }}
+ th {{ color: #6b6f76; font-weight: 500 }}
+ .note {{ margin-top: 1rem; font-size: .85rem; color: #6b6f76 }}
+</style>
+<h1>License Plate Recognition</h1>
+<div class="dim">Watching: {scope_line}</div>
+<div class="stats">
+ <div><b>{len(allow)}</b><span class="dim">allowlist</span></div>
+ <div><b>{len(deny)}</b><span class="dim">denylist</span></div>
+ <div><b>{snap.get("deduped_plates_tracked", 0)}</b><span class="dim">plates deduped</span></div>
+</div>
+{table}
+<div class="note">Watchlists are edited in the App Catalog's config
+form (applied live). Full history: the timeline's plate search.</div>
+"""
 
     def on_config_update(self, config: dict[str, Any]) -> None:
         """Live watchlist edits from the catalog's config form — one

--- a/examples/license-plate-recognition/tests/test_license_plate_recognition.py
+++ b/examples/license-plate-recognition/tests/test_license_plate_recognition.py
@@ -211,3 +211,27 @@ def test_load_config_normalises(tmp_path: Path):
     assert cfg.allowlist == ["AB12", ""]  # blank filtered at setup, not load
     assert cfg.denylist == ["BAD1"]
     assert cfg.cameras == ["cam-1"]
+
+
+# ── The /ui dashboard (RFC-0002 Phase 4 app-surface convention) ────
+
+
+def test_manifest_declares_the_ui():
+    assert PlateAlerter.manifest.has_ui is True
+
+
+def test_ui_html_renders_state_and_escapes():
+    alerter, _ = _alerter(allowlist=["OK1"], denylist=["BAD1"])
+    # A hostile "plate" from a rogue producer must render inert — the
+    # page is sandboxed AND escaped (defense in depth).
+    alerter.handle_event(_envelope(plate="<script>x</script>AB", camera="cam-1"))
+    html = alerter.ui_html()
+    assert "License Plate Recognition" in html
+    # The plate is normalised (upper, no separators) before storage, so
+    # the hostile payload survives as <SCRIPT>… — assert the ESCAPED
+    # uppercase form renders and the raw tag never does.
+    assert "<SCRIPT>" not in html and "<script>" not in html
+    assert "&lt;SCRIPT&gt;" in html
+    assert ">1<" in html                         # allowlist count renders
+    assert "App Catalog" in html                 # points at the config form
+    assert "<script" not in html.lower()         # the page itself has no JS

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
@@ -119,6 +119,23 @@ class _ContractRequestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802 — http.server API
         path = self.path.split("?", 1)[0].rstrip("/") or "/"
+        # RFC-0002 Phase 4 app-surface convention: GET /ui is the one
+        # HTML route — core proxies /api/v1/apps/{id}/ui here. Optional
+        # (apps opt in via a ui callable); everything else stays JSON.
+        if path == "/ui" and getattr(self.server, "ui", None) is not None:
+            try:
+                html = self.server.ui()
+            except Exception:
+                logger.exception("contract /ui failed")
+                self._send_json(500, {"error": "internal error"})
+                return
+            payload = str(html).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
         route = self.server.routes.get(path)
         if route is None:
             self._send_json(404, {"error": f"unknown path {path!r}"})
@@ -215,6 +232,8 @@ class _ContractHTTPServer(ThreadingHTTPServer):
     action: "Callable[[str, dict[str, Any]], Any] | None"
     # When set, POST /actions requires this X-Internal-Api-Key value.
     action_token: "str | None"
+    # Optional GET /ui HTML renderer (RFC-0002 Phase 4). None = no UI.
+    ui: "Callable[[], str] | None"
 
 
 class ContractServer:
@@ -234,6 +253,7 @@ class ContractServer:
         state: Callable[[], dict[str, Any]],
         action: "Callable[[str, dict[str, Any]], Any] | None" = None,
         action_token: "str | None" = None,
+        ui: "Callable[[], str] | None" = None,
         host: str = "0.0.0.0",
         port: int = 0,
     ) -> None:
@@ -242,6 +262,7 @@ class ContractServer:
         self._routes = {"/health": health, "/manifest": manifest, "/state": state}
         self._action = action
         self._action_token = action_token
+        self._ui = ui
         self._server: _ContractHTTPServer | None = None
         self._thread: threading.Thread | None = None
 
@@ -261,6 +282,7 @@ class ContractServer:
         server.routes = self._routes
         server.action = self._action
         server.action_token = self._action_token
+        server.ui = self._ui
         self._server = server
         self._thread = threading.Thread(
             target=server.serve_forever,
@@ -399,6 +421,8 @@ class ContractMixin:
             state=self.state_snapshot,
             action=self._dispatch_action,
             action_token=action_token,
+            # Apps opt into the /ui surface by defining ui_html() -> str.
+            ui=getattr(self, "ui_html", None),
             host=bind_host,
             port=int(port),
         )

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
@@ -193,6 +193,10 @@ class AppManifest:
     # invoke on the app's contract surface via the server's JWT-only
     # proxy. Empty ⇒ no Actions section renders.
     actions: list[Action] = field(default_factory=list)
+    # RFC-0002 Phase 4 app-surface convention: True ⇒ the app serves an
+    # HTML dashboard at GET /ui on its contract port, and core proxies
+    # it at /api/v1/apps/{id}/ui (the catalog renders it sandboxed).
+    has_ui: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """The ``GET /manifest`` payload (and the ``manifest_json``
@@ -209,4 +213,5 @@ class AppManifest:
             "emits": [a.to_dict() for a in self.emits],
             "state_schema": [v.to_dict() for v in self.state_schema],
             "actions": [a.to_dict() for a in self.actions],
+            "has_ui": bool(self.has_ui),
         }

--- a/sdk/opennvr-app-sdk/tests/test_contract.py
+++ b/sdk/opennvr-app-sdk/tests/test_contract.py
@@ -739,3 +739,49 @@ def test_tier0_bridged_into_on_detections_when_opted_in():
     fired = det.handle_event(_tier0_ev())
     assert len(fired) == 1
     assert det._events_seen == 1
+
+
+# ── GET /ui (RFC-0002 Phase 4 app-surface convention) ──────────────
+
+
+class _UiDetector(_EchoDetector):
+    def ui_html(self) -> str:
+        return "<title>Echo</title><h1>hello dashboard</h1>"
+
+
+class _BrokenUiDetector(_EchoDetector):
+    def ui_html(self) -> str:
+        raise RuntimeError("renderer bug")
+
+
+def test_serves_ui_as_html_when_the_app_defines_it():
+    det = _UiDetector(_cfg(), AlertDispatcher([_RecorderChannel()]))
+    server = det.start_contract_server()
+    try:
+        resp = _get(server.port, "/ui")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/html")
+        assert "hello dashboard" in resp.text
+    finally:
+        det.stop_contract_server()
+
+
+def test_no_ui_hook_means_404_not_a_blank_page():
+    det = _detector()
+    server = det.start_contract_server()
+    try:
+        resp = _get(server.port, "/ui")
+        assert resp.status_code == 404
+    finally:
+        det.stop_contract_server()
+
+
+def test_a_raising_ui_renderer_is_a_500_never_a_crash():
+    det = _BrokenUiDetector(_cfg(), AlertDispatcher([_RecorderChannel()]))
+    server = det.start_contract_server()
+    try:
+        assert _get(server.port, "/ui").status_code == 500
+        # The contract surface survives the renderer bug.
+        assert _get(server.port, "/health").status_code == 200
+    finally:
+        det.stop_contract_server()

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -1188,3 +1188,62 @@ async def get_install_status(
             "message": None,
         }
     return _serialize_intent(row)
+
+
+# Cap on proxied app-UI documents. An app dashboard is a small
+# self-contained page; anything bigger is a bug or an abuse vector.
+UI_PROXY_MAX_BYTES = 1_000_000
+
+
+@router.get("/{app_id}/ui")
+async def get_app_ui(
+    app_id: str,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Proxy the app's ``GET /ui`` dashboard (RFC-0002 Phase 4).
+
+    The app-surface routing convention: an app that sets ``has_ui`` in
+    its manifest serves ONE self-contained HTML document at ``/ui`` on
+    its contract port, and this route is how the operator UI reaches it
+    — apps never get their own public ports. Deliberately minimal:
+
+    * **user-JWT only** (like actions): dashboards are operator surface;
+      the service key must never satisfy this route.
+    * ``/ui`` exactly — no subpaths, no assets, no methods but GET. A
+      dashboard that needs more than one self-contained document should
+      argue for widening the convention in an RFC, not around it.
+    * the response is size-capped and always served as text/html; the
+      catalog renders it inside a SANDBOXED iframe (no scripts), so
+      pages should be static HTML/CSS.
+    """
+    row = _get_app_or_404(db, app_id)
+    manifest = row.manifest_json if isinstance(row.manifest_json, dict) else {}
+    if not manifest.get("has_ui"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"App '{app_id}' declares no UI (manifest.has_ui).",
+        )
+    base_url = row.url.rstrip("/")
+    if validate_app_url(base_url) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="App URL is blocked by policy.",
+        )
+    try:
+        async with httpx.AsyncClient(timeout=STATUS_PROBE_TIMEOUT_S) as client:
+            resp = await client.get(f"{base_url}/ui")
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"App '{app_id}' is unreachable.",
+        )
+    if resp.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"App '{app_id}' answered {resp.status_code} for /ui.",
+        )
+    body = resp.content[:UI_PROXY_MAX_BYTES]
+    from fastapi.responses import HTMLResponse
+
+    return HTMLResponse(content=body.decode("utf-8", errors="replace"))

--- a/server/tests/test_app_ui_proxy.py
+++ b/server/tests/test_app_ui_proxy.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""RFC-0002 Phase 4: the /apps/{id}/ui proxy — the app-surface routing
+convention. Apps never get their own public ports; the ONE self-contained
+HTML dashboard an app serves at /ui on its contract port reaches the
+operator through this JWT-gated route.
+
+Pinned here: the route exists and is user-JWT-only (a dashboard is
+operator surface — the service key must never satisfy it, same
+governance as actions); has_ui is the opt-in gate; upstream failures
+are clean 502s, never pass-through surprises.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_uiproxy_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+from routers.apps import UI_PROXY_MAX_BYTES, router  # noqa: E402
+
+
+def _route(path: str):
+    return next(r for r in router.routes if r.path == path)
+
+
+def test_route_exists_and_is_get_only():
+    route = _route("/apps/{app_id}/ui")
+    assert route.methods == {"GET"}
+
+
+def test_route_is_user_jwt_only_like_actions():
+    # The dependency chain must run through get_current_active_user and
+    # NOT get_read_principal: the internal service key reads state, but
+    # a dashboard is operator surface (same governance as actions).
+    route = _route("/apps/{app_id}/ui")
+    dep_names = {
+        d.call.__name__
+        for d in route.dependant.dependencies
+        if getattr(d, "call", None)
+    }
+    assert "get_current_active_user" in dep_names
+    assert "get_read_principal" not in dep_names
+
+
+def test_size_cap_is_a_real_number():
+    # A dashboard is a small page; the cap guards the proxy, not taste.
+    assert 0 < UI_PROXY_MAX_BYTES <= 5_000_000


### PR DESCRIPTION
…oard

RFC-0002 Phase 4's final checkbox (closes gap 5): apps that want a UI get ONE convention instead of their own ports. An app sets has_ui in its manifest and serves ONE self-contained, static HTML document at GET /ui on its contract port; core proxies it at /api/v1/apps/{id}/ui; the catalog renders it in a sandboxed iframe and refetches on an interval. Deliberately minimal — no subpaths, no assets, no methods but GET, no scripts. A dashboard needing more argues for widening the convention in an RFC, not around it.

- SDK: ContractServer gains an optional ui callable (apps opt in by defining ui_html() -> str); GET /ui serves text/html, a raising renderer is a JSON 500 that never takes the contract surface down. AppManifest.has_ui (additive, default False) is the discovery flag.
- core: GET /api/v1/apps/{app_id}/ui — user-JWT ONLY (same governance as actions: dashboards are operator surface, the service key must never satisfy this route); 404 unless the manifest opts in; validate_app_url re-checked; upstream failure/non-200 is a clean 502; response size-capped (1MB) and always served as text/html.
- LPR: ui_html() — the dashboard the model promised: recent reads with severity colors, watchlist sizes, dedup metric, camera scope, and a pointer at the catalog config form for edits. Static HTML/CSS only, all dynamic text escaped (defense in depth under the sandbox); manifest v2 sets has_ui.
- frontend: AppView renders an 'App dashboard' card for enabled apps with has_ui — sandboxed iframe (sandbox="", srcDoc: no scripts, no navigation, no same-origin), 15s refetch, graceful unreachable state. Catalog manifest type gains has_ui.

Tests: SDK 3 (/ui served as html, 404 without the hook, raising renderer = 500 with /health surviving), server 3 (route GET-only, user-JWT-only — asserted against the dependency chain so a governance regression fails CI, size cap sane), LPR 2 (has_ui declared; render + escape matrix, including a hostile plate surviving normalisation as an ESCAPED uppercase tag). Suites: server 934 (fully clean), SDK 201, camera-agent 827, LPR 18; frontend build passes.