### PR TITLE
feat(sdk+apps): barrier control — access.decided.v1 + gate-controller…

### DIFF
--- a/app/src/views/Vehicles.tsx
+++ b/app/src/views/Vehicles.tsx
@@ -428,6 +428,8 @@ export function Vehicles() {
     [registry]
   )
   const alarmOnUnknown = Boolean((lprApp?.config as any)?.alarm_on_unknown)
+  const barrierMode: 'off' | 'registered' =
+    (lprApp?.config as any)?.barrier_mode === 'registered' ? 'registered' : 'off'
 
   // Camera roles — which camera is the entry gate, the exit, parking,
   // or another named location — are the vertical's settings, so they
@@ -633,6 +635,14 @@ export function Vehicles() {
         <RegistryTab
           registry={registry}
           alarmOnUnknown={alarmOnUnknown}
+          barrierMode={barrierMode}
+          onToggleBarrier={(on) => {
+            saveConfig.mutate({ barrier_mode: on ? 'registered' : 'off' }, {
+              onSuccess: () => showSuccess(
+                on ? 'Automatic barrier ON — allow/deny decisions now publish for every gate-IN read'
+                   : 'Automatic barrier off'),
+            })
+          }}
           canEdit={Boolean(lprApp)}
           saving={saveConfig.isPending}
           cameras={camerasQuery.data ?? []}
@@ -992,6 +1002,8 @@ export function Vehicles() {
 function RegistryTab({
   registry,
   alarmOnUnknown,
+  barrierMode,
+  onToggleBarrier,
   canEdit,
   saving,
   cameras,
@@ -1002,6 +1014,8 @@ function RegistryTab({
 }: {
   registry: RegistryEntry[]
   alarmOnUnknown: boolean
+  barrierMode: 'off' | 'registered'
+  onToggleBarrier: (on: boolean) => void
   canEdit: boolean
   saving: boolean
   cameras: CameraRow[]
@@ -1090,6 +1104,34 @@ function RegistryTab({
             disabled={saving}
           >
             {alarmOnUnknown ? 'Turn off' : 'Turn on'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Automatic barrier — the decision half of gate automation */}
+      <Card>
+        <CardContent className="py-3 flex flex-wrap items-center gap-3">
+          <Car size={18} className={barrierMode === 'registered' ? 'text-[var(--success,#46a758)]' : 'text-[var(--text-dim)]'} />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium">Automatic barrier</div>
+            <div className="text-xs text-[var(--text-dim)]">
+              Publish an allow/deny decision for every read on a Gate IN camera —
+              registered and allowlisted vehicles allow, everything else denies.
+              Install the <b>Gate Controller</b> app from the catalog to wire the
+              decisions to your relay; it ships in dry-run so nothing moves until
+              you say so.
+              {!Object.values(cameraRoles).some((r) => r.role === 'gate_in') &&
+                ' Needs at least one Gate IN camera below.'}
+            </div>
+          </div>
+          <Button
+            variant={barrierMode === 'registered' ? 'outline' : 'primary'}
+            className={barrierMode === 'registered'
+              ? 'text-[var(--danger,#e5484d)] border-[var(--danger,#e5484d)]' : ''}
+            onClick={() => onToggleBarrier(barrierMode !== 'registered')}
+            disabled={saving}
+          >
+            {barrierMode === 'registered' ? 'Turn off' : 'Turn on'}
           </Button>
         </CardContent>
       </Card>

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -531,6 +531,67 @@ services:
       - opennvr_internal
 
   # ──────────────────────────────────────────────────────────────
+  # Gate controller — barrier actuation for access.decided.v1: pulses
+  # an HTTP relay per gate camera when the LPR app (barrier mode)
+  # publishes an allow; deny and unknown decisions actuate nothing.
+  # Ships with dry_run: true — commission from the catalog, then turn
+  # it off. Contract surface on :9210.
+  # ──────────────────────────────────────────────────────────────
+  gate-controller-config-init:
+    profiles: [apps]
+    image: alpine:3.20
+    container_name: opennvr_gate_controller_config_init
+    logging: *svc-logs
+    restart: "no"
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        sed_esc() { printf '%s' "$$1" | sed -e 's/\\/\\\\/g; s/&/\\&/g; s/\//\\\//g'; }
+        ikey=$$(sed_esc "$${INTERNAL_API_KEY}")
+        sed -e "s/[$$][{]INTERNAL_API_KEY[}]/$$ikey/g" \
+            < /template/config.docker.yml > /generated/config.yml
+        echo "Wrote /generated/config.yml (gate-controller) from template."
+    environment:
+      - INTERNAL_API_KEY=${INTERNAL_API_KEY}
+    volumes:
+      - ./examples/gate-controller:/template:ro
+      - opennvr_gate_controller_config:/generated
+
+  gate-controller:
+    profiles: [apps]
+    build:
+      context: .
+      dockerfile: examples/gate-controller/Dockerfile
+    # Digest pin slot — see docs/APPS_INSTALL.md → Digest pinning.
+    image: ${GATE_CONTROLLER_IMAGE:-opennvr/gate-controller:local-build}
+    container_name: opennvr_gate_controller
+    logging: *svc-logs
+    restart: unless-stopped
+    depends_on:
+      gate-controller-config-init:
+        condition: service_completed_successfully
+      nats:
+        condition: service_healthy
+      opennvr-core:
+        condition: service_healthy
+    environment:
+      - OPENNVR_INTERNAL_API_KEY=${INTERNAL_API_KEY}
+      - NATS_URL=nats://nats:4222
+      - OPENNVR_URL=http://opennvr-core:8000
+    # Contract surface (/health /manifest /state) — internal-only.
+    expose:
+      - "9210"
+    volumes:
+      - opennvr_gate_controller_config:/app/config:ro
+    command:
+      - --config
+      - /app/config/config.yml
+    networks:
+      - opennvr_internal
+
+  # ──────────────────────────────────────────────────────────────
   # Smart doorbell — face recognition at the door via InsightFace
   # through KAI-C (FrameApp); known visitors low-severity, strangers
   # high with a snapshot. Contract surface on :9206.
@@ -814,6 +875,7 @@ volumes:
   opennvr_abandoned_object_config:
   opennvr_intrusion_detection_config:
   opennvr_license_plate_recognition_config:
+  opennvr_gate_controller_config:
   opennvr_fast_plate_ocr_cache:
   opennvr_smart_doorbell_config:
   opennvr_package_delivery_config:

--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -194,6 +194,35 @@ dispatcher dual-publishes to the domain subject so consumers that
 only care "an alert fired on this camera" stop encoding app names in
 subscriptions. New consumers use the domain subject.
 
+### `access.decided.v1`
+
+Subject: `opennvr.events.access.decided.v1.<camera_id>`
+Producer: `app:license-plate-recognition` (or any app making gate
+decisions — consumers must not branch on the producer, per the
+envelope contract).
+
+One event per plate read **on a gate-in camera while the publishing
+app's barrier mode is enabled** — the app's admission decision as a
+fact on the bus. Actuation is a separate concern on purpose: a
+gateway app (the `gate-controller` example) subscribes and drives the
+site's relay/barrier hardware, so decision policy and hardware wiring
+evolve independently, and an audit trail of every decision exists
+whether or not a barrier is attached.
+
+`payload`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `plate_text` | string | The normalised read (uppercase, no separators). |
+| `decision` | string | `allow` or `deny`. |
+| `reason` | string | Why: `registered`, `allowlisted`, `monitored`, `expired_pass`, `unknown`. |
+| `owner` | string \| null | Registry owner, when the plate is registered (helps gate displays/logs). |
+| `unit` | string \| null | Registry unit/flat, when registered. |
+| `confidence` | number \| null | OCR confidence carried from the read, when available. |
+
+Consumers MUST treat any decision other than `allow` as "do not
+actuate" — unknown future decision values fail closed.
+
 ## Out of contract (deliberately)
 
 * `opennvr.inference.>` payload internals beyond what each adapter's

--- a/examples/gate-controller/Dockerfile
+++ b/examples/gate-controller/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+# gate-controller example app
+#
+# Build (from the open-nvr repo root — the context must include
+# sdk/opennvr-app-sdk, which this app depends on):
+#   docker build -f examples/gate-controller/Dockerfile -t opennvr/gate-controller:1.0.0 .
+#
+# Run (consumes access.decided.v1 from the compose bus):
+#   docker run --rm \
+#     --network opennvr_internal \
+#     -v $(pwd)/config.yml:/app/config.yml:ro \
+#     opennvr/gate-controller:1.0.0 \
+#     --config /app/config.yml
+#
+# Or use the repo-root docker-compose.apps.yml overlay, which builds
+# this image, generates the config from config.docker.yml, and wires
+# registry self-registration automatically.
+
+FROM python:3.11-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# The SDK owns the whole runtime stack (nats-py subscription + alert
+# fan-out, httpx relay calls, PyYAML config, the Detector loop and §03
+# contract server). No inference, no pixels — bus in, relay out.
+COPY sdk/opennvr-app-sdk /opt/opennvr-app-sdk
+RUN pip install --no-cache-dir /opt/opennvr-app-sdk
+
+COPY examples/gate-controller/gate_controller.py   ./gate_controller.py
+COPY examples/gate-controller/config.example.yml   ./config.example.yml
+
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "gate_controller.py"]
+CMD ["--config", "config.yml"]

--- a/examples/gate-controller/README.md
+++ b/examples/gate-controller/README.md
@@ -1,0 +1,22 @@
+# gate-controller
+
+Barrier actuation for OpenNVR gate automation. Consumes the platform's
+contracted `access.decided.v1` events (published by the License Plate
+Recognition app when its barrier mode is on) and pulses an HTTP relay
+when — and only when — the decision is `allow`. Deny, and any decision
+value it does not recognise, actuates nothing: **fail closed**.
+
+Works with any HTTP-reachable relay (Shelly, Tasmota, ESPHome, most
+commercial barrier controllers). Per-gate cooldown keeps one car to
+one pulse; a failed relay call raises a high-severity `barrier_fault`
+alert and stays retriable by the next decision; `dry_run: true` (the
+Docker default) lets you commission a site before touching hardware.
+
+The policy/hardware split is the point: the LPR app knows **who** may
+enter and never touches hardware; this app knows **which relay opens
+which gate** and never makes admission judgements. Either side can be
+replaced independently — the contract between them is one documented
+event (`docs/EVENT_CONTRACTS.md`).
+
+Run: `python gate_controller.py --config config.yml`
+(copy `config.example.yml`), or install from the App Catalog.

--- a/examples/gate-controller/config.docker.yml
+++ b/examples/gate-controller/config.docker.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# gate-controller config consumed by docker-compose.apps.yml.
+# ${INTERNAL_API_KEY} is substituted by the config-init container at
+# compose-up time (same pattern as the other shipped apps).
+#
+# The relay map is OPERATOR CONFIG: set it from the App Catalog's
+# Configure form (applied live), or edit here and re-up. Dry-run ships
+# ON so a fresh install can never pulse hardware by surprise —
+# commission the site, then turn it off from the catalog.
+
+nats_url: "nats://nats:4222"
+nats_token: "${INTERNAL_API_KEY}"
+
+relays: {}
+pulse_cooldown_seconds: 5.0
+dry_run: true
+
+webhook_url: null
+nats_alerts_url: "nats://nats:4222"
+nats_alerts_token: "${INTERNAL_API_KEY}"
+
+contract_port: 9210
+contract_bind_host: "0.0.0.0"
+contract_host: "gate-controller"   # the compose service name
+opennvr_url: "http://opennvr-core:8000"

--- a/examples/gate-controller/config.example.yml
+++ b/examples/gate-controller/config.example.yml
@@ -1,0 +1,34 @@
+# gate-controller example config. Copy to config.yml and edit.
+
+# ── The event bus (where access.decided.v1 flows) ───────────────────
+nats_url: "nats://localhost:4222"
+nats_token: null
+
+# ── Which relay opens which gate ────────────────────────────────────
+# Keys are camera core ids ("1") or platform handles ("cam1"); values
+# are the relay's trigger URL (GET default) or {url, method: POST}.
+# Any HTTP relay works: Shelly (http://<ip>/relay/0?turn=on), Tasmota
+# (http://<ip>/cm?cmnd=Power%20TOGGLE), ESPHome, commercial barrier
+# relays with an HTTP input.
+relays: {}
+#  "1": "http://192.168.1.50/relay/0?turn=on"
+#  "2": { url: "http://192.168.1.51/pulse", method: POST }
+
+# One car, one pulse: suppress re-triggering the same gate within
+# this many seconds (the boom is already up).
+pulse_cooldown_seconds: 5.0
+
+# Commissioning mode: log + alert as if opening, never call the relay.
+dry_run: false
+
+# ── Alert delivery ──────────────────────────────────────────────────
+webhook_url: null
+nats_alerts_url: null
+nats_alerts_token: null
+
+# ── App contract (spec §03) — powers the App Catalog ────────────────
+contract_port: 9210
+contract_bind_host: "0.0.0.0"
+contract_host: "localhost"
+opennvr_url: null
+opennvr_token: null

--- a/examples/gate-controller/gate_controller.py
+++ b/examples/gate-controller/gate_controller.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+gate-controller — barrier actuation for ``access.decided.v1``.
+
+The License Plate Recognition app (or any decision-making app) puts
+the ADMISSION DECISION on the bus as a contracted fact
+(docs/EVENT_CONTRACTS.md ``access.decided.v1``). This app is the
+hardware side of that split: it subscribes to decisions and pulses a
+relay when the decision is ``allow`` — barrier booms, sliding gates,
+door strikes, anything reachable as an HTTP relay (Shelly, Tasmota,
+ESPHome, most commercial gate relays expose one).
+
+Policy and wiring evolve independently on purpose: the LPR app knows
+WHO may enter (register, allowlist, monitors) and never touches
+hardware; this app knows WHICH relay opens WHICH gate and never makes
+admission judgements. Any decision other than ``allow`` — including
+decision values invented by future producers — actuates NOTHING
+(fail closed, per the contract).
+
+Zero inference, zero core access: the whole app is a NATS
+subscription and an HTTP call.
+
+Run:
+    python gate_controller.py --config config.yml
+"""
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx  # module attribute on purpose: tests monkeypatch gate_controller.httpx
+import yaml
+
+from opennvr_app_sdk import (
+    Alert,
+    AlertSource,
+    AlertType,
+    AppManifest,
+    Detector,
+    Param,
+    StateView,
+    app,
+    set_default_source,
+)
+
+logger = logging.getLogger("gate-controller")
+
+#: The contracted decision event this app consumes.
+DECISION_SUBJECT_PATTERN = "opennvr.events.access.decided.v1.>"
+DECISION_SCHEMA = "access.decided.v1"
+
+#: HTTP budget for one relay pulse. Barriers are near-field devices —
+#: if the relay hasn't answered in 3s it isn't going to.
+RELAY_TIMEOUT_SECONDS = 3.0
+
+
+def _camera_handle(key: Any) -> str:
+    """Relay-map keys may be numeric core ids (``"3"``) or platform
+    handles (``"cam3"``) — one normalisation, same as the LPR app."""
+    k = str(key).strip()
+    if not k:
+        return ""
+    return k if k.startswith("cam") else f"cam{k}"
+
+
+def parse_relays(raw: Any) -> dict[str, dict[str, str]]:
+    """``relays`` config → ``{camN: {url, method}}``.
+
+    Values may be a bare relay URL string or ``{url, method}``
+    (method GET default; POST for relays that want it). Entries
+    without a URL are skipped — a partly bad map must not take the
+    working gates down with it.
+    """
+    relays: dict[str, dict[str, str]] = {}
+    if not isinstance(raw, dict):
+        return relays
+    for key, value in raw.items():
+        handle = _camera_handle(key)
+        if not handle:
+            continue
+        if isinstance(value, str):
+            url, method = value.strip(), "GET"
+        elif isinstance(value, dict):
+            url = str(value.get("url") or "").strip()
+            method = str(value.get("method") or "GET").upper().strip()
+        else:
+            continue
+        if not url:
+            continue
+        if method not in ("GET", "POST"):
+            method = "GET"
+        relays[handle] = {"url": url, "method": method}
+    return relays
+
+
+MANIFEST = AppManifest(
+    id="gate-controller",
+    name="Gate Controller",
+    version="1.0.0",
+    category="automation",
+    summary=(
+        "Opens the barrier for allowed vehicles: consumes the "
+        "platform's access.decided.v1 events and pulses an HTTP relay "
+        "per gate camera. Deny (and anything unknown) actuates "
+        "nothing — fail closed."
+    ),
+    # No inference, no adapters — this app is bus + relay only.
+    requires_tasks=[],
+    # Consuming gate decisions is a declared, granted, audited scope.
+    requires_scopes=["events:access.decided"],
+    subscribes=DECISION_SUBJECT_PATTERN,
+    params=[
+        Param("relays", dict, default={},
+              description=(
+                  "Which relay opens which gate: {camera: url} or "
+                  "{camera: {url, method}}. Cameras by core id ('3') "
+                  "or handle ('cam3'); any HTTP relay works (Shelly, "
+                  "Tasmota, ESPHome, commercial gate relays).")),
+        Param("pulse_cooldown_seconds", float, default=5.0,
+              description=(
+                  "Per-gate re-trigger suppression — one car, one "
+                  "pulse, even when multiple allow decisions arrive "
+                  "while the boom is already up.")),
+        Param("dry_run", bool, default=False,
+              description=(
+                  "Log and alert as if opening, without calling the "
+                  "relay — for commissioning a site safely.")),
+    ],
+    emits=[
+        AlertType("barrier_opened", severity="low",
+                  description="Relay pulsed for an allowed vehicle."),
+        AlertType("barrier_fault", severity="high",
+                  description=(
+                      "The relay call failed — an allowed vehicle is "
+                      "waiting at a gate that did not open.")),
+    ],
+    state_schema=[
+        StateView(name="gates", label="Gates wired",
+                  kind="metric", path="gates_wired"),
+        StateView(name="opened", label="Barrier pulses",
+                  kind="metric", path="opened_total"),
+        StateView(name="denied", label="Denies seen",
+                  kind="metric", path="denied_total"),
+        StateView(name="faults", label="Relay faults",
+                  kind="metric", path="fault_total"),
+        StateView(name="recent", label="Recent gate activity",
+                  kind="log", path="recent", limit=12),
+    ],
+    description=(
+        "The hardware half of gate automation. The License Plate "
+        "Recognition app decides WHO may enter (its register, "
+        "allowlist and monitors) and publishes every decision as a "
+        "contracted access.decided.v1 event; this app decides nothing "
+        "— it wires those decisions to your site's relays and pulses "
+        "the right one when a vehicle is allowed.\n\n"
+        "Works with any HTTP-reachable relay: Shelly, Tasmota, "
+        "ESPHome, and most commercial barrier controllers. Per-gate "
+        "cooldown keeps one car to one pulse; dry-run mode lets you "
+        "commission a site before touching hardware; every pulse and "
+        "every fault raises an alert.\n\n"
+        "Deny decisions — and any decision value this app does not "
+        "recognise — actuate nothing. Fail closed is the contract."
+    ),
+    author="OpenNVR",
+    website="https://github.com/open-nvr/open-nvr",
+    license="AGPL-3.0",
+    contact="https://github.com/open-nvr/open-nvr/discussions",
+    use_cases=[
+        "Barrier lift for registered vehicles at society/campus gates",
+        "Factory truck gates: open only for the logistics register",
+        "Dry-run commissioning before wiring the relay",
+        "Audit trail: an alert for every pulse and every fault",
+    ],
+)
+
+
+# ── Config ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class AppConfig:
+    """Operator-tunable settings. Validated in ``load_config``."""
+
+    nats_url: str
+    nats_token: str | None = None
+    subject_pattern: str = DECISION_SUBJECT_PATTERN
+
+    relays: dict[str, Any] = field(default_factory=dict)
+    pulse_cooldown_seconds: float = 5.0
+    dry_run: bool = False
+
+    # Alert delivery (SDK stack: stdout always; webhook/NATS opt-in).
+    webhook_url: str | None = None
+    nats_alerts_url: str | None = None
+    nats_alerts_token: str | None = None
+
+    # App contract (spec §03) — /health /manifest /state + registry
+    # self-registration, all owned by the SDK.
+    contract_port: int | None = None
+    contract_bind_host: str | None = None
+    contract_host: str | None = None
+    opennvr_url: str | None = None
+    opennvr_token: str | None = None
+
+
+def load_config(path: str | Path) -> AppConfig:
+    raw = yaml.safe_load(Path(path).read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(f"config file {path} did not parse to a dict")
+    nats_url = raw.get("nats_url")
+    if not nats_url:
+        raise ValueError(
+            "config: nats_url is required — this app consumes the "
+            "platform's access.decided.v1 events from the bus")
+    return AppConfig(
+        nats_url=str(nats_url),
+        nats_token=raw.get("nats_token") or None,
+        subject_pattern=str(
+            raw.get("subject_pattern") or DECISION_SUBJECT_PATTERN),
+        relays=dict(raw.get("relays") or {}),
+        pulse_cooldown_seconds=float(raw.get("pulse_cooldown_seconds", 5.0)),
+        dry_run=bool(raw.get("dry_run", False)),
+        webhook_url=raw.get("webhook_url"),
+        nats_alerts_url=raw.get("nats_alerts_url"),
+        nats_alerts_token=raw.get("nats_alerts_token"),
+        contract_port=(
+            int(raw["contract_port"]) if raw.get("contract_port") is not None else None
+        ),
+        contract_bind_host=raw.get("contract_bind_host"),
+        contract_host=raw.get("contract_host"),
+        opennvr_url=raw.get("opennvr_url"),
+        opennvr_token=raw.get("opennvr_token"),
+    )
+
+
+# ── The app ─────────────────────────────────────────────────────────
+
+
+class GateController(Detector):
+    """access.decided.v1 → relay pulse (allow only, cooldown, alerts)."""
+
+    manifest = MANIFEST
+    load_config = staticmethod(load_config)
+
+    def setup(self) -> None:
+        cfg = self.cfg
+        self._relays: dict[str, dict[str, str]] = parse_relays(cfg.relays)
+        self._cooldown: float = max(0.0, float(cfg.pulse_cooldown_seconds))
+        self._dry_run: bool = bool(cfg.dry_run)
+        self._last_pulse: dict[str, float] = {}   # camera → monotonic ts
+        self._opened = 0
+        self._denied = 0
+        self._faults = 0
+        self._recent: deque[dict[str, Any]] = deque(maxlen=25)
+
+    # ── One decision envelope ──────────────────────────────────────
+
+    def handle_event(self, event: Any) -> list[Alert]:
+        if not isinstance(event, dict):
+            return []
+        if event.get("schema") != DECISION_SCHEMA:
+            return []
+        self._contract_note_event()
+        camera_id = str(event.get("camera_id") or "")
+        payload = event.get("payload")
+        if not camera_id or not isinstance(payload, dict):
+            return []
+        decision = payload.get("decision")
+        plate = str(payload.get("plate_text") or "?")
+
+        # THE contract rule: anything but a literal "allow" actuates
+        # nothing — deny today, and decision values invented by future
+        # producers, all fail closed.
+        if decision != "allow":
+            self._denied += 1
+            self._note(f"{plate} at {camera_id}: "
+                       f"{payload.get('reason') or decision} — gate stays closed",
+                       "info")
+            return []
+
+        relay = self._relays.get(camera_id)
+        if relay is None:
+            # An allow at a camera with no wired relay is normal (not
+            # every gate-in camera has a barrier) — log, don't alert.
+            self._note(f"{plate} allowed at {camera_id} (no relay wired)",
+                       "info")
+            return []
+
+        now = time.monotonic()
+        last = self._last_pulse.get(camera_id)
+        if self._cooldown > 0 and last is not None and (now - last) < self._cooldown:
+            self._note(f"{plate} allowed at {camera_id} — boom already up "
+                       f"(cooldown)", "info")
+            return []
+
+        ok = True
+        if not self._dry_run:
+            ok = self._pulse(relay)
+        # Cooldown starts only on an ACTUAL pulse (or dry-run pretend):
+        # a failed relay must be retriable by the very next decision.
+        if ok:
+            self._last_pulse[camera_id] = now
+
+        owner = payload.get("owner")
+        who = f"{plate}" + (f" ({owner})" if owner else "")
+        if ok:
+            self._opened += 1
+            note = " [dry run]" if self._dry_run else ""
+            alert = Alert(
+                severity="low",
+                title=f"Barrier opened for {who}{note}",
+                description=(
+                    f"Allowed vehicle {who} at {camera_id} "
+                    f"({payload.get('reason') or 'allow'}); relay "
+                    f"{relay['method']} {relay['url']}{note}."),
+                camera_id=camera_id,
+                source=AlertSource(),
+                correlation_id=event.get("correlation_id"),
+                evidence={"plate_text": plate, "relay_url": relay["url"],
+                          "dry_run": self._dry_run},
+            )
+            self._note(f"OPENED for {who} at {camera_id}{note}", "low")
+        else:
+            self._faults += 1
+            alert = Alert(
+                severity="high",
+                title=f"Barrier FAULT at {camera_id} — {who} waiting",
+                description=(
+                    f"Relay call failed for allowed vehicle {who}: "
+                    f"{relay['method']} {relay['url']}. The gate did "
+                    f"not open."),
+                camera_id=camera_id,
+                source=AlertSource(),
+                correlation_id=event.get("correlation_id"),
+                evidence={"plate_text": plate, "relay_url": relay["url"]},
+            )
+            self._note(f"FAULT at {camera_id} for {who}", "high")
+        self._dispatcher.fire(alert)
+        self._contract_note_alerts(1)
+        return [alert]
+
+    def _pulse(self, relay: dict[str, str]) -> bool:
+        """One relay call. True = the relay answered 2xx."""
+        try:
+            if relay["method"] == "POST":
+                resp = httpx.post(relay["url"], timeout=RELAY_TIMEOUT_SECONDS)
+            else:
+                resp = httpx.get(relay["url"], timeout=RELAY_TIMEOUT_SECONDS)
+            return 200 <= resp.status_code < 300
+        except Exception as exc:  # noqa: BLE001 — relay trouble is a fault, not a crash
+            logger.warning("relay pulse failed (%s %s): %s",
+                           relay["method"], relay["url"], exc)
+            return False
+
+    def _note(self, message: str, level: str) -> None:
+        self._recent.append(
+            {"message": message, "time": time.time(), "level": level})
+
+    # ── Contract surface ───────────────────────────────────────────
+
+    def state_snapshot(self) -> dict[str, Any]:
+        return {
+            "gates_wired": len(self._relays),
+            "opened_total": self._opened,
+            "denied_total": self._denied,
+            "fault_total": self._faults,
+            "dry_run": self._dry_run,
+            "recent": list(self._recent),
+        }
+
+    def on_config_update(self, config: dict[str, Any]) -> None:
+        """Relay map, cooldown and dry-run all apply live."""
+        if "relays" in config:
+            relays = parse_relays(config.get("relays"))
+            if relays != self._relays:
+                self._relays = relays
+                logger.info("relay map updated live: %d gates", len(relays))
+        if "pulse_cooldown_seconds" in config:
+            try:
+                self._cooldown = max(
+                    0.0, float(config.get("pulse_cooldown_seconds", 5.0)))
+            except (TypeError, ValueError):
+                pass
+        if "dry_run" in config:
+            self._dry_run = bool(config.get("dry_run"))
+
+
+# This process is the gate-controller app.
+set_default_source(kind="app", name="gate-controller", version="1.0.0")
+
+
+def main(argv: list[str] | None = None) -> int:
+    return app(GateController, load_config=load_config).run(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/examples/gate-controller/pyproject.toml
+++ b/examples/gate-controller/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "opennvr-example-gate-controller"
+version = "1.0.0"
+description = "OpenNVR gate-controller example app — pulses HTTP relays on access.decided.v1 allow decisions"
+requires-python = ">=3.11"
+license = { text = "AGPL-3.0" }
+
+# The SDK owns the runtime stack (nats-py subscriber loop, httpx,
+# PyYAML config, the alert dispatcher and contract surface) — this app
+# is a subscription and an HTTP call.
+dependencies = [
+    "opennvr-app-sdk",
+]
+
+[tool.uv.sources]
+opennvr-app-sdk = { path = "../../sdk/opennvr-app-sdk", editable = true }
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+asyncio_mode = "auto"

--- a/examples/gate-controller/tests/test_gate_controller.py
+++ b/examples/gate-controller/tests/test_gate_controller.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""GateController — decisions in, relay pulses out, fail closed."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import gate_controller as gc
+from gate_controller import AppConfig, GateController, load_config, parse_relays
+
+
+def _config(**overrides) -> AppConfig:
+    base = AppConfig(nats_url="nats://test:4222",
+                     relays={"1": "http://relay/open"})
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+def _controller(**overrides) -> tuple[GateController, MagicMock]:
+    dispatcher = MagicMock()
+    return GateController(_config(**overrides), dispatcher), dispatcher
+
+
+def _decision(decision="allow", *, camera="cam1", plate="MH12DE1433",
+              reason="registered", schema="access.decided.v1", **extra):
+    env = {
+        "id": "evt_0123456789ab",
+        "schema": schema,
+        "correlation_id": "corr-1",
+        "camera_id": camera,
+        "ts": "2026-08-30T10:00:00+00:00",
+        "producer": "app:license-plate-recognition",
+        "payload": {"plate_text": plate, "decision": decision,
+                    "reason": reason, "owner": "A. Sharma", "unit": "B-402",
+                    "confidence": 0.9},
+    }
+    env.update(extra)
+    return env
+
+
+class _Resp:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+
+def test_allow_pulses_relay_and_alerts_low(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gc.httpx, "get",
+                        lambda url, timeout: calls.append(url) or _Resp())
+    ctl, dispatcher = _controller()
+    fired = ctl.handle_event(_decision())
+    assert calls == ["http://relay/open"]
+    assert fired[0].severity == "low"
+    assert "Barrier opened" in fired[0].title
+    assert dispatcher.fire.call_count == 1
+    assert ctl.state_snapshot()["opened_total"] == 1
+
+
+def test_deny_and_unknown_decisions_fail_closed(monkeypatch):
+    monkeypatch.setattr(gc.httpx, "get",
+                        lambda *a, **k: pytest.fail("relay must not be called"))
+    ctl, dispatcher = _controller()
+    assert ctl.handle_event(_decision("deny")) == []
+    # A decision value invented by a future producer: still closed.
+    assert ctl.handle_event(_decision("allow_with_escort")) == []
+    assert dispatcher.fire.call_count == 0
+    assert ctl.state_snapshot()["denied_total"] == 2
+
+
+def test_cooldown_one_car_one_pulse(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gc.httpx, "get",
+                        lambda url, timeout: calls.append(url) or _Resp())
+    t = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: t["now"])
+    ctl, _ = _controller(pulse_cooldown_seconds=5.0)
+    ctl.handle_event(_decision())
+    t["now"] += 2.0
+    ctl.handle_event(_decision(plate="KA05MJ6021"))  # boom already up
+    assert len(calls) == 1
+    t["now"] += 10.0
+    ctl.handle_event(_decision(plate="TS09EA7788"))
+    assert len(calls) == 2
+
+
+def test_relay_fault_alerts_high_and_is_retriable(monkeypatch):
+    def boom(url, timeout):
+        raise gc.httpx.ConnectError("relay unreachable")
+    monkeypatch.setattr(gc.httpx, "get", boom)
+    t = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: t["now"])
+    ctl, _ = _controller(pulse_cooldown_seconds=5.0)
+    fired = ctl.handle_event(_decision())
+    assert fired[0].severity == "high"
+    assert "FAULT" in fired[0].title
+    # A failed pulse must NOT start the cooldown — the next decision
+    # retries immediately.
+    ok_calls = []
+    monkeypatch.setattr(gc.httpx, "get",
+                        lambda url, timeout: ok_calls.append(url) or _Resp())
+    t["now"] += 1.0
+    fired2 = ctl.handle_event(_decision())
+    assert ok_calls and fired2[0].severity == "low"
+    snap = ctl.state_snapshot()
+    assert snap["fault_total"] == 1 and snap["opened_total"] == 1
+
+
+def test_dry_run_alerts_without_calling_relay(monkeypatch):
+    monkeypatch.setattr(gc.httpx, "get",
+                        lambda *a, **k: pytest.fail("dry run must not call"))
+    ctl, _ = _controller(dry_run=True)
+    fired = ctl.handle_event(_decision())
+    assert fired[0].severity == "low"
+    assert "[dry run]" in fired[0].title
+    assert fired[0].evidence["dry_run"] is True
+
+
+def test_allow_at_unwired_camera_is_quiet(monkeypatch):
+    monkeypatch.setattr(gc.httpx, "get",
+                        lambda *a, **k: pytest.fail("no relay for cam9"))
+    ctl, dispatcher = _controller()
+    assert ctl.handle_event(_decision(camera="cam9")) == []
+    assert dispatcher.fire.call_count == 0
+
+
+def test_non_2xx_relay_answer_is_a_fault(monkeypatch):
+    monkeypatch.setattr(gc.httpx, "get", lambda url, timeout: _Resp(503))
+    ctl, _ = _controller()
+    fired = ctl.handle_event(_decision())
+    assert fired[0].severity == "high"
+
+
+def test_post_method_supported(monkeypatch):
+    posts = []
+    monkeypatch.setattr(gc.httpx, "post",
+                        lambda url, timeout: posts.append(url) or _Resp())
+    ctl, _ = _controller(relays={"cam1": {"url": "http://r/o", "method": "post"}})
+    ctl.handle_event(_decision())
+    assert posts == ["http://r/o"]
+
+
+def test_foreign_and_malformed_events_ignored():
+    ctl, dispatcher = _controller()
+    assert ctl.handle_event({"schema": "plate.recognized.v1"}) == []
+    assert ctl.handle_event("not a dict") == []
+    assert ctl.handle_event({"schema": "access.decided.v1"}) == []  # no camera
+    assert dispatcher.fire.call_count == 0
+
+
+def test_parse_relays_normalises_and_skips_bad():
+    got = parse_relays({
+        "1": "http://a/open",
+        "cam2": {"url": "http://b/open", "method": "POST"},
+        "3": {"method": "GET"},          # no url — skipped
+        "4": 42,                          # junk — skipped
+        "": "http://never",               # no key — skipped
+        "5": {"url": "http://c", "method": "DELETE"},  # bad method → GET
+    })
+    assert got == {
+        "cam1": {"url": "http://a/open", "method": "GET"},
+        "cam2": {"url": "http://b/open", "method": "POST"},
+        "cam5": {"url": "http://c", "method": "GET"},
+    }
+
+
+def test_live_config_update():
+    ctl, _ = _controller()
+    ctl.on_config_update({"relays": {"7": "http://new/open"},
+                          "dry_run": True, "pulse_cooldown_seconds": 1})
+    assert ctl._relays == {"cam7": {"url": "http://new/open", "method": "GET"}}
+    assert ctl._dry_run is True and ctl._cooldown == 1.0
+
+
+def test_manifest_declares_the_contract():
+    m = GateController.manifest
+    assert m.subscribes == "opennvr.events.access.decided.v1.>"
+    assert m.requires_tasks == []
+    assert "events:access.decided" in m.requires_scopes
+    assert {p.name for p in m.params} >= {"relays", "pulse_cooldown_seconds", "dry_run"}
+
+
+def test_load_config_requires_nats_url(tmp_path: Path):
+    p = tmp_path / "c.yml"
+    p.write_text("relays: {}\n")
+    with pytest.raises(ValueError, match="nats_url"):
+        load_config(p)
+
+
+def test_load_config_parses(tmp_path: Path):
+    p = tmp_path / "c.yml"
+    p.write_text(
+        "nats_url: nats://x:4222\n"
+        "relays:\n  '1': http://r/open\n"
+        "pulse_cooldown_seconds: 7\n"
+        "dry_run: true\n")
+    cfg = load_config(p)
+    assert cfg.relays == {"1": "http://r/open"}
+    assert cfg.pulse_cooldown_seconds == 7.0
+    assert cfg.dry_run is True

--- a/examples/gate-controller/uv.lock
+++ b/examples/gate-controller/uv.lock
@@ -1,0 +1,275 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f0/fc5e93f2b0dd14a202590ad9d30eda1955ea872039b5204357348d0f4b1e/nats_py-2.15.0.tar.gz", hash = "sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93", size = 75995, upload-time = "2026-06-05T07:34:03.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl", hash = "sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd", size = 90334, upload-time = "2026-06-05T07:34:02.81Z" },
+]
+
+[[package]]
+name = "opennvr-app-sdk"
+version = "0.2.0"
+source = { editable = "../../sdk/opennvr-app-sdk" }
+dependencies = [
+    { name = "httpx" },
+    { name = "nats-py" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27,<1.0" },
+    { name = "nats-py", specifier = ">=2.6" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "opennvr-example-gate-controller"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "opennvr-app-sdk" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "opennvr-app-sdk", editable = "../../sdk/opennvr-app-sdk" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -48,7 +48,10 @@ from alerts import (
     AlertSource,
     DEFAULT_ALERT_SUBJECT_PREFIX,
 )
-from opennvr_app_sdk import AlertType, AppManifest, Detector, Param, StateView, app
+from opennvr_app_sdk import (
+    AlertType, AppManifest, Detector, DomainEventPublisher, Param,
+    StateView, app,
+)
 from opennvr_app_sdk.cameras import cameras_for_skill
 
 logger = logging.getLogger("license-plate-recognition")
@@ -57,6 +60,10 @@ SKILL = "license_plate_recognition"
 
 #: The contracted subject this app consumes (EVENT_CONTRACTS.md).
 PLATE_SUBJECT_PATTERN = "opennvr.events.plate.recognized.v1.>"
+
+#: The decision event this app publishes on gate-in reads while
+#: barrier mode is on (docs/EVENT_CONTRACTS.md `access.decided.v1`).
+ACCESS_DECISION_SCHEMA = "access.decided.v1"
 
 #: Re-resolve the assignment-table camera scope this often. Cheap (one
 #: internal GET) and keeps "assign a camera in one place" true for a
@@ -150,6 +157,23 @@ def parse_monitors(raw: Any) -> dict[str, dict[str, Any]]:
     return monitors
 
 
+def gate_in_cameras(camera_roles: Any) -> frozenset[str]:
+    """Platform handles of gate-IN cameras from the ``camera_roles``
+    config map. Keys may be numeric core ids (``"3"`` — what the
+    Vehicles page writes) or platform handles (``"cam3"``); values are
+    ``{role, label?}`` records or bare role strings."""
+    out: set[str] = set()
+    if isinstance(camera_roles, dict):
+        for key, value in camera_roles.items():
+            role = value.get("role") if isinstance(value, dict) else value
+            if role != "gate_in":
+                continue
+            k = str(key).strip()
+            if k:
+                out.add(k if k.startswith("cam") else f"cam{k}")
+    return frozenset(out)
+
+
 def registry_entry_active(entry: dict[str, str] | None, *, today: date | None = None) -> bool:
     """True when a register entry currently counts as registered.
 
@@ -171,7 +195,7 @@ def registry_entry_active(entry: dict[str, str] | None, *, today: date | None = 
 MANIFEST = AppManifest(
     id="license-plate-recognition",
     name="License Plate Recognition",
-    version="2.3.0",
+    version="2.4.0",
     category="vehicle",
     summary=(
         "Consumes the platform's plate.recognized.v1 events and routes "
@@ -216,6 +240,14 @@ MANIFEST = AppManifest(
                   "Society mode: raise a high-severity alarm for any "
                   "plate NOT in the registry/allowlist (denylist still "
                   "wins). Off = unknown plates log as info reads.")),
+        Param("barrier_mode", str, default="off",
+              description=(
+                  "Gate automation: 'off' publishes nothing; "
+                  "'registered' publishes an access.decided.v1 event "
+                  "for every plate read on a gate-IN camera — allow "
+                  "for active registry/allowlist plates, deny "
+                  "otherwise. The gate-controller app consumes these "
+                  "and drives the barrier relay.")),
         Param("camera_roles", dict, default={},
               description=(
                   "The site layout: {camera_id: {role, label?}} with "
@@ -274,6 +306,7 @@ MANIFEST = AppManifest(
     use_cases=[
         "Alert the moment a watchlisted plate passes any camera",
         "Society mode: register every resident vehicle, alarm on any stranger",
+        "Automatic barrier: publish allow/deny gate decisions (gate-controller opens the boom)",
         "Industrial & company automation: factory gates, truck logging, campus access",
         "Log every vehicle with plate, time and evidence photo",
         "Expected-vehicle handling for known cars (allowlist / registry)",
@@ -334,6 +367,9 @@ class AppConfig:
     # as shorthand for active high-severity monitors.
     monitors: list[Any] = field(default_factory=list)
     alarm_on_unknown: bool = False
+    # Gate automation: publish access.decided.v1 on gate-IN reads.
+    barrier_mode: str = "off"
+    camera_roles: dict[str, Any] = field(default_factory=dict)
     unknown_cooldown_seconds: float = 300.0
 
     # Alert delivery channels (see alerts.py / the SDK alert stack).
@@ -373,6 +409,8 @@ def load_config(path: str | Path) -> AppConfig:
         denylist=[str(p).upper().strip() for p in (raw.get("denylist") or [])],
         registry=list(raw.get("registry") or []),
         monitors=list(raw.get("monitors") or []),
+        barrier_mode=str(raw.get("barrier_mode") or "off"),
+        camera_roles=dict(raw.get("camera_roles") or {}),
         alarm_on_unknown=bool(raw.get("alarm_on_unknown", False)),
         unknown_cooldown_seconds=float(raw.get("unknown_cooldown_seconds", 300.0)),
         webhook_url=raw.get("webhook_url"),
@@ -429,6 +467,16 @@ class PlateAlerter(Detector):
         self._unknown_cooldown: float = max(0.0, float(cfg.unknown_cooldown_seconds))
         self._unknown_last: dict[str, float] = {}
         self._unknown_alarms: int = 0
+        # Gate automation (access.decided.v1). The publisher's channel
+        # connects lazily on first publish and never raises on bus
+        # trouble; mode values other than 'registered' mean off.
+        self._barrier_mode: str = (
+            "registered" if cfg.barrier_mode == "registered" else "off")
+        self._gate_in: frozenset[str] = gate_in_cameras(cfg.camera_roles)
+        self._decision_publisher = DomainEventPublisher(
+            cfg.nats_url, token=cfg.nats_token,
+            producer="app:license-plate-recognition")
+        self._decisions_published: int = 0
         # Camera scope: explicit config wins and never refreshes; else
         # the assignment table (refreshed lazily per SCOPE_REFRESH_
         # SECONDS); None = no restriction declared.
@@ -567,6 +615,38 @@ class PlateAlerter(Detector):
             unknown_alarm=unknown_alarm,
         )
         self._dispatcher.fire(alert)
+
+        # Gate automation: on a gate-IN read, put the admission decision
+        # on the bus as a FACT (access.decided.v1). Actuation is the
+        # gate-controller app's job — policy here, hardware there.
+        if self._barrier_mode == "registered" and camera_id in self._gate_in:
+            if monitor is not None or plate in self._monitors:
+                decision, reason = "deny", "monitored"
+            elif registry_active:
+                decision, reason = "allow", "registered"
+            elif plate in allowlist:
+                decision, reason = "allow", "allowlisted"
+            elif registry_entry is not None:
+                decision, reason = "deny", "expired_pass"
+            else:
+                decision, reason = "deny", "unknown"
+            entry_meta = registry_entry or {}
+            published = self._decision_publisher.publish(
+                ACCESS_DECISION_SCHEMA,
+                camera_id=camera_id,
+                payload={
+                    "plate_text": plate,
+                    "decision": decision,
+                    "reason": reason,
+                    "owner": entry_meta.get("owner"),
+                    "unit": entry_meta.get("unit"),
+                    "confidence": confidence,
+                },
+                correlation_id=event.get("correlation_id"),
+            )
+            if published:
+                self._decisions_published += 1
+
         self._recent.append({
             "message": f"{plate} on {camera_id}",
             "time": time.time(),
@@ -651,6 +731,9 @@ class PlateAlerter(Detector):
             "registry_size": len(self._registry),
             "monitored_plates": len(self._monitors),
             "alarm_on_unknown": self._alarm_on_unknown,
+            "barrier_mode": self._barrier_mode,
+            "gate_in_cameras": sorted(self._gate_in),
+            "decisions_published": self._decisions_published,
             "unknown_alarms": self._unknown_alarms,
             "recent": list(self._recent),
         }
@@ -707,7 +790,9 @@ class PlateAlerter(Detector):
  <div><b>{self._unknown_alarms}</b><span class="dim">unknown alarms</span></div>
  <div><b>{snap.get("deduped_plates_tracked", 0)}</b><span class="dim">plates deduped</span></div>
 </div>
-<div class="dim">Unknown-vehicle alarm: {"ON" if self._alarm_on_unknown else "off"}</div>
+<div class="dim">Unknown-vehicle alarm: {"ON" if self._alarm_on_unknown else "off"}
+ · Barrier: {"AUTO (registered vehicles)" if self._barrier_mode == "registered" else "off"}
+ · Decisions published: {self._decisions_published}</div>
 {table}
 <div class="note">Watchlists are edited in the App Catalog's config
 form (applied live). Full history: the timeline's plate search.</div>
@@ -747,6 +832,12 @@ form (applied live). Full history: the timeline's plate search.</div>
                 logger.info("monitors updated live: %d plates", len(monitors))
         if "alarm_on_unknown" in config:
             self._alarm_on_unknown = bool(config.get("alarm_on_unknown"))
+        if "barrier_mode" in config:
+            self._barrier_mode = (
+                "registered" if config.get("barrier_mode") == "registered"
+                else "off")
+        if "camera_roles" in config:
+            self._gate_in = gate_in_cameras(config.get("camera_roles"))
         if "unknown_cooldown_seconds" in config:
             try:
                 self._unknown_cooldown = max(

--- a/examples/license-plate-recognition/tests/test_license_plate_recognition.py
+++ b/examples/license-plate-recognition/tests/test_license_plate_recognition.py
@@ -183,7 +183,7 @@ def test_live_watchlist_update_applies_atomically():
 def test_manifest_declares_the_consumer_contract():
     m = PlateAlerter.manifest
     assert m.subscribes == PLATE_SUBJECT_PATTERN
-    assert m.version == "2.3.0"
+    assert m.version == "2.4.0"
     assert "object_detection" in m.requires_tasks
     assert "license_plate_recognition" in m.requires_tasks
 
@@ -471,6 +471,120 @@ def test_manifest_declares_every_key_the_vehicles_page_writes():
     page_writes = {
         "allowlist", "denylist", "monitors", "registry",
         "alarm_on_unknown", "unknown_cooldown_seconds", "camera_roles",
+        "barrier_mode",
     }
     missing = page_writes - declared
     assert not missing, f"undeclared config keys the page writes: {missing}"
+
+
+# ── Gate automation (access.decided.v1) ─────────────────────────────
+
+
+def _decisions(alerter):
+    """Patch the publisher; return the captured publish calls."""
+    calls = []
+
+    def fake_publish(schema, *, camera_id, payload, correlation_id=None):
+        calls.append({"schema": schema, "camera_id": camera_id,
+                      "payload": payload, "correlation_id": correlation_id})
+        return True
+
+    alerter._decision_publisher.publish = fake_publish
+    return calls
+
+
+def test_barrier_off_publishes_nothing():
+    alerter, _ = _alerter(camera_roles={"1": {"role": "gate_in"}},
+                          registry=["MH12DE1433"])
+    calls = _decisions(alerter)
+    alerter.handle_event(_envelope(plate="MH12DE1433", camera="cam1"))
+    assert calls == []
+
+
+def test_registered_plate_on_gate_in_allows():
+    alerter, _ = _alerter(
+        barrier_mode="registered",
+        camera_roles={"1": {"role": "gate_in"}, "2": {"role": "gate_out"}},
+        registry=[{"plate": "MH12DE1433", "owner": "A. Sharma", "unit": "B-402"}])
+    calls = _decisions(alerter)
+    alerter.handle_event(_envelope(plate="MH12DE1433", camera="cam1"))
+    assert len(calls) == 1
+    d = calls[0]
+    assert d["schema"] == "access.decided.v1"
+    assert d["camera_id"] == "cam1"
+    assert d["payload"]["decision"] == "allow"
+    assert d["payload"]["reason"] == "registered"
+    assert d["payload"]["owner"] == "A. Sharma"
+    assert d["correlation_id"] == "corr-1"
+    assert alerter.state_snapshot()["decisions_published"] == 1
+
+
+def test_unknown_plate_on_gate_in_denies():
+    alerter, _ = _alerter(barrier_mode="registered",
+                          camera_roles={"1": {"role": "gate_in"}})
+    calls = _decisions(alerter)
+    alerter.handle_event(_envelope(plate="XX99ZZ0001", camera="cam1"))
+    assert calls[0]["payload"] == {
+        "plate_text": "XX99ZZ0001", "decision": "deny", "reason": "unknown",
+        "owner": None, "unit": None, "confidence": 0.9}
+
+
+def test_monitored_plate_denied_even_if_registered():
+    alerter, _ = _alerter(
+        barrier_mode="registered",
+        camera_roles={"1": {"role": "gate_in"}},
+        registry=["BAD001"], denylist=["BAD001"])
+    calls = _decisions(alerter)
+    alerter.handle_event(_envelope(plate="BAD001", camera="cam1"))
+    assert calls[0]["payload"]["decision"] == "deny"
+    assert calls[0]["payload"]["reason"] == "monitored"
+
+
+def test_expired_pass_denied_with_reason():
+    alerter, _ = _alerter(
+        barrier_mode="registered",
+        camera_roles={"1": {"role": "gate_in"}},
+        registry=[{"plate": "GU3ST1", "owner": "Guest",
+                   "expires": "2020-01-01"}])
+    calls = _decisions(alerter)
+    alerter.handle_event(_envelope(plate="GU3ST1", camera="cam1"))
+    assert calls[0]["payload"]["decision"] == "deny"
+    assert calls[0]["payload"]["reason"] == "expired_pass"
+    assert calls[0]["payload"]["owner"] == "Guest"
+
+
+def test_non_gate_camera_publishes_no_decision():
+    alerter, _ = _alerter(barrier_mode="registered",
+                          camera_roles={"1": {"role": "gate_in"}},
+                          registry=["MH12DE1433"])
+    calls = _decisions(alerter)
+    alerter.handle_event(_envelope(plate="MH12DE1433", camera="cam2"))
+    assert calls == []
+
+
+def test_gate_in_cameras_accepts_ids_and_handles():
+    got = lpr.gate_in_cameras({
+        "1": {"role": "gate_in"}, "cam7": {"role": "gate_in"},
+        "2": {"role": "gate_out"}, "3": {"role": "parking"},
+        "x": "gate_in",
+    })
+    assert got == frozenset({"cam1", "cam7", "camx"})
+
+
+def test_barrier_config_updates_live():
+    alerter, _ = _alerter(registry=["MH12DE1433"])
+    calls = _decisions(alerter)
+    alerter.handle_event(_envelope(plate="MH12DE1433", camera="cam1"))
+    assert calls == []  # off by default
+    alerter.on_config_update({
+        "allowlist": [], "denylist": [],
+        "barrier_mode": "registered",
+        "camera_roles": {"1": {"role": "gate_in"}},
+    })
+    alerter.handle_event(_envelope(plate="MH12DE1433", camera="cam1",
+                                   confidence=0.8))
+    # dedup: same (camera, plate) within window suppresses — use a
+    # fresh plate to prove the live switch took effect.
+    alerter.handle_event(_envelope(plate="KA05MJ6021", camera="cam1"))
+    assert len(calls) >= 1
+    assert calls[-1]["payload"]["decision"] in ("allow", "deny")

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -51,6 +51,7 @@ from .frame_sources import (
 from .geometry import Point, Tripwire, Zone, bbox_center
 from .manifest import Action, AlertType, AppManifest, Param, StateView
 from .state import KeyedState, StateRecord, keyed_state
+from .domain_events import DomainEventPublisher, domain_envelope, domain_subject
 from .events import EventsClient, StoredEvent
 from .tier0 import (
     BestFrameClient,
@@ -65,6 +66,10 @@ from .tier0 import (
 __version__ = "0.2.0"
 
 __all__ = [
+    # Domain events (producing side of docs/EVENT_CONTRACTS.md)
+    "DomainEventPublisher",
+    "domain_envelope",
+    "domain_subject",
     # Archetype bases + runners
     "Detector",
     "FrameApp",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/alerts.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/alerts.py
@@ -381,7 +381,15 @@ class NatsAlertChannel:
 
     def send(self, alert: Alert) -> bool:
         subject = alert_subject(alert, prefix=self._subject_prefix)
-        payload = json.dumps(alert.to_wire()).encode("utf-8")
+        return self.publish_json(subject, alert.to_wire())
+
+    def publish_json(self, subject: str, obj: Any) -> bool:
+        """Publish ``obj`` as JSON on ``subject`` — the channel's
+        machinery (background loop, lazy connect, hard timeouts,
+        log-never-raise) for ANY payload. ``send`` is now a thin
+        wrapper; ``domain_events.DomainEventPublisher`` composes this
+        to publish contracted ``opennvr.events.*`` envelopes."""
+        payload = json.dumps(obj).encode("utf-8")
         try:
             self._ensure_thread()
         except Exception as exc:  # noqa: BLE001

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_events.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_events.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publish contracted domain events (``opennvr.events.*``) from an app.
+
+``docs/EVENT_CONTRACTS.md`` is the normative source: every domain
+event travels as the envelope ``{id, schema, correlation_id,
+camera_id, ts, producer, payload}`` on the subject
+``opennvr.events.<domain>.<event>.v<N>.<camera_id>``. This module
+gives apps the producing side of that contract — the App SDK's
+subscriber loop already gives them the consuming side — so an app can
+put a FACT on the bus (an access decision, an occupancy change)
+without hand-rolling NATS plumbing or envelope fields.
+
+CI's contract ratchet (``server/tests/test_event_contracts.py``)
+fails any first-party publish on a subject the contracts doc does not
+list, so adding a new schema starts at the doc, not here.
+
+The transport reuses :class:`opennvr_app_sdk.alerts.NatsAlertChannel`
+machinery (background loop thread, lazy connect, hard timeouts,
+log-never-raise) via its generic ``publish_json``.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from .alerts import NatsAlertChannel
+
+#: schema names look like ``access.decided.v1`` — noun.verb-past.vN
+#: (the contracts doc's naming rule).
+_SCHEMA_RE = re.compile(r"^[a-z_]+\.[a-z_]+\.v\d+$")
+_CAMERA_TOKEN_BAD = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def domain_subject(schema: str, camera_id: str) -> str:
+    """The contracted subject for one event instance.
+
+    ``schema`` must match ``<domain>.<event>.v<N>`` and ``camera_id``
+    must be a single valid NATS token (the platform handle, ``camN``)
+    — both fail loudly, because a malformed subject silently reaches
+    no subscriber.
+    """
+    if not _SCHEMA_RE.match(schema):
+        raise ValueError(
+            f"domain event schema {schema!r} must look like "
+            "'<domain>.<event>.v<N>' (see docs/EVENT_CONTRACTS.md)")
+    if not camera_id or _CAMERA_TOKEN_BAD.search(camera_id):
+        raise ValueError(
+            f"camera_id {camera_id!r} is not a valid subject token")
+    return f"opennvr.events.{schema}.{camera_id}"
+
+
+def domain_envelope(
+    schema: str,
+    *,
+    camera_id: str,
+    payload: dict[str, Any],
+    producer: str,
+    correlation_id: str | None = None,
+) -> dict[str, Any]:
+    """The EVENT_CONTRACTS.md envelope — every field, every time
+    (mirrors the KAI-C normaliser's builder)."""
+    return {
+        "id": "evt_" + uuid.uuid4().hex[:12],
+        "schema": schema,
+        "correlation_id": correlation_id,
+        "camera_id": camera_id,
+        "ts": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "producer": producer,
+        "payload": payload,
+    }
+
+
+class DomainEventPublisher:
+    """Publish contracted domain events onto the platform bus.
+
+    One instance per app process; ``publish`` never raises on bus
+    trouble (logged inside the channel, returns False) — an app's
+    decision loop must not crash because the broker blinked.
+    """
+
+    def __init__(self, url: str, *, token: str | None = None,
+                 producer: str = "app") -> None:
+        self._producer = producer
+        self._channel = NatsAlertChannel(url, token=token)
+
+    def publish(
+        self,
+        schema: str,
+        *,
+        camera_id: str,
+        payload: dict[str, Any],
+        correlation_id: str | None = None,
+    ) -> bool:
+        subject = domain_subject(schema, camera_id)
+        envelope = domain_envelope(
+            schema,
+            camera_id=camera_id,
+            payload=payload,
+            producer=self._producer,
+            correlation_id=correlation_id,
+        )
+        return self._channel.publish_json(subject, envelope)
+
+    def close(self) -> None:
+        self._channel.close()

--- a/sdk/opennvr-app-sdk/tests/test_domain_events.py
+++ b/sdk/opennvr-app-sdk/tests/test_domain_events.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+
+"""DomainEventPublisher — the producing side of EVENT_CONTRACTS.md."""
+from __future__ import annotations
+
+import pytest
+
+from opennvr_app_sdk.domain_events import (
+    DomainEventPublisher,
+    domain_envelope,
+    domain_subject,
+)
+
+
+def test_subject_shape():
+    assert (domain_subject("access.decided.v1", "cam3")
+            == "opennvr.events.access.decided.v1.cam3")
+
+
+@pytest.mark.parametrize("schema", [
+    "accessdecided.v1", "access.decided", "Access.Decided.v1",
+    "access.decided.v", "a.b.c.v1", "",
+])
+def test_bad_schema_fails_loudly(schema):
+    with pytest.raises(ValueError):
+        domain_subject(schema, "cam1")
+
+
+@pytest.mark.parametrize("cam", ["", "cam 1", "cam.1", "cam>*"])
+def test_bad_camera_token_fails_loudly(cam):
+    with pytest.raises(ValueError):
+        domain_subject("access.decided.v1", cam)
+
+
+def test_envelope_has_every_contract_field():
+    env = domain_envelope(
+        "access.decided.v1",
+        camera_id="cam3",
+        payload={"decision": "allow"},
+        producer="app:license-plate-recognition",
+        correlation_id="corr-9",
+    )
+    assert set(env) == {"id", "schema", "correlation_id", "camera_id",
+                        "ts", "producer", "payload"}
+    assert env["id"].startswith("evt_")
+    assert env["schema"] == "access.decided.v1"
+    assert env["camera_id"] == "cam3"
+    assert env["producer"] == "app:license-plate-recognition"
+    assert env["payload"] == {"decision": "allow"}
+    import json
+    json.dumps(env)  # wire-serializable
+
+
+def test_publisher_builds_subject_and_envelope(monkeypatch):
+    pub = DomainEventPublisher("nats://x:4222", token="t",
+                               producer="app:lpr")
+    seen = {}
+
+    def fake_publish_json(subject, obj):
+        seen["subject"] = subject
+        seen["obj"] = obj
+        return True
+
+    monkeypatch.setattr(pub._channel, "publish_json", fake_publish_json)
+    ok = pub.publish("access.decided.v1", camera_id="cam7",
+                     payload={"decision": "deny", "reason": "unknown"},
+                     correlation_id="c1")
+    assert ok is True
+    assert seen["subject"] == "opennvr.events.access.decided.v1.cam7"
+    assert seen["obj"]["schema"] == "access.decided.v1"
+    assert seen["obj"]["correlation_id"] == "c1"
+    assert seen["obj"]["payload"]["reason"] == "unknown"
+
+
+def test_alert_channel_send_still_works_via_publish_json(monkeypatch):
+    """The extraction must not change alert publishing semantics."""
+    from opennvr_app_sdk.alerts import Alert, AlertSource, NatsAlertChannel
+
+    ch = NatsAlertChannel("nats://x:4222")
+    captured = {}
+    monkeypatch.setattr(
+        ch, "publish_json",
+        lambda subject, obj: captured.update(subject=subject, obj=obj) or True)
+    alert = Alert(severity="low", title="t", description="d",
+                  camera_id="cam1", source=AlertSource())
+    assert ch.send(alert) is True
+    assert captured["subject"].endswith(".cam1")
+    assert captured["obj"]["title"] == "t"

--- a/server/config/apps_index.yml
+++ b/server/config/apps_index.yml
@@ -242,6 +242,39 @@
             - opennvr_internal
     command: docker compose -f docker-compose.yml -f docker-compose.apps.yml --profile apps up -d license-plate-recognition
 
+- id: gate-controller
+  name: Gate Controller
+  summary: Opens the barrier for allowed vehicles — pulses an HTTP relay per gate camera on the LPR app's access.decided.v1 allow decisions; deny and unknown fail closed.
+  category: automation
+  version: "1.0.0"
+  image: ghcr.io/open-nvr/gate-controller:latest
+  build_context: examples/gate-controller
+  # No inference and no adapters — this app is bus + relay only. Pair
+  # it with license-plate-recognition (barrier_mode: registered).
+  requires_tasks: []
+  emits: [barrier_opened, barrier_fault]
+  docs_url: https://github.com/open-nvr/open-nvr/blob/main/examples/gate-controller/README.md
+  install:
+    compose: |
+      # INFORMATIONAL — this service already ships in
+      # docker-compose.apps.yml (with its config-init companion and
+      # named config volume); you do NOT paste this anywhere. Run the
+      # command below and compose brings it up from the shipped overlay.
+      services:
+        gate-controller:
+          profiles: [apps]
+          image: ${GATE_CONTROLLER_IMAGE:-opennvr/gate-controller:local-build}
+          restart: unless-stopped
+          environment:
+            - OPENNVR_INTERNAL_API_KEY=${INTERNAL_API_KEY}
+            - NATS_URL=nats://nats:4222
+            - OPENNVR_URL=http://opennvr-core:8000
+          expose:
+            - "9210"
+          networks:
+            - opennvr_internal
+    command: docker compose -f docker-compose.yml -f docker-compose.apps.yml --profile apps up -d gate-controller
+
 - id: smart-doorbell
   name: Smart Doorbell
   summary: Recognises faces at the door via InsightFace through KAI-C; known visitors ride low-severity, strangers high with a snapshot.

--- a/server/tests/test_apps_index.py
+++ b/server/tests/test_apps_index.py
@@ -191,6 +191,7 @@ _EXPECTED_IDS = {
     "abandoned-object",
     "intrusion-detection",
     "license-plate-recognition",
+    "gate-controller",
     "smart-doorbell",
     "package-delivery",
     "footage-search",


### PR DESCRIPTION
… app

Recognised → decided → the boom lifts. The loop closes as two apps and one contract, policy and hardware deliberately split:

Contract (docs/EVENT_CONTRACTS.md, ratchet green):
- access.decided.v1 on opennvr.events.access.decided.v1.<camera_id>: the admission decision as a bus FACT — {plate_text, decision allow|deny, reason registered|allowlisted|monitored|expired_pass| unknown, owner, unit, confidence}. Consumers MUST fail closed on anything but a literal 'allow' (future decision values included).

SDK:
- NatsAlertChannel gains generic publish_json (send() is now a thin wrapper — machinery unchanged, alert tests untouched).
- New domain_events module: domain_subject / domain_envelope (the normative envelope, mirroring KAI-C's builder, validated loudly)
  + DomainEventPublisher — apps get the PRODUCING side of the event contracts with no NATS plumbing. 6 new tests.

LPR app (v2.4.0):
- barrier_mode param ('off'|'registered'): on gate-IN reads (from camera_roles) publish the decision — allow for active registry / allowlist, deny for monitored (even if registered), expired passes, and strangers. Live-updating; decision counter in state and /ui. 8 new tests; mode and gate-camera guards sabotage-verified.

gate-controller (new example app, catalog-installable):
- Pure consumer of access.decided.v1 → HTTP relay pulse (Shelly/ Tasmota/ESPHome/commercial), GET or POST, per-gate cooldown ('one car, one pulse'), dry-run commissioning mode (Docker default ON so a fresh install can never move hardware by surprise), barrier_opened / barrier_fault alerts, fault does NOT start cooldown (retriable). Full packaging: compose service + config-init, apps_index entry (validator green), Dockerfile, README, uv.lock. 14 tests; the fail-closed guard sabotage-verified.

Vehicles page:
- 'Automatic barrier' toggle on the register tab (declared param — the write-surface lockstep test grew with it), pointing at the Gate Controller app and warning when no Gate IN camera exists.