### PR TITLE
fix(tier0): motion gate latches open on scenes with no static backgro…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,10 @@ DETECT_PIPELINE_ENABLED=true
 # for finer motion/track granularity.
 DETECT_FPS=2
 
-# Stationary-track gating: once an object hasn't moved for ~10s it stops
-# being re-detected every frame and is re-verified every Nth frame instead
+# Stationary-track gating: once an object has held still for 50 FRAMES
+# (~25 s at DETECT_FPS=2 — the threshold counts frames, so it halves if
+# you double the fps) it stops being re-detected every frame and is
+# re-verified every Nth frame instead
 # (staggered per object; any motion touching it re-checks immediately).
 # This is what keeps a parked car or a person sitting still from pinning
 # the detector at full rate forever. 0 disables (every track, every frame).
@@ -267,7 +269,10 @@ DETECT_GATE_MODE=shadow    # shadow (default: measure only) | off | enforce (act
 # right for a large fleet and wastes most of the box for a small one —
 # measured on 8 cores with one camera (yolov8n @640): 2 threads 449ms vs
 # 8 threads 176ms, near-linear. Set a number to pin it; it is then never
-# retuned. 0/empty = automatic.
+# retuned. 0/empty = automatic — but ONLY on the default cvdnn backend.
+# With DETECT_ONNX_BACKEND=ort (or the rfdetr detector) there is no
+# auto-tuning: unset pins 2 threads per session, and an explicit 0 hands
+# the choice to ONNX Runtime, which claims a full core count per session.
 DETECT_CV_THREADS=
 DETECT_VISITS_ENABLED=true # persist finished visits + best-frame evidence to the events store
 EVENTS_PLATE_ENRICHMENT=true # OCR vehicle visits' best frames (fast_plate_ocr) into plate_text

--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,16 @@ DETECT_MIN_SPAWN_SCORE=0.5
 # the camera when that happens. 0 restores the old wedge-able behavior.
 # 150 frames ≈ 75 s at the default DETECT_FPS=2.
 DETECT_MOTION_CALIBRATION_MAX_FRAMES=150
+# Consecutive deadline hits before the gate gives up on the scene and
+# LATCHES OPEN (detector on every frame). The deadline above bounds one
+# episode, but a scene with no STATIC BACKGROUND — a PTZ mid-pan, a
+# moving/handheld source, a mast in high wind — re-trips calibration at
+# once, turning the deadline into a duty cycle: ~1 analysed frame per
+# DETECT_MOTION_CALIBRATION_MAX_FRAMES, indefinitely, and quietly (the
+# repeat WARN is demoted to debug). Latching makes that loud, bounded
+# and per-camera; a quiet frame releases it. 0 = deadline only.
+# 2 x 150 frames is ~150 s at DETECT_FPS=2 before giving up.
+DETECT_MOTION_MAX_FORCED_EXITS=2
 # Raise on noisy sensors (fewer phantom motion pixels); 1-255.
 DETECT_MOTION_THRESHOLD=30
 # Minimum contour area counted as motion; raise to ignore small flicker.
@@ -115,6 +125,13 @@ DETECT_MOTION_LIGHTNING_THRESHOLD=0.8
 # false = motion gate OFF entirely: full-frame detection on every frame.
 # The escape hatch for scenes the gate cannot model — costs full-frame
 # inference at DETECT_FPS on that camera, so use the tunables first.
+# NOTE the gate models a STATIC BACKGROUND. A permanently moving frame
+# (moving camera, PTZ that never rests) can never calibrate, and no
+# threshold tuning changes that — the frame fraction in motion never
+# falls below the 5% "quiet" bar. For such a source this flag is the
+# CORRECT setting, not a fallback. This var is global: to un-gate a
+# single moving camera in an otherwise fixed fleet, leave it true and
+# rely on DETECT_MOTION_MAX_FORCED_EXITS, which latches per-camera.
 DETECT_MOTION_ENABLED=true
 
 # Decode-side frame skip (ffmpeg -skip_frame). Decode — not the model — is

--- a/detect-pipeline/ENABLEMENT.md
+++ b/detect-pipeline/ENABLEMENT.md
@@ -11,7 +11,7 @@ read your shadow data first.**
 
 ## The ladder: `off → shadow (default) → enforce → +dispatch`
 
