### PR TITLE
fix(kai-c): seed registration no longer truncates the #371 receipt file

### DIFF
--- a/kai-c/kai_c/registry.py
+++ b/kai-c/kai_c/registry.py
@@ -345,6 +345,15 @@ class AdapterRegistry:
         # queue for adapters that SHOULD register but couldn't yet.
         self._state_store = state_store or RegistryStateStore(None)
         self._pending: dict[str, PendingRegistration] = {}
+        # Read the receipts NOW, at construction, not in
+        # ``restore_persisted``. The lifespan handler runs the
+        # ADAPTER_REGISTRY seed loop first, and every registration
+        # persists — so by the time restore runs, the file has already
+        # been rewritten from a registry that holds no runtime adapters
+        # yet. Snapshotting here (plus the ``_restored`` carry-over in
+        # ``_persist_locked``) makes those writes lossless.
+        self._boot_receipts: list[dict[str, Any]] = self._state_store.load()
+        self._restored = False
         self._lock = threading.Lock()
         # §05 observability — bounded per-adapter rollups fed by the
         # /metrics scrape on the same 60s poll (see refresh()).
@@ -774,6 +783,21 @@ class AdapterRegistry:
                     "url": p.url,
                     "granted_permissions": sorted(p.granted_keys),
                 })
+        # Receipts read at construction that ``restore_persisted`` has
+        # not consumed yet are still ours to keep. Without this, the
+        # first seed registration of the boot — ADAPTER_REGISTRY always
+        # holds at least ``default`` — serialises an EMPTY runtime set
+        # over the file, and the restore that follows reads back the
+        # receipts it just destroyed. That silently unregistered
+        # fast_plate_ocr on every restart: the exact #371 hole this
+        # file exists to close. A name a seed has since claimed is
+        # dropped on purpose — configuration beats history.
+        if not self._restored:
+            known = {e["name"] for e in entries}
+            for receipt in self._boot_receipts:
+                if receipt["name"] in known or receipt["name"] in self._adapters:
+                    continue
+                entries.append(dict(receipt))
         entries.sort(key=lambda e: e["name"])
         self._state_store.save(entries)
 
@@ -832,9 +856,12 @@ class AdapterRegistry:
         seed — configuration wins over history). Returns what was
         queued, for the boot log. Actual registration happens on the
         first ``retry_pending`` pass, so an unreachable adapter can
-        never slow down boot."""
+        never slow down boot.
+
+        Reads the snapshot taken at construction, not the file: the
+        seed loop that ran first has already rewritten it."""
         queued: list[PendingRegistration] = []
-        for entry in self._state_store.load():
+        for entry in self._boot_receipts:
             name = entry["name"]
             with self._lock:
                 if name in self._adapters or name in self._pending:
@@ -853,6 +880,13 @@ class AdapterRegistry:
                 "restoring %d persisted adapter registration(s): %s",
                 len(queued), ", ".join(p.name for p in queued),
             )
+        # The snapshot has been consumed — every entry worth keeping is
+        # now in ``_pending``. Flip the flag and write once, so a
+        # receipt a seed claimed (or one that was never restorable)
+        # leaves the file instead of lingering forever.
+        with self._lock:
+            self._restored = True
+            self._persist_locked()
         return queued
 
     async def retry_pending(self) -> None:

--- a/kai-c/test/test_persistence.py
+++ b/kai-c/test/test_persistence.py
@@ -440,3 +440,42 @@ async def test_poll_loop_drives_the_retry(tmp_path: Path, audit):
             "poll loop never retried the deferred registration")
     finally:
         await reg.aclose()
+
+
+@pytest.mark.asyncio
+async def test_seed_registration_does_not_wipe_pending_receipts(
+    tmp_path: Path, audit,
+):
+    """The real boot order: ``main.py`` runs the ADAPTER_REGISTRY seed
+    loop BEFORE ``restore_persisted()``. A seed registration must not
+    truncate the receipt file on its way through — the runtime entries
+    are still on disk and nothing has read them yet.
+
+    Regression: ``_persist_locked`` serialises only in-memory
+    ``source == "runtime"`` adapters, of which there are none that
+    early, so the seed's persist wrote ``{"adapters": []}`` over the
+    receipts and ``restore_persisted`` then read the file it had just
+    emptied. ``ADAPTER_REGISTRY`` always holds at least ``default``, so
+    this fired on EVERY boot — silently unregistering fast_plate_ocr and
+    404-ing every plate read (the exact #371 symptom the receipt file
+    was added to fix).
+    """
+    stub = _StubAdapter(url="http://127.0.0.1:9100",
+                        capabilities=_base_caps())
+    store = _store(tmp_path)
+    store.save([{"name": "fast_plate_ocr", "url": stub.url,
+                 "granted_permissions": []}])
+
+    reg = _registry_for(stub, audit, store)
+    # Seed loop first, exactly as the lifespan handler orders it.
+    await reg.register("default", stub.url, source="seed")
+    assert [e["name"] for e in store.load()] == ["fast_plate_ocr"], (
+        "the seed registration truncated the receipt file"
+    )
+
+    # …and the restore that follows still finds it.
+    queued = reg.restore_persisted()
+    assert [p.name for p in queued] == ["fast_plate_ocr"]
+    await reg.retry_pending()
+    assert reg.get("fast_plate_ocr") is not None
+    await reg.aclose()


### PR DESCRIPTION
The durable-receipt fix did not survive its own boot. main.py runs the ADAPTER_REGISTRY seed loop BEFORE restore_persisted(), and register() persists unconditionally while _persist_locked serialises only in-memory source == "runtime" adapters -- of which there are none that early. So the first seed of every boot wrote {"adapters": []} over the file, and restore_persisted() then read back the receipts it had just destroyed. ADAPTER_REGISTRY always holds at least "default", so this fired on EVERY restart, not in a race.

fast_plate_ocr was the only casualty in practice: whisper/piper/ollamavlm re-register because their own one-shot registrars re-run on compose up, whereas fast-plate-ocr-register is restart:"no" and so genuinely depends on the receipt. Result: plate reads 404 after any core restart and the Vehicles page silently stops gaining rows -- precisely the #371 symptom the receipt file exists to prevent.

The fix snapshots the receipts in __init__ and carries the unconsumed ones through every write, rather than reordering the lifespan. That keeps the file from ever being transiently empty, so a crash between the seed loop and restore cannot lose them either, and correctness stops depending on restore_persisted() being called at all. A name a seed has since claimed is dropped on purpose -- configuration still beats history.

The existing tests missed this because none of them registers a seed before restoring: test_restart_restores_runtime_adapter_and_grants skips the seed loop entirely, and test_seed_name_wins_over_persisted_entry asserts restore_persisted() == [], which is also what an emptied file produces -- passing for the wrong reason and leaving the collision path unverified. The new test closes that gap.

Fixes #381