### PR TITLE
fix(alerts): "info" is a notice, not an escalation to HIGH

### DIFF
--- a/server/services/alerts_inbox.py
+++ b/server/services/alerts_inbox.py
@@ -50,6 +50,10 @@ SUBJECT = "opennvr.alerts.>"
 _RETRY_SECONDS = 60.0
 
 _SEVERITIES = ("low", "medium", "high", "critical")
+#: Levels apps use that map onto ours. Anything not listed here or in
+#: _SEVERITIES is an unknown value and surfaces as "high" (see below).
+_SEVERITY_ALIASES = {"info": "low", "notice": "low", "debug": "low",
+                     "warning": "medium", "warn": "medium", "error": "high"}
 
 #: Ring configuration lives in SecuritySetting under this key. The UI
 #: reads it to decide what each severity does in the browser:
@@ -100,6 +104,15 @@ def apply_alert(envelope: object) -> str:
         return "malformed"
 
     severity = envelope.get("severity")
+    if isinstance(severity, str):
+        severity = severity.strip().lower()
+    # Apps (the LPR example among them) fire routine notices at "info",
+    # a level below "low" that the inbox does not have. Field bug: every
+    # plain "Plate X read" was promoted to HIGH by the fallback below and
+    # rang the beep — and turning off the unknown-vehicle alarm changed
+    # nothing, because those were never unknown-vehicle alerts. Notices
+    # are the lowest tier we have, never the second-highest.
+    severity = _SEVERITY_ALIASES.get(severity, severity)
     if severity not in _SEVERITIES:
         # Unknown severity must still SURFACE — an app bug in one field
         # cannot be allowed to hide a fired alert. High, not critical:

--- a/server/tests/test_alerts_inbox.py
+++ b/server/tests/test_alerts_inbox.py
@@ -158,6 +158,26 @@ def test_unknown_severity_surfaces_as_high(db):
     assert _rows(SessionLocal)[0].severity == "high"
 
 
+def test_info_is_a_notice_not_an_escalation(db):
+    """Field bug: the LPR app fires routine "Plate X read" at "info", a
+    level the inbox lacks; the unknown-severity fallback promoted every
+    one to HIGH and rang the beep — while the operator's "alarm on
+    unknown vehicles" toggle (which governs a different alert entirely)
+    appeared to do nothing. Levels apps commonly use map onto ours;
+    only genuinely unknown values escalate."""
+    SessionLocal, _ = db
+    for i, (given, expected) in enumerate([
+        ("info", "low"), ("INFO", "low"), ("notice", "low"),
+        ("warning", "medium"), ("error", "high"), (" Low ", "low"),
+    ]):
+        assert apply_alert(_envelope(alert_id=f"alrt_sev{i}",
+                                     severity=given)) == "stored"
+    got = {r.alert_id: r.severity for r in _rows(SessionLocal)}
+    assert got == {"alrt_sev0": "low", "alrt_sev1": "low", "alrt_sev2": "low",
+                   "alrt_sev3": "medium", "alrt_sev4": "high",
+                   "alrt_sev5": "low"}
+
+
 def test_unparseable_fired_at_still_stores(db):
     SessionLocal, _ = db
     assert apply_alert(_envelope(fired_at="not-a-date")) == "stored"


### PR DESCRIPTION
The LPR app fires routine "Plate X read" alerts at severity "info", a level below "low" that the inbox does not have. The unknown-severity fallback promoted every one to HIGH — which rings continuously by default — so turning off "Alarm on unknown vehicles" appeared to do nothing: those were never unknown-vehicle alerts. Common app levels now map onto ours (info / notice / debug -> low, warning -> medium, error -> high); only genuinely unknown values still surface as high.

