### PR TITLE
fix(core): deleted cameras no longer hold skill claims (#372)

### DIFF
--- a/server/migrations/versions/ff77bb88cc99_sweep_deleted_camera_skill_claims.py
+++ b/server/migrations/versions/ff77bb88cc99_sweep_deleted_camera_skill_claims.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""sweep skill_assignments rows pointing at deleted cameras (#372)
+
+Camera deletion is a soft delete, and until this release it left the
+camera's ``skill_assignments`` rows behind. Under the assignment table's
+union semantics ("the assignment list for that skill is the whole
+truth"), one stale row on a binned camera kept the restriction armed
+while scoping consumers to a camera that no longer exists — the LPR app
+ignored every live camera because a deleted one still claimed the skill.
+
+The query side now filters tombstoned cameras and both delete paths
+clean up their claims, so this migration is the one-time sweep for rows
+that installs accumulated BEFORE the fix: claims on soft-deleted
+cameras, plus any orphans whose camera row is gone entirely.
+
+Data-only; no schema change. Downgrade is a no-op — the swept rows were
+semantically dead, and resurrecting tombstone claims would re-create the
+bug this fixes.
+
+Revision ID: ff77bb88cc99
+Revises: ee11ff22aa33
+Create Date: 2026-09-01
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "ff77bb88cc99"
+down_revision = "ee11ff22aa33"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(sa.text(
+        """
+        DELETE FROM skill_assignments
+        WHERE camera_id IN (
+            SELECT id FROM cameras WHERE deleted_at IS NOT NULL
+        )
+        OR camera_id NOT IN (SELECT id FROM cameras)
+        """
+    ))
+    if result.rowcount:
+        print(f"#372 sweep: removed {result.rowcount} skill claim(s) "
+              "referencing deleted cameras")
+
+
+def downgrade() -> None:
+    # Data-only cleanup of semantically-dead rows; nothing to restore.
+    pass

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -1474,6 +1474,12 @@ async def delete_camera(
         # Irreversible soft delete: tombstone + deactivate.
         camera.is_active = False
         camera.deleted_at = datetime.now(UTC)
+        # #372: a binned camera must not keep claiming skills — a stale
+        # claim scoped consumers (the LPR app) to a camera that no
+        # longer exists while every live camera was ignored. Released in
+        # the same commit as the tombstone.
+        from services.skill_assignments import release_camera_claims
+        released_claims = release_camera_claims(db, camera_id)
         db.commit()
 
         camera_logger.log_action(
@@ -1497,6 +1503,7 @@ async def delete_camera(
                     "camera_name": camera_name,
                     "deleted_at": camera.deleted_at.isoformat(),
                     "stream_teardown": (teardown or {}).get("status", "failed"),
+                    "skill_claims_released": released_claims,
                 },
                 ip=request.client.host if request and request.client else None,
                 user_agent=request.headers.get("user-agent") if request else None,
@@ -1618,6 +1625,12 @@ async def hard_delete_camera(
     camera_event_rows = (
         db.query(CameraEvent).filter(CameraEvent.camera_id == camera_id).delete()
     )
+    # #372: skill claims have a plain FK to cameras (no cascade) — they
+    # must go before the camera row, and normally already went at soft
+    # delete; this catches rows left by installs that binned the camera
+    # before that cleanup existed.
+    from services.skill_assignments import release_camera_claims
+    release_camera_claims(db, camera_id)
     db.delete(camera)
     db.commit()
 

--- a/server/services/skill_assignments.py
+++ b/server/services/skill_assignments.py
@@ -192,10 +192,16 @@ def set_operator_assignments(
 
 def skill_view(db: Session, skill: str) -> dict[str, Any]:
     """``GET /api/v1/skills/{id}/cameras``: the skill's union, with the
-    per-consumer claims visible so a release is never a surprise."""
+    per-consumer claims visible so a release is never a surprise.
+
+    Live cameras only (#372) — the operator view must show the same
+    union the consumers act on, or a binned camera's stale claim looks
+    like a working assignment."""
     rows = (
         db.query(SkillAssignment)
-        .filter(SkillAssignment.skill == (skill or "").strip())
+        .join(Camera, Camera.id == SkillAssignment.camera_id)
+        .filter(SkillAssignment.skill == (skill or "").strip(),
+                Camera.deleted_at.is_(None))
         .order_by(SkillAssignment.camera_id, SkillAssignment.consumer)
         .all()
     )
@@ -215,11 +221,52 @@ def skill_view(db: Session, skill: str) -> dict[str, Any]:
     }
 
 
+def release_camera_claims(db: Session, camera_id: int) -> int:
+    """Camera deletion cleanup (#372): drop every skill claim on the
+    camera, returning how many rows went. Called by BOTH delete paths —
+    soft delete (the bin) and hard delete (the purge; also prevents the
+    FK from failing the camera row delete). No commit here: the caller
+    owns the transaction, so the cleanup lands atomically with the
+    tombstone/purge it belongs to.
+
+    The query-side ``deleted_at`` filter above already makes stale rows
+    inert, so this is hygiene + belt: rows from installs deleted before
+    this fix are handled by the filter (and swept by migration
+    ff77bb88cc99) even if this cleanup never ran for them."""
+    removed = (
+        db.query(SkillAssignment)
+        .filter(SkillAssignment.camera_id == camera_id)
+        .delete(synchronize_session=False)
+    )
+    if removed:
+        logger.info(
+            "released %d skill claim(s) for deleted camera %s",
+            removed, camera_id,
+        )
+    return removed
+
+
 def assignments_by_skill(db: Session) -> dict[str, list[int]]:
     """skill -> sorted union of camera ids. The registry's Phase 2
     source: an empty list never appears (no rows = no key), so
-    ``skill not in map`` IS 'dormant' for the status derivation."""
+    ``skill not in map`` IS 'dormant' for the status derivation.
+
+    Only LIVE cameras count (issue #372). Camera deletion is a soft
+    delete, and a stale assignment row pointing at a binned camera used
+    to keep the restriction ARMED while scoping consumers to a camera
+    that no longer exists — the LPR app would ignore every live camera
+    because one deleted one still 'claimed' the skill. The join also
+    drops orphan rows whose camera was hard-deleted. When the last live
+    assignment goes, the key disappears and the restriction correctly
+    lifts (CAMERA_ASSIGNMENTS.md: 'the assignment list for that skill
+    is the whole truth' — the truth must not include tombstones)."""
     out: dict[str, set[int]] = {}
-    for row in db.query(SkillAssignment).all():
+    rows = (
+        db.query(SkillAssignment)
+        .join(Camera, Camera.id == SkillAssignment.camera_id)
+        .filter(Camera.deleted_at.is_(None))
+        .all()
+    )
+    for row in rows:
         out.setdefault(row.skill, set()).add(row.camera_id)
     return {k: sorted(v) for k, v in out.items()}

--- a/server/tests/test_skill_assignments.py
+++ b/server/tests/test_skill_assignments.py
@@ -235,3 +235,123 @@ def test_api_routes_exist_with_auth():
     paths = {r.path for r in _skills_router.routes}
     assert "/skills/{skill_id}/cameras" in paths
     assert "/skills/{skill_id}/cameras/{camera_id}" in paths
+
+
+# ── Issue #372: deleted cameras must not hold skill claims ─────────
+#
+# Camera deletion is a soft delete. A stale claim on a binned camera
+# used to keep the restriction ARMED while scoping consumers (the LPR
+# app) to a camera that no longer exists — every live camera ignored,
+# nothing warning anyone. "The assignment list for that skill is the
+# whole truth" must mean the truth about LIVE cameras.
+
+from datetime import UTC, datetime  # noqa: E402
+
+
+def _soft_delete(s, cam_id):
+    cam = s.query(models.Camera).get(cam_id)
+    cam.is_active = False
+    cam.deleted_at = datetime.now(UTC)
+    s.commit()
+
+
+def test_deleted_camera_drops_out_of_the_union(db):
+    """The QA scenario from #372: LPR assigned to a camera that later
+    lands in the bin. The union must shrink to the live cameras, and
+    when the LAST live claim goes the restriction must lift entirely
+    (empty map = dormant/no restriction), not stay armed pointing at a
+    tombstone."""
+    s, (gate, yard) = db
+    svc.declare(s, skill=LPR, camera_id=gate, consumer="operator")
+    svc.declare(s, skill=LPR, camera_id=yard, consumer="operator")
+    s.commit()
+    assert svc.assignments_by_skill(s) == {LPR: [gate, yard]}
+
+    _soft_delete(s, yard)
+    assert svc.assignments_by_skill(s) == {LPR: [gate]}
+
+    _soft_delete(s, gate)
+    # No key at all — 'skill not in map' IS the dormant/unrestricted
+    # signal, so consumers fall back to every live camera.
+    assert svc.assignments_by_skill(s) == {}
+
+
+def test_deleted_camera_hidden_from_skill_view(db):
+    """The operator view must show the same union consumers act on."""
+    s, (gate, yard) = db
+    svc.declare(s, skill=LPR, camera_id=gate, consumer="operator")
+    svc.declare(s, skill=LPR, camera_id=yard, consumer="operator")
+    s.commit()
+    _soft_delete(s, yard)
+    view = svc.skill_view(s, LPR)
+    assert view["union"] == [gate]
+    assert [c["camera_id"] for c in view["cameras"]] == [gate]
+
+
+def test_orphan_claim_for_missing_camera_is_ignored(db):
+    """A row whose camera was hard-deleted entirely (pre-fix installs)
+    must be invisible too — the join, not just the tombstone filter."""
+    s, (gate, _) = db
+    svc.declare(s, skill=LPR, camera_id=gate, consumer="operator")
+    s.commit()
+    s.add(models.SkillAssignment(skill=LPR, camera_id=99999,
+                                 consumer="operator"))
+    s.commit()
+    assert svc.assignments_by_skill(s) == {LPR: [gate]}
+    assert svc.skill_view(s, LPR)["union"] == [gate]
+
+
+def test_release_camera_claims_drops_only_that_camera(db):
+    s, (gate, yard) = db
+    svc.declare(s, skill=LPR, camera_id=gate, consumer="operator")
+    svc.declare(s, skill="object_detection", camera_id=gate,
+                consumer="app:x")
+    svc.declare(s, skill=LPR, camera_id=yard, consumer="operator")
+    s.commit()
+    assert svc.release_camera_claims(s, gate) == 2
+    s.commit()
+    assert s.query(models.SkillAssignment).filter_by(
+        camera_id=gate).count() == 0
+    assert svc.assignments_by_skill(s) == {LPR: [yard]}
+    # Idempotent — a second release finds nothing.
+    assert svc.release_camera_claims(s, gate) == 0
+
+
+def test_both_delete_endpoints_release_claims():
+    """Lockstep: the cleanup must be wired into BOTH camera delete
+    paths (soft delete commits it with the tombstone; hard delete needs
+    it before the camera row for the FK). A helper nothing calls is the
+    bug back again."""
+    src = (Path(__file__).resolve().parents[1]
+           / "routers" / "cameras.py").read_text()
+    assert src.count("release_camera_claims(db, camera_id)") == 2
+
+
+def test_migration_sweep_matches_the_query_filter(db):
+    """The one-time migration sweep (ff77bb88cc99) must remove exactly
+    the rows the fixed query ignores: claims on soft-deleted cameras
+    and orphans. Executes the migration's own DELETE (extracted from
+    the file, so this stays lockstep with what actually ships) against
+    a DB seeded with all three row kinds."""
+    import re
+
+    from sqlalchemy import text
+
+    s, (gate, yard) = db
+    svc.declare(s, skill=LPR, camera_id=gate, consumer="operator")
+    svc.declare(s, skill=LPR, camera_id=yard, consumer="operator")
+    s.commit()
+    _soft_delete(s, yard)                                  # tombstone claim
+    s.add(models.SkillAssignment(skill=LPR, camera_id=99999,
+                                 consumer="operator"))     # orphan claim
+    s.commit()
+
+    mig = (Path(__file__).resolve().parents[1] / "migrations" / "versions"
+           / "ff77bb88cc99_sweep_deleted_camera_skill_claims.py").read_text()
+    m = re.search(r'sa\.text\(\s*"""(.*?)"""', mig, re.S)
+    assert m, "migration DELETE statement not found"
+    s.execute(text(m.group(1)))
+    s.commit()
+
+    left = s.query(models.SkillAssignment).all()
+    assert [(r.skill, r.camera_id) for r in left] == [(LPR, gate)]


### PR DESCRIPTION
Camera deletion is a soft delete, and it left the camera's skill_assignments rows behind. Under union semantics ('the assignment list for that skill is the whole truth') one stale claim on a binned camera kept the restriction armed while scoping consumers to a camera that no longer exists — QA's install had LPR pinned to deleted camera 4 and silently ignoring all three live ones.

Three layers, so the truth is live-cameras-only from every direction:

* Query side: assignments_by_skill and skill_view join Camera and filter deleted_at IS NULL. The join also drops orphan rows whose camera row is gone entirely. When the last LIVE claim disappears the key disappears — the restriction correctly lifts instead of pointing at a tombstone, and the operator view shows the same union the consumers act on.

* Write side: release_camera_claims() drops a camera's claims inside BOTH delete paths — soft delete commits it atomically with the tombstone (count lands in the audit log), and hard delete runs it before the camera row, which also fixes a latent FK failure: the purge deleted Recording/TimelineEvent/CameraEvent rows but not skill_assignments, so hard-deleting an assigned camera could refuse on the foreign key.

* One-time sweep: migration ff77bb88cc99 deletes claims referencing soft-deleted or missing cameras, cleaning installs (like QA's) that accumulated stale rows before this fix. Data-only, no schema change.

6 new tests including the QA scenario end to end (deleted camera drops out of the union; last live claim lifts the restriction), an orphan-row guard, a lockstep check that both delete endpoints call the cleanup, and a migration test that executes the DELETE extracted from the migration file itself. Query-filter and migration guards sabotage-verified.

Fixes #372.


Claude-Session: https://claude.ai/code/session_01Q9zaseSNDvn1g4FiVG2wCN