### PR TITLE
feat(occupancy): history — occupancy.changed.v1 contract, persistence…

### DIFF
--- a/app/src/views/Occupancy.tsx
+++ b/app/src/views/Occupancy.tsx
@@ -28,6 +28,7 @@ import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { RefreshCw, Settings2, Users } from 'lucide-react'
+import { api } from '../lib/api'
 import { apiService } from '../lib/apiService'
 import { extractApiError } from '../lib/apiError'
 import { useSnackbar } from '../components/Snackbar'
@@ -45,6 +46,13 @@ type OccupancyCameraState = {
   level?: string        // over | under | normal | …
   last_count?: number
   pending?: number
+}
+
+type HistoryResp = {
+  hours: number
+  bucket_minutes: number
+  cameras: { camera_id: number; samples: { t: string; avg: number; max: number }[] }[]
+  busiest_hours: { hour: number; avg: number }[]
 }
 
 type OccupancyState = {
@@ -93,6 +101,19 @@ export function Occupancy() {
 
   const occApp = findOccupancyApp(appsQuery.data)
 
+  // History charts (occupancy.changed.v1 samples persisted by core).
+  const historyQuery = useQuery({
+    queryKey: ['occupancy-history'],
+    queryFn: async () => {
+      const { data } = await api.get('/api/v1/occupancy/history', { params: { hours: 24 } })
+      return data as HistoryResp
+    },
+    enabled: Boolean(occApp),
+    retry: 0,
+    refetchInterval: 60_000,
+  })
+  const history = historyQuery.data
+
   const statusQuery = useQuery({
     queryKey: ['app-status', occApp?.id],
     queryFn: async () => {
@@ -140,6 +161,12 @@ export function Occupancy() {
     },
     onError: (e) => showError(extractApiError(e, 'Could not save thresholds.')),
   })
+
+  const seriesFor = (key: string) => {
+    const m = /^cam(\d+)$/.exec(key)
+    const id = m ? Number(m[1]) : Number(key)
+    return history?.cameras.find((c) => c.camera_id === id)?.samples ?? []
+  }
 
   const zones = useMemo(
     () => Object.entries(state?.cameras ?? {}).sort(([a], [b]) => a.localeCompare(b)),
@@ -235,6 +262,19 @@ export function Occupancy() {
         </CardContent>
       </Card>
 
+      {/* ── Busiest hours (7 days of occupancy.changed.v1 samples) ── */}
+      {(history?.busiest_hours?.length ?? 0) > 0 && (
+        <Card>
+          <CardContent className="py-3">
+            <div className="text-sm font-medium mb-0.5">Busiest hours</div>
+            <div className="text-xs text-[var(--text-dim)] mb-2">
+              Average head-count by hour of day, last 7 days — staff the peaks.
+            </div>
+            <BusiestHoursChart hours={history!.busiest_hours} />
+          </CardContent>
+        </Card>
+      )}
+
       {/* ── Per-zone live board ───────────────────────────────────── */}
       {statusQuery.isPending && Boolean(occApp) ? (
         <Skeleton className="h-40" />
@@ -277,6 +317,10 @@ export function Occupancy() {
                       />
                     </div>
                   )}
+                  <OccupancySparkline
+                    samples={seriesFor(key)}
+                    ceiling={maxOccupancy}
+                  />
                 </CardContent>
               </Card>
             )
@@ -284,5 +328,121 @@ export function Occupancy() {
         </div>
       )}
     </section>
+  )
+}
+
+// ── Charts ──────────────────────────────────────────────────────────
+// Single-series marks styled to the dataviz method: 2px line, soft
+// area fill, emphasized endpoint, recessive dashed ceiling gridline,
+// text in text tokens (never the series color), tabular numerals,
+// native hover titles per sample. One hue (the app accent) — identity
+// is carried by the card, so no legend is needed.
+
+/** 24h trend inside a zone card. */
+function OccupancySparkline({
+  samples,
+  ceiling,
+}: {
+  samples: { t: string; avg: number; max: number }[]
+  ceiling: number
+}) {
+  if (samples.length < 2) {
+    return (
+      <div className="mt-2 text-[11px] text-[var(--text-dim)]">
+        Trend appears as history accrues.
+      </div>
+    )
+  }
+  const W = 220, H = 44, PAD = 3
+  const t0 = new Date(samples[0].t).getTime()
+  const t1 = new Date(samples[samples.length - 1].t).getTime()
+  const span = Math.max(1, t1 - t0)
+  const top = Math.max(ceiling, ...samples.map((s) => s.max), 1)
+  const x = (t: string) => PAD + ((new Date(t).getTime() - t0) / span) * (W - 2 * PAD)
+  const y = (v: number) => H - PAD - (v / top) * (H - 2 * PAD)
+  const line = samples.map((s, i) => `${i ? 'L' : 'M'}${x(s.t).toFixed(1)},${y(s.avg).toFixed(1)}`).join(' ')
+  const area = `${line} L${x(samples[samples.length - 1].t).toFixed(1)},${H - PAD} L${x(samples[0].t).toFixed(1)},${H - PAD} Z`
+  const last = samples[samples.length - 1]
+  return (
+    <div className="mt-2">
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" style={{ height: H }} role="img"
+           aria-label={`Occupancy over the last 24 hours, currently ${last.avg}`}>
+        {ceiling > 0 && (
+          <line x1={PAD} x2={W - PAD} y1={y(ceiling)} y2={y(ceiling)}
+                stroke="var(--danger,#e5484d)" strokeOpacity="0.35"
+                strokeWidth="1" strokeDasharray="3 3" />
+        )}
+        <path d={area} fill="var(--accent,#3b82f6)" fillOpacity="0.14" />
+        <path d={line} fill="none" stroke="var(--accent,#3b82f6)" strokeWidth="2"
+              strokeLinejoin="round" strokeLinecap="round" />
+        {samples.map((sm) => (
+          <circle key={sm.t} cx={x(sm.t)} cy={y(sm.avg)} r="5"
+                  fill="transparent">
+            <title>{`${new Date(sm.t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} · avg ${sm.avg} · peak ${sm.max}`}</title>
+          </circle>
+        ))}
+        <circle cx={x(last.t)} cy={y(last.avg)} r="3.5"
+                fill="var(--accent,#3b82f6)" stroke="var(--bg-1,#fff)" strokeWidth="2" />
+      </svg>
+      <div className="flex justify-between text-[10px] text-[var(--text-dim)]" style={{ fontVariantNumeric: 'tabular-nums' }}>
+        <span>24h ago</span>
+        <span>avg {last.avg} now</span>
+      </div>
+    </div>
+  )
+}
+
+/** Average head-count by hour of day (7d) — one sequential hue, the
+ * peak bar direct-labeled, everything else on hover. */
+function BusiestHoursChart({ hours }: { hours: { hour: number; avg: number }[] }) {
+  const byHour = new Map(hours.map((h) => [h.hour, h.avg]))
+  const slots = Array.from({ length: 24 }, (_, h) => ({ hour: h, avg: byHour.get(h) ?? 0 }))
+  const top = Math.max(...slots.map((s) => s.avg), 1)
+  const peak = slots.reduce((a, b) => (b.avg > a.avg ? b : a))
+  const W = 720, H = 96, PAD = 4, LABEL_H = 14
+  const bw = (W - 2 * PAD) / 24
+  const y = (v: number) => (H - LABEL_H - PAD) * (1 - v / top) + PAD
+  const fmtHour = (h: number) => `${String(h).padStart(2, '0')}:00`
+  return (
+    <div className="overflow-x-auto">
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" style={{ minWidth: 480, height: H }}
+           role="img" aria-label={`Busiest hour is ${fmtHour(peak.hour)} with an average of ${peak.avg}`}>
+        {slots.map((sl) => {
+          const barTop = y(sl.avg)
+          const barH = Math.max(H - LABEL_H - PAD - barTop, sl.avg > 0 ? 2 : 0)
+          const isPeak = sl.hour === peak.hour && sl.avg > 0
+          return (
+            <g key={sl.hour}>
+              {barH > 0 && (
+                <rect
+                  x={PAD + sl.hour * bw + 1}
+                  y={barTop}
+                  width={bw - 2}
+                  height={barH}
+                  rx="3"
+                  fill="var(--accent,#3b82f6)"
+                  fillOpacity={isPeak ? 1 : 0.55}
+                />
+              )}
+              <rect x={PAD + sl.hour * bw} y={0} width={bw} height={H - LABEL_H}
+                    fill="transparent">
+                <title>{`${fmtHour(sl.hour)} · avg ${sl.avg}`}</title>
+              </rect>
+              {isPeak && (
+                <text x={PAD + sl.hour * bw + bw / 2} y={Math.max(barTop - 4, 10)}
+                      textAnchor="middle" fontSize="10"
+                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                      fill="var(--text,#1a1a1a)">{sl.avg}</text>
+              )}
+              {sl.hour % 6 === 0 && (
+                <text x={PAD + sl.hour * bw + bw / 2} y={H - 3}
+                      textAnchor="middle" fontSize="9"
+                      fill="var(--text-dim,#6b7280)">{fmtHour(sl.hour)}</text>
+              )}
+            </g>
+          )
+        })}
+      </svg>
+    </div>
   )
 }

--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -223,6 +223,27 @@ whether or not a barrier is attached.
 Consumers MUST treat any decision other than `allow` as "do not
 actuate" — unknown future decision values fail closed.
 
+### `occupancy.changed.v1`
+
+Subject: `opennvr.events.occupancy.changed.v1.<camera_id>`
+Producer: `app:occupancy-counting` (or any app measuring zone
+occupancy — consumers must not branch on the producer).
+
+Fired when a zone's head-count CHANGES — sampled, not per-frame: the
+producer publishes on every committed level transition and otherwise
+at most once per ~10s per camera while the count moves. This is the
+history feed behind the Occupancy page's charts; core persists the
+samples (90-day retention).
+
+`payload`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `count` | int | Entities currently in the zone. |
+| `level` | string | The committed alerting band: `normal`, `over`, `under`. Additive: consumers must tolerate new bands. |
+| `max_occupancy` | int \| null | The zone's configured ceiling at publish time (charts scale against it). |
+| `min_occupancy` | int \| null | The configured floor, when set. |
+
 ## Out of contract (deliberately)
 
 * `opennvr.inference.>` payload internals beyond what each adapter's

--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -78,6 +79,7 @@ from opennvr_app_sdk import (
     AlertType,
     AppManifest,
     Detector,
+    DomainEventPublisher,
     Param,
     StateView,
     app,
@@ -126,10 +128,17 @@ def _scope_to_assignment(discovered: list[dict]) -> list[dict]:
     return scoped
 
 
+#: The contracted history feed this app publishes (EVENT_CONTRACTS.md):
+#: on every committed level transition, and otherwise at most once per
+#: this many seconds per camera while the count moves.
+OCCUPANCY_SCHEMA = "occupancy.changed.v1"
+PUBLISH_MIN_INTERVAL_SECONDS = 10.0
+
+
 MANIFEST = AppManifest(
     id="occupancy-counting",
     name="Occupancy Counting",
-    version="1.1.0",
+    version="1.2.0",
     category="analytics",
     summary="Alerts on zone occupancy threshold crossings (over / under / cleared).",
     requires_tasks=["object_detection"],  # checked vs GET /api/v1/adapters
@@ -538,6 +547,13 @@ class OccupancyCounter(Detector):
 
     def setup(self) -> None:
         self._states: dict[str, _ZoneState] = {}
+        # occupancy.changed.v1 sampling state: last published (count, ts)
+        # per camera. The publisher never raises on bus trouble.
+        self._occupancy_publisher = DomainEventPublisher(
+            self._config.nats_url, token=self._config.nats_token,
+            producer="app:occupancy-counting")
+        self._last_published: dict[str, tuple[int, float]] = {}
+        self._history_events_published: int = 0
         # Only auto-derived camera sets are refreshed; an explicit list is
         # the operator's word and is never second-guessed.
         self._auto_cameras: bool = bool(
@@ -685,6 +701,10 @@ class OccupancyCounter(Detector):
         candidate = self._classify(camera, count)
         state = self._states.setdefault(camera_id, _ZoneState())
         state.last_count = count
+        # History feed (EVENT_CONTRACTS.md occupancy.changed.v1) —
+        # sampled here, forced below on committed transitions.
+        self._publish_occupancy(camera_id, camera, count, state.level,
+                                force=False)
 
         # Already in the candidate band → nothing to commit; clear any
         # half-formed pending transition (the level is stable).
@@ -708,6 +728,8 @@ class OccupancyCounter(Detector):
         state.level = candidate
         state.pending = None
         state.pending_count = 0
+        self._publish_occupancy(camera_id, camera, count, candidate,
+                                force=True)
 
         # Returning to normal → only fire if clear_alerts is on.
         if candidate == "normal" and not self._config.clear_alerts:
@@ -718,6 +740,33 @@ class OccupancyCounter(Detector):
             previous=previous, event=event,
         )]
 
+    def _publish_occupancy(self, camera_id: str, camera: Any,
+                           count: int, level: str, *, force: bool) -> None:
+        """Sampled occupancy.changed.v1 publish: always on a committed
+        level transition (``force``), otherwise only when the count
+        changed and the per-camera interval has passed. Bus trouble is
+        the channel's problem (log-never-raise), never the counter's."""
+        last = self._last_published.get(camera_id)
+        now = time.monotonic()
+        if not force:
+            if last is not None and last[0] == count:
+                return
+            if last is not None and (now - last[1]) < PUBLISH_MIN_INTERVAL_SECONDS:
+                return
+        self._last_published[camera_id] = (count, now)
+        ok = self._occupancy_publisher.publish(
+            OCCUPANCY_SCHEMA,
+            camera_id=camera_id,
+            payload={
+                "count": count,
+                "level": level,
+                "max_occupancy": getattr(camera, "max_occupancy", None),
+                "min_occupancy": getattr(camera, "min_occupancy", None),
+            },
+        )
+        if ok:
+            self._history_events_published += 1
+
     def state_snapshot(self) -> dict[str, Any]:
         """``GET /state`` — live occupancy per configured camera plus
         two roll-ups (total people, zones over limit) for the app's
@@ -725,6 +774,7 @@ class OccupancyCounter(Detector):
         return {
             "total_people": sum(s.last_count for s in self._states.values()),
             "zones_over": sum(1 for s in self._states.values() if s.level == "over"),
+            "history_events_published": self._history_events_published,
             "cameras": {
                 camera_id: {
                     "level": state.level,

--- a/examples/occupancy-counting/tests/conftest.py
+++ b/examples/occupancy-counting/tests/conftest.py
@@ -1,0 +1,28 @@
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_domain_event_publisher(monkeypatch):
+    """Unit tests must never dial NATS: the occupancy.changed.v1
+    publisher is stubbed with a recorder. Tests that care read
+    ``app._occupancy_publisher.calls``."""
+    import occupancy_counting as oc
+
+    class _StubPublisher:
+        def __init__(self, url, *, token=None, producer="app"):
+            self.url = url
+            self.token = token
+            self.producer = producer
+            self.calls = []
+
+        def publish(self, schema, *, camera_id, payload, correlation_id=None):
+            self.calls.append({"schema": schema, "camera_id": camera_id,
+                               "payload": payload})
+            return True
+
+        def close(self):  # pragma: no cover - symmetry
+            pass
+
+    monkeypatch.setattr(oc, "DomainEventPublisher", _StubPublisher)

--- a/examples/occupancy-counting/tests/test_occupancy_counting.py
+++ b/examples/occupancy-counting/tests/test_occupancy_counting.py
@@ -507,3 +507,47 @@ def test_explicit_camera_list_ignores_assignments(tmp_path, monkeypatch):
         "    zone: [[0, 0], [1920, 0], [1920, 1080], [0, 1080]]\n"
     )))
     assert list(cfg.cameras) == ["cam1"] and called["n"] == 0
+
+
+# ── occupancy.changed.v1 history feed ───────────────────────────────
+
+
+def test_history_publishes_on_count_change_and_transition(monkeypatch):
+    t = {"now": 1000.0}
+    monkeypatch.setattr(oc.time, "monotonic", lambda: t["now"])
+    app = _counter(_camera())
+    app.handle_event(_event(1))
+    calls = app._occupancy_publisher.calls
+    assert len(calls) == 1
+    assert calls[0]["schema"] == "occupancy.changed.v1"
+    assert calls[0]["camera_id"] == "cam-1"
+    assert calls[0]["payload"] == {
+        "count": 1, "level": "normal", "max_occupancy": 2,
+        "min_occupancy": None}
+    # Same count again → nothing (change-driven, not per-frame).
+    app.handle_event(_event(1))
+    assert len(calls) == 1
+    # A committed level transition publishes even inside the interval.
+    t["now"] += 1.0
+    app.handle_event(_event(3))  # over max_occ=2, debounce=1 → commit
+    levels = [c["payload"]["level"] for c in calls]
+    assert "over" in levels
+    assert calls[-1]["payload"]["count"] == 3
+
+
+def test_history_interval_suppresses_chatter(monkeypatch):
+    t = {"now": 1000.0}
+    monkeypatch.setattr(oc.time, "monotonic", lambda: t["now"])
+    app = _counter(_camera())
+    app.handle_event(_event(1))
+    t["now"] += 2.0
+    app.handle_event(_event(2))   # count changed but < 10s → suppressed…
+    calls = app._occupancy_publisher.calls
+    normal_only = [c for c in calls if c["payload"]["level"] == "normal"]
+    assert len(normal_only) == 1
+    t["now"] += 10.0
+    app.handle_event(_event(2))   # …interval passed → published
+    normal_only = [c for c in app._occupancy_publisher.calls
+                   if c["payload"]["level"] == "normal"]
+    assert len(normal_only) == 2
+    assert app.state_snapshot()["history_events_published"] >= 2

--- a/server/main.py
+++ b/server/main.py
@@ -72,6 +72,7 @@ from routers import (
     mediamtx_admin,
     mediamtx_hooks,
     network as network_router,
+    occupancy as occupancy_router,
     onvif as onvif_router,
     orphaned_recordings,
     password_policy,
@@ -541,6 +542,18 @@ async def lifespan(app: FastAPI):
 
     asyncio.create_task(background_plate_event_consumer())
 
+    # Occupancy history: consume occupancy.changed.v1 samples into the
+    # history store (EVENT_CONTRACTS.md). Same best-effort posture.
+    async def background_occupancy_event_consumer():
+        try:
+            from services.occupancy_event_consumer import run_consumer_loop
+
+            await run_consumer_loop()
+        except Exception as e:
+            main_logger.error(f"Occupancy consumer failed: {e}", exc_info=True)
+
+    asyncio.create_task(background_occupancy_event_consumer())
+
     # Start camera connectivity reconciler — safety net for the MediaMTX
     # runOnReady/runOnNotReady hooks (catches missed hooks and restarts of
     # either process). The loop delays its first pass internally so startup
@@ -770,6 +783,7 @@ app.include_router(
 )
 app.include_router(system, prefix=settings.api_prefix)
 app.include_router(events_router, prefix=settings.api_prefix)
+app.include_router(occupancy_router.router, prefix=settings.api_prefix)
 
 
 # =============================================================================

--- a/server/migrations/versions/ee11ff22aa33_add_occupancy_samples.py
+++ b/server/migrations/versions/ee11ff22aa33_add_occupancy_samples.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""add occupancy_samples (occupancy.changed.v1 history)
+
+Revision ID: ee11ff22aa33
+Revises: dd00ee11ff22
+Create Date: 2026-08-31
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "ee11ff22aa33"
+down_revision = "dd00ee11ff22"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "occupancy_samples",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column("camera_id", sa.Integer(), nullable=False, index=True),
+        sa.Column("count", sa.Integer(), nullable=False),
+        sa.Column("level", sa.String(length=16), nullable=False,
+                  server_default="normal"),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False,
+                  index=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("occupancy_samples")

--- a/server/models.py
+++ b/server/models.py
@@ -1074,3 +1074,24 @@ class AppInstallIntent(Base):
     requested_by = Column(String(100), nullable=True)
     requested_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+
+class OccupancySample(Base):
+    """One sampled zone head-count from the bus (RFC round: occupancy
+    history). Written by ``services/occupancy_event_consumer.py`` from
+    contracted ``occupancy.changed.v1`` events — change-driven samples,
+    not per-frame — and read by the Occupancy page's history charts.
+    Retention: the consumer prunes rows older than 90 days."""
+
+    __tablename__ = "occupancy_samples"
+
+    id = Column(Integer, primary_key=True, index=True)
+    # Core camera id, parsed from the platform handle ("cam3" → 3) so
+    # history queries owner-scope through the cameras table like every
+    # other read surface.
+    camera_id = Column(Integer, nullable=False, index=True)
+    count = Column(Integer, nullable=False)
+    # The committed alerting band at sample time: normal | over | under
+    # (additive — future producers may add bands).
+    level = Column(String(16), nullable=False, default="normal")
+    ts = Column(DateTime(timezone=True), nullable=False, index=True)

--- a/server/routers/occupancy.py
+++ b/server/routers/occupancy.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 OpenNVR
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Occupancy history — the read side of ``occupancy.changed.v1``.
+
+The consumer writes samples; this router serves the Occupancy page's
+charts: a bucketed series per camera over the requested window plus
+busiest-hours-of-day over the last 7 days. Owner-scoped through the
+cameras table like every other read surface."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from core.database import get_db
+from core.auth import get_current_active_user
+from models import Camera, OccupancySample, User
+
+router = APIRouter(tags=["occupancy"])
+
+
+def occupancy_history(
+    db: Session,
+    *,
+    hours: int = 24,
+    owner_id: int | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """Bucketed occupancy series + busiest hours. Bucketing happens in
+    Python (dialect portability; the feed is change-driven so windows
+    stay small)."""
+    now = now or datetime.now(timezone.utc)
+    hours = max(1, min(int(hours), 24 * 7))
+    bucket_minutes = 60 if hours > 24 else 15
+    start = now - timedelta(hours=hours)
+    week_start = now - timedelta(days=7)
+
+    q = db.query(OccupancySample).filter(OccupancySample.ts >= week_start)
+    if owner_id is not None:
+        q = q.join(Camera, Camera.id == OccupancySample.camera_id).filter(
+            Camera.owner_id == owner_id
+        )
+
+    series: dict[int, dict[datetime, list[int]]] = {}
+    hour_of_day: dict[int, list[int]] = {}
+    for row in q.all():
+        ts = row.ts if row.ts.tzinfo else row.ts.replace(tzinfo=timezone.utc)
+        hour_of_day.setdefault(ts.hour, []).append(row.count)
+        if ts < start:
+            continue
+        bucket = ts.replace(
+            minute=(ts.minute // bucket_minutes) * bucket_minutes
+            if bucket_minutes < 60 else 0,
+            second=0, microsecond=0,
+        )
+        series.setdefault(row.camera_id, {}).setdefault(bucket, []).append(
+            row.count)
+
+    cameras = [
+        {
+            "camera_id": camera_id,
+            "samples": [
+                {
+                    "t": bucket.isoformat(),
+                    "avg": round(sum(counts) / len(counts), 1),
+                    "max": max(counts),
+                }
+                for bucket, counts in sorted(buckets.items())
+            ],
+        }
+        for camera_id, buckets in sorted(series.items())
+    ]
+    busiest = [
+        {"hour": hour, "avg": round(sum(counts) / len(counts), 1)}
+        for hour, counts in sorted(hour_of_day.items())
+    ]
+    return {
+        "hours": hours,
+        "bucket_minutes": bucket_minutes,
+        "cameras": cameras,
+        "busiest_hours": busiest,
+    }
+
+
+@router.get("/occupancy/history")
+async def get_occupancy_history(
+    hours: int = 24,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """Occupancy trends for the charts: bucketed avg/max per camera over
+    the window, and busiest hours of day over the last 7 days."""
+    return occupancy_history(
+        db,
+        hours=hours,
+        owner_id=None if current_user.is_superuser else current_user.id,
+    )

--- a/server/services/occupancy_event_consumer.py
+++ b/server/services/occupancy_event_consumer.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 OpenNVR
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Core consumes ``occupancy.changed.v1`` into the history store.
+
+The occupancy app measures; core remembers. Contracted samples
+(docs/EVENT_CONTRACTS.md) land as ``occupancy_samples`` rows so the
+Occupancy page can chart trends and busiest hours — the producer keeps
+zero history and can restart freely.
+
+Best-effort by design, exactly like the plate consumer: no NATS URL,
+missing nats-py, or a down broker degrades to "no history accrues";
+live state on the page keeps working. Retention is enforced HERE (the
+only writer): every ``_PRUNE_EVERY`` applied samples, rows older than
+``RETENTION_DAYS`` are deleted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+SUBJECT = "opennvr.events.occupancy.changed.v1.>"
+
+RETENTION_DAYS = 90
+_PRUNE_EVERY = 500
+_RETRY_SECONDS = 60.0
+
+_CAMERA_HANDLE = re.compile(r"^cam(\d+)$")
+_applies_since_prune = 0
+
+
+def apply_occupancy_event(envelope: object) -> str:
+    """Apply one ``occupancy.changed.v1`` envelope to the history store.
+
+    Pure-decision core, unit-testable without a bus. Status tokens:
+
+    * ``"applied"``   — sample row written.
+    * ``"bad-camera"``— camera_id is not a core handle (``camN``);
+      nothing to join history to.
+    * ``"malformed"`` — no usable count in the payload.
+    """
+    global _applies_since_prune
+    if not isinstance(envelope, dict):
+        return "malformed"
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        return "malformed"
+    count = payload.get("count")
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        return "malformed"
+    handle = str(envelope.get("camera_id") or "")
+    m = _CAMERA_HANDLE.match(handle)
+    if not m:
+        return "bad-camera"
+    camera_id = int(m.group(1))
+    level = str(payload.get("level") or "normal")[:16]
+
+    ts = datetime.now(timezone.utc)
+    raw_ts = envelope.get("ts")
+    if isinstance(raw_ts, str):
+        try:
+            parsed = datetime.fromisoformat(raw_ts)
+            if parsed.tzinfo is not None:
+                ts = parsed
+        except ValueError:
+            pass
+
+    from core.database import SessionLocal
+    from models import OccupancySample
+
+    db = SessionLocal()
+    try:
+        db.add(OccupancySample(camera_id=camera_id, count=count,
+                               level=level, ts=ts))
+        _applies_since_prune += 1
+        if _applies_since_prune >= _PRUNE_EVERY:
+            _applies_since_prune = 0
+            cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+            db.query(OccupancySample).filter(
+                OccupancySample.ts < cutoff).delete()
+        db.commit()
+        return "applied"
+    finally:
+        db.close()
+
+
+async def _handle_message(msg) -> None:
+    try:
+        envelope = json.loads(msg.data.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        logger.debug("occupancy consumer: undecodable message on %s",
+                     msg.subject)
+        return
+    try:
+        status = await asyncio.to_thread(apply_occupancy_event, envelope)
+        if status != "applied":
+            logger.debug("occupancy consumer: %s for %s", status, msg.subject)
+    except Exception:  # noqa: BLE001
+        logger.warning("occupancy consumer: apply failed", exc_info=True)
+
+
+async def run_consumer_loop() -> None:
+    """Subscribe to ``occupancy.changed.v1`` for the process lifetime.
+    Returns immediately with no NATS URL; retries slowly otherwise."""
+    from core.config import settings
+
+    url = (getattr(settings, "nats_url", "") or "").strip()
+    if not url:
+        logger.info("occupancy consumer disabled (no NATS_URL) — no "
+                    "occupancy history accrues")
+        return
+    try:
+        import nats
+    except ImportError:
+        logger.warning("occupancy consumer disabled: nats-py not installed")
+        return
+
+    token = (getattr(settings, "internal_api_key", "") or "").strip() or None
+
+    while True:
+        try:
+            client = await nats.connect(url, connect_timeout=5, token=token)
+            await client.subscribe(SUBJECT, cb=_handle_message)
+            logger.info("occupancy consumer subscribed to %s", SUBJECT)
+            try:
+                while True:
+                    await asyncio.sleep(3600)
+            finally:
+                try:
+                    await client.drain()
+                except Exception:  # noqa: BLE001
+                    pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "occupancy consumer: connect/subscribe failed (%s); "
+                "retrying in %ss", exc, int(_RETRY_SECONDS))
+            await asyncio.sleep(_RETRY_SECONDS)

--- a/server/tests/test_occupancy_history.py
+++ b/server/tests/test_occupancy_history.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Occupancy history: the consumer's decision core and the read-side
+rollups behind the Occupancy page's charts."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_occh_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.database as cdb  # noqa: E402
+import models  # noqa: E402
+import services.occupancy_event_consumer as occ  # noqa: E402
+from routers.occupancy import occupancy_history  # noqa: E402
+
+NOW = datetime(2026, 8, 31, 12, 0, tzinfo=timezone.utc)
+
+
+def _envelope(count, *, camera="cam1", level="normal", ts=None, **overrides):
+    env = {
+        "id": "evt_0123456789ab",
+        "schema": "occupancy.changed.v1",
+        "correlation_id": None,
+        "camera_id": camera,
+        "ts": (ts or NOW).isoformat(),
+        "producer": "app:occupancy-counting",
+        "payload": {"count": count, "level": level,
+                    "max_occupancy": 25, "min_occupancy": None},
+    }
+    env.update(overrides)
+    return env
+
+
+@pytest.fixture()
+def db(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    monkeypatch.setitem(sys.modules, "models", models)
+    eng = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    models.Base.metadata.create_all(eng)
+    SessionLocal = sessionmaker(bind=eng)
+    monkeypatch.setattr(cdb, "SessionLocal", SessionLocal)
+    s = SessionLocal()
+    role = models.Role(name="admin"); s.add(role); s.commit()
+    users = {}
+    for name in ("alice", "bob"):
+        u = models.User(username=name, email=f"{name}@x", hashed_password="x",
+                        role_id=role.id)
+        s.add(u); s.commit()
+        users[name] = u
+    cams = {}
+    for name, owner in (("hall", "alice"), ("lot", "bob")):
+        c = models.Camera(name=name, ip_address="10.0.0.9",
+                          owner_id=users[owner].id)
+        s.add(c); s.commit()
+        cams[name] = c
+    yield s, users, cams
+    s.close()
+
+
+# ── The consumer's decision core ────────────────────────────────────
+
+
+def test_apply_inserts_sample(db):
+    s, _users, cams = db
+    assert occ.apply_occupancy_event(
+        _envelope(7, camera=f"cam{cams['hall'].id}", level="over")) == "applied"
+    row = s.query(models.OccupancySample).one()
+    assert (row.camera_id, row.count, row.level) == (cams["hall"].id, 7, "over")
+    assert row.ts is not None
+
+
+def test_apply_rejects_junk(db):
+    assert occ.apply_occupancy_event("nope") == "malformed"
+    assert occ.apply_occupancy_event({"payload": {}}) == "malformed"
+    assert occ.apply_occupancy_event(_envelope(-1)) == "malformed"
+    assert occ.apply_occupancy_event(_envelope(True)) == "malformed"
+    assert occ.apply_occupancy_event(_envelope(3, camera="lobby")) == "bad-camera"
+    s, _u, _c = db
+    assert s.query(models.OccupancySample).count() == 0
+
+
+def test_retention_prunes_old_rows(db, monkeypatch):
+    s, _users, cams = db
+    old = NOW - timedelta(days=120)
+    s.add(models.OccupancySample(camera_id=cams["hall"].id, count=1,
+                                 level="normal", ts=old))
+    s.commit()
+    monkeypatch.setattr(occ, "_PRUNE_EVERY", 1)
+    monkeypatch.setattr(occ, "_applies_since_prune", 0)
+    assert occ.apply_occupancy_event(
+        _envelope(2, camera=f"cam{cams['hall'].id}")) == "applied"
+    counts = [r.count for r in s.query(models.OccupancySample).all()]
+    assert counts == [2]  # the 120-day-old row was pruned
+
+
+# ── The read-side rollups ───────────────────────────────────────────
+
+
+def _sample(s, cam, count, *, hours_ago=1.0, level="normal"):
+    s.add(models.OccupancySample(
+        camera_id=cam.id, count=count, level=level,
+        ts=NOW - timedelta(hours=hours_ago)))
+    s.commit()
+
+
+def test_history_buckets_and_owner_scope(db):
+    s, users, cams = db
+    _sample(s, cams["hall"], 4, hours_ago=1.2)
+    _sample(s, cams["hall"], 8, hours_ago=1.1)   # same hour bucket
+    _sample(s, cams["hall"], 2, hours_ago=5.0)
+    _sample(s, cams["lot"], 30, hours_ago=1.0)   # bob's camera
+    _sample(s, cams["hall"], 9, hours_ago=30.0)  # outside 24h window
+
+    got = occupancy_history(s, hours=48, owner_id=users["alice"].id, now=NOW)
+    assert got["bucket_minutes"] == 60
+    assert [c["camera_id"] for c in got["cameras"]] == [cams["hall"].id]
+    samples = got["cameras"][0]["samples"]
+    # 3 buckets in the 48h window: 30h ago, 5h ago, ~1h ago.
+    assert len(samples) == 3
+    merged = samples[-1]
+    assert merged["avg"] == 6.0 and merged["max"] == 8
+    # Busiest hours cover 7d and only alice's cameras.
+    hours = {b["hour"]: b["avg"] for b in got["busiest_hours"]}
+    assert 30 not in [a for a in hours.values()]  # bob's 30 excluded
+
+
+def test_history_fleet_view_and_fine_buckets(db):
+    s, _users, cams = db
+    _sample(s, cams["lot"], 30, hours_ago=0.1)
+    got = occupancy_history(s, hours=24, owner_id=None, now=NOW)
+    assert got["bucket_minutes"] == 15
+    assert [c["camera_id"] for c in got["cameras"]] == [cams["lot"].id]


### PR DESCRIPTION
…, charts

Round 2 of the competitive plan: the 2026 occupancy market is sold on history and comparisons; we were live-only. Now the vertical remembers.

Contract (EVENT_CONTRACTS.md, ratchet green):
- occupancy.changed.v1: sampled, not per-frame — the producer publishes on every committed level transition and otherwise at most once per ~10s per camera while the count moves. Payload {count, level, max_occupancy, min_occupancy}.

Occupancy app (v1.2.0):
- Publishes via the SDK's DomainEventPublisher (producer app:occupancy-counting): forced on transitions, sampled otherwise; counter in state. Unit tests stub the publisher at the module seam (autouse conftest) so the suite never dials NATS. 2 new tests.

Core:
- occupancy_samples table (+ migration ee11ff22aa33; graph green) — camera_id parsed from the platform handle so history owner-scopes through the cameras table like every read surface.
- services/occupancy_event_consumer.py: best-effort lifespan consumer mirroring the plate consumer; 90-day retention enforced at the only writer (prune every 500 applies). Decision core unit-tested (insert / junk / bad-camera / retention).
- GET /api/v1/occupancy/history: bucketed avg+max per camera over the window (15-min buckets ≤24h, hourly above) + busiest hours of day over 7 days. Owner-scoped. 2 tests.

Occupancy page:
- Per-zone 24h sparkline in each live card (2px line, soft area, emphasized endpoint, dashed ceiling gridline, per-sample hover titles, text in text tokens) and a Busiest-hours bar chart (single hue, peak direct-labeled, per-bar hover, 6-hourly axis) — built to the dataviz method; single-series so no legend/palette questions. History accrues from the moment the app update runs; the card says so honestly until then.