### PR TITLE
fix(occupancy): one alert per breach, not one per flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Occupancy alert storm.** A zone hovering at its limit flipped
+  over/normal on almost every frame, and with the return-to-normal silent
+  each upward flip fired a fresh HIGH alert — one every second or two. The
+  app now holds a per-zone `alert_cooldown_seconds` (default 120) between
+  repeats of the same over/under alert, and the shipped config debounces
+  a new band over 3 frames instead of 1. The live level on the page still
+  tracks every flip.
 - **Plate reads are written by agreement, not by whoever read first.**
   The early track-confirm read (taken when the car is smallest) used to be
   final, and on blurry footage it put a hallucination into the register at

--- a/examples/occupancy-counting/config.docker.yml
+++ b/examples/occupancy-counting/config.docker.yml
@@ -32,8 +32,15 @@ watch_labels:
   - "person"
 max_occupancy: 10
 min_occupancy: null
-debounce_frames: 1
+# A new band must hold for this many consecutive frames before it commits
+# (3 frames ≈ 1.5 s at Tier-0's 2 fps): a single noisy frame no longer
+# flips a zone over and back.
+debounce_frames: 3
 clear_alerts: false
+# Once a zone has alerted over (or under), the same alert is not repeated
+# for this zone within this window however often the count flickers
+# across the limit. The page still shows the live level. 0 disables.
+alert_cooldown_seconds: 120
 
 # ── Alert delivery ─────────────────────────────────────────────────
 # Alerts always go to stdout (``docker compose logs occupancy-counting``).

--- a/examples/occupancy-counting/config.example.yml
+++ b/examples/occupancy-counting/config.example.yml
@@ -59,8 +59,14 @@ min_occupancy: null
 # clear_alerts:    when true, also fire a low-severity CLEARED alert
 #                  when a zone returns to normal occupancy. Off by
 #                  default (most operators only want the breach).
-debounce_frames: 1
+# alert_cooldown_seconds: after an OVER (or UNDER) alert, the same alert
+#                  is not repeated for that zone within this window,
+#                  however often the count flickers across the limit —
+#                  a zone hovering AT the limit otherwise alerts every
+#                  frame it crosses upward. 0 disables.
+debounce_frames: 3
 clear_alerts: false
+alert_cooldown_seconds: 120
 
 # ── Webhook (optional) ────────────────────────────────────────────
 #

--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -71,7 +71,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from opennvr_app_sdk import (
@@ -106,6 +106,13 @@ DISCOVERY_REFRESH_S: int = 300
 # to exactly those cameras; when none is, nothing is restricted and the
 # app watches every camera, exactly as before assignments existed.
 SKILL: str = "occupancy_counting"
+
+# A zone whose count hovers AT the limit flips over/normal on almost every
+# frame; with the return-to-normal silent (clear_alerts off) each upward
+# flip fired a fresh HIGH alert — one every second or two, in the field.
+# Edge-triggering stops a *steady* over-occupancy from repeating; only a
+# per-zone cooldown stops a *flickering* one. 0 disables (legacy).
+ALERT_COOLDOWN_SECONDS_DEFAULT: int = 120
 
 
 def _scope_to_assignment(discovered: list[dict]) -> list[dict]:
@@ -155,6 +162,8 @@ MANIFEST = AppManifest(
               description="Consecutive frames a new band must persist before firing."),
         Param("clear_alerts", bool, default=False,
               description="Also fire a low-severity alert when a zone returns to normal."),
+        Param("alert_cooldown_seconds", int, default=ALERT_COOLDOWN_SECONDS_DEFAULT,
+              description="After an over/under alert, do not repeat the same alert for this zone within this many seconds, however often the count flickers across the limit."),
         Param("zones", "geometry.polygon", per_camera=True),  # drawn in the catalog UI
     ],
     # Store listing (the catalog's Details section).
@@ -244,6 +253,7 @@ class AppConfig:
     clear_alerts: bool
     cameras: dict[str, CameraZone]  # keyed by camera_id for O(1) lookup
     webhook_url: str | None