-### 0. `off` (default) — Tier-0 only
+### 0. `off` — Tier-0 only
 ```
 DETECT_PIPELINE_ENABLED=true
 DETECT_GATE_MODE=off

--- a/detect-pipeline/README.md
+++ b/detect-pipeline/README.md
@@ -273,7 +273,7 @@ DETECT_MOTION_LIGHTNING_THRESHOLD=0.8  # frame fraction that re-triggers calibra
 DETECT_MOTION_CALIBRATION_MAX_FRAMES=150  # calibration deadline (#373): force the gate open after
                                   # N consecutive calibrating frames (0 = old wedge-able behavior)
 DETECT_DETECTOR=onnx              # onnx (YOLOv8, default) | hog | blob | stub
-DETECT_ONNX_BACKEND=cvdnn         # cvdnn (zero-dep CPU, default) | ort (ONNX Runtime)
+DETECT_ONNX_BACKEND=auto          # auto (default: ort if installed, else cvdnn) | cvdnn | ort
 DETECT_ONNX_PROVIDERS=            # ort EPs, e.g. OpenVINOExecutionProvider (Intel N100)
 DETECT_HWACCEL=vaapi              # + uncomment devices: /dev/dri in compose
 DETECT_GATE_MODE=shadow           # shadow (default: measure only) | off | enforce (act) — see ENABLEMENT.md
@@ -281,8 +281,10 @@ DETECT_GATE_HEARTBEAT_S=0         # >0: force a periodic escalate even on static
 DETECT_GATE_CRITICAL_CLASSES=     # e.g. person,weapon — always escalate, bypass suppression
 DETECT_GATE_COOLDOWN_S=30         # re-escalate the same track at most once per N seconds
 DETECT_METRICS_PORT=9109          # Prometheus /metrics (0 to disable)
-DETECT_CV_THREADS=2               # cv2 intra-op thread cap (0 = uncapped); compose also
-                                  # exports OMP_NUM_THREADS with the same value
+DETECT_CV_THREADS=                # empty (default) = AUTO: cores / concurrent cameras,
+                                  # retuned as cameras come and go. An explicit value
+                                  # opts out of that and is never retuned; compose also
+                                  # exports OMP_NUM_THREADS from it
 DETECT_DISPATCH_KAIC_URL=         # set to enable Tier-1 dispatch (#10); empty = off
 DETECT_DISPATCH_TASK=caption      # default task for routed adapters
 # always_analyze is per-camera (gate config), deliberately not a global env.

--- a/detect-pipeline/detect_pipeline/metrics.py
+++ b/detect-pipeline/detect_pipeline/metrics.py
@@ -14,6 +14,8 @@ pipeline/gate core stays metric-free and unit-testable. Names follow
     tier0_frames_total{camera}                         counter
     tier0_detector_runs_total{camera}                  counter
     tier0_detector_skipped_total{camera,reason}        counter  reason=calibrating|no_motion
+    tier0_motion_forced_exits_total{camera}            counter
+    tier0_motion_latched_open{camera}                  gauge
     tier0_tracks_active{camera}                        gauge
     tier0_events_published_total{camera}               counter
     gate_escalations_total{camera,reason}              counter
@@ -222,6 +224,18 @@ def record_frame(
     # Bounded-load guards (#track-explosion) — never cap silently:
     if getattr(result, "regions_capped", False):
         metrics.inc("tier0_regions_capped_total", cam)
+    # Motion gate: the #373 deadline firing is the signal that the gate
+    # cannot model this scene. It used to be invisible — the repeat WARN
+    # is demoted to debug, so a gate feeding the detector 1.5% of frames
+    # looked exactly like a quiet camera. The counter is incremented on
+    # the per-frame EDGE; the gauge says the gate has latched open.
+    if getattr(result, "motion_forced_exit", False):
+        metrics.inc("tier0_motion_forced_exits_total", cam)
+    metrics.gauge(
+        "tier0_motion_latched_open",
+        1.0 if getattr(result, "motion_latched_open", False) else 0.0,
+        cam,
+    )
     skipped = int(getattr(result, "skipped_stationary", 0) or 0)
     if skipped:
         metrics.inc("tier0_stationary_skipped_total", cam, value=float(skipped))

--- a/detect-pipeline/detect_pipeline/motion.py
+++ b/detect-pipeline/detect_pipeline/motion.py
@@ -56,6 +56,21 @@ class MotionConfig:
     #: deadline (pre-#373 behaviour). Default 150 ≈ 75 s at 2 fps —
     #: real calibration settles in well under 50 frames.
     calibration_max_frames: int = 150
+    #: Consecutive deadline-forced exits before the gate concludes this
+    #: scene has NO STATIC BACKGROUND and stays open for good. The
+    #: deadline above bounds each episode, but on a scene the gate can
+    #: never model — a PTZ mid-pan, a moving source, a mast in high wind
+    #: — calibration re-trips immediately and the deadline degrades into
+    #: a DUTY CYCLE: one open frame every ``calibration_max_frames``,
+    #: i.e. the detector sees ~1% of frames, near-silently (the repeat
+    #: WARN is demoted to debug). Latching open after this many
+    #: consecutive forced exits turns that into a bounded, loud,
+    #: self-healing failure. A natural calibration resets the count and
+    #: releases the latch. 0 disables the latch (deadline-only, #373
+    #: behaviour). Default 2 ≈ 150 s at 2 fps before giving up: one
+    #: exit could be a genuine dawn flash over a busy road, two is a
+    #: scene that will not settle.
+    calibration_max_forced_exits: int = 2
 
 
 def _grab_contours(found) -> list:
@@ -96,6 +111,13 @@ class MotionDetector:
         self.calibrating_frames = 0
         self.forced_calibration_exits = 0
         self._forced_exit_warned = False
+        #: Forced exits with no natural calibration in between, and
+        #: whether the gate has given up on modelling this scene.
+        self.consecutive_forced_exits = 0
+        self.latched_open = False
+        #: Per-frame edge for metrics: did the deadline fire THIS frame?
+        #: Cumulative counters must not be fed to a Prometheus ``inc``.
+        self.forced_exit_this_frame = False
         self.blur_radius = blur_radius
         self.interpolation = interpolation
         self.contrast_values = np.zeros((contrast_frame_history, 2), np.uint8)
@@ -124,6 +146,12 @@ class MotionDetector:
         self.calibrating = False
         self.calibrating_frames = 0
         self.forced_calibration_exits += 1
+        self.consecutive_forced_exits += 1
+        self.forced_exit_this_frame = True
+        cap = self.config.calibration_max_forced_exits
+        if cap > 0 and self.consecutive_forced_exits >= cap:
+            self._latch_open(limit)
+            return
         msg = (
             "motion gate %s: calibration did not settle after %d frames "
             "— forcing the gate OPEN so detection runs (forced exits so "
@@ -141,9 +169,36 @@ class MotionDetector:
             self._forced_exit_warned = True
             log.warning(msg, *args)
 
+    def _latch_open(self, limit: int) -> None:
+        """Give up gating a scene that has no static background.
+
+        ``calibration_max_forced_exits`` consecutive deadline exits mean
+        the quiet frame that clears calibration is never coming — the
+        background model has nothing stable to lock onto. Re-entering
+        calibration only to force out again throttles the detector to
+        one frame in ``calibration_max_frames``, forever. So the gate
+        stays open until the scene proves itself modelable again; a
+        genuinely quiet frame releases the latch (a PTZ that finished
+        its pan starts being gated again, with no operator action).
+        """
+        self.latched_open = True
+        log.warning(
+            "motion gate %s: NO STATIC BACKGROUND — %d consecutive "
+            "calibration deadlines of %d frames each. This scene cannot "
+            "be modelled by the motion gate, so it is LATCHED OPEN: the "
+            "detector now runs on every frame (higher CPU on this "
+            "camera, but it was previously seeing ~1 frame in %d). "
+            "Usual causes: a PTZ mid-pan, a moving/handheld source, or "
+            "a camera shaking in wind. If that is permanent, set "
+            "DETECT_MOTION_ENABLED=false. The latch releases by itself "
+            "if the scene ever goes quiet.",
+            self.label or "?", self.consecutive_forced_exits, limit, limit,
+        )
+
     def detect(self, luma: np.ndarray) -> list[tuple[int, int, int, int]]:
         """Return motion boxes (x1, y1, x2, y2) in full-frame coordinates."""
         motion_boxes: list[tuple[int, int, int, int]] = []
+        self.forced_exit_this_frame = False
         if not self.config.enabled:
             # Gate OFF: the whole frame is "in motion" every frame, so
             # region selection scans the full frame and the detector
@@ -208,21 +263,33 @@ class MotionDetector:
             self.config.skip_motion_threshold is not None
             and pct_motion > self.config.skip_motion_threshold
         ):
-            self.calibrating = True
-            # #373: dropped frames still count toward the deadline — a
-            # scene permanently above skip_motion_threshold must not
-            # wedge the gate shut forever either.
-            self._enforce_calibration_deadline()
+            if not self.latched_open:
+                # A latched-open gate must not be dragged back into
+                # calibration by this path — that is the duty cycle the
+                # latch exists to break. The frame is still dropped:
+                # "too noisy to use" is independent of gating.
+                self.calibrating = True
+                # #373: dropped frames still count toward the deadline — a
+                # scene permanently above skip_motion_threshold must not
+                # wedge the gate shut forever either.
+                self._enforce_calibration_deadline()
             return []
 
-        # Calibrated once motion is small and few contours remain.
+        # Calibrated once motion is small and few contours remain. A
+        # genuinely quiet frame is also the evidence that releases the
+        # latch: the scene does have a stable background after all.
         if pct_motion < 0.05 and len(motion_boxes) <= 4:
             self.calibrating = False
+            self.consecutive_forced_exits = 0
+            self.latched_open = False
 
         # Lightning/IR/whole-frame change: recalibrate. This does NOT stop
         # detection here; it flips is_calibrating() so the pipeline stops sending
         # regions to the detector while recording continues.
-        if self.calibrating or pct_motion > self.config.lightning_threshold:
+        # A latched-open gate ignores both re-trip paths by design.
+        if not self.latched_open and (
+            self.calibrating or pct_motion > self.config.lightning_threshold
+        ):
             self.calibrating = True
 
         # #373: bound the episode — after calibration_max_frames of

--- a/detect-pipeline/detect_pipeline/onnx_detector.py
+++ b/detect-pipeline/detect_pipeline/onnx_detector.py
@@ -191,8 +191,13 @@ def _ort_session_options(ort):
     each believed they owned every core. The detector pool caps how many
     sessions exist; this caps how wide each one is.
 
-    0/unset means "let ORT decide", matching what DETECT_CV_THREADS=0 means
-    for OpenCV.
+    An EXPLICIT 0 means "let ORT decide". Unset/empty pins 2 instead —
+    deliberately conservative, because this path has no equivalent of the
+    OpenCV governor: WorkerManager._tune_inference_threads only ever calls
+    cv2.setNumThreads, so an unset value here would leave every session
+    claiming the whole box. That asymmetry is a real gap (the ort/rfdetr
+    paths never widen on an idle host the way the cvdnn path does), but it
+    is a safe default rather than an accidental one.
     """
     import os as _os
 

--- a/detect-pipeline/detect_pipeline/pipeline.py
+++ b/detect-pipeline/detect_pipeline/pipeline.py
@@ -72,6 +72,13 @@ class FrameResult:
     # True when the per-frame region budget dropped at least one candidate
     # this frame (exported as tier0_regions_capped_total — no silent caps).
     regions_capped: bool = False
+    # Motion-gate state, for metrics. ``motion_forced_exit`` is a per-frame
+    # EDGE (did the calibration deadline fire on this frame?), not the
+    # detector's running total — a cumulative value fed to a Prometheus
+    # ``inc`` would compound every frame. ``motion_latched_open`` says the
+    # gate gave up on a scene with no static background.
+    motion_forced_exit: bool = False
+    motion_latched_open: bool = False
     # Per-stage wall time for the frame (decode/motion/region/detect/track) — lets
     # the test-bed see *where* time goes, not just the end-to-end total.
     stage_latency_s: dict[str, float] = field(default_factory=dict)
@@ -201,7 +208,13 @@ class DetectPipeline:
             _t = time.monotonic()
             tracks = self.tracker.update([])
             stages["track"] = time.monotonic() - _t
-            return FrameResult(tracks, motion_boxes, [], True, stage_latency_s=stages)
+            return FrameResult(
+                tracks, motion_boxes, [], True, stage_latency_s=stages,
+                motion_forced_exit=getattr(
+                    self.motion, "forced_exit_this_frame", False),
+                motion_latched_open=getattr(
+                    self.motion, "latched_open", False),
+            )
 
         frame_shape = (frame.height, frame.width)
         self._frame_idx += 1
@@ -272,6 +285,9 @@ class DetectPipeline:
             detections=dets, detect_latency_s=detect_latency_s, stage_latency_s=stages,
             skipped_stationary=skipped, regions_capped=regions_capped,
             track_population=self.tracker.population,
+            motion_forced_exit=getattr(
+                self.motion, "forced_exit_this_frame", False),
+            motion_latched_open=getattr(self.motion, "latched_open", False),
         )
 
     def run(self, on_tracks: OnTracks | None = None) -> None:

--- a/detect-pipeline/detect_pipeline/run.py
+++ b/detect-pipeline/detect_pipeline/run.py
@@ -40,7 +40,6 @@ Env:
   DETECT_DECODE_IDLE        adaptive decode while quiet (default nokey; none = off)
   DETECT_DECODE_IDLE_AFTER  quiet seconds before idling (default 60)
   DETECT_HWACCEL_DEVICE     e.g. /dev/dri/renderD128
-  DETECT_MODEL_SIZE         detector input square (default 320)
   DETECT_REFRESH_SECONDS    camera-list reconcile interval (default 30)
 """
 from __future__ import annotations

--- a/detect-pipeline/detect_pipeline/service.py
+++ b/detect-pipeline/detect_pipeline/service.py
@@ -115,6 +115,8 @@ def motion_config_from_env() -> "MotionConfig":
             "DETECT_MOTION_LIGHTNING_THRESHOLD", 0.8),
         calibration_max_frames=_env_int(
             "DETECT_MOTION_CALIBRATION_MAX_FRAMES", 150),
+        calibration_max_forced_exits=_env_int(
+            "DETECT_MOTION_MAX_FORCED_EXITS", 2),
     )
 
 

--- a/detect-pipeline/test/test_motion.py
+++ b/detect-pipeline/test/test_motion.py
@@ -184,7 +184,8 @@ def test_motion_config_from_env_defaults(monkeypatch):
     for var in ("DETECT_MOTION_ENABLED", "DETECT_MOTION_THRESHOLD",
                 "DETECT_MOTION_CONTOUR_AREA", "DETECT_MOTION_FRAME_ALPHA",
                 "DETECT_MOTION_LIGHTNING_THRESHOLD",
-                "DETECT_MOTION_CALIBRATION_MAX_FRAMES"):
+                "DETECT_MOTION_CALIBRATION_MAX_FRAMES",
+                "DETECT_MOTION_MAX_FORCED_EXITS"):
         monkeypatch.delenv(var, raising=False)
     cfg = motion_config_from_env()
     assert cfg == MotionConfig()  # env-less = library defaults, verbatim
@@ -198,6 +199,7 @@ def test_motion_config_from_env_overrides(monkeypatch):
     monkeypatch.setenv("DETECT_MOTION_FRAME_ALPHA", "0.05")
     monkeypatch.setenv("DETECT_MOTION_LIGHTNING_THRESHOLD", "0.95")
     monkeypatch.setenv("DETECT_MOTION_CALIBRATION_MAX_FRAMES", "600")
+    monkeypatch.setenv("DETECT_MOTION_MAX_FORCED_EXITS", "5")
     cfg = motion_config_from_env()
     assert cfg.enabled is False
     assert cfg.threshold == 45
@@ -205,6 +207,7 @@ def test_motion_config_from_env_overrides(monkeypatch):
     assert cfg.frame_alpha == 0.05
     assert cfg.lightning_threshold == 0.95
     assert cfg.calibration_max_frames == 600
+    assert cfg.calibration_max_forced_exits == 5
 
 
 def test_motion_config_from_env_rejects_junk(monkeypatch):
@@ -225,3 +228,117 @@ def test_worker_constructs_motion_from_env_with_camera_label():
            / "detect_pipeline" / "service.py").read_text()
     assert "motion_config_from_env(), label=self.spec.camera_id" in src
     assert "MotionDetector((h, w), MotionConfig())" not in src
+
+
+# ── The deadline as a DUTY CYCLE: latch open on an unmodelable scene ──
+#
+# #373 bounded each calibration episode, but on a scene with NO STATIC
+# BACKGROUND (a PTZ mid-pan, a moving source) calibration re-trips the
+# very next frame, so the deadline stops being an escape hatch and
+# becomes a clock: one analysed frame every calibration_max_frames,
+# forever, and quietly — the repeat WARN is demoted to debug. Measured
+# on a real install: 6124/6220 frames skipped (98.5%), plate events
+# arriving in exact 75 s multiples (150 frames / DETECT_FPS=2).
+
+
+def _no_background_frame(rng: np.random.Generator) -> np.ndarray:
+    """Every pixel churns: motion pct ~1.0, above the 0.8 lightning bar.
+
+    This is the regime a moving camera produces — unlike ``_busy_frame``
+    (pct ~0.3), it RE-TRIPS calibration on every frame, so the gate can
+    never stay open and the deadline repeats indefinitely.
+    """
+    return rng.integers(0, 255, (H, W), dtype=np.uint8)
+
+
+def test_repeated_forced_exits_latch_the_gate_open():
+    """The fix: after N consecutive deadline exits the gate concludes
+    the scene has no static background and stops re-gating it."""
+    md = MotionDetector(
+        (H, W),
+        MotionConfig(calibration_max_frames=10, calibration_max_forced_exits=2),
+        label="cam1",
+    )
+    rng = np.random.default_rng(11)
+    for _ in range(100):
+        md.detect(_no_background_frame(rng))
+    assert md.latched_open is True
+    assert md.is_calibrating() is False
+    # The duty cycle is broken: no further forced exits accumulate,
+    # because calibration is never re-entered.
+    assert md.forced_calibration_exits == 2
+    exits_at_latch = md.forced_calibration_exits
+    for _ in range(100):
+        md.detect(_no_background_frame(rng))
+        assert md.is_calibrating() is False, "a latched gate must never re-gate"
+    assert md.forced_calibration_exits == exits_at_latch
+
+
+def test_latch_disabled_preserves_the_deadline_duty_cycle():
+    """Regression guard for #373: with the latch off, behaviour is
+    exactly as before — the deadline keeps firing forever."""
+    md = MotionDetector(
+        (H, W),
+        MotionConfig(calibration_max_frames=10, calibration_max_forced_exits=0),
+    )
+    rng = np.random.default_rng(11)
+    for _ in range(100):
+        md.detect(_no_background_frame(rng))
+    assert md.latched_open is False
+    assert md.forced_calibration_exits > 2, "deadline should keep re-firing"
+
+
+def test_latch_releases_when_the_scene_goes_quiet():
+    """A PTZ that finishes its pan must start being gated again, with
+    no operator action — the latch is an observation, not a setting."""
+    md = MotionDetector(
+        (H, W),
+        # frame_alpha high so the background re-converges within the
+        # test; release speed is a property of the background model,
+        # not of the latch.
+        MotionConfig(calibration_max_frames=10, calibration_max_forced_exits=2,
+                     frame_alpha=0.5),
+    )
+    rng = np.random.default_rng(11)
+    for _ in range(60):
+        md.detect(_no_background_frame(rng))
+    assert md.latched_open is True
+
+    _warm_up(md, frames=120)                 # the pan stops; scene is static
+    assert md.latched_open is False
+    assert md.consecutive_forced_exits == 0
+    assert md.is_calibrating() is False      # gated again, and calibrated
+
+
+def test_natural_calibration_resets_the_forced_exit_counter():
+    """Consecutive is the operative word: a scene that settles between
+    episodes never accumulates its way to a latch."""
+    md = MotionDetector(
+        (H, W),
+        MotionConfig(calibration_max_frames=10, calibration_max_forced_exits=2,
+                     frame_alpha=0.5),
+    )
+    rng = np.random.default_rng(5)
+    for _ in range(3):
+        for _ in range(30):                  # unmodelable stretch -> one exit
+            md.detect(_no_background_frame(rng))
+        _warm_up(md, frames=120)             # ...then the scene settles
+        assert md.consecutive_forced_exits == 0
+    assert md.latched_open is False
+
+
+def test_forced_exit_this_frame_is_a_per_frame_edge():
+    """The metrics counter increments on this flag, so it must be true
+    only on the frame the deadline fires — a sticky flag would inflate
+    tier0_motion_forced_exits_total by one per frame thereafter."""
+    md = MotionDetector(
+        (H, W),
+        MotionConfig(calibration_max_frames=10, calibration_max_forced_exits=0),
+    )
+    rng = np.random.default_rng(11)
+    edges = 0
+    for _ in range(100):
+        md.detect(_no_background_frame(rng))
+        if md.forced_exit_this_frame:
+            edges += 1
+    assert edges == md.forced_calibration_exits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,6 +381,11 @@ services:
       # from starving CPU-bound co-tenants; raise it on big machines.
       # Empty = sized to the fleet (cores / concurrent inferences).
       - DETECT_CV_THREADS=${DETECT_CV_THREADS:-}
+      - DETECT_VISITS_ENABLED=${DETECT_VISITS_ENABLED:-}
+      - DETECT_GATE_COOLDOWN_S=${DETECT_GATE_COOLDOWN_S:-}
+      - DETECT_DISPATCH_TASK=${DETECT_DISPATCH_TASK:-}
+      - DETECT_HWACCEL_DEVICE=${DETECT_HWACCEL_DEVICE:-}
+      - DETECT_REFRESH_SECONDS=${DETECT_REFRESH_SECONDS:-}
       # Per-camera analysis rate. Detection runs on every analyzed frame,
       # so this is the pipeline's main CPU dial — see .env.example.
       - DETECT_FPS=${DETECT_FPS:-2}
@@ -412,6 +417,7 @@ services:
       - DETECT_MOTION_FRAME_ALPHA=${DETECT_MOTION_FRAME_ALPHA:-}
       - DETECT_MOTION_LIGHTNING_THRESHOLD=${DETECT_MOTION_LIGHTNING_THRESHOLD:-}
       - DETECT_MOTION_CALIBRATION_MAX_FRAMES=${DETECT_MOTION_CALIBRATION_MAX_FRAMES:-}
+      - DETECT_MOTION_MAX_FORCED_EXITS=${DETECT_MOTION_MAX_FORCED_EXITS:-}
       # Opt-in CPU saving (docs/CAMERA_ASSIGNMENTS.md): skip analysis on
       # cameras whose assignments are all detection-free. Empty = off.
       - DETECT_SKIP_UNASSIGNED=${DETECT_SKIP_UNASSIGNED:-}

--- a/docs/AI_ADAPTER_CONTRACT.md
+++ b/docs/AI_ADAPTER_CONTRACT.md
@@ -1632,7 +1632,7 @@ Seven adapters ship in v0.1, all conforming to this contract and pulled from `gh
 | InsightFace | IMAGE | face_detection, face_recognition | REST-based face DB (no shared-volume coupling). |
 | Whisper | AUDIO | speech_to_text | `faster-whisper` runtime, CPU + GPU. |
 | Piper | AUDIO | text_to_speech | Inline-audio response option for low-latency loops. |
