### PR TITLE
feat(kai-c): Phase 5 — per-skill budgets + event-scope grants (RFC-0002)

### DIFF
--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -70,6 +70,10 @@ export type AppManifest = {
   // RFC-0002 Phase 4: the app serves an HTML dashboard at /ui on its
   // contract port; AppView renders it via core's proxy, sandboxed.
   has_ui?: boolean
+  // RFC-0002 Phase 5: event scopes the app requested (granted at
+  // registration, each grant audited) — plate reads are PII, so who
+  // consumes them is visible here, not buried in code.
+  requires_scopes?: string[]
 }
 
 export type ManifestAction = {

--- a/app/src/views/AppView.tsx
+++ b/app/src/views/AppView.tsx
@@ -335,6 +335,18 @@ export function AppView() {
                   </div>
                 </div>
               )}
+              {(app.manifest?.requires_scopes ?? []).length > 0 && (
+                <div>
+                  <div className="text-xs text-[var(--text-dim)] mb-1">
+                    Event scopes (granted at registration, audited)
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {(app.manifest?.requires_scopes ?? []).map((sc) => (
+                      <Badge key={sc} variant="info">{sc}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
               {app.url && (
                 <div className="text-xs text-[var(--text-dim)]">
                   Contract: <span className="font-mono">{app.url}</span>

--- a/docs/rfcs/RFC-0002-skills-and-apps.md
+++ b/docs/rfcs/RFC-0002-skills-and-apps.md
@@ -330,12 +330,31 @@ fresh install.
 
 ### Phase 5 — Budgets and scopes
 
-- [ ] Per-skill Tier-1 budgets at KAI-C (calls/min per camera per
+- [x] Per-skill Tier-1 budgets at KAI-C (calls/min per camera per
       skill), with shed-and-report semantics like Tier-0's region
-      shedding — never silent drops.
-- [ ] Subscription scopes: manifests request event scopes
-      (`events:plate.recognized`); install grants; bus-side
-      enforcement; grants visible in App Catalog; every grant audited.
+      shedding — never silent drops. *(shipped — `kai_c/budgets.py`:
+      sliding per-(adapter, camera) windows, env-configured
+      (`KAIC_BUDGET_PER_CAMERA_PER_MIN` + per-adapter overrides),
+      429 + `inference.refused_budget` audit +
+      `kaic_budget_shed_total` metric + rate-limited WARNING; calls
+      without a camera_id are exempt.)*
+- [x] Subscription scopes: manifests request event scopes
+      (`events:plate.recognized`); install grants; grants visible in
+      App Catalog; every grant audited. *(shipped —
+      `AppManifest.requires_scopes`; registration auto-grants and
+      writes one `app.scope_granted` audit row per scope; the catalog
+      renders the granted scopes on the app page; LPR declares
+      `events:plate.recognized`.)*
+- [ ] **Bus-side scope enforcement** *(staged follow-up — the one
+      Phase 5 piece not shipped)*: today every bus client shares the
+      deployment token, so a granted scope is policy + audit, not a
+      wire-level barrier. The enforcement design: NATS authorization
+      config with one user per installed app, whose `subscribe`
+      permissions are exactly its granted scopes' subjects; core
+      renders that config from the grant table on install/uninstall
+      and reloads the broker. Requires per-app credential delivery to
+      app containers — a deployment-surface change big enough to want
+      its own review.
 
 **Accept when:** an app without the plate scope cannot receive plate
 events, and a runaway subscriber degrades predictably instead of

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -80,6 +80,9 @@ MANIFEST = AppManifest(
     # Decision 7: the OCR adapter installs WITH the app (the overlay
     # ships + registers it); yolov8 is the standard stack's, reused.
     requires_adapters=["fast_plate_ocr"],
+    # Plates are PII (decision 6): consuming plate.recognized.v1 is a
+    # declared scope — granted at registration, audited, catalog-visible.
+    requires_scopes=["events:plate.recognized"],
     subscribes=PLATE_SUBJECT_PATTERN,
     params=[
         Param("dedup_window_seconds", float, default=60.0,

--- a/kai-c/kai_c/budgets.py
+++ b/kai-c/kai_c/budgets.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RFC-0002 Phase 5: per-skill Tier-1 budgets, enforced at KAI-C.
+
+One skill's runaway consumer must degrade ITSELF, not starve the
+stack. KAI-C is the enforcement point because it is where every
+governed inference call already meets (the same argument that placed
+the Phase 0 domain-event normaliser here): Tier-1 dispatch, core's
+enrichment, and any app all pass through ``/api/v1/infer/{adapter}``,
+so a budget here needs no cooperation from initiators.
+
+The budget is **calls per minute per (adapter, camera)** — the RFC's
+"per camera per skill", with the adapter as the skill's provider-side
+name. Sliding one-minute window, in memory (KAI-C is a single
+process; restart forgiveness is fine for a rate limit).
+
+**Shed-and-report, never silent** (Tier-0's region-shedding
+discipline): an over-budget call is refused with HTTP 429 and a §3.5-
+shaped error body, audited as ``inference.refused_budget``, counted in
+``kaic_budget_shed_total{adapter,camera}``, and logged at WARNING
+(rate-limited to once per window per bucket so a storm reports itself
+without becoming its own log flood).
+
+Configuration (env):
+
+* ``KAIC_BUDGET_PER_CAMERA_PER_MIN`` — the global default (int).
+  ``0`` disables budgeting entirely. Default 120: generous enough
+  that a normal install never sees it, tight enough that a hot loop
+  (an app re-inferring every frame) degrades predictably.
+* ``KAIC_BUDGET_OVERRIDES`` — per-adapter overrides, e.g.
+  ``"fast_plate_ocr=30,caption=60"``. ``0`` disables for that adapter.
+
+Calls WITHOUT a ``camera_id`` are exempt: they are conformance probes,
+health checks, and ad-hoc operator calls — not per-camera skill
+traffic, and starving them would break the platform's own plumbing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections import deque
+
+logger = logging.getLogger("kai-c.budgets")
+
+DEFAULT_PER_CAMERA_PER_MIN = 120
+WINDOW_SECONDS = 60.0
+
+#: Bound on distinct (adapter, camera) buckets — a producer minting
+#: fresh camera ids per call must not grow memory unbounded. At the
+#: cap, the stalest bucket is evicted (its window restarts — the cheap
+#: failure direction, one extra minute of grace).
+MAX_BUCKETS = 4096
+
+
+def parse_overrides(raw: str | None) -> dict[str, int]:
+    """``"a=30,b=0"`` → ``{"a": 30, "b": 0}``. Malformed pairs are
+    logged and skipped — a typo must not take budgeting down."""
+    out: dict[str, int] = {}
+    for pair in (raw or "").split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        name, sep, value = pair.partition("=")
+        try:
+            if not sep:
+                raise ValueError("missing '='")
+            out[name.strip()] = max(0, int(value.strip()))
+        except ValueError as exc:
+            logger.warning("KAIC_BUDGET_OVERRIDES: skipping %r (%s)", pair, exc)
+    return out
+
+
+class SkillBudgets:
+    """Sliding-window rate limits per (adapter, camera). Thread-safe."""
+
+    def __init__(
+        self,
+        *,
+        default_per_min: int = DEFAULT_PER_CAMERA_PER_MIN,
+        overrides: dict[str, int] | None = None,
+        clock=time.monotonic,
+    ) -> None:
+        self.default_per_min = max(0, int(default_per_min))
+        self.overrides = dict(overrides or {})
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._windows: dict[tuple[str, str], deque[float]] = {}
+        # (adapter, camera) → shed count, for /metrics. Never reset.
+        self._shed: dict[tuple[str, str], int] = {}
+        # bucket → last WARNING timestamp (log flood control).
+        self._warned_at: dict[tuple[str, str], float] = {}
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "SkillBudgets":
+        env = os.environ if env is None else env
+        try:
+            default = int(env.get("KAIC_BUDGET_PER_CAMERA_PER_MIN",
+                                  DEFAULT_PER_CAMERA_PER_MIN))
+        except ValueError:
+            logger.warning(
+                "KAIC_BUDGET_PER_CAMERA_PER_MIN is not an int; using %d",
+                DEFAULT_PER_CAMERA_PER_MIN)
+            default = DEFAULT_PER_CAMERA_PER_MIN
+        return cls(default_per_min=default,
+                   overrides=parse_overrides(env.get("KAIC_BUDGET_OVERRIDES")))
+
+    def limit_for(self, adapter: str) -> int:
+        """The per-minute limit for one adapter (0 = unlimited)."""
+        return self.overrides.get(adapter, self.default_per_min)
+
+    def admit(self, adapter: str, camera_id: str | None) -> bool:
+        """True = within budget (and the call is counted); False = shed.
+
+        Exempt: no camera_id (probes/operator calls), or a limit of 0.
+        """
+        if not camera_id:
+            return True
+        limit = self.limit_for(adapter)
+        if limit <= 0:
+            return True
+        now = self._clock()
+        key = (adapter, str(camera_id))
+        with self._lock:
+            window = self._windows.get(key)
+            if window is None:
+                if len(self._windows) >= MAX_BUCKETS:
+                    stalest = min(
+                        self._windows,
+                        key=lambda k: self._windows[k][-1]
+                        if self._windows[k] else 0.0,
+                    )
+                    del self._windows[stalest]
+                window = self._windows[key] = deque()
+            cutoff = now - WINDOW_SECONDS
+            while window and window[0] < cutoff:
+                window.popleft()
+            if len(window) >= limit:
+                self._shed[key] = self._shed.get(key, 0) + 1
+                last = self._warned_at.get(key, -WINDOW_SECONDS)
+                if now - last >= WINDOW_SECONDS:
+                    self._warned_at[key] = now
+                    logger.warning(
+                        "budget shed: %s on camera %s is over %d calls/min "
+                        "(%d shed so far) — the caller receives 429s until "
+                        "the window drains",
+                        adapter, camera_id, limit, self._shed[key],
+                    )
+                return False
+            window.append(now)
+            return True
+
+    def shed_total(self) -> dict[tuple[str, str], int]:
+        with self._lock:
+            return dict(self._shed)
+
+    def render_metrics(self) -> str:
+        """Prometheus lines for the shed counter (appended to /metrics)."""
+        shed = self.shed_total()
+        if not shed:
+            return ""
+        lines = [
+            "# HELP kaic_budget_shed_total Inference calls refused over "
+            "the per-(adapter, camera) budget (RFC-0002 Phase 5).",
+            "# TYPE kaic_budget_shed_total counter",
+        ]
+        for (adapter, camera), count in sorted(shed.items()):
+            lines.append(
+                f'kaic_budget_shed_total{{adapter="{adapter}",'
+                f'camera="{camera}"}} {count}'
+            )
+        return "\n".join(lines) + "\n"

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -43,6 +43,7 @@ from urllib.parse import urlparse
 from fastapi import Header
 
 from kai_c.audit import AuditEventType, AuditStore, new_correlation_id
+from kai_c.budgets import SkillBudgets
 from kai_c.connector import KaiConnector
 from kai_c.correlation import CORRELATION_ID_HEADER, CorrelationIdMiddleware
 from kai_c.domain_events import normalise_completion
@@ -254,6 +255,10 @@ def _validate_adapters_match_sovereignty() -> None:
 _audit = AuditStore()
 _registry: AdapterRegistry | None = None
 _nats_publisher: NatsPublisher | None = None
+
+# RFC-0002 Phase 5: per-(adapter, camera) inference budgets. Built once
+# from env at import (config is env-only; tests construct their own).
+_skill_budgets = SkillBudgets.from_env()
 
 
 # ============================================================
@@ -884,7 +889,7 @@ async def kaic_prometheus_metrics():
     from kai_c.metrics import proxy_metrics
     summaries = get_registry().list_summaries()
     return PlainTextResponse(
-        proxy_metrics.render(summaries),
+        proxy_metrics.render(summaries) + _skill_budgets.render_metrics(),
         media_type="text/plain; version=0.0.4; charset=utf-8",
     )
 
@@ -1345,6 +1350,37 @@ async def v1_infer(
         correlation_id = new_correlation_id()
 
     camera_id = payload.get("camera_id") if isinstance(payload, dict) else None
+
+    # RFC-0002 Phase 5: shed-and-report, never silent. Over-budget calls
+    # are refused BEFORE the adapter sees them — audited, counted in
+    # /metrics (kaic_budget_shed_total), and answered with a §3.5-shaped
+    # 429 the caller can distinguish from an adapter failure. Calls
+    # without a camera_id (probes, operator one-offs) are exempt.
+    if not _skill_budgets.admit(adapter_name, camera_id):
+        audit.emit(
+            AuditEventType.INFERENCE_REFUSED_BUDGET,
+            correlation_id=correlation_id,
+            adapter=adapter_name,
+            camera_id=camera_id,
+            error_category="budget",
+            error_code="skill_budget_exceeded",
+        )
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "error": {
+                    "category": "budget",
+                    "code": "skill_budget_exceeded",
+                    "message": (
+                        f"over {_skill_budgets.limit_for(adapter_name)} "
+                        f"calls/min for {adapter_name} on camera "
+                        f"{camera_id} — retry after the window drains"
+                    ),
+                    "transient": True,
+                }
+            },
+        )
+
     started = time.monotonic()
 
     try:

--- a/kai-c/test/test_budgets.py
+++ b/kai-c/test/test_budgets.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RFC-0002 Phase 5: per-(adapter, camera) budgets — shed-and-report.
+
+The discipline under test is Tier-0's region-shedding rule applied to
+Tier-1: a runaway consumer degrades ITSELF (429s until its window
+drains) and the shed is REPORTED (counter, metrics lines, warning) —
+never a silent drop, and never collateral damage to another camera or
+adapter.
+"""
+from __future__ import annotations
+
+from kai_c.budgets import (
+    DEFAULT_PER_CAMERA_PER_MIN,
+    MAX_BUCKETS,
+    SkillBudgets,
+    parse_overrides,
+)
+
+
+class _Clock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+
+def _budgets(limit=3, **kw):
+    return SkillBudgets(default_per_min=limit, clock=_Clock(), **kw)
+
+
+def test_admits_until_the_limit_then_sheds():
+    b = SkillBudgets(default_per_min=3, clock=_Clock())
+    assert all(b.admit("ocr", "cam1") for _ in range(3))
+    assert b.admit("ocr", "cam1") is False
+    assert b.shed_total() == {("ocr", "cam1"): 1}
+
+
+def test_window_slides_and_readmits():
+    clock = _Clock()
+    b = SkillBudgets(default_per_min=2, clock=clock)
+    assert b.admit("ocr", "cam1") and b.admit("ocr", "cam1")
+    assert b.admit("ocr", "cam1") is False
+    clock.now += 61.0
+    assert b.admit("ocr", "cam1") is True
+
+
+def test_buckets_are_isolated_per_adapter_and_camera():
+    b = SkillBudgets(default_per_min=1, clock=_Clock())
+    assert b.admit("ocr", "cam1")
+    assert b.admit("ocr", "cam1") is False       # cam1 over budget…
+    assert b.admit("ocr", "cam2") is True        # …cam2 unaffected
+    assert b.admit("caption", "cam1") is True    # …other skill unaffected
+
+
+def test_no_camera_and_zero_limit_are_exempt():
+    b = SkillBudgets(default_per_min=1, clock=_Clock())
+    for _ in range(10):
+        assert b.admit("ocr", None) is True      # probes never starve
+        assert b.admit("ocr", "") is True
+    z = SkillBudgets(default_per_min=0, clock=_Clock())
+    for _ in range(10):
+        assert z.admit("ocr", "cam1") is True    # 0 = budgeting off
+    assert z.shed_total() == {}
+
+
+def test_per_adapter_overrides_win():
+    b = SkillBudgets(default_per_min=100,
+                     overrides={"fast_plate_ocr": 1, "caption": 0},
+                     clock=_Clock())
+    assert b.limit_for("fast_plate_ocr") == 1
+    assert b.limit_for("caption") == 0
+    assert b.limit_for("yolov8") == 100
+    assert b.admit("fast_plate_ocr", "cam1")
+    assert b.admit("fast_plate_ocr", "cam1") is False
+    for _ in range(5):
+        assert b.admit("caption", "cam1") is True
+
+
+def test_parse_overrides_skips_garbage():
+    assert parse_overrides("a=30, b = 0 ,broken,c=x,d=-5") == {
+        "a": 30, "b": 0, "d": 0}
+    assert parse_overrides(None) == {}
+    assert parse_overrides("") == {}
+
+
+def test_from_env_reads_default_and_overrides():
+    b = SkillBudgets.from_env({
+        "KAIC_BUDGET_PER_CAMERA_PER_MIN": "7",
+        "KAIC_BUDGET_OVERRIDES": "fast_plate_ocr=2",
+    })
+    assert b.default_per_min == 7
+    assert b.overrides == {"fast_plate_ocr": 2}
+    b2 = SkillBudgets.from_env({"KAIC_BUDGET_PER_CAMERA_PER_MIN": "junk"})
+    assert b2.default_per_min == DEFAULT_PER_CAMERA_PER_MIN
+
+
+def test_metrics_render_reports_the_shed():
+    b = SkillBudgets(default_per_min=1, clock=_Clock())
+    assert b.render_metrics() == ""              # nothing shed, no series
+    b.admit("ocr", "cam1")
+    b.admit("ocr", "cam1")
+    b.admit("ocr", "cam1")
+    out = b.render_metrics()
+    assert "# TYPE kaic_budget_shed_total counter" in out
+    assert 'kaic_budget_shed_total{adapter="ocr",camera="cam1"} 2' in out
+
+
+def test_bucket_cap_evicts_stalest_not_unbounded():
+    clock = _Clock()
+    b = SkillBudgets(default_per_min=10, clock=clock)
+    for i in range(MAX_BUCKETS + 50):
+        clock.now += 0.001
+        b.admit("ocr", f"cam{i}")
+    assert len(b._windows) <= MAX_BUCKETS
+
+
+def test_shed_warning_is_rate_limited(caplog):
+    import logging
+    clock = _Clock()
+    b = SkillBudgets(default_per_min=1, clock=clock)
+    b.admit("ocr", "cam1")
+    with caplog.at_level(logging.WARNING, logger="kai-c.budgets"):
+        for _ in range(50):
+            b.admit("ocr", "cam1")               # a shed storm
+    warnings = [r for r in caplog.records if "budget shed" in r.message]
+    assert len(warnings) == 1                    # reports, doesn't flood

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
@@ -187,6 +187,15 @@ class AppManifest:
     summary: str = ""
     requires_tasks: list[str] = field(default_factory=list)
     requires_adapters: list[str] = field(default_factory=list)
+    # RFC-0002 Phase 5: event scopes this app requests, e.g.
+    # ["events:plate.recognized"]. Scopes name DOMAIN events (the
+    # opennvr.events.* tree, docs/EVENT_CONTRACTS.md) — plate reads are
+    # PII (decision 6), so consuming them is a declared, granted,
+    # audited capability, visible in the App Catalog. Registration
+    # auto-grants and audits each scope today; bus-side enforcement
+    # (per-app NATS users whose subscribe permissions ARE the grants)
+    # is the staged follow-up recorded in the RFC.
+    requires_scopes: list[str] = field(default_factory=list)
     subscribes: str | None = None
     params: list[Param] = field(default_factory=list)
     emits: list[AlertType] = field(default_factory=list)
@@ -214,6 +223,7 @@ class AppManifest:
             "summary": self.summary,
             "requires_tasks": list(self.requires_tasks),
             "requires_adapters": list(self.requires_adapters),
+            "requires_scopes": list(self.requires_scopes),
             "subscribes": self.subscribes,
             "params": [p.to_dict() for p in self.params],
             "emits": [a.to_dict() for a in self.emits],

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -626,6 +626,24 @@ async def register_app(
             ),
         },
     )
+    # RFC-0002 Phase 5: event-scope grants. v1 policy is grant-on-
+    # registration — but every grant is a distinct audit row (the RFC's
+    # "every grant audited"), the manifest snapshot makes grants
+    # catalog-visible, and the audit trail is what a future deny policy
+    # or bus-side enforcement (per-app NATS users) will reconcile from.
+    scopes = manifest.get("requires_scopes") or []
+    if isinstance(scopes, list):
+        for scope in scopes:
+            if not isinstance(scope, str) or not scope.strip():
+                continue
+            write_audit_log(
+                db,
+                action="app.scope_granted",
+                user_id=principal.id if principal is not None else None,
+                entity_type="app",
+                entity_id=app_id,
+                details={"scope": scope.strip(), "policy": "grant-on-registration"},
+            )
     return _serialize_app(row)
 
 

--- a/server/tests/test_app_ui_proxy.py
+++ b/server/tests/test_app_ui_proxy.py
@@ -57,3 +57,11 @@ def test_route_is_user_jwt_only_like_actions():
 def test_size_cap_is_a_real_number():
     # A dashboard is a small page; the cap guards the proxy, not taste.
     assert 0 < UI_PROXY_MAX_BYTES <= 5_000_000
+
+
+def test_register_route_audits_scope_grants():
+    # RFC-0002 Phase 5: "every grant audited" — source-level guard that
+    # registration writes one app.scope_granted row per manifest scope.
+    src = (_HERE / "routers" / "apps.py").read_text()
+    assert 'action="app.scope_granted"' in src
+    assert '"policy": "grant-on-registration"' in src


### PR DESCRIPTION
The last phase. A runaway consumer now degrades ITSELF instead of starving the stack, and consuming PII-bearing domain events is a declared, granted, audited, catalog-visible capability.

Budgets (kai_c/budgets.py, enforced in /api/v1/infer):
- calls/min per (adapter, camera), sliding one-minute windows. KAI-C is the enforcement point for the same reason it hosts the Phase 0 normaliser: every governed initiator (dispatch, enrichment, apps) already meets there, so budgets need no caller cooperation.
- Shed-and-report, never silent (Tier-0's region-shedding discipline): over-budget = §3.5-shaped 429 (transient, named limit), the previously-unused inference.refused_budget audit event, kaic_budget_shed_total{adapter,camera} on /metrics, and a WARNING rate-limited to once per window per bucket — a storm reports itself without becoming its own flood.
- Config: KAIC_BUDGET_PER_CAMERA_PER_MIN (default 120; 0 = off) + KAIC_BUDGET_OVERRIDES ('fast_plate_ocr=30,caption=60'). Calls without a camera_id are exempt (probes and operator one-offs are not per-camera skill traffic). Buckets bounded at 4096, stalest evicted (one minute of grace — the cheap failure direction).

Scopes:
- AppManifest.requires_scopes (e.g. events:plate.recognized); LPR declares it — plates are PII (decision 6), so who consumes them is visible on the app page, not buried in code.
- Registration auto-grants, writing one app.scope_granted audit row per scope ('every grant audited'); the App Catalog renders the granted scopes.
- Bus-side enforcement is the ONE Phase 5 piece deliberately staged: every bus client shares the deployment token today, so a grant is policy + audit, not yet a wire barrier. The RFC now records the enforcement design (per-app NATS users whose subscribe permissions ARE the grants, rendered from the grant table, broker reloaded) and why it wants its own review (per-app credential delivery).
- RFC Phase 5 checkboxes updated to exactly this state.

Tests: 10 budget tests (limit/slide/isolation/exemptions/overrides/ env/metrics/bucket-cap/log-rate-limit; sabotage-verified: collapsing the per-camera key fails 3), grant-audit source guard. Suites: kai-c 173, server 935, SDK 201, LPR 18; frontend build passes.