### PR TITLE
fix(lpr): show the crop the plate was READ from, not the vehicle fram…

### DIFF
--- a/app/src/services/vehiclesService.ts
+++ b/app/src/services/vehiclesService.ts
@@ -68,4 +68,12 @@ export const vehiclesService = {
   // can't load them — fetch as a blob and objectURL it (AuthedImage).
   getEventEvidence: (eventId: number) =>
     api.get(`/api/v1/events/${eventId}/evidence`, { responseType: 'blob' }),
+
+  // The crop the PLATE was read from (#382). Multi-frame OCR reads
+  // candidate crops, not the vehicle-best frame, so this is the only
+  // image that actually shows the plate the row is captioned with.
+  // 404s when the read came from the evidence frame itself or predates
+  // the column — callers fall back to getEventEvidence.
+  getEventPlateEvidence: (eventId: number) =>
+    api.get(`/api/v1/events/${eventId}/plate-evidence`, { responseType: 'blob' }),
 }

--- a/app/src/views/Vehicles.tsx
+++ b/app/src/views/Vehicles.tsx
@@ -55,6 +55,23 @@ type PlateEvent = {
   ended_at?: string | null
   has_evidence?: boolean
   evidence_url?: string | null
+  // The crop the plate was READ from (#382); falls back to the
+  // vehicle-best frame above when absent.
+  has_plate_evidence?: boolean
+  plate_evidence_url?: string | null
+  payload?: { plate_merged?: boolean } | null
+}
+
+// Prefer the crop the plate was read from; the vehicle-best frame is the
+// fallback. They are different images by construction — multi-frame OCR
+// reads plate candidates, while the best frame is picked for the biggest
+// VEHICLE box, which at close range is exactly when the plate leaves the
+// crop. Showing the latter beside a plate number captions a photo that
+// often does not contain that plate (#382).
+function plateImage(e: PlateEvent) {
+  return e.has_plate_evidence
+    ? { key: 'plate-evidence', fetch: () => apiService.getEventPlateEvidence(e.id) }
+    : { key: 'evidence', fetch: () => apiService.getEventEvidence(e.id) }
 }
 
 type PlateStats = {
@@ -848,10 +865,10 @@ export function Vehicles() {
                   return (
                     <tr key={e.id} className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-2)]">
                       <td className="px-3 py-1.5">
-                        {e.has_evidence ? (
+                        {(e.has_plate_evidence || e.has_evidence) ? (
                           <AuthedImage
-                            queryKey={['evidence', e.id]}
-                            fetchBlob={() => apiService.getEventEvidence(e.id)}
+                            queryKey={[plateImage(e).key, e.id]}
+                            fetchBlob={plateImage(e).fetch}
                             alt={`evidence for ${p}`}
                             className="h-10 w-16 object-cover rounded cursor-zoom-in"
                             onClick={() => setPreview(e)}
@@ -1086,13 +1103,22 @@ export function Vehicles() {
       {preview && (
         <Modal open onClose={() => setPreview(null)} title={`${(preview.plate_text ?? '').toUpperCase()} — ${cameraName(preview.camera_id)}`}>
           <AuthedImage
-            queryKey={['evidence', preview.id]}
-            fetchBlob={() => apiService.getEventEvidence(preview.id)}
+            queryKey={[plateImage(preview).key, preview.id]}
+            fetchBlob={plateImage(preview).fetch}
             alt="evidence"
             className="max-h-[70vh] w-auto rounded"
           />
           <div className="text-xs text-[var(--text-dim)] mt-2">
             {preview.started_at ? new Date(preview.started_at).toLocaleString() : ''}
+            {preview.payload?.plate_merged && (
+              <span className="ml-2">
+                · read reconstructed from more than one frame — this is the
+                clearer of them
+              </span>
+            )}
+            {!preview.has_plate_evidence && preview.has_evidence && (
+              <span className="ml-2">· vehicle frame (no separate plate crop stored)</span>
+            )}
           </div>
         </Modal>
       )}

--- a/server/migrations/versions/aa88bb99cc00_add_events_plate_evidence_path.py
+++ b/server/migrations/versions/aa88bb99cc00_add_events_plate_evidence_path.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 OpenNVR
+# This file is part of OpenNVR.
+#
+# OpenNVR is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenNVR is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+
+"""add events.plate_evidence_path — the crop the plate was READ from (#382)
+
+A visit stores one image: the vehicle-best frame, chosen for thumbnail
+quality (biggest, sharpest VEHICLE box). Multi-frame OCR does not read
+that frame — it reads plate-candidate crops — and the two are
+anti-correlated by construction: a car is biggest when closest, which is
+exactly when its plate slides out of the crop. So the Vehicles page was
+captioning a correct plate with a photo that does not show it.
+
+Additive and nullable: NULL means "read from the evidence crop itself,
+or enriched before this column existed", and readers fall back to
+evidence_path. No backfill is possible — the winning candidate's bytes
+were never persisted, which is the bug.
+
+Revision ID: aa88bb99cc00
+Revises: ff77bb88cc99
+Create Date: 2026-09-02 06:05:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "aa88bb99cc00"
+down_revision: str | None = "ff77bb88cc99"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("plate_evidence_path", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "plate_evidence_path")

--- a/server/models.py
+++ b/server/models.py
@@ -503,6 +503,15 @@ class TimelineEvent(Base):
     recording_ref = Column(String(500), nullable=True)
     evidence_path = Column(String(500), nullable=True)
     plate_text = Column(String(32), nullable=True)
+    # The crop the plate was actually READ from (#382). Multi-frame OCR
+    # reads plate-candidate crops, not the visit's vehicle-best frame —
+    # the two are anti-correlated by construction (a car is biggest when
+    # closest, which is when its plate leaves the crop), so showing
+    # evidence_path beside plate_text shows a photo that often does not
+    # contain the plate. NULL for rows read from the evidence crop
+    # itself, and for every row enriched before this column existed:
+    # readers fall back to evidence_path.
+    plate_evidence_path = Column(String(500), nullable=True)
     payload = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -155,6 +155,7 @@ async def ingest_track_event(
         from services.plate_attempt_cache import cache as _attempt_cache
         from services.plate_enrichment import (
             dedup_window_s, is_duplicate_sighting, note_sighting,
+            stamp_plate_evidence,
         )
 
         pending = _attempt_cache.claim(
@@ -174,6 +175,7 @@ async def ingest_track_event(
                 )
             else:
                 row.plate_text = plate
+                stamp_plate_evidence(row, pending.plate_evidence_path)
                 note_sighting(payload.camera_id, plate)
                 db.commit()
                 logger.info(
@@ -236,15 +238,25 @@ async def run_early_plate_attempt(
     read = await _ocr_jpeg(jpeg, f"cam{camera_id}")
     if read is None or not read.get("accepted"):
         return
+    # #382: this crop is the image the plate was READ from, and it is
+    # gone the moment this task returns. Store it ONCE here and carry
+    # the path — both the claim below and the ingest-time claim need it,
+    # and content-addressing makes a repeat store free anyway.
+    from services.plate_enrichment import store_plate_crop
+
+    plate_crop_rel = store_plate_crop(jpeg)
     _attempt_cache.put(
         camera_id, track_id,
         plate=read["plate"], confidence=read["confidence"], attempt_ts=ts,
+        plate_evidence_path=plate_crop_rel,
     )
     # Duplicate sighting (fragmented track re-reading the car we just
     # read): still PARK the read — the ingest claim is what lets the
     # visit skip its whole OCR sweep — but skip the race-cover row
     # write; the claim path makes the fold decision with fresher state.
-    from services.plate_enrichment import is_duplicate_sighting, note_sighting
+    from services.plate_enrichment import (
+        is_duplicate_sighting, note_sighting, stamp_plate_evidence,
+    )
 
     if is_duplicate_sighting(camera_id, read["plate"]):
         note_sighting(camera_id, read["plate"])
@@ -276,6 +288,7 @@ async def run_early_plate_attempt(
                 or row.ended_at >= attempt_dt - timedelta(seconds=10)
             ):
                 row.plate_text = read["plate"][:32]
+                stamp_plate_evidence(row, plate_crop_rel)
                 note_sighting(camera_id, row.plate_text)
                 db.commit()
                 logger.info(

--- a/server/routers/timeline_events.py
+++ b/server/routers/timeline_events.py
@@ -56,6 +56,20 @@ def _serialize(e: TimelineEvent) -> dict:
         "plate_text": e.plate_text,
         "has_evidence": bool(e.evidence_path),
         "evidence_url": f"/api/v1/events/{e.id}/evidence" if e.evidence_path else None,
+        # The crop the plate was READ from (#382), when it differs from the
+        # vehicle-best frame above. Additive and often null — clients fall
+        # back to evidence_url. Deliberately false when the two paths are
+        # EQUAL: the fallback sweep OCRs the evidence frame itself, and
+        # content-addressing then makes them one file, so there is no
+        # second image to offer and the caller should just use evidence_url.
+        "has_plate_evidence": bool(
+            e.plate_evidence_path
+            and e.plate_evidence_path != e.evidence_path
+        ),
+        "plate_evidence_url": (
+            f"/api/v1/events/{e.id}/plate-evidence"
+            if e.plate_evidence_path else None
+        ),
         "payload": e.payload,
     }
 
@@ -110,6 +124,39 @@ async def get_event_evidence(
     from services.evidence_store import resolve_evidence
 
     path = resolve_evidence(e.evidence_path)
+    if path is None:
+        raise HTTPException(status_code=404, detail="evidence file missing")
+    return FileResponse(path, media_type="image/jpeg",
+                        headers={"Cache-Control": "max-age=86400"})
+
+
+@router.get("/events/{event_id}/plate-evidence")
+async def get_event_plate_evidence(
+    event_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """The crop this row's PLATE was read from (#382).
+
+    Distinct from the best-frame evidence above: multi-frame OCR reads
+    plate-candidate crops, and the vehicle-best frame is — by
+    construction — usually the one where the plate has left the crop.
+    404 when the read came from the evidence frame itself or predates
+    the column; callers fall back to ``/evidence``.
+    """
+    e = db.query(TimelineEvent).filter(TimelineEvent.id == event_id).first()
+    if e is None or not e.plate_evidence_path:
+        raise HTTPException(status_code=404,
+                            detail="no plate evidence for this event")
+    from services.timeline_service import can_access_event
+
+    if not can_access_event(db, e, user=current_user):
+        # 404, not 403: don't confirm the event exists on someone else's camera.
+        raise HTTPException(status_code=404,
+                            detail="no plate evidence for this event")
+    from services.evidence_store import resolve_evidence
+
+    path = resolve_evidence(e.plate_evidence_path)
     if path is None:
         raise HTTPException(status_code=404, detail="evidence file missing")
     return FileResponse(path, media_type="image/jpeg",

--- a/server/services/plate_attempt_cache.py
+++ b/server/services/plate_attempt_cache.py
@@ -38,6 +38,13 @@ class PendingRead:
     confidence: float
     attempt_ts: float          # wall-clock, from the producer
     stored_monotonic: float    # for TTL sweeping
+    # Relative evidence path of the crop this read came from (#382), so
+    # the claiming visit can show the image its plate was READ from
+    # rather than the vehicle-best frame. A PATH, not the bytes: this
+    # cache is deliberately modest, and the JPEG is already on disk.
+    # None when the crop could not be stored — the visit then falls
+    # back to its vehicle frame, exactly as before.
+    plate_evidence_path: str | None = None
 
 
 class PlateAttemptCache:
@@ -56,7 +63,8 @@ class PlateAttemptCache:
             return len(self._entries)
 
     def put(self, camera_id: int, track_id: str, *, plate: str,
-            confidence: float, attempt_ts: float) -> None:
+            confidence: float, attempt_ts: float,
+            plate_evidence_path: str | None = None) -> None:
         """Park an accepted read. A later read for the same track only
         replaces a parked one when its confidence is higher — attempts
         keep the best, never the latest."""
@@ -75,6 +83,7 @@ class PlateAttemptCache:
                 plate=plate, confidence=float(confidence),
                 attempt_ts=float(attempt_ts),
                 stored_monotonic=self._clock(),
+                plate_evidence_path=plate_evidence_path,
             )
 
     def claim(self, camera_id: int, track_id: str, *,

--- a/server/services/plate_enrichment.py
+++ b/server/services/plate_enrichment.py
@@ -296,6 +296,54 @@ def merge_reads(a: dict | None, b: dict | None) -> dict | None:
 MAX_INGEST_ATTEMPTS: int = 4
 
 
+# ── Plate evidence: the crop the read actually came from (#382) ─────
+
+
+def store_plate_crop(jpeg: bytes | None) -> str | None:
+    """Persist the crop a plate was READ from; return its relative path.
+
+    Separate from the visit's ``evidence_path``, which is the
+    vehicle-best frame — chosen for thumbnail quality and, by
+    construction, usually the WRONG frame for the plate (a car is
+    biggest when closest, which is when its plate leaves the crop).
+    Multi-frame OCR reads candidate crops instead, so without this the
+    only image ever stored is one that often does not contain the plate
+    the row is captioned with.
+
+    Best-effort: any failure answers None and the caller simply keeps
+    ``plate_evidence_path`` NULL, falling back to the vehicle frame.
+    Evidence storage must never cost us a plate we successfully read.
+    """
+    if not jpeg:
+        return None
+    try:
+        from services.evidence_store import save_evidence_jpeg
+
+        return save_evidence_jpeg(jpeg)
+    except Exception:  # noqa: BLE001
+        logger.debug("plate evidence: could not store crop", exc_info=True)
+        return None
+
+
+def stamp_plate_evidence(row, rel_path: str | None, *,
+                         merged: bool = False) -> None:
+    """Record which crop a row's plate was read from, and whether the
+    read was reconstructed from more than one of them.
+
+    ``merged`` rides in the existing ``payload`` JSON rather than a
+    column of its own — it is a display caveat, not queryable state.
+    The dict is UPDATED, never replaced: ``payload`` already carries
+    ``stationary`` for tier0 visits (see ``timeline_service``), and
+    dropping that to record a caption would be a poor trade.
+    """
+    if rel_path:
+        row.plate_evidence_path = rel_path
+    if merged:
+        payload = dict(row.payload or {})
+        payload["plate_merged"] = True
+        row.payload = payload
+
+
 # ── Duplicate-sighting dedup ────────────────────────────────────────
 # A broken track fragments one physical pass into several visits — a
 # moving camera, an occlusion, a starved re-verify — and multi-frame OCR
@@ -476,25 +524,41 @@ async def enrich_event_plate(
         # camera_id is the platform HANDLE ("cam{N}") — see _ocr_jpeg's
         # callers; "3" != "cam3" would silently drop consumer-side scoping.
         camera_handle = f"cam{row.camera_id}"
-        rejects: list[dict] = []
+        # Each read is kept WITH the crop it came from (#382): the
+        # winning crop is the only image that actually shows this plate,
+        # and it is discarded the moment this function returns unless we
+        # persist it here.
+        rejects: list[tuple[dict, bytes]] = []
         winner: dict | None = None
+        winner_jpeg: bytes | None = None
+        was_merged = False
         for jpeg in attempts:
             read = await _ocr_jpeg(jpeg, camera_handle, event_id=int(row.id))
             if read is None:
                 continue
             if read["accepted"]:
-                winner = read
+                winner, winner_jpeg = read, jpeg
                 break                    # early exit — budget saved
             # Character-consensus with every earlier reject: two near
             # misses of the same plate often reconstruct the truth.
-            for prev in rejects:
+            for prev, prev_jpeg in rejects:
                 merged = merge_reads(prev, read)
                 if merged is not None and merged["accepted"]:
-                    winner = merged
+                    winner, was_merged = merged, True
+                    # A merged plate appears WHOLE in neither crop. Keep
+                    # the more confident of the two contributors — the
+                    # closest thing to a photo of this read — and label
+                    # the row so the UI never passes it off as a clean
+                    # single-frame read.
+                    winner_jpeg = (
+                        prev_jpeg
+                        if prev["confidence"] >= read["confidence"]
+                        else jpeg
+                    )
                     break
             if winner is not None:
                 break
-            rejects.append(read)
+            rejects.append((read, jpeg))
 
         if winner is None:
             return                       # honest non-read beats a guess
@@ -513,14 +577,14 @@ async def enrich_event_plate(
             )
             return
         row.plate_text = plate
+        stamp_plate_evidence(row, store_plate_crop(winner_jpeg),
+                             merged=was_merged)
         note_sighting(row.camera_id, plate)
         db.commit()
         logger.info(
             "plate enrichment: event %s -> %s (conf=%.2f, attempts=%d%s)",
             event_id, row.plate_text, winner["confidence"],
-            len(rejects) + 1,
-            ", merged" if winner.get("characters") and rejects
-            and winner["plate"] not in [r["plate"] for r in rejects] else "",
+            len(rejects) + 1, ", merged" if was_merged else "",
         )
     except Exception:
         logger.warning("plate enrichment failed for event %s", event_id,

--- a/server/tests/test_plate_multiframe.py
+++ b/server/tests/test_plate_multiframe.py
@@ -389,3 +389,203 @@ def test_early_attempt_rejected_read_parks_nothing(db, monkeypatch):
     asyncio.run(ica.run_early_plate_attempt(1, "42", 1000.0, b"jpg"))
     assert len(fresh) == 0
     assert _plate_of(SessionLocal, row_id) is None
+
+
+# ── #382: the crop the plate was actually READ from ────────────────
+#
+# A visit stores ONE image — the vehicle-best frame, chosen for the
+# biggest/sharpest VEHICLE box. Multi-frame OCR does not read it; it
+# reads plate candidates, and the two are anti-correlated by
+# construction (a car is biggest when closest, which is when its plate
+# leaves the crop). Before this round the winning candidate's bytes were
+# dropped when the sweep returned, so the Vehicles page captioned a
+# correct plate with a photo that often did not contain it.
+
+
+@pytest.fixture()
+def stored_crops(monkeypatch):
+    """Capture what reaches the evidence store, keyed by its fake path.
+
+    ``store_plate_crop`` imports ``save_evidence_jpeg`` at call time, so
+    patching the module attribute is enough — and it keeps the test off
+    the real JPEG-magic validation and the recordings volume.
+    """
+    import services.evidence_store as es
+
+    seen: dict[str, bytes] = {}
+
+    def fake_save(data: bytes) -> str:
+        rel = f"xx/{data.decode()}.jpg"
+        seen[rel] = data
+        return rel
+
+    monkeypatch.setattr(es, "save_evidence_jpeg", fake_save)
+    return seen
+
+
+def _row(SessionLocal, row_id):
+    s = SessionLocal()
+    try:
+        return s.get(models.TimelineEvent, row_id)
+    finally:
+        s.close()
+
+
+def test_sweep_stores_the_crop_the_winning_read_came_from(
+    db, monkeypatch, stored_crops,
+):
+    """The THIRD candidate wins — so the third crop is the only image
+    that shows this plate, and it is the one that must be stored."""
+    SessionLocal, row_id = db
+    ocr = _ScriptedOcr([None, None, _accepted("WIN123")])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, [b"one", b"two", b"three"]))
+
+    row = _row(SessionLocal, row_id)
+    assert row.plate_text == "WIN123"
+    assert row.plate_evidence_path == "xx/three.jpg", (
+        "stored the wrong crop — the image shown would not be the image "
+        "the plate was read from (#382)")
+    assert stored_crops["xx/three.jpg"] == b"three"
+    # The vehicle-best frame is untouched: it is still the thumbnail.
+    assert row.evidence_path is None
+
+
+def test_merged_read_stores_the_clearer_contributor_and_marks_the_row(
+    db, monkeypatch, stored_crops,
+):
+    """A merged plate appears WHOLE in neither crop. Keep the more
+    confident contributor and say so, rather than passing it off as a
+    clean single-frame read."""
+    SessionLocal, row_id = db
+    # Same disagreement as the merge test above; `a` is the more
+    # confident contributor overall (0.60 vs 0.20 min-confidence).
+    a = _rejected("H644LX", [0.9, 0.9, 0.9, 0.9, 0.9, 0.60])
+    b = _rejected("H644LK", [0.95, 0.95, 0.95, 0.95, 0.95, 0.20])
+    monkeypatch.setattr(pe, "_ocr_jpeg", _ScriptedOcr([a, b]))
+
+    # Pre-existing payload must survive the merge stamp.
+    s = SessionLocal()
+    s.get(models.TimelineEvent, row_id).payload = {"stationary": False}
+    s.commit()
+    s.close()
+
+    asyncio.run(pe.enrich_event_plate(row_id, [b"first", b"second"]))
+
+    row = _row(SessionLocal, row_id)
+    assert row.plate_text == "H644LX"
+    assert row.plate_evidence_path == "xx/first.jpg", (
+        "merged read kept the less confident contributor's crop")
+    assert row.payload["plate_merged"] is True
+    assert row.payload["stationary"] is False, (
+        "the merge stamp replaced payload instead of updating it — "
+        "stationary was collateral")
+
+
+def test_fallback_path_stores_the_evidence_crop_it_read(
+    db, monkeypatch, stored_crops,
+):
+    """With no candidates the sweep OCRs the evidence frame itself. One
+    rule for every path: store what was read. In production that is the
+    same bytes as evidence_path, so content-addressing makes it the same
+    file and the extra column costs nothing."""
+    SessionLocal, row_id = db
+    s = SessionLocal()
+    s.get(models.TimelineEvent, row_id).evidence_path = "ab/abc.jpg"
+    s.commit()
+    s.close()
+
+    # enrich_event_plate imports resolve_evidence at CALL time from
+    # services.evidence_store, so that is the module to patch.
+    import services.evidence_store as es
+
+    monkeypatch.setattr(
+        es, "resolve_evidence",
+        lambda rel: _types.SimpleNamespace(read_bytes=lambda: b"evidence"),
+    )
+    monkeypatch.setattr(pe, "_ocr_jpeg", _ScriptedOcr([_accepted("FALL01")]))
+    asyncio.run(pe.enrich_event_plate(row_id, None))
+
+    row = _row(SessionLocal, row_id)
+    assert row.plate_text == "FALL01"
+    assert row.plate_evidence_path == "xx/evidence.jpg", (
+        "the fallback still read a real crop — storing it costs nothing "
+        "(content-addressed) and keeps one rule for every path")
+
+
+def test_a_failed_crop_store_never_costs_us_the_plate(db, monkeypatch):
+    """Evidence storage is best-effort. A full disk must lose the photo,
+    never the read."""
+    import services.evidence_store as es
+
+    SessionLocal, row_id = db
+
+    def boom(_data):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(es, "save_evidence_jpeg", boom)
+    monkeypatch.setattr(pe, "_ocr_jpeg", _ScriptedOcr([_accepted("KEEP01")]))
+    asyncio.run(pe.enrich_event_plate(row_id, [b"x"]))
+
+    row = _row(SessionLocal, row_id)
+    assert row.plate_text == "KEEP01"
+    assert row.plate_evidence_path is None
+
+
+def test_early_attempt_carries_its_crop_through_to_the_row(
+    db, monkeypatch, stored_crops,
+):
+    """The early-attempt path discarded its winning crop too. It must
+    store it once and park the PATH, so both the race-cover write and a
+    later ingest claim can stamp the row."""
+    from routers import internal_camera_agent as ica
+    from services import plate_attempt_cache as pac
+
+    SessionLocal, row_id = db
+    fresh = pac.PlateAttemptCache()
+    monkeypatch.setattr(pac, "cache", fresh)
+
+    s = SessionLocal()
+    row = s.get(models.TimelineEvent, row_id)
+    row.track_id = "42"
+    started = row.started_at.replace(tzinfo=timezone.utc)
+    cam_id = row.camera_id
+    s.commit()
+    s.close()
+
+    async def fake_ocr(jpeg, camera_handle, event_id=None):
+        return _accepted("EARLY7")
+
+    monkeypatch.setattr(pe, "_ocr_jpeg", fake_ocr)
+    asyncio.run(ica.run_early_plate_attempt(
+        cam_id, "42", started.timestamp() + 5.0, b"earlycrop"))
+
+    # Parked for a visit that has not landed yet...
+    parked = fresh.claim(cam_id, "42",
+                         started_ts=started.timestamp(),
+                         ended_ts=started.timestamp() + 30)
+    assert parked is not None
+    assert parked.plate_evidence_path == "xx/earlycrop.jpg"
+    # ...and stamped on the row the attempt raced.
+    row = _row(SessionLocal, row_id)
+    assert row.plate_text == "EARLY7"
+    assert row.plate_evidence_path == "xx/earlycrop.jpg"
+
+
+
+def test_ingest_claim_stamps_the_parked_crop():
+    """Lockstep with the claim path: the parked crop must reach the row,
+    or an early-attempt read shows the vehicle frame again."""
+    src = (_HERE / "routers" / "internal_camera_agent.py").read_text()
+    assert "stamp_plate_evidence(row, pending.plate_evidence_path)" in src, (
+        "the ingest claim no longer stamps the early attempt's crop — "
+        "those rows fall back to the vehicle-best frame (#382)")
+
+
+def test_events_api_exposes_the_plate_crop():
+    src = (_HERE / "routers" / "timeline_events.py").read_text()
+    assert '"plate_evidence_url"' in src, (
+        "the events payload no longer offers the plate crop — the UI "
+        "cannot show it")
+    assert '@router.get("/events/{event_id}/plate-evidence")' in src, (
+        "the plate-evidence route is gone — the UI would 404")


### PR DESCRIPTION
…e (#382)

A visit persists exactly one image: the vehicle-best frame, chosen by Tier-0 for thumbnail quality (biggest, sharpest VEHICLE box). Multi-frame OCR does not read that frame -- it reads plate CANDIDATE crops -- and the two are anti-correlated by construction: a car is biggest when closest, which is exactly when its plate slides out of the crop. The winning candidate's bytes were dropped when the enrichment task returned, so the Vehicles page captioned a correct plate with a photo that frequently did not contain it. Reported case H644LX: the modal showed a rear windshield with the plate sliced off at the bottom edge.

This is the half of #378 that 918fec7 explicitly deferred:

    best-frame selection ... takes the LARGEST vehicle box -- which at
    close range is exactly when the plate leaves the crop. That
    anti-correlation between "best vehicle frame" and "legible plate" is
    the remaining half of #378 and is not addressed here.

Not a regression of that guard, which is intact and working: 102 of 103 register rows on the reporting install are full 6-character plates, against a pre-fix baseline of 12 fragments in 200 reads. What changed is the symptom. Pre-#378 the text was truncated and the image matched it (you could see the cut). #380 fixed the text by reading candidates, and left the image alone -- so the plate became right and the picture became wrong, which reads as the old bug returning while being its opposite.

* events.plate_evidence_path -- additive and nullable. NULL means "read from the evidence crop itself, or enriched before this column", and every reader falls back to evidence_path. No backfill is possible: the bytes were never kept, which is the bug.

* The sweep now carries each read WITH the crop it came from, so the winner's bytes survive to the commit. Merged reads appear whole in neither crop, so the more confident contributor is kept and the row is marked plate_merged -- in the existing payload JSON, updated not replaced (stationary lives there), since a display caveat does not earn a column. Storage is best-effort throughout: a full disk loses the photo, never the read.

* The early-attempt path discarded its winning crop too. It now stores once at OCR time and parks the PATH on PendingRead -- not the bytes; that cache is deliberately modest -- so both the race-cover write and the ingest claim can stamp the row.

* has_plate_evidence is false when the two paths are EQUAL: the fallback sweep OCRs the evidence frame itself and content-addressing makes them one file, so there is no second image to offer.

Deliberately unchanged: which frame Tier-0 picks as best. The thumbnail wants the biggest vehicle box and the plate wants a legible plate; those are different frames by nature, which is what platecands.py was built around. Keeping two images is the fix, not re-tuning one selector.

Server suite 1011 passed / 1 skipped, including 5 new cases pinning the winning-candidate crop, the merged contributor, payload preservation, the best-effort storage failure, and the early-attempt hand-off. Migration verified up and down against Postgres.

Fixes #382