### PR TITLE
fix(tier0): motion gate can no longer wedge in 'calibrating' (#373)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,26 @@ DETECT_TRACK_TTL=300
 # still match existing tracks — hysteresis, like Frigate min_score.
 DETECT_MIN_SPAWN_SCORE=0.5
 
+# Motion gate (#373). The gate skips the detector until the scene
+# "calibrates" (a frame with <5% motion). A permanently busy scene
+# (trees, rain, a busy road) never calibrates, so the deadline forces
+# the gate open after N consecutive calibrating frames — a WARN names
+# the camera when that happens. 0 restores the old wedge-able behavior.
+# 150 frames ≈ 75 s at the default DETECT_FPS=2.
+DETECT_MOTION_CALIBRATION_MAX_FRAMES=150
+# Raise on noisy sensors (fewer phantom motion pixels); 1-255.
+DETECT_MOTION_THRESHOLD=30
+# Minimum contour area counted as motion; raise to ignore small flicker.
+DETECT_MOTION_CONTOUR_AREA=10
+# Background adapt rate in steady state.
+DETECT_MOTION_FRAME_ALPHA=0.01
+# Frame fraction that re-triggers calibration (dawn / IR-cut flashes).
+DETECT_MOTION_LIGHTNING_THRESHOLD=0.8
+# false = motion gate OFF entirely: full-frame detection on every frame.
+# The escape hatch for scenes the gate cannot model — costs full-frame
+# inference at DETECT_FPS on that camera, so use the tunables first.
+DETECT_MOTION_ENABLED=true
+
 # Decode-side frame skip (ffmpeg -skip_frame). Decode — not the model — is
 # Tier-0's dominant CPU cost: the camera's full frame rate is decompressed
 # even though only DETECT_FPS frames are analyzed. This dial drops frames

--- a/detect-pipeline/README.md
+++ b/detect-pipeline/README.md
@@ -265,6 +265,13 @@ DETECT_DECODE_FAST=false          # true = skip h264 loop filter (opt-in, not bi
 DETECT_DECODE_IDLE=nokey          # adaptive decode while quiet (dial 6, default on; none = off)
 DETECT_DECODE_IDLE_AFTER=60       # quiet seconds before a camera idles
 DETECT_STATIONARY_INTERVAL=10     # re-verify stationary tracks every Nth frame (0 = every frame)
+DETECT_MOTION_ENABLED=true        # false = motion gate OFF: detector runs on every frame (costly)
+DETECT_MOTION_THRESHOLD=30        # pixel-diff threshold 1-255 (raise on noisy sensors)
+DETECT_MOTION_CONTOUR_AREA=10     # min contour area counted as motion (raise to ignore small flicker)
+DETECT_MOTION_FRAME_ALPHA=0.01    # background adapt rate, steady state
+DETECT_MOTION_LIGHTNING_THRESHOLD=0.8  # frame fraction that re-triggers calibration (dawn/IR flash)
+DETECT_MOTION_CALIBRATION_MAX_FRAMES=150  # calibration deadline (#373): force the gate open after
+                                  # N consecutive calibrating frames (0 = old wedge-able behavior)
 DETECT_DETECTOR=onnx              # onnx (YOLOv8, default) | hog | blob | stub
 DETECT_ONNX_BACKEND=cvdnn         # cvdnn (zero-dep CPU, default) | ort (ONNX Runtime)
 DETECT_ONNX_PROVIDERS=            # ort EPs, e.g. OpenVINOExecutionProvider (Intel N100)

--- a/detect-pipeline/detect_pipeline/motion.py
+++ b/detect-pipeline/detect_pipeline/motion.py
@@ -20,17 +20,25 @@ whole-frame brightness change from flooding the detector at dawn/dusk.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import cv2
 import numpy as np
 
+log = logging.getLogger(__name__)
+
 
 @dataclass
 class MotionConfig:
-    """Motion tunables — defaults match Frigate 6f80bcd19."""
+    """Motion tunables — defaults match Frigate 6f80bcd19.
 
-    enabled: bool = True
+    All fields are operator-tunable via ``DETECT_MOTION_*`` env vars
+    (see ``service.py``) — issue #373 found them hardcoded, which left
+    no way to rescue a camera whose scene never calibrated.
+    """
+
+    enabled: bool = True                      # False = gate OFF: full-frame motion every frame (detector always runs; costly)
     threshold: int = 30                       # pixel-diff threshold (1–255)
     contour_area: int = 10                    # min contour area to count as motion
     frame_alpha: float = 0.01                 # background running-avg alpha, steady state
@@ -38,6 +46,16 @@ class MotionConfig:
     skip_motion_threshold: float | None = None  # >this fraction -> drop frame entirely (off by default)
     improve_contrast: bool = True
     frame_height: int | None = 100            # downscale luma to this tall for motion (None = full)
+    #: #373: calibration deadline. Calibration clears only on a "quiet"
+    #: frame (<5% motion, <=4 boxes) — a scene with continuous motion
+    #: (trees, rain, a busy road) may NEVER produce one, and the gate
+    #: then skipped every frame for the life of the worker with no
+    #: signal. After this many consecutive calibrating frames the gate
+    #: forces itself open (WARN logged): a scene that is always busy is
+    #: the scene, and the detector should see it. 0 disables the
+    #: deadline (pre-#373 behaviour). Default 150 ≈ 75 s at 2 fps —
+    #: real calibration settles in well under 50 frames.
+    calibration_max_frames: int = 150
 
 
 def _grab_contours(found) -> list:
@@ -57,8 +75,12 @@ class MotionDetector:
         blur_radius: int = 1,
         contrast_frame_history: int = 50,
         interpolation: int = cv2.INTER_NEAREST,
+        label: str = "",
     ) -> None:
         self.config = config or MotionConfig()
