### PR TITLE
feat(sdk+app): app store listing — ui_mode internal/external + catalo…

### DIFF
--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -74,6 +74,27 @@ export type AppManifest = {
   // registration, each grant audited) — plate reads are PII, so who
   // consumes them is visible here, not buried in code.
   requires_scopes?: string[]
+  // How the app's UI reaches the operator: "internal" (default) embeds
+  // the sandboxed /ui dashboard; "external" means the app is a full
+  // application — the catalog shows an "Open app" button to ui_url
+  // ("{host}" in it is replaced with the browser's hostname).
+  ui_mode?: 'internal' | 'external'
+  ui_url?: string
+  // Store listing (the Details section): long-form description
+  // (blank-line-separated paragraphs), authorship, and the concrete
+  // jobs the app solves.
+  description?: string
+  author?: string
+  website?: string
+  license?: string
+  use_cases?: string[]
+}
+
+/** Resolve an external ui_url for THIS browser: apps rarely know their
+ * deployment hostname at build time, so "{host}" is substituted with
+ * wherever the operator is browsing from. */
+export function resolveUiUrl(uiUrl: string): string {
+  return uiUrl.split('{host}').join(window.location.hostname)
 }
 
 export type ManifestAction = {

--- a/app/src/views/AppView.tsx
+++ b/app/src/views/AppView.tsx
@@ -26,7 +26,7 @@
 import { useMemo, useState } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Boxes, RefreshCw, Settings2, Trash2, Activity } from 'lucide-react'
+import { ArrowLeft, Boxes, RefreshCw, Settings2, Trash2, Activity, ExternalLink, BookOpen } from 'lucide-react'
 import { apiService } from '../lib/apiService'
 import { extractApiError } from '../lib/apiError'
 import { useSnackbar } from '../components/Snackbar'
@@ -37,6 +37,7 @@ import {
   LiveStateViews,
   asStringList,
   statusVariant,
+  resolveUiUrl,
   type RegisteredApp,
   type AppStatusResp,
   type ManifestAction,
@@ -119,7 +120,12 @@ export function AppView() {
     return set
   }, [caps.data])
 
-  const hasUi = Boolean(app?.manifest?.has_ui)
+  // "internal" embeds the sandboxed /ui dashboard; "external" means the
+  // app is a full application — we link out instead of embedding.
+  const uiMode = app?.manifest?.ui_mode === 'external' ? 'external' : 'internal'
+  const externalUrl =
+    uiMode === 'external' && app?.manifest?.ui_url ? resolveUiUrl(app.manifest.ui_url) : null
+  const hasUi = Boolean(app?.manifest?.has_ui) && uiMode === 'internal'
   const appUi = useAppUi(appId, hasUi && Boolean(app?.enabled))
   const requires = asStringList(app?.manifest?.requires_tasks)
   const missing = requires.filter((t) => !availableTasks.has(t))
@@ -218,6 +224,16 @@ export function AppView() {
               <span className="text-xs text-[var(--text-dim)]">up {formatUptime(uptimeS)}</span>
             )}
             <div className="flex items-center gap-2 pt-1">
+              {externalUrl && (
+                <Button
+                  variant="primary"
+                  onClick={() => window.open(externalUrl, '_blank', 'noopener,noreferrer')}
+                  disabled={!app.enabled}
+                  title={app.enabled ? externalUrl : 'Enable the app first'}
+                >
+                  <ExternalLink size={14} /> Open app
+                </Button>
+              )}
               <Button
                 variant={app.enabled ? 'default' : 'primary'}
                 onClick={() => toggle.mutate()}
@@ -243,8 +259,35 @@ export function AppView() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* ── Live dashboard ─────────────────────────────────────── */}
+        {/* ── Details + live dashboard ───────────────────────────── */}
         <div className="lg:col-span-2 space-y-4">
