### PR TITLE
feat(sdk+app): Occupancy — the second first-class vertical + the prov…

### DIFF
--- a/app/src/hooks/usePermissions.tsx
+++ b/app/src/hooks/usePermissions.tsx
@@ -124,6 +124,7 @@ export const NAV_PERMISSIONS = {
   '/': null, // Dashboard - always visible
   '/live': 'live.view',
   '/vehicles': 'live.view', // plate reads are camera history — same tier as live view
+  '/occupancy': 'live.view', // live head-counts — same tier as live view
   '/playback': 'recordings.view',
   '/playback/sync': 'recordings.view',
   '/cameras': 'cameras.view',

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -80,6 +80,7 @@ const PlaybackView = lazy(() => importPlaybackView().then((m) => ({ default: m.P
 const SyncPlayback = lazy(() => importSyncPlayback().then((m) => ({ default: m.SyncPlayback })))
 const Cameras = lazy(reloadOnStale(() => import('./views/Cameras').then((m) => ({ default: m.Cameras }))))
 const Vehicles = lazy(reloadOnStale(() => import('./views/Vehicles').then((m) => ({ default: m.Vehicles }))))
+const Occupancy = lazy(reloadOnStale(() => import('./views/Occupancy').then((m) => ({ default: m.Occupancy }))))
 const Settings = lazy(reloadOnStale(() => import('./views/Settings').then((m) => ({ default: m.Settings }))))
 const Events = lazy(reloadOnStale(() => import('./views/Events').then((m) => ({ default: m.Events }))))
 const Updates = lazy(reloadOnStale(() => import('./views/Updates').then((m) => ({ default: m.Updates }))))
@@ -163,6 +164,7 @@ const router = createBrowserRouter([
           { path: 'playback/sync', element: <SyncPlayback /> },
           { path: 'cameras', element: <Cameras /> },
           { path: 'vehicles', element: <Vehicles /> },
+          { path: 'occupancy', element: <Occupancy /> },
           { path: 'rbac/*', element: <AccessControl /> },
           { path: 'byok', element: <BYOK /> },
           { path: 'network/*', element: <NetworkView /> },

--- a/app/src/shell/AppShell.tsx
+++ b/app/src/shell/AppShell.tsx
@@ -18,7 +18,7 @@
 
 import { Outlet, NavLink, Link, useLocation } from 'react-router-dom'
 import { DeviceBlockedOverlay } from '../components/DeviceBlockedOverlay'
-import { Menu, Monitor, Camera, Car, Settings as SettingsIcon, Bell, Maximize, Minimize, LogOut, User as UserIcon, Sun, Moon, MonitorPlay, RefreshCcw, FileSearch, Brain, FileCheck, AlertTriangle, Plug, LifeBuoy, KeyRound, Shield, Network, Cpu, Boxes, Cloud, Database, ChevronDown, Layers } from 'lucide-react'
+import { Menu, Monitor, Camera, Car, Users, Settings as SettingsIcon, Bell, Maximize, Minimize, LogOut, User as UserIcon, Sun, Moon, MonitorPlay, RefreshCcw, FileSearch, Brain, FileCheck, AlertTriangle, Plug, LifeBuoy, KeyRound, Shield, Network, Cpu, Boxes, Cloud, Database, ChevronDown, Layers } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { apiService } from '../lib/apiService'
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
@@ -150,16 +150,26 @@ export function AppShell() {
       const { data } = await apiService.getApps()
       return (Array.isArray(data) ? data : []) as {
         enabled?: boolean
-        manifest?: { requires_tasks?: string[] } | null
+        manifest?: { requires_tasks?: string[]; provides?: string[] } | null
       }[]
     },
     retry: 0,
     staleTime: 60_000,
     refetchInterval: 120_000,
   })
-  const lprEnabled = (appsNav.data ?? []).some(
-    (a) => a.enabled && (a.manifest?.requires_tasks ?? []).includes('license_plate_recognition')
-  )
+  // The curated first-class pages, capability-keyed on manifest
+  // `provides` (with a legacy predicate for manifests that predate the
+  // field). Adding a vertical = one row here + its page — the nav
+  // scales with what THIS install enabled, never with catalog size.
+  const apps = appsNav.data ?? []
+  const providesEnabled = (capability: string, legacy?: (m: any) => boolean) =>
+    apps.some((a) => a.enabled && (
+      (a.manifest?.provides ?? []).includes(capability) ||
+      (legacy ? legacy(a.manifest ?? {}) : false)
+    ))
+  const lprEnabled = providesEnabled('vehicles',
+    (m) => (m.requires_tasks ?? []).includes('license_plate_recognition'))
+  const occupancyEnabled = providesEnabled('occupancy')
 
   const visibleGroups = useMemo(
     () => {
@@ -167,6 +177,9 @@ export function AppShell() {
       const appItems = [
         ...(lprEnabled && canView('/vehicles')
           ? [{ to: '/vehicles', label: 'Vehicles', icon: <Car size={16} />, perm: '/vehicles' as const }]
+          : []),
+        ...(occupancyEnabled && canView('/occupancy')
+          ? [{ to: '/occupancy', label: 'Occupancy', icon: <Users size={16} />, perm: '/occupancy' as const }]
           : []),
       ]
       if (appItems.length > 0) {
@@ -176,7 +189,7 @@ export function AppShell() {
       return groups
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hasPermission, lprEnabled]
+    [hasPermission, lprEnabled, occupancyEnabled]
   )
   const pinnedGroups = visibleGroups.filter((g) => g.pinned)
   const menuGroups = visibleGroups.filter((g) => !g.pinned)

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -91,6 +91,9 @@ export type AppManifest = {
   // Where a deployment can reach the developer for custom work
   // (mailto: or https:) — rendered as a "Contact" action.
   contact?: string
+  // Vertical capabilities this app provides ("vehicles", "occupancy")
+  // — first-class pages in the main nav light up per capability.
+  provides?: string[]
 }
 
 /** Resolve an external ui_url for THIS browser: apps rarely know their

--- a/app/src/views/Occupancy.tsx
+++ b/app/src/views/Occupancy.tsx
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2026 OpenNVR
+ * This file is part of OpenNVR.
+ *
+ * OpenNVR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenNVR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Occupancy — the second first-class vertical, proving the pattern
+// generalizes: capability-keyed on manifest `provides` ("occupancy"),
+// so a community-built replacement app lights the same page. Live
+// data comes from the providing app's /state through core's proxy;
+// thresholds write through the same live config path as everything
+// else. Zones are drawn in the catalog's geometry editor — this page
+// links there rather than duplicating it.
+
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { RefreshCw, Settings2, Users } from 'lucide-react'
+import { apiService } from '../lib/apiService'
+import { extractApiError } from '../lib/apiError'
+import { useSnackbar } from '../components/Snackbar'
+import {
+  Badge, Button, Card, CardContent,
+  EmptyState, PageHeader, Skeleton,
+} from '../components/ui'
+import type { RegisteredApp } from './AppCatalog'
+
+export const OCCUPANCY_CAPABILITY = 'occupancy'
+
+type CameraRow = { id: number; name: string }
+
+type OccupancyCameraState = {
+  level?: string        // over | under | normal | …
+  last_count?: number
+  pending?: number
+}
+
+type OccupancyState = {
+  total_people?: number
+  zones_over?: number
+  cameras?: Record<string, OccupancyCameraState>
+}
+
+/** The enabled app providing occupancy — capability-keyed. */
+export function findOccupancyApp(apps: RegisteredApp[] | undefined): RegisteredApp | null {
+  return (
+    (apps ?? []).find(
+      (a) => a.enabled && ((a.manifest as any)?.provides ?? []).includes(OCCUPANCY_CAPABILITY)
+    ) ?? null
+  )
+}
+
+function levelBadge(level: string | undefined) {
+  if (level === 'over') return <Badge variant="destructive">over limit</Badge>
+  if (level === 'under') return <Badge variant="warning">under minimum</Badge>
+  if (level === 'normal') return <Badge variant="success">normal</Badge>
+  return <Badge variant="neutral">{level || 'counting…'}</Badge>
+}
+
+export function Occupancy() {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useSnackbar()
+
+  const appsQuery = useQuery({
+    queryKey: ['apps'],
+    queryFn: async () => {
+      const { data } = await apiService.getApps()
+      return (Array.isArray(data) ? data : []) as RegisteredApp[]
+    },
+    retry: 0,
+  })
+  const camerasQuery = useQuery({
+    queryKey: ['cameras'],
+    queryFn: async () => {
+      const { data } = await apiService.getCameras()
+      const list = Array.isArray(data) ? data : (data as any)?.cameras
+      return (Array.isArray(list) ? list : []) as CameraRow[]
+    },
+    retry: 0,
+  })
+
+  const occApp = findOccupancyApp(appsQuery.data)
+
+  const statusQuery = useQuery({
+    queryKey: ['app-status', occApp?.id],
+    queryFn: async () => {
+      const { data } = await apiService.getAppStatus(occApp!.id)
+      return data as { state?: OccupancyState }
+    },
+    enabled: Boolean(occApp),
+    retry: 0,
+    refetchInterval: 5000,
+  })
+  const state = statusQuery.data?.state
+
+  // The app's zone states are keyed by the platform camera handle
+  // ("cam3") — resolve to the operator's camera names, tolerantly.
+  const cameraName = (key: string) => {
+    const m = /^cam(\d+)$/.exec(key)
+    const id = m ? Number(m[1]) : Number(key)
+    return camerasQuery.data?.find((c) => c.id === id)?.name ?? key
+  }
+
+  const maxOccupancy = Number((occApp?.config as any)?.max_occupancy ?? 0) || 0
+  const minOccupancy = Number((occApp?.config as any)?.min_occupancy ?? 0) || 0
+  const [draftMax, setDraftMax] = useState<string | null>(null)
+  const [draftMin, setDraftMin] = useState<string | null>(null)
+
+  const saveThresholds = useMutation({
+    mutationFn: async () => {
+      if (!occApp) throw new Error('No enabled occupancy app.')
+      const cfg = { ...((occApp.config ?? {}) as Record<string, any>) }
+      const nextMax = Number(draftMax ?? maxOccupancy)
+      if (!Number.isFinite(nextMax) || nextMax < 1) {
+        throw new Error('Max occupancy must be at least 1.')
+      }
+      cfg.max_occupancy = Math.floor(nextMax)
+      const nextMin = Number(draftMin ?? minOccupancy)
+      if (Number.isFinite(nextMin) && nextMin > 0) cfg.min_occupancy = Math.floor(nextMin)
+      else delete cfg.min_occupancy
+      await apiService.updateAppConfig(occApp.id, cfg)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['apps'] })
+      setDraftMax(null)
+      setDraftMin(null)
+      showSuccess('Thresholds saved — applied live')
+    },
+    onError: (e) => showError(extractApiError(e, 'Could not save thresholds.')),
+  })
+
+  const zones = useMemo(
+    () => Object.entries(state?.cameras ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+    [state]
+  )
+
+  if (!appsQuery.isPending && !occApp) {
+    return (
+      <section className="space-y-4">
+        <PageHeader
+          title="Occupancy"
+          description="Live head-counts per watched zone, with over/under-occupancy alerts."
+        />
+        <EmptyState
+          icon={<Users size={28} />}
+          title="No occupancy app enabled"
+          description="Install and enable Occupancy Counting from the App Catalog — it rides the detection stream the platform already produces, so it adds zero inference cost."
+        />
+      </section>
+    )
+  }
+
+  return (
+    <section className="space-y-4">
+      <PageHeader
+        title="Occupancy"
+        description="Live head-counts per watched zone — riding the platform's detection stream, zero extra inference. Thresholds apply live."
+        actions={
+          <div className="flex items-center gap-2">
+            {occApp && (
+              <Link to={`/app-catalog/${occApp.id}`}>
+                <Button variant="outline">
+                  <Settings2 size={14} /> Configure zones
+                </Button>
+              </Link>
+            )}
+            <Button onClick={() => statusQuery.refetch()} disabled={statusQuery.isFetching}>
+              <RefreshCw size={14} className={statusQuery.isFetching ? 'animate-spin' : ''} /> Refresh
+            </Button>
+          </div>
+        }
+      />
+
+      {/* ── Live tiles ────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {[
+          { label: 'People counted now', value: state?.total_people },
+          { label: 'Zones over limit', value: state?.zones_over },
+          { label: 'Zones watched', value: zones.length || undefined },
+          { label: 'Max per zone', value: maxOccupancy || '—' },
+        ].map((t) => (
+          <Card key={t.label}>
+            <CardContent className="py-3">
+              <div className="text-2xl font-semibold">{t.value ?? '…'}</div>
+              <div className="text-xs text-[var(--text-dim)]">{t.label}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* ── Thresholds (applied live) ─────────────────────────────── */}
+      <Card>
+        <CardContent className="py-3 flex flex-wrap items-end gap-3">
+          <label className="text-xs text-[var(--text-dim)]">
+            Max occupancy (alert when over)
+            <input
+              type="number"
+              min={1}
+              value={draftMax ?? String(maxOccupancy || '')}
+              onChange={(e) => setDraftMax(e.target.value)}
+              className="block mt-0.5 py-1.5 px-2 rounded border border-[var(--border)] bg-[var(--bg-2)] text-sm text-[var(--text)] w-40"
+            />
+          </label>
+          <label className="text-xs text-[var(--text-dim)]">
+            Min occupancy (0 = off)
+            <input
+              type="number"
+              min={0}
+              value={draftMin ?? String(minOccupancy || 0)}
+              onChange={(e) => setDraftMin(e.target.value)}
+              className="block mt-0.5 py-1.5 px-2 rounded border border-[var(--border)] bg-[var(--bg-2)] text-sm text-[var(--text)] w-40"
+            />
+          </label>
+          <Button
+            onClick={() => saveThresholds.mutate()}
+            disabled={saveThresholds.isPending || !occApp || (draftMax === null && draftMin === null)}
+          >
+            Save thresholds
+          </Button>
+          <span className="text-xs text-[var(--text-dim)] ml-auto">
+            Zones are drawn per camera in the app's Configure form.
+          </span>
+        </CardContent>
+      </Card>
+
+      {/* ── Per-zone live board ───────────────────────────────────── */}
+      {statusQuery.isPending && Boolean(occApp) ? (
+        <Skeleton className="h-40" />
+      ) : zones.length === 0 ? (
+        <EmptyState
+          icon={<Users size={28} />}
+          title="No zones counting yet"
+          description="Draw a zone on a camera in the app's Configure form (Configure zones above) and its live head-count appears here within seconds."
+        />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {zones.map(([key, z]) => {
+            const count = Number(z.last_count ?? 0)
+            const pct = maxOccupancy > 0
+              ? Math.min(100, Math.round((count / maxOccupancy) * 100))
+              : 0
+            return (
+              <Card key={key}>
+                <CardContent className="py-4">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <div className="text-sm font-medium">{cameraName(key)}</div>
+                      <div className="text-3xl font-semibold mt-1">
+                        {count}
+                        {maxOccupancy > 0 && (
+                          <span className="text-sm font-normal text-[var(--text-dim)]"> / {maxOccupancy}</span>
+                        )}
+                      </div>
+                    </div>
+                    {levelBadge(z.level)}
+                  </div>
+                  {maxOccupancy > 0 && (
+                    <div className="mt-3 h-1.5 rounded bg-[var(--bg-2)] overflow-hidden">
+                      <div
+                        className={`h-full rounded ${z.level === 'over'
+                          ? 'bg-[var(--danger,#e5484d)]'
+                          : pct >= 80 ? 'bg-[var(--warning,#b7791f)]'
+                          : 'bg-[var(--success,#46a758)]'}`}
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -212,6 +212,8 @@ MANIFEST = AppManifest(
     # Plates are PII (decision 6): consuming plate.recognized.v1 is a
     # declared scope — granted at registration, audited, catalog-visible.
     requires_scopes=["events:plate.recognized"],
+    # This app powers the first-class Vehicles page.
+    provides=["vehicles"],
     subscribes=PLATE_SUBJECT_PATTERN,
     params=[
         Param("dedup_window_seconds", float, default=60.0,

--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -129,10 +129,12 @@ def _scope_to_assignment(discovered: list[dict]) -> list[dict]:
 MANIFEST = AppManifest(
     id="occupancy-counting",
     name="Occupancy Counting",
-    version="1.0.0",
+    version="1.1.0",
     category="analytics",
     summary="Alerts on zone occupancy threshold crossings (over / under / cleared).",
     requires_tasks=["object_detection"],  # checked vs GET /api/v1/adapters
+    # This app powers the first-class Occupancy page.
+    provides=["occupancy"],
     subscribes="opennvr.inference.>",
     params=[
         Param("watch_labels", list, default=["person"]),
@@ -145,6 +147,27 @@ MANIFEST = AppManifest(
         Param("clear_alerts", bool, default=False,
               description="Also fire a low-severity alert when a zone returns to normal."),
         Param("zones", "geometry.polygon", per_camera=True),  # drawn in the catalog UI
+    ],
+    # Store listing (the catalog's Details section).
+    description=(
+        "Live head-counts for the spaces you care about. Draw a zone "
+        "on any camera and the app counts the people (or any watched "
+        "label) inside it, riding the detection stream the platform "
+        "already produces — zero extra inference cost.\n\n"
+        "Set a maximum and it alerts the moment a zone goes over "
+        "(and, optionally, when it drops under a minimum or returns "
+        "to normal). The first-class Occupancy page shows every zone "
+        "live; thresholds apply immediately."
+    ),
+    author="OpenNVR",
+    website="https://github.com/open-nvr/open-nvr",
+    license="AGPL-3.0",
+    contact="https://github.com/open-nvr/open-nvr/discussions",
+    use_cases=[
+        "Over-occupancy alarms for halls, gyms, canteens, waiting areas",
+        "Factory floor and warehouse zone limits (safety compliance)",
+        "Live 'people now' board across every watched space",
+        "Under-occupancy: know when a manned post is left empty",
     ],
     emits=[
         AlertType("occupancy_over", severity="high"),

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
@@ -196,6 +196,13 @@ class AppManifest:
     # (per-app NATS users whose subscribe permissions ARE the grants)
     # is the staged follow-up recorded in the RFC.
     requires_scopes: list[str] = field(default_factory=list)
+    # Vertical capabilities this app PROVIDES to the platform UI —
+    # e.g. ["vehicles"], ["occupancy"]. A first-class page in the main
+    # product lights up when any enabled app provides its capability,
+    # so a community-built replacement app declaring the same
+    # capability lights the same page (three-tier model: few curated
+    # pages, capability-keyed; everything else generic).
+    provides: list[str] = field(default_factory=list)
     subscribes: str | None = None
     params: list[Param] = field(default_factory=list)
     emits: list[AlertType] = field(default_factory=list)
@@ -267,6 +274,7 @@ class AppManifest:
             "requires_tasks": list(self.requires_tasks),
             "requires_adapters": list(self.requires_adapters),
             "requires_scopes": list(self.requires_scopes),
+            "provides": list(self.provides),
             "subscribes": self.subscribes,
             "params": [p.to_dict() for p in self.params],
             "emits": [a.to_dict() for a in self.emits],

--- a/sdk/opennvr-app-sdk/tests/test_manifest.py
+++ b/sdk/opennvr-app-sdk/tests/test_manifest.py
@@ -109,6 +109,7 @@ def test_ui_and_listing_defaults():
     assert d["license"] == ""
     assert d["use_cases"] == []
     assert d["contact"] == ""
+    assert d["provides"] == []
 
 
 def test_external_ui_mode_serializes():


### PR DESCRIPTION
…ides contract

The pattern proves it generalizes: vertical #2 costs one manifest field, one nav row, and one page.

SDK:
- manifest gains provides: the vertical capabilities an app POWERS ('vehicles', 'occupancy'). The proper capability contract for first-class pages — a community replacement app declaring the same capability lights the same page. Serialized like every listing field; older cores pass it through untouched.

Apps:
- LPR declares provides=['vehicles']; occupancy-counting (v1.1.0) declares provides=['occupancy'] and gains its store listing (description, author, use-cases, contact).

Frontend:
- AppShell nav generalized: providesEnabled(capability, legacy?) — vehicles keeps its requires_tasks legacy predicate for manifests that predate the field; adding a vertical is now one row.
- New /occupancy page (live.view tier): live per-zone board polling the providing app's state through core's proxy (5s) — count vs max with a colored fill bar, over/under/normal badges, camera names resolved from the platform handles; tiles for people-now / zones-over / zones-watched / max-per-zone; threshold editor writing max/min occupancy through the app's declared params (validated, applied live); zones link to the catalog's geometry editor rather than duplicating it; honest empty states (no app → catalog; no zones → configure).

Zero core changes — the whole vertical rides existing surfaces.