-| fast-plate-ocr | IMAGE | license_plate_recognition | Two-stage chain candidate with YOLOv8. |
+| fast-plate-ocr | IMAGE | license_plate_recognition | Ships the two-stage chain: localises the plate (yolo-v9-t-384-license-plate-end2end) before OCR, and returns `plate_detection{found, box, confidence}` alongside `plate_text`. |
 | BLIP | IMAGE | image_captioning | Scene-caption adapter used by the camera-agent. |
 | ByteTrack | GENERIC | multi_object_tracking | First non-detection adapter — post-processor over an upstream detector's results. |
 

--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -155,6 +155,7 @@ empty/failed reads do not fire).
 | `confidence` | number \| null | Adapter-reported confidence for the read, when available. |
 | `vehicle_label` | string \| null | Upstream detection label (`car`/`truck`/`bus`) when the chain knows it. |
 | `event_id` | int \| null | Timeline visit row this read enriches, when initiated from a visit. |
+| `plate_box` | `[x1,y1,x2,y2]` \| absent | Optional. Where the adapter localised the plate, in the pixel space of the crop it was given. Consumers use it to reject **partial** reads: a crop whose edge cuts through the plate still OCRs the surviving characters at high confidence, so `confidence` cannot distinguish `K884` (a fragment of `K884RS`) from a whole plate — only the geometry can. Absent when the adapter reports no localisation. |
 
 #### Producer convergence (Phase 0 exit criterion)
 

