### PR TITLE
docs: size DETECT_MAX_REGIONS to the host; ship 4 in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,9 +84,20 @@ INFERENCE_TAP_STREAM=auto
 # Detector confidence floor (default 0.4). Real people/vehicles usually
 # score >0.6; wire-phantoms live in the 0.25-0.4 band.
 DETECT_CONF=0.4
-# Hard cap on detector crops per frame (default 8; 0 = unbounded).
+# Hard cap on detector crops per frame (built-in default 8; 0 = unbounded).
 # Motion regions get slots first; track re-verifies round-robin the rest.
-DETECT_MAX_REGIONS=8
+#
+# SIZE THIS TO THE HOST. Each region is a full detector pass (~0.1 s on a
+# typical CPU with the cvdnn backend), and the per-frame budget is
+# 1/DETECT_FPS seconds. When the configured count doesn't fit, the budget
+# controller cuts regions at runtime ("detector regions cut to N" warnings)
+# and coverage ROTATES across frames — fast objects can cross the frame
+# unscanned. A pinned value the host actually sustains beats a higher one
+# it can't: 4 is the safe choice for CPU-only hosts (laptops, macOS/Windows
+# Docker VMs). With real headroom — DETECT_HWACCEL, DETECT_ONNX_BACKEND=ort
+# on a GPU/NPU provider, or a beefy server CPU — raise it back to 8 (or
+# beyond) for finer-grained, deeper coverage of small/distant objects.
+DETECT_MAX_REGIONS=4
 # Hard cap on live tracks per camera (default 50). At the cap new tracks
 # are refused (tier0_track_spawns_dropped) until the TTL drains old ones.
 DETECT_MAX_TRACKS=50

--- a/detect-pipeline/README.md
+++ b/detect-pipeline/README.md
@@ -113,10 +113,22 @@ with an env dial and a metric (never a silent cap):
   `DETECT_MIN_SPAWN_SCORE` (default `0.5`): it takes solid evidence to
   *create* a track, weaker evidence still *matches* one (Frigate-style
   hysteresis).
-* `DETECT_MAX_REGIONS` (default `8`) — hard per-frame budget of detector
-  crops. Motion regions win slots first; track re-verifies round-robin
-  the remainder across frames (skipped tracks coast, they don't age).
-  Capped frames count on `tier0_regions_capped_total`.
+* `DETECT_MAX_REGIONS` (built-in default `8`; `.env.example` ships `4`) —
+  hard per-frame budget of detector crops. Motion regions win slots first;
+  track re-verifies round-robin the remainder across frames (skipped
+  tracks coast, they don't age). Capped frames count on
+  `tier0_regions_capped_total`.
+
+  Size it to the host: each region is a full detector pass, and the frame
+  budget is `1/DETECT_FPS` seconds. Configure more than the host sustains
+  and the budget controller sheds regions at runtime ("detector regions
+  cut to N" warnings) — coverage then rotates across frames, and a fast
+  object can cross the frame while its patch isn't scanned. A pinned
+  count the hardware actually delivers gives every frame the same
+  complete coverage; `4` is the CPU-only sweet spot (laptops,
+  macOS/Windows Docker VMs). With `DETECT_HWACCEL` and/or
+  `DETECT_ONNX_BACKEND=ort` on a GPU/NPU provider, raise it to `8`+ for
+  deeper coverage of small and distant objects.
 * `DETECT_MAX_TRACKS` (default `50`) + `DETECT_TRACK_TTL` (default
   `300` s) — a hard ceiling on live tracks, and a wall-clock TTL so a
   track that is never positively re-detected always drains (frame-based


### PR DESCRIPTION
Field-tuning lesson from the 4-camera reference stack: a CPU-only host asked for 8 regions, sustained 2-4, and the budget controller's runtime shedding made coverage rotate across frames — fast vehicles crossed the frame unscanned and looked like missed detections. Pinning the count at what the host delivers (4) gave every frame the same complete coverage and stopped the cut/restore churn.

.env.example now ships 4 (the safe CPU-only value) with a comment explaining the sizing math (region cost vs the 1/DETECT_FPS budget) and when to raise it back: DETECT_HWACCEL / DETECT_ONNX_BACKEND=ort on a GPU/NPU, or a server-class CPU, buys 8+ regions for deeper coverage of small and distant objects. README bullet expanded to match. Built-in code default stays 8 — docs-only change.