+    alert_cooldown_seconds: int = ALERT_COOLDOWN_SECONDS_DEFAULT
     nats_alerts_url: str | None = None
     nats_alerts_token: str | None = None
     nats_alerts_subject_prefix: str = "opennvr.alerts"
@@ -327,6 +337,11 @@ def load_config(path: str) -> AppConfig:
         raise ValueError("config: 'debounce_frames' must be >= 1")
 
     clear_alerts = bool(raw.get("clear_alerts", False))
+    try:
+        cooldown = max(0, int(raw.get("alert_cooldown_seconds",
+                                      ALERT_COOLDOWN_SECONDS_DEFAULT)))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("config: 'alert_cooldown_seconds' must be an integer") from exc
 
     # App-level default thresholds; per-camera entries may override.
     default_max = raw.get("max_occupancy")
@@ -492,6 +507,7 @@ def load_config(path: str) -> AppConfig:
         debounce_frames=debounce,
         clear_alerts=clear_alerts,
         cameras=cameras,
+        alert_cooldown_seconds=cooldown,
         webhook_url=str(raw["webhook_url"]) if raw.get("webhook_url") else None,
         nats_alerts_url=nats_alerts_url,
         nats_alerts_token=nats_alerts_token,
@@ -529,6 +545,11 @@ class _ZoneState:
     pending: str | None = None
     pending_count: int = 0
     last_count: int = 0
+    # Wall-clock of the last alert fired per level ("over" / "under"):
+    # the cooldown ledger. Transitions still commit (the level shown on
+    # the page is always current); only the alert is withheld.
+    last_alert_at: dict[str, float] = field(default_factory=dict)
+    alerts_suppressed: int = 0
 
 
 # ── The rule ───────────────────────────────────────────────────────
@@ -735,6 +756,16 @@ class OccupancyCounter(Detector):
         if candidate == "normal" and not self._config.clear_alerts:
             return []
 
+        # Cooldown: the same over/under alert for this zone within the
+        # window is the count flickering across the limit, not news.
+        if candidate in ("over", "under") and self._config.alert_cooldown_seconds > 0:
+            now = time.time()
+            last = state.last_alert_at.get(candidate)
+            if last is not None and (now - last) < self._config.alert_cooldown_seconds:
+                state.alerts_suppressed += 1
+                return []
+            state.last_alert_at[candidate] = now
+
         return [self._build_alert(
             camera=camera, count=count, level=candidate,
             previous=previous, event=event,
@@ -780,6 +811,7 @@ class OccupancyCounter(Detector):
                     "level": state.level,
                     "last_count": state.last_count,
                     "pending": state.pending,
+                    "alerts_suppressed": state.alerts_suppressed,
                 }
                 for camera_id, state in self._states.items()
             },

--- a/examples/occupancy-counting/tests/test_occupancy_counting.py
+++ b/examples/occupancy-counting/tests/test_occupancy_counting.py
@@ -551,3 +551,40 @@ def test_history_interval_suppresses_chatter(monkeypatch):
                    if c["payload"]["level"] == "normal"]
     assert len(normal_only) == 2
     assert app.state_snapshot()["history_events_published"] >= 2
+
+
+# ── Alert storm (field): a zone hovering AT the limit ──────────────
+
+
+def test_flicker_across_the_limit_alerts_once_per_cooldown(monkeypatch):
+    """Field report: 21 identical HIGH alerts in ~15 s from one zone.
+    With clear_alerts off, every upward flip 10→11 fired; the cooldown
+    turns a flickering breach into one alert per window while the
+    committed level (what the page shows) still tracks every flip."""
+    t = {"now": 1000.0}
+    monkeypatch.setattr(oc.time, "time", lambda: t["now"])
+    app = _counter(_camera(max_occ=2))
+    fired = []
+    for i in range(10):
+        fired += app.handle_event(_event(3))      # over
+        fired += app.handle_event(_event(2))      # back to normal (silent)
+        t["now"] += 1.0
+    assert len(fired) == 1
+    assert app.state_snapshot()["cameras"]["cam-1"]["alerts_suppressed"] == 9
+    # the live level still reflects the latest frame
+    assert app.state_snapshot()["cameras"]["cam-1"]["level"] == "normal"
+    # past the window it may alert again
+    t["now"] += oc.ALERT_COOLDOWN_SECONDS_DEFAULT
+    assert len(app.handle_event(_event(3))) == 1
+
+
+def test_cooldown_is_per_level_and_can_be_disabled(monkeypatch):
+    t = {"now": 1000.0}
+    monkeypatch.setattr(oc.time, "time", lambda: t["now"])
+    app = _counter(_camera(max_occ=2, min_occ=1))
+    assert len(app.handle_event(_event(3))) == 1     # over
+    assert len(app.handle_event(_event(0))) == 1     # under — a different alert
+    assert len(app.handle_event(_event(3))) == 0     # over again, in cooldown
+    app._config.alert_cooldown_seconds = 0
+    app.handle_event(_event(2))
+    assert len(app.handle_event(_event(3))) == 1     # disabled → legacy behaviour