--- a/docs/tier0-consumption.md
+++ b/docs/tier0-consumption.md
@@ -91,7 +91,8 @@ Beyond costing nothing (one detector, N subscribers — versus every app
 driving its own inference stream):
 
 * **`track_id`** — stable across frames, so "the same person" is free.
-* **`stationary`** — the object hasn't moved for ~10 s. Dwell and
+* **`stationary`** — the object has held still for 50 frames (~25 s at
+  the default `DETECT_FPS=2`; it counts frames, not seconds). Dwell and
   abandoned-object rules can read it instead of re-deriving it.
 * **`best: true`** — Tier-0 retained the sharpest crop for that track and
   serves it at `<pipeline>/best_frame?camera=&track=`. Run an expensive

--- a/kai-c/kai_c/domain_events.py
+++ b/kai-c/kai_c/domain_events.py
@@ -91,6 +91,18 @@ def _normalise_fast_plate_ocr(
         "vehicle_label": None,
         "event_id": event_id,
     }
+    # Additive optional field (EVENT_CONTRACTS.md "additive-only"): the
+    # plate box the adapter localised, in the OCR'd crop's pixel space.
+    # Consumers use it to reject PARTIAL reads — a crop whose edge cuts
+    # through the plate still OCRs the surviving characters at high
+    # confidence, so only the geometry can tell "K884" (a fragment of
+    # "K884RS") from a whole plate. Forwarded, not judged: KAI-C does not
+    # have the crop, and the consumer that stores the plate does.
+    detection = result.get("plate_detection")
+    if isinstance(detection, dict):
+        box = detection.get("box")
+        if isinstance(box, (list, tuple)) and len(box) == 4:
+            payload["plate_box"] = list(box)
     subject = f"opennvr.events.plate.recognized.v1.{camera_id}"
     return subject, _envelope(
         "plate.recognized.v1",

--- a/kai-c/test/test_domain_events.py
+++ b/kai-c/test/test_domain_events.py
@@ -145,3 +145,32 @@ async def test_publish_domain_event_failure_counts_never_raises():
     ) is False
     assert pub.failed_count == 1
     assert pub._client is None  # forced rebuild on next call