+          {(app.manifest?.description || (app.manifest?.use_cases ?? []).length > 0) && (
+            <Card>
+              <CardHeader>
+                <BookOpen size={16} className="text-[var(--text-dim)]" />
+                <CardTitle>Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                {(app.manifest?.description ?? '')
+                  .split(/\n{2,}/)
+                  .map((p) => p.trim())
+                  .filter(Boolean)
+                  .map((p, i) => (
+                    <p key={i} className="leading-relaxed">{p}</p>
+                  ))}
+                {(app.manifest?.use_cases ?? []).length > 0 && (
+                  <div>
+                    <div className="text-xs text-[var(--text-dim)] mb-1">What you can do with it</div>
+                    <ul className="list-disc pl-5 space-y-0.5">
+                      {(app.manifest?.use_cases ?? []).map((u) => (
+                        <li key={u}>{u}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
           {hasUi && app.enabled && (
             <Card>
               <CardHeader>
@@ -345,6 +388,32 @@ export function AppView() {
                       <Badge key={sc} variant="info">{sc}</Badge>
                     ))}
                   </div>
+                </div>
+              )}
+              {(app.manifest?.author || app.manifest?.website || app.manifest?.license) && (
+                <div className="space-y-1">
+                  {app.manifest?.author && (
+                    <div className="text-xs text-[var(--text-dim)]">
+                      By <span className="text-[var(--text)]">{app.manifest.author}</span>
+                    </div>
+                  )}
+                  {app.manifest?.website && (
+                    <div className="text-xs">
+                      <a
+                        href={app.manifest.website}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="text-[var(--accent,var(--text))] hover:underline inline-flex items-center gap-1"
+                      >
+                        <ExternalLink size={11} /> {app.manifest.website}
+                      </a>
+                    </div>
+                  )}
+                  {app.manifest?.license && (
+                    <div className="text-xs text-[var(--text-dim)]">
+                      License: {app.manifest.license}
+                    </div>
+                  )}
                 </div>
               )}
               {app.url && (

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -101,6 +101,33 @@ MANIFEST = AppManifest(
         AlertType("plate_watchlist", severity="high"),
     ],
     has_ui=True,   # GET /ui dashboard, proxied at /api/v1/apps/{id}/ui
+    ui_mode="internal",
+    # Store listing — what the catalog's Details section renders. This
+    # example is the reference for community manifests: fill these in
+    # and your app has a storefront, no frontend work needed.
+    description=(
+        "Turns any camera into a license plate reader. The platform runs "
+        "the detect → crop → OCR chain once per vehicle visit and "
+        "publishes plate.recognized.v1 events; this app consumes them "
+        "and applies your watchlists live.\n\n"
+        "Plates on the denylist raise a high-severity alert the moment "
+        "they are read; allowlisted plates log as expected vehicles; "
+        "everything else is recorded with its evidence photo. Every read "
+        "is kept in the timeline with the best frame, searchable from "
+        "the Vehicles page.\n\n"
+        "Assign cameras the License Plate Recognition skill "
+        "(Cameras → edit → Assignments) to choose where OCR runs — "
+        "inference is budgeted and runs in the platform, not in this app."
+    ),
+    author="OpenNVR",
+    website="https://github.com/open-nvr/open-nvr",
+    license="AGPL-3.0",
+    use_cases=[
+        "Alert the moment a watchlisted plate passes any camera",
+        "Log every vehicle with plate, time and evidence photo",
+        "Expected-vehicle handling for known cars (allowlist)",
+        "Searchable vehicle history from the Vehicles page",
+    ],
     state_schema=[
         StateView(name="allowlist_size", label="Allowlist",
                   kind="metric", path="allowlist_size"),

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
@@ -211,6 +211,44 @@ class AppManifest:
     # HTML dashboard at GET /ui on its contract port, and core proxies
     # it at /api/v1/apps/{id}/ui (the catalog renders it sandboxed).
     has_ui: bool = False
+    # How the app's UI reaches the operator:
+    #   "internal" (default) — the sandboxed GET /ui dashboard above is
+    #       the whole surface, embedded in the catalog's app page.
+    #   "external" — the app is a full application with its own web UI
+    #       (multi-page, scripted, its own auth); the catalog renders an
+    #       "Open app" button instead of embedding. External UIs are NOT
+    #       proxied by core: the operator's browser talks to the app
+    #       directly, so ``ui_url`` must be reachable from the browser,
+    #       not just the compose network.
+    ui_mode: str = "internal"
+    # Where "Open app" points when ``ui_mode="external"``. Apps rarely
+    # know their deployment hostname at build time, so the literal
+    # placeholder ``{host}`` is replaced by the catalog with the hostname
+    # the operator is browsing from: ``"http://{host}:8090/"``.
+    ui_url: str = ""
+
+    # ── Store listing (the catalog's Details section) ───────────────
+    # The app's storefront: the catalog app page renders these so an
+    # operator can understand the app completely before enabling it.
+    # ``description`` is long-form text — blank-line-separated blocks
+    # render as paragraphs. ``use_cases`` is a short list of the
+    # concrete jobs the app solves ("Alarm on unregistered vehicles").
+    description: str = ""
+    author: str = ""
+    website: str = ""
+    license: str = ""
+    use_cases: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.ui_mode not in ("internal", "external"):
+            raise ValueError(
+                f"ui_mode must be 'internal' or 'external', got {self.ui_mode!r}"
+            )
+        if self.ui_mode == "external" and not self.ui_url:
+            raise ValueError(
+                "ui_mode='external' requires ui_url (the browser-reachable "
+                "URL of the app's UI; '{host}' is substituted by the catalog)"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """The ``GET /manifest`` payload (and the ``manifest_json``
@@ -230,4 +268,11 @@ class AppManifest:
             "state_schema": [v.to_dict() for v in self.state_schema],
             "actions": [a.to_dict() for a in self.actions],
             "has_ui": bool(self.has_ui),
+            "ui_mode": self.ui_mode,
+            "ui_url": self.ui_url,
+            "description": self.description,
+            "author": self.author,
+            "website": self.website,
+            "license": self.license,
+            "use_cases": list(self.use_cases),
         }

--- a/sdk/opennvr-app-sdk/tests/test_manifest.py
+++ b/sdk/opennvr-app-sdk/tests/test_manifest.py
@@ -94,3 +94,49 @@ def test_state_view_serializes_and_defaults_empty():
         "columns": [], "description": "",
     }
     assert wire[1]["columns"] == ["id", "count"]
+
+
+# ── App-UI mode + store listing ─────────────────────────────────────
+
+
+def test_ui_and_listing_defaults():
+    d = AppManifest(id="x", name="X", version="1", category="test").to_dict()
+    assert d["ui_mode"] == "internal"
+    assert d["ui_url"] == ""
+    assert d["description"] == ""
+    assert d["author"] == ""
+    assert d["website"] == ""
+    assert d["license"] == ""
+    assert d["use_cases"] == []
+
+
+def test_external_ui_mode_serializes():
+    m = AppManifest(
+        id="x", name="X", version="1", category="test",
+        ui_mode="external", ui_url="http://{host}:8090/",
+        description="Long form.\n\nSecond paragraph.",
+        author="Acme", website="https://acme.example", license="MIT",
+        use_cases=["Alarm on unregistered vehicles", "Gate history"],
+    )
+    d = m.to_dict()
+    assert d["ui_mode"] == "external"
+    assert d["ui_url"] == "http://{host}:8090/"
+    assert d["use_cases"] == ["Alarm on unregistered vehicles", "Gate history"]
+    import json
+    json.dumps(d)  # listing fields must stay JSON-serializable
+
+
+def test_unknown_ui_mode_rejected():
+    import pytest
+
+    with pytest.raises(ValueError, match="ui_mode"):
+        AppManifest(id="x", name="X", version="1", category="test",
+                    ui_mode="popup")
+
+
+def test_external_without_url_rejected():
+    import pytest
+
+    with pytest.raises(ValueError, match="ui_url"):
+        AppManifest(id="x", name="X", version="1", category="test",
+                    ui_mode="external")


### PR DESCRIPTION
…g Details section

The catalog's app page becomes a real storefront, and full applications get a first-class door:

- SDK manifest: ui_mode ('internal' = the sandboxed GET /ui dashboard embedded as today; 'external' = the app is a full multi-page application — the catalog renders an 'Open app' button to ui_url instead of embedding). ui_url supports a '{host}' placeholder the catalog substitutes with the operator's browsing hostname, since apps rarely know their deployment host at build time. Validated in __post_init__: unknown modes and external-without-url fail at app boot, not silently in the catalog.
- SDK manifest store listing: description (blank-line paragraphs), author, website, license, use_cases — the app's storefront, rendered by the catalog with zero app-specific frontend code.
- AppView: Details card (description + 'What you can do with it'), About card gains author/website/license, header gains the external 'Open app' button; the embedded dashboard only renders for ui_mode internal.
- LPR example manifest fills the listing in — the reference for community manifests.

Server untouched: the manifest is a passthrough snapshot, so older cores store and serve the new fields unchanged.