--- a/server/services/alerts_inbox.py
+++ b/server/services/alerts_inbox.py
@@ -140,12 +140,20 @@ def apply_alert(envelope: object) -> str:
             evidence=_json_or_none(envelope.get("evidence")),
             tags=_json_or_none(envelope.get("tags")),
         )
+        # Snapshot BEFORE commit: commit expires the instance, and every
+        # attribute read after it is a fresh SELECT the write path has no
+        # reason to depend on.
+        stored = {
+            "alert_id": row.alert_id, "severity": severity,
+            "title": row.title, "description": row.description,
+            "camera_id": row.camera_id, "fired_at": str(row.fired_at),
+        }
         db.add(row)
         db.commit()
         logger.info(
             "alert inbox: [%s] %s (camera=%s source=%s alert_id=%s)",
-            severity.upper(), row.title, row.camera_id,
-            source_name or "?", row.alert_id,
+            severity.upper(), stored["title"], stored["camera_id"],
+            source_name or "?", stored["alert_id"],
         )
         # Beyond the browser: phone call / SMS / hooter relay per the
         # configured alarm actions — fire-and-forget, the inbox write
@@ -153,11 +161,7 @@ def apply_alert(envelope: object) -> str:
         try:
             from services.alarm_actions import dispatch_in_background
 
-            dispatch_in_background({
-                "alert_id": row.alert_id, "severity": severity,
-                "title": row.title, "description": row.description,
-                "camera_id": row.camera_id, "fired_at": str(row.fired_at),
-            })
+            dispatch_in_background(stored)
         except Exception:  # noqa: BLE001
             logger.debug("alarm action dispatch failed to start",
                          exc_info=True)

--- a/server/tests/test_alerts_inbox.py
+++ b/server/tests/test_alerts_inbox.py
@@ -75,6 +75,17 @@ def db(monkeypatch):
     models.Base.metadata.create_all(eng)
     SessionLocal = sessionmaker(bind=eng)
     monkeypatch.setattr(cdb, "SessionLocal", SessionLocal)
+    # apply_alert fires alarm actions on a daemon thread that opens its
+    # own session. On this StaticPool — ONE sqlite connection shared by
+    # every session — that thread's close() is a ROLLBACK on the same
+    # connection, and when it lands while the next apply_alert holds an
+    # uncommitted INSERT, that insert vanishes: ObjectDeletedError on the
+    # post-commit refresh, seen as a CI-only flake. Production sessions
+    # have their own connections; the action tests below call
+    # dispatch_alarm_actions directly. Keep the thread out of here.
+    import services.alarm_actions as _aa
+
+    monkeypatch.setattr(_aa, "dispatch_in_background", lambda alert: None)
     s = SessionLocal()
     role = models.Role(name="admin")
     s.add(role)


### PR DESCRIPTION
A zone whose count hovers AT max_occupancy flips over/normal on almost every frame; with clear_alerts off the return is silent and every upward flip fired a fresh HIGH alert — 21 identical alerts in ~15 s on QA's Gate-In camera. Edge-triggering only stops a steady breach from repeating; a flickering one needs a cooldown. alert_cooldown_seconds (default 120, per zone, per level, 0 = legacy) withholds repeats while the committed level — what the Occupancy page shows — still tracks every flip; the shipped config also debounces a new band over 3 frames instead of 1.