+
+
+def test_plate_box_is_forwarded_when_the_adapter_localised_the_plate():
+    """The consumer that stores the plate needs the geometry to reject
+    PARTIAL reads — a crop whose edge cuts the plate still OCRs the
+    surviving characters at high confidence. KAI-C forwards, never judges:
+    it does not hold the crop the box is measured against."""
+    result = dict(PLATE_RESULT, plate_detection={
+        "found": True, "confidence": 0.87, "box": [847, 463, 1076, 550],
+    })
+    out = normalise_completion("fast_plate_ocr", result, camera_id="cam1",
+                               correlation_id=None, event_id=7)
+    assert out is not None
+    _, env = out
+    assert env["payload"]["plate_box"] == [847, 463, 1076, 550]
+
+
+def test_plate_box_is_omitted_when_absent_or_malformed():
+    """Additive-only: the field simply does not appear, so a consumer on
+    the old contract sees exactly what it saw before."""
+    _, env = normalise_completion("fast_plate_ocr", PLATE_RESULT,
+                                  camera_id="cam1", correlation_id=None,
+                                  event_id=7)
+    assert "plate_box" not in env["payload"]
+    for bad in ({"found": False}, {"box": None}, {"box": [1, 2, 3]}, {"box": "x"}):
+        _, env = normalise_completion(
+            "fast_plate_ocr", dict(PLATE_RESULT, plate_detection=bad),
+            camera_id="cam1", correlation_id=None, event_id=7)
+        assert "plate_box" not in env["payload"]