+        #: Camera id (or similar) for log attribution — #373's wedge was
+        #: invisible partly because nothing could say WHICH camera.
+        self.label = label
         self.frame_shape = frame_shape  # (height, width) of the luma input
         # Downscale for speed, but never *up*scale a small input (clamp).
         fh = min(self.config.frame_height or frame_shape[0], frame_shape[0])
@@ -66,7 +88,14 @@ class MotionDetector:
         self.motion_frame_size = (fh, fh * frame_shape[1] // frame_shape[0])
         self.avg_frame = np.zeros(self.motion_frame_size, np.float32)
         self.motion_frame_count = 0
-        self.calibrating = True
+        # Gate OFF (#373): never calibrating, and detect() returns a
+        # full-frame motion box so the detector runs on every frame.
+        self.calibrating = self.config.enabled
+        #: #373: consecutive calibrating frames in the CURRENT episode,
+        #: and how many times the deadline forced the gate open.
+        self.calibrating_frames = 0
+        self.forced_calibration_exits = 0
+        self._forced_exit_warned = False
         self.blur_radius = blur_radius
         self.interpolation = interpolation
         self.contrast_values = np.zeros((contrast_frame_history, 2), np.uint8)
@@ -76,11 +105,53 @@ class MotionDetector:
     def is_calibrating(self) -> bool:
         return self.calibrating
 
+    def _enforce_calibration_deadline(self) -> None:
+        """#373: bound every calibration episode. Called once per frame
+        after the calibration flags settle. A scene with continuous
+        motion never produces the 'quiet' frame that clears calibration,
+        and the gate then skipped EVERY frame for the life of the worker
+        — detector never ran, no visits, no plates, and the only
+        evidence was a Prometheus counter. After
+        ``calibration_max_frames`` consecutive calibrating frames the
+        gate forces itself open and says so."""
+        if not self.calibrating:
+            self.calibrating_frames = 0
+            return
+        self.calibrating_frames += 1
+        limit = self.config.calibration_max_frames
+        if limit <= 0 or self.calibrating_frames < limit:
+            return
+        self.calibrating = False
+        self.calibrating_frames = 0
+        self.forced_calibration_exits += 1
+        msg = (
+            "motion gate %s: calibration did not settle after %d frames "
+            "— forcing the gate OPEN so detection runs (forced exits so "
+            "far: %d). The scene likely has continuous motion; tune "
+            "DETECT_MOTION_THRESHOLD / DETECT_MOTION_CONTOUR_AREA (or "
+            "DETECT_MOTION_LIGHTNING_THRESHOLD if this repeats), or set "
+            "DETECT_MOTION_ENABLED=false to disable the gate for good."
+        )
+        args = (self.label or "?", limit, self.forced_calibration_exits)
+        if self._forced_exit_warned:
+            # Repeats mean the scene re-trips calibration continuously —
+            # keep the log readable; the counter carries the tally.
+            log.debug(msg, *args)
+        else:
+            self._forced_exit_warned = True
+            log.warning(msg, *args)
+
     def detect(self, luma: np.ndarray) -> list[tuple[int, int, int, int]]:
         """Return motion boxes (x1, y1, x2, y2) in full-frame coordinates."""
         motion_boxes: list[tuple[int, int, int, int]] = []
         if not self.config.enabled:
-            return motion_boxes
+            # Gate OFF: the whole frame is "in motion" every frame, so
+            # region selection scans the full frame and the detector
+            # always runs. This is the #373 escape hatch for scenes the
+            # gate cannot model — it costs full-frame inference at
+            # DETECT_FPS, so it is an explicit operator choice
+            # (DETECT_MOTION_ENABLED=false), never a default.
+            return [(0, 0, self.frame_shape[1], self.frame_shape[0])]
 
         gray = luma[0 : self.frame_shape[0], 0 : self.frame_shape[1]]
         resized = cv2.resize(
@@ -138,6 +209,10 @@ class MotionDetector:
             and pct_motion > self.config.skip_motion_threshold
         ):
             self.calibrating = True
+            # #373: dropped frames still count toward the deadline — a
+            # scene permanently above skip_motion_threshold must not
+            # wedge the gate shut forever either.
+            self._enforce_calibration_deadline()
             return []
 
         # Calibrated once motion is small and few contours remain.
@@ -149,6 +224,10 @@ class MotionDetector:
         # regions to the detector while recording continues.
         if self.calibrating or pct_motion > self.config.lightning_threshold:
             self.calibrating = True
+
+        # #373: bound the episode — after calibration_max_frames of
+        # consecutive calibrating, force the gate open (with a WARN).
+        self._enforce_calibration_deadline()
 
         alpha = 0.2 if self.calibrating else self.config.frame_alpha
         if motion_boxes:

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -87,6 +87,37 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    import os as _os
+    raw = (_os.environ.get(name) or "").strip().lower()
+    if not raw:
+        return default
+    if raw in ("1", "true", "yes", "on"):
+        return True
+    if raw in ("0", "false", "no", "off"):
+        return False
+    log.warning("%s=%r is not a boolean; using %s", name, raw, default)
+    return default
+
+
+def motion_config_from_env() -> "MotionConfig":
+    """#373: the MotionConfig fields, operator-tunable at last. Before
+    this, the worker constructed the motion gate from hardcoded defaults
+    with no env plumbing — a camera whose scene never calibrated could
+    not be tuned or un-gated without a code change. Factored out (and
+    module-level) so tests pin the env-var names to the fields."""
+    return MotionConfig(
+        enabled=_env_bool("DETECT_MOTION_ENABLED", True),
+        threshold=_env_int("DETECT_MOTION_THRESHOLD", 30),
+        contour_area=_env_int("DETECT_MOTION_CONTOUR_AREA", 10),
+        frame_alpha=_env_float("DETECT_MOTION_FRAME_ALPHA", 0.01),
+        lightning_threshold=_env_float(
+            "DETECT_MOTION_LIGHTNING_THRESHOLD", 0.8),
+        calibration_max_frames=_env_int(
+            "DETECT_MOTION_CALIBRATION_MAX_FRAMES", 150),
+    )
+
+
 def _env_labels(name: str, default_csv: str) -> frozenset[str] | None:
     """Parse a comma-separated label allowlist; "all"/"*" → None (no filter)."""
     import os as _os
@@ -520,7 +551,9 @@ class CameraWorker:
         lifecycle = VisitLifecycle(
             self.spec.camera_id, nvr_camera_id=self.spec.nvr_camera_id
         )
-        motion = MotionDetector((h, w), MotionConfig())
+        motion = MotionDetector(
+            (h, w), motion_config_from_env(), label=self.spec.camera_id,
+        )
         tracker = Tracker((h, w), TrackConfig(
             fps=self.spec.fps,
             max_tracks=_env_int("DETECT_MAX_TRACKS", 50),

--- a/detect-pipeline/test/test_motion.py
+++ b/detect-pipeline/test/test_motion.py
@@ -20,9 +20,16 @@ def _warm_up(md: MotionDetector, value: int = 120, frames: int = 60) -> None:
         md.detect(_flat(value))
 
 
-def test_disabled_returns_empty():
+def test_disabled_gate_is_wide_open():
+    """#373 semantics change: enabled=False used to return [] while
+    ``calibrating`` stayed True — which WEDGED the pipeline (never
+    calibrated, never detected). Disabling the gate now means the gate
+    is OPEN: never calibrating, full-frame motion every frame, so the
+    detector always runs."""
     md = MotionDetector((H, W), MotionConfig(enabled=False))
-    assert md.detect(_flat(255)) == []
+    assert md.is_calibrating() is False
+    assert md.detect(_flat(255)) == [(0, 0, W, H)]
+    assert md.is_calibrating() is False
 
 
 def test_static_scene_calibrates_and_goes_quiet():
@@ -74,3 +81,147 @@ def test_boxes_scale_to_full_frame_when_downscaled():
     assert boxes
     x1, y1, x2, y2 = boxes[0]
     assert x2 <= W and y2 <= H              # scaled coords stay within the full frame
+
+
+# ── Issue #373: the calibration wedge ──────────────────────────────
+#
+# Calibration clears only on a frame with <5% motion and <=4 boxes. A
+# scene with CONTINUOUS moderate motion (trees, rain, a busy road)
+# never produces one — QA saw 1629/1629 frames skipped as
+# "calibrating" over 13 minutes: detector never ran, no visits, no
+# plates, no signal anywhere. The deadline bounds every calibration
+# episode; the env plumbing (tested below) makes the gate tunable.
+
+def _busy_frame(rng: np.random.Generator) -> np.ndarray:
+    """A frame where ~a third of the scene churns every call — motion
+    every frame (pct ~0.3: above the 0.05 calibration bar, below the
+    0.8 lightning bar), which is exactly the #373 wedge regime."""
+    frame = _flat(120)
+    frame[0:120, 0:100] = rng.integers(0, 255, (120, 100), dtype=np.uint8)
+    return frame
+
+
+def test_continuous_motion_wedges_forever_without_deadline():
+    """Pin the BUG first (deadline off = pre-#373 behaviour): the gate
+    never opens, ever — this is what QA lived through, and what the
+    deadline exists to bound."""
+    md = MotionDetector((H, W), MotionConfig(calibration_max_frames=0))
+    rng = np.random.default_rng(42)
+    for _ in range(300):
+        md.detect(_busy_frame(rng))
+    assert md.is_calibrating() is True
+    assert md.forced_calibration_exits == 0
+
+
+def test_deadline_forces_the_gate_open_on_a_busy_scene():
+    """The fix: same scene, deadline on — after calibration_max_frames
+    consecutive calibrating frames the gate forces itself open and the
+    detector gets to run."""
+    md = MotionDetector(
+        (H, W), MotionConfig(calibration_max_frames=25), label="cam5",
+    )
+    rng = np.random.default_rng(42)
+    opened_at = None
+    for i in range(60):
+        md.detect(_busy_frame(rng))
+        if opened_at is None and not md.is_calibrating():
+            opened_at = i + 1
+    assert opened_at == 25, f"gate should open exactly at the deadline, got {opened_at}"
+    assert md.forced_calibration_exits >= 1
+    # And it STAYS open on this scene (motion stays under the
+    # lightning threshold, so nothing re-trips calibration).
+    assert md.is_calibrating() is False
+
+
+def test_natural_calibration_never_trips_the_deadline():
+    """A normal static scene calibrates in a handful of frames — the
+    deadline must never fire there, and the episode counter resets."""
+    md = MotionDetector((H, W), MotionConfig(calibration_max_frames=150))
+    _warm_up(md)
+    assert md.is_calibrating() is False
+    assert md.forced_calibration_exits == 0
+    assert md.calibrating_frames == 0
+
+
+def test_lightning_recalibration_episode_is_also_bounded():
+    """A whole-frame change flips calibrating back on; that EPISODE is
+    bounded too — the counter restarts per episode, not per lifetime."""
+    # Deadline 30 > the ~17 frames a static scene needs to calibrate
+    # naturally, so warm-up must NOT trip a forced exit.
+    md = MotionDetector((H, W), MotionConfig(calibration_max_frames=30))
+    _warm_up(md)
+    assert md.forced_calibration_exits == 0
+    md.detect(_flat(255))                    # flash -> recalibrating
+    assert md.is_calibrating() is True
+    rng = np.random.default_rng(7)
+    for _ in range(45):                      # stays busy after the flash
+        md.detect(_busy_frame(rng))
+    assert md.is_calibrating() is False
+    assert md.forced_calibration_exits == 1
+
+
+def test_skip_threshold_scene_counts_toward_the_deadline():
+    """A scene permanently above skip_motion_threshold drops every
+    frame AND used to wedge calibration — the dropped frames must count
+    toward the deadline so the forced-exit counter (the operator
+    signal) still ticks."""
+    md = MotionDetector(
+        (H, W),
+        MotionConfig(skip_motion_threshold=0.2, calibration_max_frames=10),
+    )
+    rng = np.random.default_rng(3)
+    for _ in range(40):
+        frame = rng.integers(0, 255, (H, W), dtype=np.uint8)  # ~full-frame churn
+        md.detect(frame)
+    assert md.forced_calibration_exits >= 1
+
+
+# ── Issue #373: env plumbing (DETECT_MOTION_*) ─────────────────────
+
+
+def test_motion_config_from_env_defaults(monkeypatch):
+    from detect_pipeline.service import motion_config_from_env
+    for var in ("DETECT_MOTION_ENABLED", "DETECT_MOTION_THRESHOLD",
+                "DETECT_MOTION_CONTOUR_AREA", "DETECT_MOTION_FRAME_ALPHA",
+                "DETECT_MOTION_LIGHTNING_THRESHOLD",
+                "DETECT_MOTION_CALIBRATION_MAX_FRAMES"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = motion_config_from_env()
+    assert cfg == MotionConfig()  # env-less = library defaults, verbatim
+
+
+def test_motion_config_from_env_overrides(monkeypatch):
+    from detect_pipeline.service import motion_config_from_env
+    monkeypatch.setenv("DETECT_MOTION_ENABLED", "false")
+    monkeypatch.setenv("DETECT_MOTION_THRESHOLD", "45")
+    monkeypatch.setenv("DETECT_MOTION_CONTOUR_AREA", "25")
+    monkeypatch.setenv("DETECT_MOTION_FRAME_ALPHA", "0.05")
+    monkeypatch.setenv("DETECT_MOTION_LIGHTNING_THRESHOLD", "0.95")
+    monkeypatch.setenv("DETECT_MOTION_CALIBRATION_MAX_FRAMES", "600")
+    cfg = motion_config_from_env()
+    assert cfg.enabled is False
+    assert cfg.threshold == 45
+    assert cfg.contour_area == 25
+    assert cfg.frame_alpha == 0.05
+    assert cfg.lightning_threshold == 0.95
+    assert cfg.calibration_max_frames == 600
+
+
+def test_motion_config_from_env_rejects_junk(monkeypatch):
+    from detect_pipeline.service import motion_config_from_env
+    monkeypatch.setenv("DETECT_MOTION_ENABLED", "maybe")
+    monkeypatch.setenv("DETECT_MOTION_THRESHOLD", "very")
+    cfg = motion_config_from_env()
+    assert cfg.enabled is True          # junk falls back to defaults
+    assert cfg.threshold == 30
+
+
+def test_worker_constructs_motion_from_env_with_camera_label():
+    """Lockstep: the worker must build MotionDetector from
+    motion_config_from_env() with the camera id as label — a hardcoded
+    MotionConfig() here is #373 all over again."""
+    from pathlib import Path as _P
+    src = (_P(__file__).resolve().parents[1]
+           / "detect_pipeline" / "service.py").read_text()
+    assert "motion_config_from_env(), label=self.spec.camera_id" in src
+    assert "MotionDetector((h, w), MotionConfig())" not in src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -402,6 +402,16 @@ services:
       - DETECT_MAX_TRACKS=${DETECT_MAX_TRACKS:-}
       - DETECT_TRACK_TTL=${DETECT_TRACK_TTL:-}
       - DETECT_MIN_SPAWN_SCORE=${DETECT_MIN_SPAWN_SCORE:-}
+      # Motion-gate tunables (#373; see .env.example). The calibration
+      # deadline keeps a permanently-busy scene from wedging the gate
+      # shut — before it, a scene that never went quiet skipped EVERY
+      # frame as "calibrating" and detection silently never ran.
+      - DETECT_MOTION_ENABLED=${DETECT_MOTION_ENABLED:-}
+      - DETECT_MOTION_THRESHOLD=${DETECT_MOTION_THRESHOLD:-}
+      - DETECT_MOTION_CONTOUR_AREA=${DETECT_MOTION_CONTOUR_AREA:-}
+      - DETECT_MOTION_FRAME_ALPHA=${DETECT_MOTION_FRAME_ALPHA:-}
+      - DETECT_MOTION_LIGHTNING_THRESHOLD=${DETECT_MOTION_LIGHTNING_THRESHOLD:-}
+      - DETECT_MOTION_CALIBRATION_MAX_FRAMES=${DETECT_MOTION_CALIBRATION_MAX_FRAMES:-}
       # Opt-in CPU saving (docs/CAMERA_ASSIGNMENTS.md): skip analysis on
       # cameras whose assignments are all detection-free. Empty = off.
       - DETECT_SKIP_UNASSIGNED=${DETECT_SKIP_UNASSIGNED:-}


### PR DESCRIPTION
QA found three cameras where Tier-0 skipped 100% of frames as 'calibrating' for the life of the worker — 1629/1629 over 13 minutes. Calibration clears only on a 'quiet' frame (<5% motion, <=4 boxes), which a scene with continuous motion (trees, rain, a busy road) may never produce: the detector never ran, no visits were written, LPR saw nothing, and worker_up=1 made the stack look healthy.

* Calibration deadline. Every calibration episode is now bounded: after DETECT_MOTION_CALIBRATION_MAX_FRAMES consecutive calibrating frames (default 150 ≈ 75 s at 2 fps — natural calibration settles in ~17) the gate forces itself open with a WARN naming the camera, the frame count, and which knobs to tune. First forced exit per worker logs WARNING, repeats log DEBUG plus the forced_calibration_exits counter, so a scene that re-trips continuously can't flood the log. Frames dropped by skip_motion_threshold count toward the deadline too. 0 restores the old behaviour.

* Env plumbing. MotionConfig was constructed hardcoded with no way to tune or disable the gate in the container. All fields now ride DETECT_MOTION_* env vars (service.py motion_config_from_env(), passthrough in compose, documented in .env.example + README), and the detector carries the camera id as a log label.

* Disabled means OPEN. enabled=False used to return no motion while calibrating stayed True — a permanent wedge of its own. It now means the gate is off: never calibrating, full-frame motion every frame, detector always runs (the explicit escape hatch; costly, documented).

9 new tests: the wedge pinned as-was (deadline 0), forced-open at exactly the deadline, natural calibration never trips it, per-episode bounding after a lightning flash, skip-threshold scenes still tick the counter, env defaults/overrides/junk, and a lockstep guard that the worker builds the gate from env with the camera label. Deadline enforcement on both paths is sabotage-verified. Playback/recording untouched — the gate only decides whether the detector runs.

Fixes #373.


Claude-Session: https://claude.ai/code/session_01Q9zaseSNDvn1g4FiVG2wCN