### PR TITLE
fix(kai-c): adapter registrations survive restarts (#371)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,7 @@ AI-adapters/
 
 # Launcher-written host network hints (mounted into opennvr-core)
 data/net-hints/
+
+# KAI-C runtime adapter-registration receipts (#371) — machine state,
+# never source. In Docker this lives on the opennvr_kai_c_state volume.
+kai-c-state/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -461,6 +461,11 @@ services:
       # container recreates; otherwise MediaMTX keeps serving its cached
       # JWKS and rejects every stream token until it is restarted.
       - opennvr_jwt_keys:/app/keys
+      # KAI-C adapter-registration receipts (#371) — runtime-registered
+      # adapters (e.g. fast_plate_ocr from the LPR app overlay) are
+      # re-registered from this file on boot, so restarting/recreating
+      # this container no longer silently kills plate recognition.
+      - opennvr_kai_c_state:/app/kai-c-state
       # Host LAN IP hints, rewritten by the launchers on every run so ONVIF
       # discovery keeps seeing the host's *current* networks even when the
       # OPENNVR_HOST_IP/OPENNVR_LAN_IPS env vars (frozen at container
@@ -505,6 +510,9 @@ services:
       # mediamtx service, losing it no longer breaks live WebRTC.
       - MEDIAMTX_WEBRTC_HOSTS=${MEDIAMTX_WEBRTC_HOSTS:-}
       - KAI_C_URL=http://127.0.0.1:8100
+      # Where KAI-C persists runtime adapter registrations (#371) —
+      # points at the opennvr_kai_c_state volume mounted above.
+      - KAI_C_STATE_DIR=/app/kai-c-state
       # ONVIF discovery auto-detection: inside this bridge container the only
       # visible network is the compose bridge, so the launchers export the
       # host's LAN IPs as the real subnet hints — OPENNVR_HOST_IP (default
@@ -700,3 +708,7 @@ volumes:
   # Rotate by removing the volume with core stopped, then restart
   # mediamtx so it refetches the JWKS.
   opennvr_jwt_keys:
+  # KAI-C runtime adapter registrations + grants (#371). Removing this
+  # volume forgets app-registered adapters — re-run the app overlay's
+  # registrar (or re-register on the AI Models page) to restore them.
+  opennvr_kai_c_state:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,6 +16,14 @@ if [ -d "/app/keys" ]; then
     chown -R opennvr:opennvr /app/keys 2>/dev/null || true
 fi
 
+# KAI-C adapter-registration state volume (#371) — first mount is
+# root-owned; KAI-C (running as opennvr under supervisord) must be able
+# to write its receipts file there or persistence silently degrades to
+# the old restart-amnesia behaviour (it WARNs, but still).
+if [ -d "/app/kai-c-state" ]; then
+    chown -R opennvr:opennvr /app/kai-c-state 2>/dev/null || true
+fi
+
 # Recordings tree: MediaMTX used to run as root, so segment dirs it created
 # under the shared mount were root-owned — unlinkable by the backend
 # (uid 1000), which broke retention aging and the camera hard-delete purge

--- a/kai-c/kai_c/persistence.py
+++ b/kai-c/kai_c/persistence.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Durable adapter-registration state (issue #371).
+
+The registry itself stays an in-memory cache — this module is the thin
+receipt file underneath it, so that adapters registered at RUNTIME (an
+app overlay's one-shot registrar, an operator on the AI Models page)
+survive a KAI-C restart. Before this file existed, restarting
+``opennvr-core`` silently forgot every runtime registration: the
+one-shot registrar had already exited, nothing re-registered the
+adapter, and every plate read 404'd with no operator signal.
+
+Design constraints, in order:
+
+* **Never block or break boot.** A missing, unreadable, or corrupt
+  state file degrades to "no persisted adapters" with a WARNING —
+  exactly the pre-#371 behaviour, never a crash loop.
+* **Persist intent, not state.** We store (name, url, granted
+  permission keys) — the operator's decisions. Capabilities, health,
+  and fingerprints are re-fetched from the live adapter on restore, so
+  the §11.3 drift machinery (not a stale snapshot) decides what the
+  adapter looks like today. A restored grant is re-applied through the
+  normal ``grant_permissions`` path, which intersects against the
+  freshly-declared key set: a key the adapter no longer declares is
+  dropped, a key it newly declares stays pending. No approval
+  side-channel.
+* **Atomic writes.** tmp + ``os.replace`` so a power cut mid-write
+  leaves the previous file, not half a JSON document.
+
+Only runtime-registered adapters are persisted. Seeds from
+``ADAPTER_REGISTRY`` are re-registered from configuration on every
+boot (config-as-consent, §8.5) — persisting them too would let a
+seed the operator *removed from config* resurrect from disk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+STATE_FILE_NAME = "adapters.json"
+STATE_VERSION = 1
+
+
+class RegistryStateStore:
+    """Load/save the runtime-adapter receipt file.
+
+    ``directory=None`` disables persistence entirely (unit tests, or an
+    operator explicitly opting out with ``KAI_C_STATE_DIR=""``) — every
+    method becomes a no-op that reports "nothing persisted".
+    """
+
+    def __init__(self, directory: str | Path | None) -> None:
+        self._path: Path | None = None
+        if directory:
+            self._path = Path(directory) / STATE_FILE_NAME
+
+    @property
+    def path(self) -> Path | None:
+        return self._path
+
+    @property
+    def enabled(self) -> bool:
+        return self._path is not None
+
+    def load(self) -> list[dict[str, Any]]:
+        """Return the persisted adapter entries — ``[{name, url,
+        granted_permissions}]`` — or ``[]`` for missing/disabled/corrupt
+        state. Never raises: a broken file is a WARNING and an empty
+        list, because failing boot over a receipt file would be worse
+        than the amnesia it fixes."""
+        if self._path is None or not self._path.exists():
+            return []
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                "adapter state file %s is unreadable (%s) — starting with "
+                "no persisted adapters; runtime registrations will "
+                "re-persist as they arrive", self._path, exc,
+            )
+            return []
+        entries = raw.get("adapters") if isinstance(raw, dict) else None
+        if not isinstance(entries, list):
+            logger.warning(
+                "adapter state file %s has an unexpected shape — ignoring it",
+                self._path,
+            )
+            return []
+        out: list[dict[str, Any]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            url = entry.get("url")
+            if not isinstance(name, str) or not name:
+                continue
+            if not isinstance(url, str) or not url:
+                continue
+            granted = entry.get("granted_permissions")
+            keys = [k for k in granted if isinstance(k, str)] \
+                if isinstance(granted, list) else []
+            out.append({
+                "name": name,
+                "url": url,
+                "granted_permissions": sorted(set(keys)),
+            })
+        return out
+
+    def save(self, entries: list[dict[str, Any]]) -> None:
+        """Atomically write the entries. Best-effort: an unwritable
+        state dir is a WARNING (once per process would be nicer, but
+        writes are rare — one per registration/grant), never an
+        exception into the registration path."""
+        if self._path is None:
+            return
+        payload = {"version": STATE_VERSION, "adapters": entries}
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(
+                dir=str(self._path.parent), prefix=".adapters-", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump(payload, fh, indent=2, sort_keys=True)
+                os.replace(tmp, self._path)
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except OSError as exc:
+            logger.warning(
+                "could not persist adapter state to %s: %s — runtime "
+                "registrations will NOT survive a restart until this is "
+                "fixed", self._path, exc,
+            )

--- a/kai-c/kai_c/registry.py
+++ b/kai-c/kai_c/registry.py
@@ -56,6 +56,7 @@ from kai_c.contract_types import (
     Permissions,
 )
 from kai_c.metrics import MetricsRollup, parse_adapter_metrics, proxy_metrics
+from kai_c.persistence import RegistryStateStore
 from kai_c.sovereignty import (
     SovereigntyViolation,
     adapter_summary_for_audit,
@@ -221,6 +222,12 @@ class RegisteredAdapter:
     last_polled: float = 0.0
     consecutive_health_failures: int = 0
     granted_permissions: set[str] = field(default_factory=set)
+    #: "runtime" — registered via the API (an app overlay's registrar,
+    #: an operator) and therefore PERSISTED across restarts (#371);
+    #: "seed" — from ADAPTER_REGISTRY configuration, re-registered from
+    #: env on every boot and never persisted (a seed removed from
+    #: config must not resurrect from disk).
+    source: str = "runtime"
 
     def declared_keys(self) -> list[str]:
         """The permission keys this adapter declares in /capabilities."""
@@ -244,6 +251,31 @@ class RegisteredAdapter:
         """Fail-closed serving gate: only a fully-approved adapter may
         serve inference (§8 / §11)."""
         return self.approval_status == "approved"
+
+
+@dataclass
+class PendingRegistration:
+    """An adapter we KNOW should exist but could not (yet) register —
+    a seed whose container was still booting, or a persisted runtime
+    adapter that was unreachable during restore. The poll loop retries
+    these every cycle until they register or hit a policy violation
+    (#371 — before this, a failed registration was permanent silence).
+
+    ``grant_all_on_register`` carries the §8.5 config-as-consent
+    semantics for seeds: their declared keys are granted on successful
+    (re-)registration, exactly as the startup seed loop would have.
+    Restored runtime adapters instead re-apply ``granted_keys`` — the
+    operator's actual recorded decisions — through the normal grant
+    path, so capability drift while we were down still lands the
+    adapter in ``pending`` for any newly-declared key."""
+
+    name: str
+    url: str
+    source: str  # "seed" | "runtime"
+    grant_all_on_register: bool = False
+    granted_keys: tuple[str, ...] = ()
+    last_error: str = ""
+    attempts: int = 0
 
 
 # ── Async HTTP helpers ─────────────────────────────────────────────
@@ -303,11 +335,16 @@ class AdapterRegistry:
         poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS,
         http_client: httpx.AsyncClient | None = None,
         auth_token: str | None = None,
+        state_store: RegistryStateStore | None = None,
     ) -> None:
         self._sovereignty_mode = sovereignty_mode.lower()
         self._audit = audit
         self._poll_interval = poll_interval_seconds
         self._adapters: dict[str, RegisteredAdapter] = {}
+        # #371: durable receipts for runtime registrations + the retry
+        # queue for adapters that SHOULD register but couldn't yet.
+        self._state_store = state_store or RegistryStateStore(None)
+        self._pending: dict[str, PendingRegistration] = {}
         self._lock = threading.Lock()
         # §05 observability — bounded per-adapter rollups fed by the
         # /metrics scrape on the same 60s poll (see refresh()).
@@ -348,10 +385,16 @@ class AdapterRegistry:
 
     # ── Public API ─────────────────────────────────────────────────
 
-    async def register(self, name: str, url: str) -> RegisteredAdapter:
+    async def register(
+        self, name: str, url: str, *, source: str = "runtime"
+    ) -> RegisteredAdapter:
         """Register an adapter. Polls /capabilities, runs sovereignty,
         stores. Raises ``SovereigntyViolation`` on policy failure,
-        ``httpx.HTTPError`` on adapter unreachability."""
+        ``httpx.HTTPError`` on adapter unreachability.
+
+        ``source="runtime"`` registrations are persisted so they
+        survive a KAI-C restart (#371); ``source="seed"`` ones come
+        from ADAPTER_REGISTRY configuration and are not."""
         url = url.rstrip("/")
 
         # URL-only sovereignty check (no capabilities yet for the
@@ -376,6 +419,7 @@ class AdapterRegistry:
             url=url,
             capabilities=caps,
             fingerprint=caps.model.fingerprint,
+            source=source,
         )
         # §8 / §11 approval gate: do NOT auto-grant. An adapter that
         # declares any permission starts with an EMPTY granted set →
@@ -384,6 +428,10 @@ class AdapterRegistry:
         # declares no permission is trivially approved (∅ ⊆ ∅).
         with self._lock:
             self._adapters[name] = adapter
+            # A successful registration supersedes any queued retry for
+            # the same name (a restore raced a fresh runtime register).
+            self._pending.pop(name, None)
+            self._persist_locked()
 
         # §11.2 audit — adapter.registered
         self._audit.emit(
@@ -409,6 +457,11 @@ class AdapterRegistry:
     async def deregister(self, name: str, *, reason: str = "operator_action") -> None:
         with self._lock:
             adapter = self._adapters.pop(name, None)
+            # An explicit removal also cancels any queued retry and
+            # drops the persisted receipt — a deregistered adapter must
+            # not resurrect on the next restart.
+            self._pending.pop(name, None)
+            self._persist_locked()
         if adapter is None:
             return
         # Drop the metrics series so the rollup store stays bounded by
@@ -526,6 +579,7 @@ class AdapterRegistry:
                 }
                 adapter.capabilities = new_caps
                 status = adapter.approval_status
+                self._persist_locked()
             self._audit.emit(
                 AuditEventType.ADAPTER_CAPABILITY_DRIFT,
                 adapter=name,
@@ -560,6 +614,8 @@ class AdapterRegistry:
             )
             adapter.granted_permissions.difference_update(stale_grants)
             status_after = adapter.approval_status
+            if stale_grants:
+                self._persist_locked()
         if stale_grants:
             self._emit_grant_event(
                 AuditEventType.ADAPTER_PERMISSION_REVOKED,
@@ -616,6 +672,7 @@ class AdapterRegistry:
             granted_now = sorted(set(keys) & declared)
             adapter.granted_permissions.update(granted_now)
             status = adapter.approval_status
+            self._persist_locked()
         grant_id = self._emit_grant_event(
             AuditEventType.ADAPTER_PERMISSION_GRANTED,
             adapter=name,
@@ -647,6 +704,7 @@ class AdapterRegistry:
             revoked_now = sorted(set(keys) & adapter.granted_permissions)
             adapter.granted_permissions.difference_update(revoked_now)
             status = adapter.approval_status
+            self._persist_locked()
         grant_id = self._emit_grant_event(
             AuditEventType.ADAPTER_PERMISSION_REVOKED,
             adapter=name,
@@ -674,6 +732,7 @@ class AdapterRegistry:
             declared = adapter.declared_keys()
             adapter.granted_permissions.update(declared)
             status = adapter.approval_status
+            self._persist_locked()
         grant_id = self._emit_grant_event(
             AuditEventType.ADAPTER_PERMISSION_GRANTED,
             adapter=name,
@@ -686,6 +745,170 @@ class AdapterRegistry:
             name, len(declared), actor, status,
         )
         return adapter, grant_id
+
+    # ── #371: persistence + deferred-registration retry ─────────────
+
+    def _persist_locked(self) -> None:
+        """Write the runtime-adapter receipts. MUST be called with
+        ``self._lock`` held (every caller already is — this is the
+        one-liner they share). Best-effort: the store logs and swallows
+        I/O failures, so a full disk can't take down a grant call."""
+        if not self._state_store.enabled:
+            return
+        entries = [
+            {
+                "name": a.name,
+                "url": a.url,
+                "granted_permissions": sorted(a.granted_permissions),
+            }
+            for a in self._adapters.values()
+            if a.source == "runtime"
+        ]
+        # Runtime adapters queued for a restore retry keep their receipt
+        # too — a second restart while the adapter is still down must
+        # not forget it (that would re-open the exact hole this fixes).
+        for p in self._pending.values():
+            if p.source == "runtime" and p.name not in self._adapters:
+                entries.append({
+                    "name": p.name,
+                    "url": p.url,
+                    "granted_permissions": sorted(p.granted_keys),
+                })
+        entries.sort(key=lambda e: e["name"])
+        self._state_store.save(entries)
+
+    def defer(
+        self,
+        name: str,
+        url: str,
+        *,
+        source: str,
+        grant_all_on_register: bool = False,
+        granted_keys: list[str] | None = None,
+        error: str = "",
+    ) -> None:
+        """Queue an adapter the registry should keep trying to register
+        — a seed whose container is still booting, or a persisted
+        runtime adapter that was unreachable at restore. Retried every
+        poll cycle by ``retry_pending``."""
+        with self._lock:
+            if name in self._adapters:
+                return
+            self._pending[name] = PendingRegistration(
+                name=name,
+                url=url.rstrip("/"),
+                source=source,
+                grant_all_on_register=grant_all_on_register,
+                granted_keys=tuple(sorted(granted_keys or [])),
+                last_error=error,
+            )
+            if source == "runtime":
+                self._persist_locked()
+        logger.info(
+            "adapter %s @ %s queued for registration retry (%s)",
+            name, url, error or "unreachable",
+        )
+
+    def pending_registrations(self) -> list[dict[str, Any]]:
+        """The adapters we know about but could not register — surfaced
+        additively on GET /api/v1/adapters so a missing adapter is a
+        visible row, not silence (#371)."""
+        with self._lock:
+            return [
+                {
+                    "name": p.name,
+                    "url": p.url,
+                    "source": p.source,
+                    "attempts": p.attempts,
+                    "last_error": p.last_error,
+                }
+                for p in self._pending.values()
+            ]
+
+    def restore_persisted(self) -> list[PendingRegistration]:
+        """Load the receipt file and queue every persisted runtime
+        adapter for registration. Called once from the lifespan handler
+        AFTER config seeds (a name colliding with a seed defers to the
+        seed — configuration wins over history). Returns what was
+        queued, for the boot log. Actual registration happens on the
+        first ``retry_pending`` pass, so an unreachable adapter can
+        never slow down boot."""
+        queued: list[PendingRegistration] = []
+        for entry in self._state_store.load():
+            name = entry["name"]
+            with self._lock:
+                if name in self._adapters or name in self._pending:
+                    continue
+                pending = PendingRegistration(
+                    name=name,
+                    url=entry["url"],
+                    source="runtime",
+                    granted_keys=tuple(entry["granted_permissions"]),
+                    last_error="restore pending",
+                )
+                self._pending[name] = pending
+            queued.append(pending)
+        if queued:
+            logger.info(
+                "restoring %d persisted adapter registration(s): %s",
+                len(queued), ", ".join(p.name for p in queued),
+            )
+        return queued
+
+    async def retry_pending(self) -> None:
+        """Try to register everything in the pending queue. Runs on
+        every poll cycle (and once right after restore). Transient
+        failures stay queued; a sovereignty violation is audited and
+        dropped — policy won't fix itself by retrying."""
+        with self._lock:
+            batch = list(self._pending.values())
+        for p in batch:
+            try:
+                await self.register(p.name, p.url, source=p.source)
+            except SovereigntyViolation as exc:
+                self._audit.emit(
+                    AuditEventType.INFERENCE_REFUSED_SOVEREIGNTY,
+                    adapter=p.name,
+                    reason=str(exc),
+                    sovereignty_mode=self._sovereignty_mode,
+                    registration_url=p.url,
+                )
+                logger.warning(
+                    "dropping pending adapter %s: sovereignty refused (%s)",
+                    p.name, exc,
+                )
+                with self._lock:
+                    self._pending.pop(p.name, None)
+                    if p.source == "runtime":
+                        self._persist_locked()
+                continue
+            except Exception as exc:  # unreachable / bad capabilities
+                with self._lock:
+                    current = self._pending.get(p.name)
+                    if current is not None:
+                        current.attempts += 1
+                        current.last_error = str(exc)
+                logger.debug(
+                    "registration retry failed for %s @ %s: %s",
+                    p.name, p.url, exc,
+                )
+                continue
+            # Registered. Re-apply the recorded consent through the
+            # NORMAL grant paths (audited, drift-safe): seeds get the
+            # §8.5 config-as-consent approve-all; restored runtime
+            # adapters get exactly the keys the operator had granted —
+            # intersected against today's declared set, so new scope
+            # stays pending.
+            if p.grant_all_on_register:
+                self.approve_all(p.name, actor="system:startup-config")
+            elif p.granted_keys:
+                self.grant_permissions(
+                    p.name, list(p.granted_keys), actor="system:state-restore"
+                )
+            logger.info(
+                "pending adapter %s registered after %d retry attempt(s)",
+                p.name, p.attempts,
+            )
 
     def permissions_view(self, name: str) -> dict[str, Any] | None:
         """The §11 permission view for one adapter — declared keys with
@@ -867,6 +1090,14 @@ class AdapterRegistry:
                     await self.refresh(name)
                 except Exception as exc:
                     logger.exception("refresh failed for %s: %s", name, exc)
+            # #371: adapters that should exist but couldn't register yet
+            # (seed containers still booting, restored adapters whose
+            # container comes up after ours) get another try each cycle.
+            if not self._stop_flag.is_set():
+                try:
+                    await self.retry_pending()
+                except Exception as exc:
+                    logger.exception("pending-registration retry pass failed: %s", exc)
 
     # ── Helpers ────────────────────────────────────────────────────
 

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -49,6 +49,7 @@ from kai_c.correlation import CORRELATION_ID_HEADER, CorrelationIdMiddleware
 from kai_c.domain_events import normalise_completion
 from kai_c.events import InferenceCompletedEvent
 from kai_c.nats_publisher import NatsPublisher
+from kai_c.persistence import RegistryStateStore
 from kai_c.registry import AdapterRegistry
 from kai_c.schemas import KAIRequest
 from kai_c.sovereignty import SovereigntyViolation
@@ -318,6 +319,20 @@ async def lifespan(app: FastAPI):
             "a local dev box."
         )
 
+    # #371: durable receipts for runtime adapter registrations. Default
+    # is a ``kai-c-state`` dir next to the working directory; the Docker
+    # stack points this at a named volume so the file survives container
+    # recreation. ``KAI_C_STATE_DIR=""`` (explicit empty) opts out.
+    state_dir = os.getenv("KAI_C_STATE_DIR", "./kai-c-state")
+    state_store = RegistryStateStore(state_dir or None)
+    if state_store.enabled:
+        logger.info("adapter registration state: %s", state_store.path)
+    else:
+        logger.warning(
+            "KAI_C_STATE_DIR is empty — runtime adapter registrations "
+            "will NOT survive a restart."
+        )
+
     _registry = AdapterRegistry(
         sovereignty_mode=AI_SOVEREIGNTY,
         audit=_audit,
@@ -325,10 +340,11 @@ async def lifespan(app: FastAPI):
         # /health polls authenticated past the adapter's 5-minute grace
         # window (otherwise every poll 401s).
         auth_token=INTERNAL_API_KEY or None,
+        state_store=state_store,
     )
     for name, url in ADAPTER_REGISTRY.items():
         try:
-            adapter = await _registry.register(name, url)
+            adapter = await _registry.register(name, url, source="seed")
         except SovereigntyViolation as exc:
             logger.warning("sovereignty refused %s@%s: %s", name, url, exc)
             _audit.emit(
@@ -339,10 +355,20 @@ async def lifespan(app: FastAPI):
                 registration_url=url,
             )
         except Exception as exc:
-            # Adapter unreachable / malformed /capabilities — log and
-            # continue. Operators can re-register via the v2 endpoint
-            # once the adapter is up.
-            logger.info("registration deferred for %s@%s: %s", name, url, exc)
+            # Adapter unreachable / malformed /capabilities. #371: queue
+            # it for the poll loop's retry pass instead of giving up —
+            # in compose, adapter containers routinely come up AFTER
+            # this process on a whole-stack (re)start, and "deferred
+            # forever" was indistinguishable from working. The retry
+            # keeps the §8.5 config-as-consent grant semantics.
+            logger.info(
+                "registration deferred for %s@%s (%s) — will retry each "
+                "poll cycle", name, url, exc,
+            )
+            _registry.defer(
+                name, url, source="seed",
+                grant_all_on_register=True, error=str(exc),
+            )
         else:
             # Contract §8.5 — config-as-consent. This adapter came from
             # the operator's OWN startup configuration (compose overlay /
@@ -357,6 +383,17 @@ async def lifespan(app: FastAPI):
             # seeded adapter back to pending (see registry.refresh()).
             if adapter.pending_keys():
                 _registry.approve_all(name, actor="system:startup-config")
+
+    # #371: bring back runtime registrations (app-overlay registrars,
+    # operator adds) recorded before the restart, then attempt the whole
+    # pending queue once right away — when only opennvr-core restarted,
+    # the adapter containers are still up and this restores LPR et al.
+    # within seconds instead of one poll interval.
+    _registry.restore_persisted()
+    try:
+        await _registry.retry_pending()
+    except Exception as exc:  # never let a restore problem block boot
+        logger.warning("initial pending-registration pass failed: %s", exc)
     await _registry.start_polling()
 
     # NATS publisher for the event-bus broadcast surface. Starts AFTER
@@ -1065,8 +1102,18 @@ async def v1_deregister_adapter(name: str):
 
 @app.get("/api/v1/adapters", dependencies=[Depends(require_internal_api_key)])
 async def v1_list_adapters():
-    """Lightweight adapter summaries — what the OpenNVR UI lists."""
-    return {"adapters": get_registry().list_summaries()}
+    """Lightweight adapter summaries — what the OpenNVR UI lists.
+
+    ``deferred`` (additive, #371) lists adapters the registry knows it
+    SHOULD have but could not register yet — a seed or restored adapter
+    whose container is down. Before this field existed, that state was
+    indistinguishable from "no such adapter", which is how a restart
+    silently killed LPR."""
+    registry = get_registry()
+    return {
+        "adapters": registry.list_summaries(),
+        "deferred": registry.pending_registrations(),
+    }
 
 
 @app.get("/api/v1/ai/capabilities", dependencies=[Depends(require_internal_api_key)])

--- a/kai-c/test/conftest.py
+++ b/kai-c/test/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Shared kai-c test fixtures."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_kai_c_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """#371: the lifespan handler persists adapter registrations to
+    ``KAI_C_STATE_DIR`` (default ``./kai-c-state``). Point every test at
+    its own tmp dir so no test ever writes state into the repo, and no
+    test can see another's persisted adapters."""
+    monkeypatch.setenv("KAI_C_STATE_DIR", str(tmp_path / "kai-c-state"))

--- a/kai-c/test/test_persistence.py
+++ b/kai-c/test/test_persistence.py
@@ -1,0 +1,442 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Issue #371 — adapter registrations must survive a KAI-C restart.
+
+The failure this guards against: an app overlay's ONE-SHOT registrar
+registers ``fast_plate_ocr`` at install time and exits; the registry was
+in-memory only, so the next ``opennvr-core`` restart forgot the adapter,
+every plate read 404'd, and nothing anywhere said so.
+
+The fix has three legs, each tested here:
+
+1. runtime registrations (and their permission grants) are persisted to
+   a receipt file and restored on boot;
+2. registrations that CANNOT complete yet — a seed or restored adapter
+   whose container is still booting — are queued and retried by the poll
+   loop instead of being dropped forever;
+3. the unregistered-but-expected state is visible
+   (``pending_registrations`` / the ``deferred`` field on the listing).
+
+Plus the safety property that must hold through all of it: restore
+re-applies ONLY the operator's recorded grants, intersected against the
+freshly-declared key set — a restart must never widen approval.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from kai_c.audit import AuditStore
+from kai_c.persistence import RegistryStateStore
+from kai_c.registry import AdapterRegistry
+
+from test_registry import _StubAdapter, _base_caps  # reuse the stub kit
+
+
+@pytest.fixture
+def audit(tmp_path: Path) -> AuditStore:
+    return AuditStore(path=str(tmp_path / "audit.jsonl"))
+
+
+def _store(tmp_path: Path) -> RegistryStateStore:
+    return RegistryStateStore(tmp_path / "state")
+
+
+def _registry_for(stub: _StubAdapter, audit: AuditStore,
+                  store: RegistryStateStore | None) -> AdapterRegistry:
+    transport = httpx.MockTransport(stub.respond)
+    return AdapterRegistry(
+        sovereignty_mode="local_only", audit=audit,
+        http_client=httpx.AsyncClient(transport=transport),
+        poll_interval_seconds=999,
+        state_store=store,
+    )
+
+
+class _DownThenUpStub(_StubAdapter):
+    """Refuses connections until ``bring_up()`` — the adapter container
+    that boots slower than KAI-C."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.up = False
+
+    def bring_up(self) -> None:
+        self.up = True
+
+    async def respond(self, request: httpx.Request) -> httpx.Response:
+        if not self.up:
+            raise httpx.ConnectError("connection refused", request=request)
+        return await super().respond(request)
+
+
+# ── The state store itself ─────────────────────────────────────────
+
+
+def test_store_roundtrip(tmp_path: Path):
+    store = _store(tmp_path)
+    entries = [{"name": "fast_plate_ocr",
+                "url": "http://ocr:9004",
+                "granted_permissions": ["gpu"]}]
+    store.save(entries)
+    assert store.load() == entries
+
+
+def test_store_missing_file_is_empty(tmp_path: Path):
+    assert _store(tmp_path).load() == []
+
+
+def test_store_disabled_is_inert(tmp_path: Path):
+    store = RegistryStateStore(None)
+    store.save([{"name": "x", "url": "http://x", "granted_permissions": []}])
+    assert store.load() == []
+    assert not store.enabled
+
+
+def test_store_corrupt_file_degrades_to_empty(tmp_path: Path):
+    store = _store(tmp_path)
+    store.save([{"name": "a", "url": "http://a", "granted_permissions": []}])
+    assert store.path is not None
+    store.path.write_text("{not json", encoding="utf-8")
+    # Corrupt state must mean "nothing persisted", never a crash.
+    assert store.load() == []
+
+
+def test_store_load_drops_malformed_entries(tmp_path: Path):
+    store = _store(tmp_path)
+    assert store.path is not None
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text(json.dumps({"version": 1, "adapters": [
+        {"name": "good", "url": "http://good", "granted_permissions": ["gpu", 7]},
+        {"name": "", "url": "http://nameless"},
+        {"url": "http://no-name"},
+        {"name": "no-url"},
+        "not-a-dict",
+    ]}), encoding="utf-8")
+    loaded = store.load()
+    assert loaded == [
+        {"name": "good", "url": "http://good", "granted_permissions": ["gpu"]}
+    ]
+
+
+def test_store_save_survives_unwritable_dir(tmp_path: Path, caplog):
+    target = tmp_path / "ro"
+    target.mkdir()
+    target.chmod(0o500)
+    store = RegistryStateStore(target)
+    try:
+        # Must warn, must not raise — a full disk cannot break a grant.
+        store.save([{"name": "a", "url": "http://a",
+                     "granted_permissions": []}])
+    finally:
+        target.chmod(0o700)
+
+
+# ── Persist on register / forget on deregister ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runtime_registration_is_persisted(tmp_path: Path, audit):
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps())
+    store = _store(tmp_path)
+    reg = _registry_for(stub, audit, store)
+    await reg.register("fast_plate_ocr", stub.url)
+    assert store.load() == [{
+        "name": "fast_plate_ocr", "url": stub.url,
+        "granted_permissions": [],
+    }]
+    await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_seed_registration_is_not_persisted(tmp_path: Path, audit):
+    """Seeds re-register from config every boot; persisting them would
+    resurrect a seed the operator removed from configuration."""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps())
+    store = _store(tmp_path)
+    reg = _registry_for(stub, audit, store)
+    await reg.register("default", stub.url, source="seed")
+    assert store.load() == []
+    await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_grants_are_persisted(tmp_path: Path, audit):
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps(gpu=True))
+    store = _store(tmp_path)
+    reg = _registry_for(stub, audit, store)
+    await reg.register("gpu_adapter", stub.url)
+    reg.grant_permissions("gpu_adapter", ["gpu"], actor="operator")
+    assert store.load()[0]["granted_permissions"] == ["gpu"]
+    reg.revoke_permissions("gpu_adapter", ["gpu"], actor="operator")
+    assert store.load()[0]["granted_permissions"] == []
+    await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_deregister_removes_receipt(tmp_path: Path, audit):
+    """An operator-removed adapter must NOT resurrect on restart."""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps())
+    store = _store(tmp_path)
+    reg = _registry_for(stub, audit, store)
+    await reg.register("fast_plate_ocr", stub.url)
+    await reg.deregister("fast_plate_ocr")
+    assert store.load() == []
+    # And a fresh registry restoring from the same store sees nothing.
+    reg2 = _registry_for(stub, audit, store)
+    assert reg2.restore_persisted() == []
+    await reg.aclose()
+    await reg2.aclose()
+
+
+# ── Restore across a "restart" ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_restart_restores_runtime_adapter_and_grants(tmp_path: Path, audit):
+    """The issue-#371 scenario end to end: registrar registered +
+    approved fast_plate_ocr; core restarts; the adapter container is
+    still up; the new registry must bring it back — approved — without
+    any re-registration from outside."""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps(gpu=True))
+    store = _store(tmp_path)
+    reg1 = _registry_for(stub, audit, store)
+    await reg1.register("fast_plate_ocr", stub.url)
+    reg1.approve_all("fast_plate_ocr", actor="install")
+    await reg1.aclose()
+
+    # "Restart": brand-new registry over the same state file.
+    reg2 = _registry_for(stub, audit, store)
+    assert reg2.get("fast_plate_ocr") is None
+    queued = reg2.restore_persisted()
+    assert [p.name for p in queued] == ["fast_plate_ocr"]
+    await reg2.retry_pending()
+
+    restored = reg2.get("fast_plate_ocr")
+    assert restored is not None
+    assert restored.source == "runtime"
+    assert restored.approval_status == "approved"
+    assert restored.is_serving_allowed
+    assert reg2.pending_registrations() == []
+    await reg2.aclose()
+
+
+@pytest.mark.asyncio
+async def test_restore_never_widens_approval(tmp_path: Path, audit):
+    """Sabotage guard for the security property: if the receipt has NO
+    grants recorded, restore must land the adapter PENDING even though
+    it declares permissions — a restart is not a consent act. (An
+    approve-all-on-restore bug would pass the happy-path test above;
+    this one catches it.)"""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps(gpu=True))
+    store = _store(tmp_path)
+    reg1 = _registry_for(stub, audit, store)
+    await reg1.register("gpu_adapter", stub.url)   # registered, NOT approved
+    await reg1.aclose()
+
+    reg2 = _registry_for(stub, audit, store)
+    reg2.restore_persisted()
+    await reg2.retry_pending()
+    restored = reg2.get("gpu_adapter")
+    assert restored is not None
+    assert restored.approval_status == "pending"
+    assert not restored.is_serving_allowed
+    await reg2.aclose()
+
+
+@pytest.mark.asyncio
+async def test_restored_grants_intersect_freshly_declared_keys(tmp_path: Path, audit):
+    """The adapter drifted while we were down: it now declares gpu AND
+    host_metadata, but only gpu was granted before the restart. gpu must
+    restore; host_metadata must stay pending → adapter pending overall."""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps(gpu=True))
+    store = _store(tmp_path)
+    reg1 = _registry_for(stub, audit, store)
+    await reg1.register("gpu_adapter", stub.url)
+    reg1.grant_permissions("gpu_adapter", ["gpu"], actor="operator")
+    await reg1.aclose()
+
+    caps = _base_caps(gpu=True)
+    caps["permissions"]["host_metadata"] = True
+    stub.update_capabilities(caps)
+
+    reg2 = _registry_for(stub, audit, store)
+    reg2.restore_persisted()
+    await reg2.retry_pending()
+    restored = reg2.get("gpu_adapter")
+    assert restored is not None
+    assert restored.granted_permissions == {"gpu"}
+    assert restored.approval_status == "pending"
+    await reg2.aclose()
+
+
+@pytest.mark.asyncio
+async def test_seed_name_wins_over_persisted_entry(tmp_path: Path, audit):
+    """Configuration beats history: a persisted runtime entry whose name
+    collides with an already-registered seed is skipped, not fought over."""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps())
+    store = _store(tmp_path)
+    store.save([{"name": "default", "url": "http://old-ghost:1",
+                 "granted_permissions": []}])
+    reg = _registry_for(stub, audit, store)
+    await reg.register("default", stub.url, source="seed")
+    assert reg.restore_persisted() == []
+    adapter = reg.get("default")
+    assert adapter is not None and adapter.url == stub.url
+    await reg.aclose()
+
+
+# ── Deferred registration + retry (the cold-boot race) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_deferred_seed_retries_until_up_with_config_consent(tmp_path: Path, audit):
+    """A seed whose container boots after KAI-C used to be 'deferred'
+    forever. Now: queued, visible, retried — and once it registers, the
+    §8.5 config-as-consent approve-all applies, exactly as if it had
+    been up at boot."""
+    stub = _DownThenUpStub(url="http://127.0.0.1:9100",
+                           capabilities=_base_caps(gpu=True))
+    reg = _registry_for(stub, audit, _store(tmp_path))
+    reg.defer("default", stub.url, source="seed",
+              grant_all_on_register=True, error="boot race")
+
+    await reg.retry_pending()          # still down — stays queued
+    pending = reg.pending_registrations()
+    assert len(pending) == 1
+    assert pending[0]["name"] == "default"
+    assert pending[0]["attempts"] == 1
+    assert reg.get("default") is None
+
+    stub.bring_up()
+    await reg.retry_pending()          # up now — registers + auto-grants
+    adapter = reg.get("default")
+    assert adapter is not None
+    assert adapter.approval_status == "approved"
+    assert reg.pending_registrations() == []
+    await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pending_restore_survives_a_second_restart(tmp_path: Path, audit):
+    """Restart while the adapter is STILL down: the queued restore must
+    keep its receipt (grants included), or a double restart would
+    re-open the amnesia hole."""
+    stub = _DownThenUpStub(url="http://127.0.0.1:9100",
+                           capabilities=_base_caps(gpu=True))
+    store = _store(tmp_path)
+    reg1 = _registry_for(stub, audit, store)
+    stub.bring_up()
+    await reg1.register("fast_plate_ocr", stub.url)
+    reg1.approve_all("fast_plate_ocr", actor="install")
+    await reg1.aclose()
+
+    stub.up = False                     # adapter down across restarts
+    reg2 = _registry_for(stub, audit, store)
+    reg2.restore_persisted()
+    await reg2.retry_pending()          # fails, stays pending
+    assert reg2.get("fast_plate_ocr") is None
+    # Force a rewrite of the receipt file WHILE the restore is still
+    # pending (any other runtime registration does one): the pending
+    # entry must survive the rewrite, grants intact. (First sabotage run
+    # proved the weaker "file untouched" assertion passes even when
+    # pending entries are dropped from _persist_locked.)
+    stub.bring_up()
+    await reg2.register("other_adapter", stub.url)
+    stub.up = False
+    receipts = {e["name"]: e for e in store.load()}
+    assert set(receipts) == {"fast_plate_ocr", "other_adapter"}
+    assert receipts["fast_plate_ocr"]["granted_permissions"] == ["gpu"]
+    await reg2.aclose()
+
+    reg3 = _registry_for(stub, audit, store)  # second restart
+    reg3.restore_persisted()
+    stub.bring_up()
+    await reg3.retry_pending()
+    restored = reg3.get("fast_plate_ocr")
+    assert restored is not None
+    assert restored.approval_status == "approved"
+    await reg3.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sovereignty_violation_drops_pending_and_receipt(tmp_path: Path, audit):
+    """Retrying can never become a way around policy: a pending adapter
+    that turns out to declare egress under local_only is audited,
+    dropped from the queue, and its receipt removed — not retried
+    forever, not registered."""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps(egress=["evil.example.com"]))
+    store = _store(tmp_path)
+    store.save([{"name": "egressy", "url": stub.url,
+                 "granted_permissions": []}])
+    reg = _registry_for(stub, audit, store)
+    reg.restore_persisted()
+    await reg.retry_pending()
+    assert reg.get("egressy") is None
+    assert reg.pending_registrations() == []
+    assert store.load() == []
+    await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fresh_runtime_register_supersedes_queued_restore(tmp_path: Path, audit):
+    """The overlay registrar re-runs while a restore for the same name
+    is still queued (both containers came back together): the live
+    registration wins and the queue entry is dropped."""
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps())
+    store = _store(tmp_path)
+    store.save([{"name": "fast_plate_ocr", "url": "http://stale-url:9",
+                 "granted_permissions": []}])
+    reg = _registry_for(stub, audit, store)
+    reg.restore_persisted()
+    await reg.register("fast_plate_ocr", stub.url)  # registrar beat the retry
+    assert reg.pending_registrations() == []
+    adapter = reg.get("fast_plate_ocr")
+    assert adapter is not None and adapter.url == stub.url
+    assert store.load()[0]["url"] == stub.url
+    await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_drives_the_retry(tmp_path: Path, audit):
+    """The retry must be wired into the BACKGROUND poll loop — calling
+    retry_pending() from tests proves the method, this proves the loop.
+    A pending seed with a down adapter registers within a few fast poll
+    cycles once the adapter comes up, with no explicit retry call."""
+    stub = _DownThenUpStub(url="http://127.0.0.1:9100",
+                           capabilities=_base_caps())
+    transport = httpx.MockTransport(stub.respond)
+    reg = AdapterRegistry(
+        sovereignty_mode="local_only", audit=audit,
+        http_client=httpx.AsyncClient(transport=transport),
+        poll_interval_seconds=1,
+        state_store=_store(tmp_path),
+    )
+    reg.defer("default", stub.url, source="seed",
+              grant_all_on_register=True, error="boot race")
+    await reg.start_polling()
+    try:
+        stub.bring_up()
+        import asyncio
+        for _ in range(40):            # up to ~4s of 0.1s waits
+            await asyncio.sleep(0.1)
+            if reg.get("default") is not None:
+                break
+        assert reg.get("default") is not None, (
+            "poll loop never retried the deferred registration")
+    finally:
+        await reg.aclose()

--- a/server/services/plate_enrichment.py
+++ b/server/services/plate_enrichment.py
@@ -58,7 +58,11 @@ PLATE_TASK = "license_plate_recognition"
 # broken dependency now WARNs, rate-limited so a busy gate camera can't
 # flood the log with one line per vehicle.
 _MISSING_ADAPTER_WARN_INTERVAL_SECONDS = 600.0
-_last_missing_adapter_warn: float = 0.0
+# None = never warned. NOT 0.0: time.monotonic() counts from HOST BOOT,
+# so on a machine up for less than the interval, ``now - 0.0 < 600``
+# would swallow the very first warning — the one that matters most.
+# (Caught by CI: fresh runner VMs boot seconds before pytest runs.)
+_last_missing_adapter_warn: float | None = None
 
 
 def _warn_adapter_missing(status_code: int) -> None:
@@ -67,7 +71,9 @@ def _warn_adapter_missing(status_code: int) -> None:
     import time as _time
 
     now = _time.monotonic()
-    if now - _last_missing_adapter_warn < _MISSING_ADAPTER_WARN_INTERVAL_SECONDS:
+    if (_last_missing_adapter_warn is not None
+            and now - _last_missing_adapter_warn
+            < _MISSING_ADAPTER_WARN_INTERVAL_SECONDS):
         return
     _last_missing_adapter_warn = now
     logger.warning(

--- a/server/services/plate_enrichment.py
+++ b/server/services/plate_enrichment.py
@@ -51,6 +51,34 @@ VEHICLE_LABELS = {"car", "truck", "bus", "motorcycle"}
 PLATE_MODEL = "fast_plate_ocr"
 PLATE_TASK = "license_plate_recognition"
 
+# Issue #371: a missing OCR adapter used to be a per-event DEBUG line —
+# operator-invisible, so "restart unregistered the adapter" looked
+# exactly like "no plates in frame" for hours. Best-effort stays
+# best-effort (rows keep plate_text=NULL, ingest never blocks), but a
+# broken dependency now WARNs, rate-limited so a busy gate camera can't
+# flood the log with one line per vehicle.
+_MISSING_ADAPTER_WARN_INTERVAL_SECONDS = 600.0
+_last_missing_adapter_warn: float = 0.0
+
+
+def _warn_adapter_missing(status_code: int) -> None:
+    """Rate-limited operator signal that plate OCR is failing."""
+    global _last_missing_adapter_warn
+    import time as _time
+
+    now = _time.monotonic()
+    if now - _last_missing_adapter_warn < _MISSING_ADAPTER_WARN_INTERVAL_SECONDS:
+        return
+    _last_missing_adapter_warn = now
+    logger.warning(
+        "plate enrichment: KAI-C answered %s for adapter '%s' — plate "
+        "reads are FAILING. The adapter is not registered (or not "
+        "approved) with KAI-C; check the AI Models page or "
+        "GET /api/v1/adapters. This warning repeats at most every %d s.",
+        status_code, PLATE_MODEL,
+        int(_MISSING_ADAPTER_WARN_INTERVAL_SECONDS),
+    )
+
 
 def extract_plate(response: dict | None) -> str | None:
     """Pure parser for the adapter's §5 InferResponse → normalized plate.
@@ -142,6 +170,11 @@ async def enrich_event_plate(event_id: int) -> None:
             logger.debug("plate enrichment: adapter answered %s for event %s "
                          "(fast_plate_ocr not registered?)",
                          resp.status_code, event_id)
+            if resp.status_code in (403, 404):
+                # 404 = adapter unknown to KAI-C (the #371 restart
+                # amnesia); 403 = registered but approval pending.
+                # Either way plate reads are dead until fixed — say so.
+                _warn_adapter_missing(resp.status_code)
             return
         plate = extract_plate(resp.json())
         if not plate:

--- a/server/tests/test_lpr_adapter_wiring.py
+++ b/server/tests/test_lpr_adapter_wiring.py
@@ -74,3 +74,35 @@ def test_registration_failure_degrades_it_does_not_wedge():
     assert reg.count("exit 0") == 2, (
         "both the success path and the retries-exhausted path must exit 0")
     assert "WARN: could not register" in reg
+
+
+# ── Issue #371: registrations must survive an opennvr-core restart ──
+#
+# The one-shot registrar above runs ONCE per `compose up`. KAI-C's
+# in-memory registry therefore needs its receipts file on a volume, or
+# any restart of opennvr-core silently forgets fast_plate_ocr and every
+# plate read 404s with no signal. These pin the compose wiring for the
+# persistence added in kai_c/persistence.py.
+
+_BASE = (REPO_ROOT / "docker-compose.yml").read_text()
+_ENTRYPOINT = (REPO_ROOT / "docker-entrypoint.sh").read_text()
+
+
+def test_kai_c_state_dir_is_wired_to_a_volume():
+    assert "KAI_C_STATE_DIR=/app/kai-c-state" in _BASE, (
+        "opennvr-core no longer tells KAI-C where to persist adapter "
+        "registrations — a core restart would silently kill LPR again "
+        "(issue #371)")
+    assert "- opennvr_kai_c_state:/app/kai-c-state" in _BASE, (
+        "the KAI-C state dir is not on a volume — receipts die with the "
+        "container, which is the #371 amnesia with extra steps")
+    assert "\n  opennvr_kai_c_state:" in _BASE, (
+        "the opennvr_kai_c_state volume is mounted but never declared — "
+        "compose config would fail")
+
+
+def test_kai_c_state_dir_is_writable_by_the_service_user():
+    # First mount of a named volume is root-owned; KAI-C runs as the
+    # opennvr user under supervisord. Without the chown, persistence
+    # degrades (with a WARN) back to restart amnesia.
+    assert "chown -R opennvr:opennvr /app/kai-c-state" in _ENTRYPOINT

--- a/server/tests/test_plate_enrichment_signal.py
+++ b/server/tests/test_plate_enrichment_signal.py
@@ -23,7 +23,7 @@ import services.plate_enrichment as pe  # noqa: E402
 
 
 def _reset():
-    pe._last_missing_adapter_warn = 0.0
+    pe._last_missing_adapter_warn = None
 
 
 def test_missing_adapter_warns_once(caplog):
@@ -37,6 +37,19 @@ def test_missing_adapter_warns_once(caplog):
     assert "fast_plate_ocr" in msg
     assert "404" in msg
     assert "FAILING" in msg
+
+
+def test_first_warn_fires_even_on_a_freshly_booted_host(caplog, monkeypatch):
+    """Regression: the limiter compared against an initial 0.0, and
+    time.monotonic() counts from HOST BOOT — on a machine up for less
+    than the interval (every fresh CI VM, any rebooted NVR host) the
+    FIRST warning was silently swallowed. The sentinel must be None."""
+    _reset()
+    import time as _t
+    monkeypatch.setattr(_t, "monotonic", lambda: 5.0)  # "booted 5s ago"
+    with caplog.at_level(logging.WARNING, logger="plate_enrichment"):
+        pe._warn_adapter_missing(404)
+    assert [r for r in caplog.records if r.levelno == logging.WARNING]
 
 
 def test_warn_fires_again_after_the_window(caplog, monkeypatch):

--- a/server/tests/test_plate_enrichment_signal.py
+++ b/server/tests/test_plate_enrichment_signal.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Issue #371, the "why it's silent" half: a plate read that 404s/403s
+at KAI-C must produce an operator-visible WARNING — rate-limited so a
+busy gate camera doesn't turn one dead adapter into a log flood.
+
+Before this, a missing OCR adapter was a per-event DEBUG line: a stack
+whose restart had unregistered ``fast_plate_ocr`` was indistinguishable
+from a stack with no plates in frame.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+import services.plate_enrichment as pe  # noqa: E402
+
+
+def _reset():
+    pe._last_missing_adapter_warn = 0.0
+
+
+def test_missing_adapter_warns_once(caplog):
+    _reset()
+    with caplog.at_level(logging.WARNING, logger="plate_enrichment"):
+        pe._warn_adapter_missing(404)
+        pe._warn_adapter_missing(404)   # inside the rate window — silent
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "fast_plate_ocr" in msg
+    assert "404" in msg
+    assert "FAILING" in msg
+
+
+def test_warn_fires_again_after_the_window(caplog, monkeypatch):
+    _reset()
+    with caplog.at_level(logging.WARNING, logger="plate_enrichment"):
+        pe._warn_adapter_missing(404)
+        # Simulate the window elapsing.
+        pe._last_missing_adapter_warn -= (
+            pe._MISSING_ADAPTER_WARN_INTERVAL_SECONDS + 1
+        )
+        pe._warn_adapter_missing(403)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+    assert "403" in warnings[1].getMessage()
+
+
+def test_enrichment_calls_the_warn_on_non_200():
+    """Lockstep: the warn helper must actually be wired into the non-200
+    branch of enrich_event_plate — a helper nothing calls is the silence
+    bug back again. String-level (the function needs a live DB + httpx
+    stack to execute; the call-site is what we're pinning)."""
+    src = (REPO_ROOT / "server" / "services" / "plate_enrichment.py").read_text()
+    body = src.split("async def enrich_event_plate", 1)[1]
+    assert "_warn_adapter_missing(resp.status_code)" in body


### PR DESCRIPTION
QA hit the worst kind of failure: enable the LPR app, watch it work, restart opennvr-core — and every plate read 404s forever, silently. KAI-C's adapter registry was in-memory only; the app overlay's one-shot registrar had already exited, and the boot seed loop only re-registers the hardcoded ADAPTER_REGISTRY entry. Nothing re-registered fast_plate_ocr, and best-effort enrichment hid the corpse.

Three legs:

* Persist runtime registrations. New kai_c/persistence.py writes a receipt file — (name, url, granted permission keys) — atomically on every register/deregister/grant/revoke/drift-revoke. On boot the lifespan restores it AFTER config seeds (configuration beats history) and re-applies grants through the NORMAL grant path, so a restart can never widen approval: an ungranted adapter restores pending, and keys newly declared while we were down stay pending (§11.3). Seeds are never persisted — a seed removed from config must not resurrect from disk. Docker: KAI_C_STATE_DIR on the new opennvr_kai_c_state volume, chowned in the entrypoint.

* Retry deferred registrations. A registration that can't complete yet — a seed whose container boots after KAI-C (the standard compose cold-start race), or a restored adapter still down — is queued and retried every poll cycle instead of being dropped forever, keeping the §8.5 config-as-consent grant for seeds. A sovereignty violation is audited and dropped, never retried: policy is not a race.

* Surface the failure. GET /api/v1/adapters gains an additive 'deferred' list (expected-but-unregistered adapters), and core's plate enrichment WARNs — rate-limited to one line per 10 minutes — when OCR calls 403/404 at KAI-C, instead of a per-event DEBUG that made a dead adapter indistinguishable from an empty driveway.

19 new kai-c tests + 3 server-side; the deregister-receipt, never-widen-approval, poll-loop-wiring, and pending-receipt-survival guards are all sabotage-verified (the pending-receipt test needed a second pass — the first version passed with the guard removed).

Fixes #371.


Claude-Session: https://claude.ai/code/session_01Q9zaseSNDvn1g4FiVG2wCN