--- a/server/services/plate_enrichment.py
+++ b/server/services/plate_enrichment.py
@@ -86,12 +86,93 @@ def _warn_adapter_missing(status_code: int) -> None:
     )
 
 
-def extract_plate(response: dict | None) -> str | None:
+#: A plate box within this many pixels of the crop boundary is treated as
+#: CLIPPED. Deliberately tiny: only boxes literally abutting the edge are
+#: rejected, so a plate that merely sits near the edge still reads. Measured
+#: on the fragments that motivated this: every one had a margin of 0-1 px,
+#: while whole-plate reads sat hundreds of pixels inside.
+_PLATE_EDGE_TOLERANCE_PX = 2
+
+#: JPEG start-of-image magic (0xFFD8).
+_SOI = bytes((0xFF, 0xD8))
+
+
+def jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    """(width, height) from a JPEG's SOF marker — no pixel decode.
+
+    The clipping test below needs the crop's size, and the adapter reports
+    the plate box in that crop's pixel coordinates but not the size itself.
+    Parsing the header beats decoding the image on what is a per-visit path.
+    Returns None for anything that isn't a JPEG we can read, which the
+    caller treats as "cannot judge" (never as "clipped").
+    """
+    if not isinstance(data, (bytes, bytearray)) or data[:2] != _SOI:
+        return None
+    i, n = 2, len(data)
+    while i + 3 < n:
+        if data[i] != 0xFF:
+            i += 1
+            continue
+        marker = data[i + 1]
+        if marker == 0x01 or 0xD0 <= marker <= 0xD9:
+            i += 2                       # standalone markers carry no length
+            continue
+        seg = int.from_bytes(data[i + 2:i + 4], "big")
+        if seg < 2:
+            return None
+        # SOF0-SOF15 carry the frame size; C4/C8/CC are DHT/JPG/DAC.
+        if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+            if i + 9 > n:
+                return None
+            h = int.from_bytes(data[i + 5:i + 7], "big")
+            w = int.from_bytes(data[i + 7:i + 9], "big")
+            return (w, h) if w > 0 and h > 0 else None
+        i += 2 + seg
+    return None
+
+
+def plate_box_is_clipped(
+    box, image_size, *, tolerance: int = _PLATE_EDGE_TOLERANCE_PX
+) -> bool:
+    """Does the detected plate touch the edge of the crop it was found in?
+
+    A vehicle crop is the tracked box plus a margin, clamped to the frame,
+    so a vehicle leaving frame yields a crop whose edge cuts through the
+    plate. The OCR then reads the CHARACTERS THAT SURVIVED and reports high
+    confidence for them — "K884" out of "K884RS" scored 0.98. Confidence
+    therefore cannot separate a partial read from a whole one; the geometry
+    can. Unknown/misshapen input answers False: never invent a rejection.
+    """
+    if not image_size or box is None:
+        return False
+    try:
+        x1, y1, x2, y2 = (float(v) for v in box)
+        w, h = (float(v) for v in image_size)
+    except (TypeError, ValueError):
+        return False
+    if w <= 0 or h <= 0:
+        return False
+    return (
+        x1 <= tolerance or y1 <= tolerance
+        or x2 >= w - tolerance or y2 >= h - tolerance
+    )
+
+
+def extract_plate(
+    response: dict | None, *, image_size: tuple[int, int] | None = None
+) -> str | None:
     """Pure parser for the adapter's §5 InferResponse → normalized plate.
 
     Honours the adapter's own ``accepted`` verdict when present (its
     confidence threshold, not ours), requires non-empty ``plate_text``, and
     normalizes to uppercase-no-spaces capped at the column width.
+
+    With ``image_size`` (the OCR'd crop's dimensions) a read whose plate box
+    abuts the crop boundary is rejected as a PARTIAL read. Those are worse
+    than a miss: a truncated plate is written to the register as though it
+    were a whole one, so one vehicle acquires several identities
+    ("66HH07" also arriving as "66HH", "H07", "HHO7") and watchlist
+    matching silently breaks. Without it the check is skipped.
     """
     if not isinstance(response, dict):
         return None
@@ -99,6 +180,11 @@ def extract_plate(response: dict | None) -> str | None:
     if not isinstance(result, dict):
         return None
     if result.get("accepted") is False:
+        return None
+    detection = result.get("plate_detection")
+    if isinstance(detection, dict) and plate_box_is_clipped(
+        detection.get("box"), image_size
+    ):
         return None
     text = result.get("plate_text")
     if not isinstance(text, str):
@@ -182,7 +268,7 @@ async def enrich_event_plate(event_id: int) -> None:
                 # Either way plate reads are dead until fixed — say so.
                 _warn_adapter_missing(resp.status_code)
             return
-        plate = extract_plate(resp.json())
+        plate = extract_plate(resp.json(), image_size=jpeg_dimensions(jpeg))
         if not plate:
             return
         row.plate_text = plate

--- a/server/services/plate_event_consumer.py
+++ b/server/services/plate_event_consumer.py
@@ -37,6 +37,30 @@ SUBJECT = "opennvr.events.plate.recognized.v1.>"
 _RETRY_SECONDS = 60.0
 
 
