### PR TITLE
feat(installer): refcounted adapter provisioning (RFC-0002 Phase 3, d…

### DIFF
--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -77,6 +77,9 @@ MANIFEST = AppManifest(
     # The chain the PLATFORM must be able to run for plates to flow —
     # the catalog uses this to warn when the OCR adapter is missing.
     requires_tasks=["object_detection", "license_plate_recognition"],
+    # Decision 7: the OCR adapter installs WITH the app (the overlay
+    # ships + registers it); yolov8 is the standard stack's, reused.
+    requires_adapters=["fast_plate_ocr"],
     subscribes=PLATE_SUBJECT_PATTERN,
     params=[
         Param("dedup_window_seconds", float, default=60.0,

--- a/scripts/app-installer/reconciler.py
+++ b/scripts/app-installer/reconciler.py
@@ -145,6 +145,10 @@ class CuratedApp:
     id: str
     image: str
     image_digest: str | None
+    # RFC-0002 Phase 3 (decision 7): KAI-C adapters provisioned WITH the
+    # app. Upped alongside it; refcounted across installed apps on
+    # uninstall (released only when no other installed app requires it).
+    requires_adapters: tuple[str, ...] = ()
 
 
 def load_curated_index(path: str | Path) -> dict[str, CuratedApp]:
@@ -177,15 +181,33 @@ def load_curated_index(path: str | Path) -> dict[str, CuratedApp]:
                          entry.get("id"))
             continue
         digest = entry.get("image_digest")
+        raw_adapters = entry.get("requires_adapters") or []
+        adapters = tuple(
+            a for a in raw_adapters
+            if isinstance(a, str) and _ADAPTER_RE.fullmatch(a)
+        ) if isinstance(raw_adapters, list) else ()
         index[app_id] = CuratedApp(
             id=app_id,
             image=image,
             image_digest=digest if isinstance(digest, str) else None,
+            requires_adapters=adapters,
         )
     return index
 
 
 # ── The real docker runner (production only; never imported by tests) ──
+
+
+# Adapter names are snake_case KAI-C registry names; their overlay
+# service is <name-with-dashes>-adapter (the fast-plate-ocr-adapter
+# convention). Same trust rule as app ids: only names from the baked
+# curated index ever reach an argv, and only in this validated shape.
+_ADAPTER_RE = re.compile(r"[a-z0-9]+(_[a-z0-9]+)*")
+
+
+def adapter_service_name(adapter: str) -> str:
+    """KAI-C adapter name -> its compose service (decision 7 convention)."""
+    return adapter.replace("_", "-") + "-adapter"
 
 
 def docker_runner(
@@ -237,6 +259,7 @@ def _compose_base(compose_files: tuple[str, ...], profile: str) -> list[str]:
 def build_up_argv(
     intent: Intent,
     *,
+    adapters: tuple[str, ...] = (),
     compose_files: tuple[str, ...] = DEFAULT_COMPOSE_FILES,
     profile: str = DEFAULT_PROFILE,
 ) -> list[str]:
@@ -248,19 +271,33 @@ def build_up_argv(
     (``<ID>_IMAGE``), so the reconciler deploys the exact bytes the
     curated index vouched for. When absent, the service's own ``image:``
     default is used (unpinned — dev only).
+
+    RFC-0002 Phase 3 (decision 7): the app's required adapters (from the
+    curated index) are upped in the same command, ahead of the app — an
+    already-running adapter is a no-op (reuse), a missing service block
+    fails the whole install LOUDLY (the "cannot be provisioned" refusal).
     """
-    return _compose_base(compose_files, profile) + ["up", "-d", intent.id]
+    services = [
+        adapter_service_name(a) for a in (adapters or ())
+    ] + [intent.id]
+    return _compose_base(compose_files, profile) + ["up", "-d", *services]
 
 
 def build_down_argv(
     intent: Intent,
     *,
+    release_adapters: tuple[str, ...] = (),
     compose_files: tuple[str, ...] = DEFAULT_COMPOSE_FILES,
     profile: str = DEFAULT_PROFILE,
 ) -> list[str]:
-    """``docker compose ... rm -s -f <id>`` — stop and remove exactly the
-    one app service, leaving the rest of the stack untouched."""
-    return _compose_base(compose_files, profile) + ["rm", "-s", "-f", intent.id]
+    """``docker compose ... rm -s -f <id> [adapters]`` — stop and remove
+    the app service plus any of its adapters whose refcount dropped to
+    zero (decision 7: uninstall RELEASES, and the last release removes;
+    an adapter another installed app still requires is never listed)."""
+    services = [intent.id] + [
+        adapter_service_name(a) for a in (release_adapters or ())
+    ]
+    return _compose_base(compose_files, profile) + ["rm", "-s", "-f", *services]
 
 
 def image_env_key(app_id: str) -> str:
@@ -309,6 +346,7 @@ def reconcile_intent(
     runner: Runner,
     *,
     index: dict[str, CuratedApp],
+    held_adapters: frozenset[str] = frozenset(),
     compose_files: tuple[str, ...] = DEFAULT_COMPOSE_FILES,
     profile: str = DEFAULT_PROFILE,
 ) -> tuple[str, str]:
@@ -375,7 +413,8 @@ def reconcile_intent(
         else:
             logger.info("Pinning app %r to %s", intent.id, pin)
         argv = build_up_argv(
-            intent, compose_files=compose_files, profile=profile
+            intent, adapters=curated.requires_adapters,
+            compose_files=compose_files, profile=profile,
         )
         result = runner(argv, override or None)
         if result.returncode == 0:
@@ -385,8 +424,18 @@ def reconcile_intent(
         ).strip()
 
     if intent.desired == "absent":
+        # Decision 7 refcount: release this app's adapters, but only the
+        # ones NO other installed app requires (``held_adapters``, computed
+        # by the sweep from the full intent list). A delisted app releases
+        # nothing (its requirements are unknown) — never guess a teardown.
+        curated = index.get(intent.id)
+        release = tuple(
+            a for a in (curated.requires_adapters if curated else ())
+            if a not in held_adapters
+        )
         argv = build_down_argv(
-            intent, compose_files=compose_files, profile=profile
+            intent, release_adapters=release,
+            compose_files=compose_files, profile=profile,
         )
         # No image override on teardown — ``rm`` doesn't resolve the image.
         result = runner(argv, None)
@@ -425,14 +474,28 @@ def reconcile_once(
     Returns a list of ``(id, status, message)`` for observability.
     """
     outcomes: list[tuple[str, str, str]] = []
-    for intent in store.list_intents():
+    intents = store.list_intents()
+    for intent in intents:
         if intent.status == "applied":
             continue  # nothing to do until the server flips it to pending
         if intent.id in skip_ids:
             continue  # failure backoff — the caller will retry later
+        # Decision 7 refcount: adapters still required by ANY other app
+        # whose desired state is installed. Desired state (not live
+        # containers) is the source of truth the reconciler converges on.
+        held = frozenset(
+            a
+            for other in intents
+            if other.id != intent.id and other.desired == "installed"
+            for a in (
+                index[other.id].requires_adapters
+                if other.id in index else ()
+            )
+        )
         status_, message = reconcile_intent(
             intent, runner,
-            index=index, compose_files=compose_files, profile=profile,
+            index=index, held_adapters=held,
+            compose_files=compose_files, profile=profile,
         )
         store.set_status(intent.id, status_, message, desired=intent.desired)
         outcomes.append((intent.id, status_, message))

--- a/scripts/app-installer/tests/test_reconciler.py
+++ b/scripts/app-installer/tests/test_reconciler.py
@@ -69,6 +69,7 @@ TEST_INDEX: dict[str, CuratedApp] = {
         id="license-plate-recognition",
         image="ghcr.io/open-nvr/license-plate-recognition:latest",
         image_digest="sha256:" + "d" * 64,
+        requires_adapters=("fast_plate_ocr",),
     ),
 }
 
@@ -399,3 +400,97 @@ def test_status_write_is_guarded_on_acted_desired():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+# ── RFC-0002 Phase 3: refcounted adapter provisioning (decision 7) ──
+
+
+def _lpr_intent(**kw) -> Intent:
+    base = dict(
+        id="license-plate-recognition",
+        image="ghcr.io/open-nvr/license-plate-recognition:latest",
+        image_digest="sha256:" + "d" * 64,
+        desired="installed",
+        status="pending",
+    )
+    base.update(kw)
+    return Intent(**base)
+
+
+def test_install_ups_required_adapters_ahead_of_the_app():
+    runner = FakeRunner(RunResult(0, "ok", ""))
+    status, _ = _reconcile(_lpr_intent(), runner)
+    assert status == "applied"
+    argv = runner.calls[0]
+    up_at = argv.index("-d")
+    services = argv[up_at + 1:]
+    # The adapter service is upped in the same command, BEFORE the app —
+    # an already-running adapter is a compose no-op (reuse), a missing
+    # service block fails the whole install loudly.
+    assert services == ["fast-plate-ocr-adapter", "license-plate-recognition"]
+
+
+def test_uninstall_releases_the_last_holders_adapter():
+    runner = FakeRunner(RunResult(0, "ok", ""))
+    status, _ = _reconcile(
+        _lpr_intent(desired="absent"), runner, held_adapters=frozenset()
+    )
+    assert status == "applied"
+    argv = runner.calls[0]
+    rm_at = argv.index("rm")
+    assert argv[rm_at + 1:] == [
+        "-s", "-f", "license-plate-recognition", "fast-plate-ocr-adapter"]
+
+
+def test_uninstall_never_removes_an_adapter_another_app_holds():
+    runner = FakeRunner(RunResult(0, "ok", ""))
+    _reconcile(
+        _lpr_intent(desired="absent"), runner,
+        held_adapters=frozenset({"fast_plate_ocr"}),
+    )
+    argv = runner.calls[0]
+    assert "fast-plate-ocr-adapter" not in argv
+
+
+def test_delisted_app_releases_no_adapters():
+    # An id no longer in the curated index: its requirements are unknown,
+    # so teardown removes ONLY the app service — never guess an adapter.
+    runner = FakeRunner(RunResult(0, "ok", ""))
+    status, _ = _reconcile(
+        _intent(id="ghost-app", desired="absent"), runner,
+    )
+    assert status == "applied"
+    assert [a for a in runner.calls[0] if a.endswith("-adapter")] == []
+
+
+def test_sweep_computes_held_from_other_installed_intents():
+    # LPR uninstalling while a second (hypothetical) app that also
+    # requires fast_plate_ocr stays installed -> the adapter survives.
+    index = dict(TEST_INDEX)
+    index["parking-audit"] = CuratedApp(
+        id="parking-audit",
+        image="ghcr.io/open-nvr/parking-audit:latest",
+        image_digest="sha256:" + "e" * 64,
+        requires_adapters=("fast_plate_ocr",),
+    )
+    intents = [
+        _lpr_intent(desired="absent"),
+        _intent(id="parking-audit",
+                image="ghcr.io/open-nvr/parking-audit:latest",
+                image_digest="sha256:" + "e" * 64,
+                desired="installed", status="applied"),
+    ]
+    runner = FakeRunner(RunResult(0, "ok", ""))
+    store = FakeStore(intents)
+    outcomes = reconcile_once(store, runner, index=index)
+    assert [o[0] for o in outcomes] == ["license-plate-recognition"]
+    assert "fast-plate-ocr-adapter" not in runner.calls[0]
+
+
+def test_shipped_index_carries_lpr_adapter_requirement():
+    repo_root = Path(__file__).resolve().parents[3]
+    index = load_curated_index(
+        repo_root / "server" / "config" / "apps_index.yml")
+    assert index["license-plate-recognition"].requires_adapters == (
+        "fast_plate_ocr",)
+    assert index["smart-doorbell"].requires_adapters == ("insightface",)

--- a/scripts/validate_apps_index.py
+++ b/scripts/validate_apps_index.py
@@ -407,6 +407,35 @@ def validate_entry(
                 "sha256:<64 lowercase hex chars>"
             )
 
+    # requires_adapters (RFC-0002 Phase 3, decision 7): adapters that must
+    # be provisioned WITH the app. Names are snake_case KAI-C registry
+    # names; each maps to the overlay service <name-with-dashes>-adapter.
+    # A requirement without a service block is a WARNING, not an error —
+    # it machine-checks the "cannot be provisioned" state (the historical
+    # smart-doorbell NOTE): the store card already greys the app via its
+    # unavailable task, and an install proceeds degraded exactly as the
+    # app documents. Shipping the adapter service upgrades it silently.
+    adapters = entry.get("requires_adapters", [])
+    if not isinstance(adapters, list):
+        errors.append(f"{label}: requires_adapters must be a list")
+    else:
+        for adapter in adapters:
+            if not isinstance(adapter, str) or not re.fullmatch(
+                    r"[a-z0-9]+(_[a-z0-9]+)*", adapter):
+                errors.append(
+                    f"{label}: requires_adapters entry {adapter!r} must be "
+                    "a snake_case KAI-C adapter name")
+                continue
+            service = adapter.replace("_", "-") + "-adapter"
+            if overlay_services is not None and service not in overlay_services:
+                warnings.append(
+                    f"{label}: required adapter '{adapter}' has no "
+                    f"'{service}' service in docker-compose.apps.yml — the "
+                    "app installs but that capability stays degraded until "
+                    "an operator registers the adapter with KAI-C "
+                    "themselves (RFC-0002 Phase 3)."
+                )
+
     # requires_tasks: must be a list; unknown tasks warn (free-text allowed).
     tasks = entry.get("requires_tasks", [])
     if not isinstance(tasks, list):

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
@@ -173,7 +173,11 @@ class AppManifest:
     ``subscribes`` is the NATS subject pattern for InferenceSubscriber
     apps (``None`` for FrameApps that drive inference themselves).
     ``requires_tasks`` names adapter task types the app depends on,
-    e.g. ``["object_detection"]``.
+    e.g. ``["object_detection"]``. ``requires_adapters`` (RFC-0002
+    Phase 3, decision 7) names the specific KAI-C adapters that must be
+    PROVISIONED with the app — the installer ups them alongside the app
+    and refcounts them across apps on uninstall. Adapters the standard
+    stack already ships (yolov8) are reused, not listed.
     """
 
     id: str
@@ -182,6 +186,7 @@ class AppManifest:
     category: str
     summary: str = ""
     requires_tasks: list[str] = field(default_factory=list)
+    requires_adapters: list[str] = field(default_factory=list)
     subscribes: str | None = None
     params: list[Param] = field(default_factory=list)
     emits: list[AlertType] = field(default_factory=list)
@@ -208,6 +213,7 @@ class AppManifest:
             "category": self.category,
             "summary": self.summary,
             "requires_tasks": list(self.requires_tasks),
+            "requires_adapters": list(self.requires_adapters),
             "subscribes": self.subscribes,
             "params": [p.to_dict() for p in self.params],
             "emits": [a.to_dict() for a in self.emits],

--- a/server/config/apps_index.yml
+++ b/server/config/apps_index.yml
@@ -214,6 +214,11 @@
   image: ghcr.io/open-nvr/license-plate-recognition:latest
   build_context: examples/license-plate-recognition
   requires_tasks: [object_detection, license_plate_recognition]
+  # RFC-0002 Phase 3 (decision 7): adapters that must be provisioned
+  # WITH the app. The overlay ships fast-plate-ocr-adapter + its
+  # register sidecar; the one-click reconciler ups it alongside the app
+  # and refcounts it across apps on uninstall. yolov8 = standard stack.
+  requires_adapters: [fast_plate_ocr]
   emits: [plate_read, plate_expected, plate_watchlist]
   docs_url: https://github.com/open-nvr/open-nvr/blob/main/examples/license-plate-recognition/README.md
   install:
@@ -245,6 +250,12 @@
   image: ghcr.io/open-nvr/smart-doorbell:latest
   build_context: examples/smart-doorbell
   requires_tasks: [face_recognition]
+  # The compose NOTE, machine-checked (RFC-0002 Phase 3): this app needs
+  # an InsightFace adapter that the repo does NOT ship an overlay
+  # service for — the validator warns, the store card greys the app via
+  # its unavailable face_recognition task, and an install without the
+  # adapter degrades exactly as the app's README documents.
+  requires_adapters: [insightface]
   emits: [known_visitor, unknown_visitor]
   docs_url: https://github.com/open-nvr/open-nvr/blob/main/examples/smart-doorbell/README.md
   install:

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -111,6 +111,9 @@ class IndexEntry(BaseModel):
     version: str
     image: str
     requires_tasks: list[str] = []
+    # RFC-0002 Phase 3 (decision 7): KAI-C adapters that must be
+    # provisioned with the app; the reconciler ups + refcounts them.
+    requires_adapters: list[str] = []
     emits: list[str] = []
     docs_url: str
     install: InstallSpec


### PR DESCRIPTION
…ecision 7)

The remaining Phase 3 checkboxes: apps declare the adapters that must be provisioned WITH them, the installer ups and refcounts those adapters, and 'cannot be provisioned' is machine-checked instead of living in a compose comment.

- SDK: AppManifest.requires_adapters (additive; in to_dict). Adapters the standard stack ships (yolov8) are reused, never listed. LPR declares fast_plate_ocr.
- apps_index.yml: entries carry requires_adapters — LPR: fast_plate_ocr; smart-doorbell: insightface (the historical compose NOTE, now data). IndexEntry serves the field.
- reconciler: CuratedApp carries requires_adapters (validated snake_case, from the baked index only — same trust rule as ids). Install ups the adapter services in the same compose command, AHEAD of the app: an already-running adapter is a no-op (reuse), a missing service block fails the whole install loudly (the refusal). Uninstall RELEASES: the sweep computes which adapters any OTHER installed-desired intent still requires, and only unheld adapters ride the rm — the last release removes, a held adapter is never touched, and a delisted app releases nothing (its requirements are unknown; never guess a teardown). Desired state, not live containers, is what the refcount converges on.
- validate_apps_index: requires_adapters checked per entry — bad names are errors; a requirement whose <name>-adapter service is absent from the overlay is a WARNING naming the degraded behavior (the smart-doorbell case: installs, greys via its unavailable task, works once an operator registers the adapter). Runs clean on the shipped index with exactly that one warning.
- versions: adapter services ride ADAPTER_TAG (the release-pinned set) — decision 7's 'resolve against the release's pinned set' holds by construction in the overlay.

Tests (6 new; installer suite 23): adapters up ahead of the app; last-holder release; held adapter survives (sabotage-verified: ignoring holders fails 2 tests); delisted releases nothing; the sweep computes held from other installed intents; the shipped index carries both declarations. Suites: SDK 201, server 934, LPR 18 — all green.