+def _read_is_clipped(box, evidence_path: str | None) -> bool:
+    """Partial-read guard for the bus path — see plate_box_is_clipped.
+
+    Best-effort by construction: no box, no evidence, or an unreadable
+    crop all answer False, so a missing optional field can never start
+    silently dropping good plates.
+    """
+    if box is None or not evidence_path:
+        return False
+    try:
+        from services.evidence_store import resolve_evidence
+        from services.plate_enrichment import (
+            jpeg_dimensions, plate_box_is_clipped,
+        )
+
+        path = resolve_evidence(evidence_path)
+        if path is None:
+            return False
+        return plate_box_is_clipped(box, jpeg_dimensions(path.read_bytes()))
+    except Exception:  # noqa: BLE001
+        logger.debug("plate consumer: clipping check failed", exc_info=True)
+        return False
+
+
 def apply_plate_event(envelope: object) -> str:
     """Apply one ``plate.recognized.v1`` envelope to the timeline.
 
@@ -78,6 +102,14 @@ def apply_plate_event(envelope: object) -> str:
             return "not-found"
         if row.plate_text:
             return "already-set"
+        # Same partial-read rule as the synchronous producer. The two are
+        # racing writers for one column, so a guard on only one of them is
+        # no guard at all — a clipped read rejected by plate_enrichment
+        # would simply land here instead. KAI-C forwards the plate box
+        # (optional, additive); the crop it was measured in is this row's
+        # evidence, so the geometry is reproducible here.
+        if _read_is_clipped(payload.get("plate_box"), row.evidence_path):
+            return "clipped"
         row.plate_text = plate.strip()[:32]
         db.commit()
         logger.info(

--- a/server/tests/test_detect_pipeline_wiring.py
+++ b/server/tests/test_detect_pipeline_wiring.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Every Tier-0 knob the code reads must reach the container that runs it.
+
+``docker-compose.yml`` has no ``env_file:`` — each service enumerates its
+environment by hand, so a variable added to the code and to
+``.env.example`` is still inert in a compose install until someone
+remembers the third list. Nothing checked that, and it silently ate a
+shipped knob: ``DETECT_MOTION_MAX_FORCED_EXITS`` was added to the code
+and documented at length in ``.env.example`` while never being passed to
+the container, so the motion-gate latch could not be tuned or disabled
+by any operator on a compose install.
+
+The failure is invisible from the outside — the code falls back to its
+own default, the service starts clean, and the log says nothing — which
+is exactly why it needs a test rather than a review habit.
+
+Deliberately string-level (no yaml dependency in this suite; same style
+as test_lpr_adapter_wiring and test_tier0_metrics' compose guard).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_PKG = REPO_ROOT / "detect-pipeline" / "detect_pipeline"
+_COMPOSE = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+_ENV_EXAMPLE = (REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+
+#: Read by the code but intentionally NOT passed to the container.
+#: Every entry needs a reason — "we forgot" is the bug this test exists
+#: to catch, so an unexplained addition here defeats the whole guard.
+DELIBERATELY_UNPLUMBED = {
+    # Dead on the shipped DETECT_DETECTOR=onnx path: run.py's
+    # `model_size = cfg.onnx_input if cfg.detector in ("onnx", "rfdetr")`
+    # overrides it before use. Plumbing it would ship a knob that
+    # silently does nothing — the same defect in a new place.
+    "DETECT_MODEL_SIZE",
+    # Metrics label only, derived from the model path when unset; no
+    # operator reason to override it in a compose install.
+    "DETECT_MODEL_ID",
+}
+
+
+def _read_by_code() -> set[str]:
+    """Every DETECT_* env name the pipeline package looks up."""
+    names: set[str] = set()
+    for path in sorted(_PKG.glob("*.py")):
+        names |= set(re.findall(r'["\'](DETECT_[A-Z0-9_]+)["\']',
+                                path.read_text(encoding="utf-8")))
+    return names
+
+
+def _passed_to_container() -> set[str]:
+    """Env names enumerated on the detect-pipeline service."""
+    lines = _COMPOSE.splitlines()
+    start = next(i for i, l in enumerate(lines)
+                 if l.startswith("  detect-pipeline:"))
+    end = next((i for i in range(start + 1, len(lines))
+                if re.match(r"^  [a-z0-9_-]+:", lines[i])), len(lines))
+    block = "\n".join(lines[start:end])
+    return set(re.findall(r"^\s+- ([A-Z0-9_]+)=", block, re.M))
+
+
+def test_the_service_block_is_actually_found():
+    """Guard the guard: a compose refactor that renames the service must
+    fail loudly here, not silently reduce every assertion below to a
+    comparison of two empty sets."""
+    passed = _passed_to_container()
+    assert len(passed) > 20, (
+        "found only %d env vars on the detect-pipeline service — the "
+        "block parser is no longer matching docker-compose.yml, so the "
+        "wiring assertions below are vacuous" % len(passed))
+    assert "DETECT_FPS" in passed
+
+
+def test_every_knob_the_code_reads_reaches_the_container():
+    missing = sorted(_read_by_code() - _passed_to_container()
+                     - DELIBERATELY_UNPLUMBED)
+    assert not missing, (
+        "read by detect_pipeline but never passed to the container — "
+        "setting these in .env does nothing, and the code silently uses "
+        "its own default instead: " + ", ".join(missing) + ". Add them to "
+        "the detect-pipeline service's environment: block in "
+        "docker-compose.yml, or to DELIBERATELY_UNPLUMBED with a reason.")
+
+
+def test_every_documented_knob_reaches_the_container():
+    """The direction that would have caught the shipped regression.
+
+    A variable can be plumbed but undocumented (harmless), never the
+    other way round: documenting a knob in .env.example promises an
+    operator it works.
+    """
+    documented = set(re.findall(r"(?m)^(DETECT_[A-Z0-9_]+)=", _ENV_EXAMPLE))
+    broken = sorted(documented - _passed_to_container()
+                    - DELIBERATELY_UNPLUMBED)
+    assert not broken, (
+        ".env.example documents these knobs but docker-compose.yml never "
+        "passes them to detect-pipeline, so following the documentation "
+        "has no effect: " + ", ".join(broken))
+
+
+def test_the_motion_gate_latch_is_tunable():
+    """The specific regression, pinned by name.
+
+    The latch decides when Tier-0 gives up gating a scene with no static
+    background. Its default is sane, so a broken knob looks like nothing
+    is wrong until an operator tries to change it on a camera where the
+    default is wrong.
+    """
+    assert "DETECT_MOTION_MAX_FORCED_EXITS" in _passed_to_container(), (
+        "the motion-gate latch threshold is not passed to the container; "
+        "operators cannot tune or disable the latch on a compose install")

--- a/server/tests/test_timeline_events.py
+++ b/server/tests/test_timeline_events.py
@@ -239,3 +239,79 @@ def test_extract_plate_and_wants_plate():
     assert wants_plate("person", "ab/x.jpg") is False
     assert wants_plate("car", None) is False
     assert wants_plate("car", "ab/x.jpg", enabled=False) is False
+
+
+# ── Partial plate reads (fragments) ────────────────────────────────
+#
+# A vehicle crop is the tracked box plus a margin, clamped to the frame,
+# so a vehicle leaving frame yields a crop whose edge cuts the plate.
+# fast_plate_ocr then reads the characters that SURVIVED and reports high
+# confidence for them: "K884" (of "K884RS") scored 0.9835. Those landed in
+# events.plate_text as if whole, so one Audi arrived as 66HH07, 66HH, H07
+# and HHO7 — four identities, and the watchlist matched none of them.
+# Confidence cannot separate partial from whole; the geometry can.
+
+def _jpeg_of(width: int, height: int) -> bytes:
+    """Smallest byte string with a readable SOF0 frame header."""
+    return (bytes((0xFF, 0xD8, 0xFF, 0xC0, 0x00, 0x11, 0x08))
+            + height.to_bytes(2, "big") + width.to_bytes(2, "big")
+            + bytes(8))
+
+
+def test_jpeg_dimensions_reads_the_sof_header():
+    from services.plate_enrichment import jpeg_dimensions
+    assert jpeg_dimensions(_jpeg_of(1077, 720)) == (1077, 720)
+    assert jpeg_dimensions(_jpeg_of(1, 1)) == (1, 1)
+    # "Cannot judge" cases must be None, never a guess.
+    assert jpeg_dimensions(b"") is None
+    assert jpeg_dimensions(b"not a jpeg at all") is None
+    assert jpeg_dimensions(bytes((0xFF, 0xD8))) is None      # SOI, no frame
+    assert jpeg_dimensions(None) is None
+
+
+def test_plate_box_is_clipped_uses_measured_geometry():
+    from services.plate_enrichment import plate_box_is_clipped
+    # Real fragment: "K884" out of "K884RS", box flush with the right edge.
+    assert plate_box_is_clipped([847, 463, 1076, 550], (1077, 720)) is True
+    # Real whole read: "66HH07", 307 px clear of the nearest edge.
+    assert plate_box_is_clipped([401, 307, 596, 369], (1035, 720)) is False
+    # Every edge counts, not just the right one.
+    assert plate_box_is_clipped([0, 100, 50, 150], (500, 500)) is True
+    assert plate_box_is_clipped([100, 0, 150, 50], (500, 500)) is True
+    assert plate_box_is_clipped([100, 100, 150, 500], (500, 500)) is True
+
+
+def test_plate_box_is_clipped_never_invents_a_rejection():
+    from services.plate_enrichment import plate_box_is_clipped
+    good = [401, 307, 596, 369]
+    assert plate_box_is_clipped(good, None) is False       # size unknown
+    assert plate_box_is_clipped(None, (100, 100)) is False  # no box
+    assert plate_box_is_clipped("nonsense", (100, 100)) is False
+    assert plate_box_is_clipped([1, 2, 3], (100, 100)) is False
+    assert plate_box_is_clipped(good, (0, 0)) is False
+
+
+def test_extract_plate_rejects_a_clipped_read():
+    from services.plate_enrichment import extract_plate
+    clipped = {"result": {
+        "plate_text": "K884", "confidence": 0.9835, "accepted": True,
+        "plate_detection": {"found": True, "box": [847, 463, 1076, 550]},
+    }}
+    # High confidence and accepted=True — only the geometry says otherwise.
+    assert extract_plate(clipped, image_size=(1077, 720)) is None
+    # Without the crop size the check cannot run, so behaviour is unchanged.
+    assert extract_plate(clipped) == "K884"
+
+
+def test_extract_plate_keeps_a_whole_read():
+    from services.plate_enrichment import extract_plate
+    whole = {"result": {
+        "plate_text": "66HH07", "confidence": 0.9993, "accepted": True,
+        "plate_detection": {"found": True, "box": [401, 307, 596, 369]},
+    }}
+    assert extract_plate(whole, image_size=(1035, 720)) == "66HH07"
+    # A response with no localisation block is unaffected by the guard.
+    assert extract_plate(
+        {"result": {"plate_text": "66HH07", "accepted": True}},
+        image_size=(1035, 720),
+    ) == "66HH07"


### PR DESCRIPTION
…und (#377)

#373 bounded every calibration episode with a deadline, but on a scene the gate can never model the deadline stops being an escape hatch and becomes a DUTY CYCLE: calibration re-trips on the very next frame, so the detector sees one frame in calibration_max_frames, indefinitely — and near-silently, since the repeat WARN is demoted to DEBUG.

Measured on a moving-camera source with stock settings at DETECT_FPS=2:

    tier0_frames_total            6220
    tier0_detector_skipped_total  6124   98.5%, reason=calibrating
    tier0_detector_runs_total       96    1.5%

~40 forced exits produced 2 WARN lines, both reading "forced exits so far: 1", so the operator signal said "this happened once" when it was the steady state. Downstream, visits (and the LPR plate reads riding on them) arrived in exact 75 s multiples — 150 frames / DETECT_FPS=2 — which reads as "the pipeline is minutes behind" rather than "the detector is switched off". End-to-end latency was in fact never above 9 s.

The binding condition is pct_motion, not the box count. Calibration clears only on pct_motion < 0.05, and a frame with no static background never gets there: measured median 0.81, never once below 0.05 across 200 frames, with zero pixels showing low temporal variance. No amount of DETECT_MOTION_CONTOUR_AREA or DETECT_MOTION_LIGHTNING_THRESHOLD tuning changes that — the gate's premise, a modelable background, is absent.

* Latch. After DETECT_MOTION_MAX_FORCED_EXITS consecutive deadline exits (default 2 ≈ 150 s at 2 fps) the gate concludes the scene is unmodelable and stays open: one decisive WARN naming the real cause, and the detector runs on every frame thereafter. This fixes the duty cycle and the silence with one mechanism — there is no repeating log to suppress. 0 restores #373 behaviour, and a regression test pins it.

* Release. A genuinely quiet frame clears the latch and resets the counter, so a PTZ that finishes its pan is gated again with no operator action. The latch is an observation about the scene, not a setting.

* skip_motion_threshold. That branch sets calibrating and returns before the main block, so it would have silently overridden the latch; it now checks the latch first. Off by default, but the latch is not sound without it.

Why this belongs in code rather than in the docs for DETECT_MOTION_ENABLED: that var is global. An install with one PTZ and ten fixed cameras otherwise has to choose between a blind PTZ and paying full-frame inference on the whole fleet. A latch is per-MotionDetector, therefore per-camera, automatic.

Also exports the signal that was missing — #371's lesson is that a broken chain must not look like an idle one:

    tier0_motion_forced_exits_total{camera}   counter, per-frame EDGE
    tier0_motion_latched_open{camera}         gauge

The counter rides a per-frame boolean, not the detector's running total: a cumulative value handed to a Prometheus inc() compounds every frame. This follows regions_capped, which is a boolean for the same reason.

5 new tests: repeated forced exits latch and then stop accumulating, the latch releases on a quiet scene, latch disabled reproduces the #373 duty cycle, natural calibration between episodes never latches, and the metrics edge fires exactly once per deadline. Full detect-pipeline suite green (392 passed, 1 skipped).

Verified on the reported scene: calibrating skips freeze at 298 (the two deadline episodes before the latch) while frames and detector runs then climb in lockstep — +255/+255/+0 across two scrapes two minutes apart — and visit gaps collapse from 75 s multiples to 0-7 s.

Refs #373, #375, #371. Plate recall on such footage is a separate defect (#378) and is deliberately not addressed here.