### PR TITLE
Apply per-camera RBAC to alerts, apps, timeline, occupancy and the ca…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `can_manage` for PTZ/presets) or superuser on a registered camera;
   onboarding an unregistered device (Add Camera wizard) still works, but
   PTZ against an unregistered IP is refused. Reported by Furkan Arslan.
+- **Per-camera RBAC now covers every surface, not just the camera list.**
+  Camera assignments (ownership + `CameraPermission` grants) scoped the
+  camera routes, streams and recordings, but the newer read surfaces
+  either copied the owner-only rule (timeline, plates, occupancy history
+  — a user *granted* a camera saw its stream but none of its history) or
+  scoped nothing (the alerts inbox rang every alarm on the site for every
+  user; app `/status` state and per-camera config were fleet-wide). One
+  `services/camera_scope` rule (owned + `can_view` to see, owned +
+  `can_manage` to control, superuser everything, owner-less cameras
+  superuser-only) now applies to: timeline/plate/vehicle-report queries
+  and evidence photos; occupancy history/heatmap/footfall/report; the
+  alerts inbox (list, unacked count, ack — camera-less alerts reach
+  everyone; ring policy, alarm actions and test alarms are superuser
+  only); app `/status` state and per-camera config entries (a
+  non-superuser may edit only the per-camera geometry of cameras they
+  manage, site-wide app settings and enable/disable are superuser only;
+  camera-targeted actions need `can_manage`); and the camera-agent
+  example in `auth_mode: opennvr` (roster, frames, rings, prompt roster,
+  tool camera resolver, alarms/monitors/events feed follow the caller's
+  server-side assignment). The UI hides the site-wide controls from
+  non-superusers; enforcement is server-side.
 
 ### Added
 

--- a/app/src/views/Alarms.tsx
+++ b/app/src/views/Alarms.tsx
@@ -21,6 +21,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { BellRing, CheckCheck, PhoneCall, Volume2 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { playTestSound } from '../components/AlertBell'
+import { useAuth } from '../auth/AuthContext'
 import { api } from '../lib/api'
 import {
   alertsInboxService,
@@ -48,6 +49,11 @@ const SEVERITY_STYLE: Record<string, string> = {
 
 export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
   const qc = useQueryClient()
+  // The alarm POLICY (ring modes, actions, test alarms) is a site
+  // decision — superuser-only on the server; everyone else gets their
+  // cameras' alarms and a read-only view of how the site rings.
+  const { user } = useAuth()
+  const isAdmin = !!user?.is_superuser
   const [onlyUnacked, setOnlyUnacked] = useState(false)
   const [severityFilter, setSeverityFilter] = useState<string | null>(null)
 
@@ -143,8 +149,10 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
                 >
                   <span className="capitalize">{sev}</span>
                   <select
-                    className="bg-[var(--panel)] border border-[var(--border)] rounded px-1 py-0.5"
+                    className="bg-[var(--panel)] border border-[var(--border)] rounded px-1 py-0.5 disabled:opacity-60"
                     value={ring[sev]}
+                    disabled={!isAdmin}
+                    title={isAdmin ? undefined : 'Only an administrator can change the site alarm policy'}
                     onChange={(e) =>
                       saveRing.mutate({
                         ...ring,
@@ -164,6 +172,7 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
           )}
         </div>
 
+        {isAdmin && (
         <div className="border border-[var(--border)] rounded p-3 space-y-2">
           <div className="font-medium">Verify the alarm chain</div>
           <div className="text-[12px] text-[var(--text-dim)]">
@@ -189,7 +198,9 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
             </div>
           )}
         </div>
+        )}
 
+        {isAdmin && (
         <div className="border border-[var(--border)] rounded p-3 space-y-2 md:col-span-2">
           <div className="font-medium">Arm vehicle alarms (LPR)</div>
           <div className="text-[12px] text-[var(--text-dim)]">
@@ -210,8 +221,9 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
             sound policy above, they ring until acknowledged.
           </div>
         </div>
+        )}
 
-        <AlarmActionsCard />
+        {isAdmin && <AlarmActionsCard />}
       </div>
 
       {/* Filters */}

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -27,6 +27,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Activity, ArrowRight, Boxes, Check, Copy, Download, ExternalLink, RefreshCw, Settings2, Trash2 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
+import { useAuth } from '../auth/AuthContext'
 import { extractApiError } from '../lib/apiError'
 import { Modal } from '../components/Modal'
 import { useSnackbar } from '../components/Snackbar'
@@ -351,6 +352,12 @@ export function AppConfigModal({ app, onClose }: { app: RegisteredApp; onClose: 
   const queryClient = useQueryClient()
   const { showSuccess } = useSnackbar()
   const params = app.manifest?.params ?? []
+  // Site-wide params are superuser-only on the server; anyone else may
+  // draw/edit only the per-camera entries of cameras they manage (the
+  // server merges those into the stored config and refuses the rest).
+  const { user: me } = useAuth()
+  const isAdmin = !!me?.is_superuser
+  const canEditParam = (p: ManifestParam) => isAdmin || p.per_camera === true
   const [values, setValues] = useState<Record<string, string | boolean>>(() =>
     Object.fromEntries(params.map((p) => [p.name, initialFormValue(p, app.config)]))
   )
@@ -370,6 +377,7 @@ export function AppConfigModal({ app, onClose }: { app: RegisteredApp; onClose: 
     setError(null)
     const config: Record<string, any> = {}
     for (const p of params) {
+      if (!canEditParam(p)) continue   // untouched site-wide keys stay as stored
       const raw = values[p.name]
       const t = (p.type || '').toLowerCase()
       if (isJsonParam(p)) {
@@ -445,7 +453,15 @@ export function AppConfigModal({ app, onClose }: { app: RegisteredApp; onClose: 
                   </span>
                 </label>
                 {p.description && <div className="text-xs text-[var(--text-dim)] mb-1">{p.description}</div>}
-                {t === 'geometry.polygon' || t === 'geometry.tripwire' ? (
+                {!canEditParam(p) ? (
+                  <div
+                    className="w-full px-2 py-1.5 text-sm font-mono rounded border border-[var(--border)] bg-[var(--bg-2)] text-[var(--text-dim)] whitespace-pre-wrap break-all"
+                    title="Site-wide setting — only an administrator can change it"
+                  >
+                    {String(value ?? '') || '—'}
+                    <span className="ml-2 text-[11px] font-sans">(administrator only)</span>
+                  </div>
+                ) : t === 'geometry.polygon' || t === 'geometry.tripwire' ? (
                   <GeometryEditor
                     kind={t === 'geometry.tripwire' ? 'tripwire' : 'polygon'}
                     value={String(value ?? '')}
@@ -1052,6 +1068,11 @@ function AppCard({ app, tasks, skill, onConfigure }: { app: RegisteredApp; tasks
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { showSuccess, showError } = useSnackbar()
+  // Enable/disable is a site decision (superuser-only on the server;
+  // uninstall keeps its own apps.install permission); everyone can open
+  // Configure for their cameras' zones.
+  const { user: me } = useAuth()
+  const isAdmin = !!me?.is_superuser
   const [uninstallPollActive, setUninstallPollActive] = useState(false)
   const [uninstallNote, setUninstallNote] = useState<string | null>(null)
   // Manifest-declared operator action currently open in its form modal.
@@ -1160,6 +1181,7 @@ function AppCard({ app, tasks, skill, onConfigure }: { app: RegisteredApp; tasks
         )}
 
         <div className="flex items-center gap-2 pt-1">
+          {isAdmin && (
           <Button
             variant={app.enabled ? 'default' : 'primary'}
             onClick={() => toggleMutation.mutate()}
@@ -1168,6 +1190,7 @@ function AppCard({ app, tasks, skill, onConfigure }: { app: RegisteredApp; tasks
           >
             {toggleMutation.isPending ? 'Working…' : app.enabled ? 'Disable' : 'Enable'}
           </Button>
+          )}
           <Button variant="outline" onClick={onConfigure}>
             <Settings2 size={14} /> Configure
           </Button>

--- a/app/src/views/Occupancy.tsx
+++ b/app/src/views/Occupancy.tsx
@@ -30,6 +30,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { FileText, Flame, RefreshCw, Settings2, Users } from 'lucide-react'
 import { api } from '../lib/api'
 import { apiService } from '../lib/apiService'
+import { useAuth } from '../auth/AuthContext'
 import { extractApiError } from '../lib/apiError'
 import { useSnackbar } from '../components/Snackbar'
 import {
@@ -240,6 +241,10 @@ export function Occupancy() {
   const minOccupancy = Number((occApp?.config as any)?.min_occupancy ?? 0) || 0
   const [draftMax, setDraftMax] = useState<string | null>(null)
   const [draftMin, setDraftMin] = useState<string | null>(null)
+  // Thresholds are the app's SITE-WIDE config — superuser-only on the
+  // server; other users see them, and their own cameras' occupancy.
+  const { user: me } = useAuth()
+  const canConfigure = !!me?.is_superuser
 
   const saveThresholds = useMutation({
     mutationFn: async () => {
@@ -355,6 +360,7 @@ export function Occupancy() {
       )}
 
       {/* ── Thresholds (applied live) ─────────────────────────────── */}
+      {canConfigure && (
       <Card>
         <CardContent className="py-3 flex flex-wrap items-end gap-3">
           <label className="text-xs text-[var(--text-dim)]">
@@ -388,6 +394,7 @@ export function Occupancy() {
           </span>
         </CardContent>
       </Card>
+      )}
 
       {/* ── Busiest hours (7 days of occupancy.changed.v1 samples) ── */}
       {(history?.busiest_hours?.length ?? 0) > 0 && (

--- a/app/src/views/Vehicles.tsx
+++ b/app/src/views/Vehicles.tsx
@@ -34,6 +34,7 @@ import {
   RefreshCw, Search, ShieldAlert, ShieldCheck, Trash2, Upload,
 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
+import { useAuth } from '../auth/AuthContext'
 import { Link } from 'react-router-dom'
 import { alertsInboxService, type InboxAlert } from '../services/alertsInboxService'
 import { extractApiError } from '../lib/apiError'
@@ -477,6 +478,11 @@ export function Vehicles() {
   const [range, setRange] = useState<(typeof RANGE_PRESETS)[number]>(RANGE_PRESETS[0])
   const [preview, setPreview] = useState<PlateEvent | null>(null)
   const [tab, setTab] = useState<'reads' | 'registry' | 'monitoring' | 'alarms'>('reads')
+  // The register, monitors, barrier and alarm mode are the LPR app's
+  // SITE-WIDE config — superuser-only on the server. Everyone else
+  // gets the reads and alarms for their own cameras.
+  const { user: me } = useAuth()
+  const canConfigure = !!me?.is_superuser
   const [historyPlate, setHistoryPlate] = useState<string | null>(null)
   const [reportOpen, setReportOpen] = useState(false)
   const [registerPrefill, setRegisterPrefill] = useState('')
@@ -752,7 +758,7 @@ export function Vehicles() {
           { key: 'registry', label: `Vehicle register (${registry.length})` },
           { key: 'monitoring', label: `Monitoring (${monitors.length})` },
           { key: 'alarms', label: 'Alarms' },
-        ] as const).map((t) => (
+        ] as const).filter((t) => canConfigure || t.key === 'reads' || t.key === 'alarms').map((t) => (
           <button
             key={t.key}
             onClick={() => setTab(t.key)}
@@ -775,7 +781,7 @@ export function Vehicles() {
       ) : tab === 'monitoring' ? (
         <MonitoringTab
           monitors={monitors}
-          canEdit={Boolean(lprApp)}
+          canEdit={Boolean(lprApp) && canConfigure}
           saving={saveConfig.isPending}
           cameras={camerasQuery.data ?? []}
           onSave={saveMonitors}
@@ -862,7 +868,7 @@ export function Vehicles() {
                    : 'Automatic barrier off'),
             })
           }}
-          canEdit={Boolean(lprApp)}
+          canEdit={Boolean(lprApp) && canConfigure}
           saving={saveConfig.isPending}
           cameras={camerasQuery.data ?? []}
           cameraRoles={cameraRoles}
@@ -922,6 +928,7 @@ export function Vehicles() {
                         {new Date(r.time * 1000).toLocaleTimeString()}
                       </td>
                       <td className="py-1 text-right">
+                        {canConfigure && (
                         <Button
                           variant="outline"
                           onClick={() => {
@@ -931,6 +938,7 @@ export function Vehicles() {
                         >
                           <Plus size={13} /> Register
                         </Button>
+                        )}
                       </td>
                     </tr>
                   ))}
@@ -1065,7 +1073,7 @@ export function Vehicles() {
                           : <Badge variant="neutral">{e.label || 'vehicle'}</Badge>}
                       </td>
                       <td className="px-3 py-1.5 text-right pr-4 whitespace-nowrap">
-                        {lprApp && !registered && (
+                        {lprApp && canConfigure && !registered && (
                           <button
                             title="Register this vehicle — one click adds the plate to the Vehicle register; add owner details there any time"
                             className="text-[var(--text-dim)] hover:text-[var(--text)] mr-2"
@@ -1086,7 +1094,7 @@ export function Vehicles() {
                             <BookUser size={15} />
                           </button>
                         )}
-                        {lprApp && !inDeny && (
+                        {lprApp && canConfigure && !inDeny && (
                           <button
                             title="Monitor this plate — alert whenever it is seen (configure in the Monitoring tab)"
                             className="text-[var(--text-dim)] hover:text-[var(--text)] mr-2"

--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -828,6 +828,8 @@ class OpennvrAuthClient(_ReusableClientMixin):
         # device_token -> (checked_at_monotonic, allowed, negative_ttl_used)
         self._device_cache: dict[str, tuple[float, bool, float]] = {}
         self._device_fail_ttl = 10.0   # short: enforcement resumes fast after a blip
+        # token -> (checked_at_monotonic, visible server camera ids, ttl)
+        self._scope_cache: dict[str, tuple[float, frozenset[int], float]] = {}
 
     async def login(self, username: str, password: str,
                     totp_code: str | None = None, *,
@@ -900,6 +902,49 @@ class OpennvrAuthClient(_ReusableClientMixin):
             self._cache.clear()   # crude but bounded; refills within a TTL
         self._cache[token] = (now, user)
         return user
+
+    async def visible_cameras(self, token: str,
+                              user: dict | None = None) -> set[int] | None:
+        """The server-side camera ids this bearer's user may SEE — the
+        server's own ``GET /api/v1/cameras`` (owned + granted; paused
+        cameras included since their history stays theirs) — or ``None``
+        for a superuser, who sees the fleet.
+
+        FAIL-CLOSED: an unreachable server or a non-200 yields the EMPTY
+        set, never "everything" — a hiccup must not widen what a guard can
+        watch. Cached per token for the TTL like ``me()``; the negative
+        result is cached only briefly so recovery is quick."""
+        if user is not None and user.get("is_superuser"):
+            return None
+        now = time.monotonic()
+        hit = self._scope_cache.get(token)
+        if hit is not None and now - hit[0] < hit[2]:
+            return set(hit[1])
+        ids: set[int] = set()
+        ttl = self._ttl
+        try:
+            resp = await self._client().get(
+                f"{self._root}/api/v1/cameras/",
+                params={"limit": 1000, "active_only": "false"},
+                headers={"Authorization": f"Bearer {token}"})
+            if resp.status_code == 200:
+                data = resp.json()
+                rows = data.get("cameras") if isinstance(data, dict) else data
+                for row in rows or []:
+                    try:
+                        ids.add(int(row["id"]))
+                    except (KeyError, TypeError, ValueError):
+                        continue
+            else:
+                ttl = self._device_fail_ttl
+        except Exception as exc:
+            logger.warning("auth: camera-scope lookup failed (failing closed): %s",
+                           exc)
+            ttl = self._device_fail_ttl
+        if len(self._scope_cache) >= self._cache_max:
+            self._scope_cache.clear()
+        self._scope_cache[token] = (now, frozenset(ids), ttl)
+        return ids
 
     async def device_allowed(self, device_token: str | None) -> bool:
         """True iff the server's device firewall permits this browser.

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -67,8 +67,14 @@ from adapter_clients import (
 from context import (
     CameraContext,
     CameraSpec,
+    camera_in_scope,
+    camera_scope,
+    reset_camera_scope,
     run_app_alert_subscriber,
     run_event_subscriber,
+    scoped_cameras,
+    set_camera_scope,
+    spawn_unscoped,
 )
 from frame_sources import build_frame_source, discover_local_cameras
 from monitor_host import MonitorHost
@@ -890,7 +896,7 @@ def _frames_for(runtime, max_frames: int = 3) -> list[dict]:
     so the UI can SHOW what the agent saw in the chat. Reads the per-turn frame
     cache (populated by the vision tools) for the cameras in last_cameras_used —
     no extra fetch. Capped in count and size to keep the response small."""
-    roles = {c.camera_id: c.role for c in runtime.cfg.cameras}
+    roles = {c.camera_id: c.role for c in runtime.visible_cameras()}
     out: list[dict] = []
     seen: set[str] = set()
     for cid in getattr(runtime.tools, "last_cameras_used", []) or []:
@@ -986,7 +992,7 @@ class TaskManager:
         while len(self._order) > self._max:
             old = self._order.pop(0)
             self._tasks.pop(old, None)
-        asyncio.create_task(self._run(task), name=f"agent-task-{task.id}")
+        spawn_unscoped(self._run(task), name=f"agent-task-{task.id}")
         logger.info("task #%d queued: %r", task.id, task.query)
         return task
 
@@ -1214,7 +1220,7 @@ class MonitorManager:
             self._monitors.pop(old, None)
         if kind not in self._CONVERGED:
             # Legacy poll loop — only kind="notify" lands here now.
-            self._tasks[mon.id] = asyncio.create_task(self._loop(mon), name=f"monitor-{mon.id}")
+            self._tasks[mon.id] = spawn_unscoped(self._loop(mon), name=f"monitor-{mon.id}")
         logger.info("monitor #%d (%s %r on %s) started", mon.id, kind, target, camera_ids)
         return mon
 
@@ -1704,7 +1710,7 @@ class AlarmManager:
             old = self._order.pop(0)
             self.stop(old)
             self._alarms.pop(old, None)
-        self._tasks[alarm.id] = asyncio.create_task(self._loop(alarm), name=f"alarm-{alarm.id}")
+        self._tasks[alarm.id] = spawn_unscoped(self._loop(alarm), name=f"alarm-{alarm.id}")
         logger.info("alarm #%d %r (%s on %s, %s) armed", alarm.id, alarm.name,
                     alarm.target, camera_ids, alarm.window_label())
         return alarm
@@ -2407,7 +2413,7 @@ class ReportScheduler:
 
     def start(self) -> None:
         if self._task is None:
-            self._task = asyncio.create_task(self._loop(), name="report-scheduler")
+            self._task = spawn_unscoped(self._loop(), name="report-scheduler")
 
     def stop_all(self) -> None:
         if self._task:
@@ -3386,6 +3392,12 @@ class CameraAgentRuntime:
         self.persist()
         return self.ring_defaults()
 
+    def visible_cameras(self) -> list[CameraSpec]:
+        """The roster as the CURRENT CALLER may see it — the full fleet
+        outside a scoped request (background loops, auth_mode none). Every
+        request-serving read of ``cfg.cameras`` goes through here."""
+        return scoped_cameras(self.cfg.cameras)
+
     def events_feed(self, limit: int = 50) -> list[dict[str, Any]]:
         """ONE feed of what happened — alarm rings, watch hits, and app
         alerts relayed off the bus — newest first. The demo's Events card
@@ -3407,7 +3419,10 @@ class CameraAgentRuntime:
                         "detail": str(al.summary or ""),
                         "severity": str(al.severity or "info"),
                         "kind": "app", "source": al.app_id})
-        out = [e for e in out if e.get("ts")]
+        # A caller sees the alarms/watches/alerts of THEIR cameras; an
+        # entry about no camera in particular reaches everyone.
+        out = [e for e in out if e.get("ts")
+               and (not e["camera_id"] or camera_in_scope(e["camera_id"]))]
         out.sort(key=lambda e: e["ts"], reverse=True)
         return out[:limit]
 
@@ -3780,7 +3795,7 @@ class CameraAgentRuntime:
         # "all cameras" reads wrong on a single-camera install (the one
         # camera IS the fleet, but the operator armed it on THAT camera
         # and expects to hear its name back).
-        _fleet = {c.camera_id for c in self.cfg.cameras}
+        _fleet = {c.camera_id for c in self.visible_cameras()}
         where = ("all cameras" if len(_fleet) > 1 and set(cams) == _fleet
                  else ", ".join(cams))
         window = alarm.window_label()
@@ -3848,7 +3863,7 @@ class CameraAgentRuntime:
             return "What's the person's name?"
         cam = str(args.get("camera_id") or "").strip()
         if not self.context.known_camera(cam):
-            cams = [c.camera_id for c in self.cfg.cameras]
+            cams = [c.camera_id for c in self.visible_cameras()]
             return f"Which camera should I capture from? Available: {cams}."
         try:
             frame = await self.context.get_frame(cam)
@@ -4017,7 +4032,7 @@ class CameraAgentRuntime:
         # "all cameras" reads wrong on a single-camera install (the one
         # camera IS the fleet, but the operator armed it on THAT camera
         # and expects to hear its name back).
-        _fleet = {c.camera_id for c in self.cfg.cameras}
+        _fleet = {c.camera_id for c in self.visible_cameras()}
         where = ("all cameras" if len(_fleet) > 1 and set(cams) == _fleet
                  else ", ".join(cams))
         if kind == "notify":
@@ -4865,7 +4880,7 @@ class CameraAgentRuntime:
         """Compose the system prompt the LLM sees: the agent's identity + the
         operator's base prompt + a per-camera roster + task guidance."""
         roster = "\n".join(
-            f"- {cam.camera_id}: {cam.role}" for cam in self.cfg.cameras
+            f"- {cam.camera_id}: {cam.role}" for cam in self.visible_cameras()
         )
         # Per-turn wall clock, in the container's local timezone (TZ is passed
         # through by the compose files). Without this the model cannot turn
@@ -5123,6 +5138,22 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             return "operator"       # arm/create/ack/remove verbs
         return "viewer"             # look + chat (/ask, /converse, /say, GETs)
 
+    def _scoped_rules(rules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Monitors/alarms the caller may see: every camera the rule
+        watches must be in their scope (a rule armed on the yard is not a
+        guard-of-the-gate's business, even if it also covers the gate)."""
+        return [r for r in rules
+                if all(camera_in_scope(str(c)) for c in (r.get("camera_ids") or []))]
+
+    def _rule_visible(rules: list[dict[str, Any]], rule_id: int) -> bool:
+        return any(int(r.get("id", -1)) == int(rule_id) for r in _scoped_rules(rules))
+
+    def _scoped_notes(notes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Alarm events / watch notifications for the caller's cameras
+        (an entry naming no camera reaches everyone)."""
+        return [n for n in notes
+                if not n.get("camera") or camera_in_scope(str(n.get("camera")))]
+
     @app.middleware("http")
     async def _auth_gate(request: Request, call_next):
         if runtime.cfg.auth_mode != "opennvr":
@@ -5153,7 +5184,23 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 status_code=403)
         request.state.agent_user = user
         request.state.agent_tier = tier
-        return await call_next(request)
+        # Per-camera RBAC: bind the caller's visible cameras for the rest
+        # of this request (tools, rings, roster — see context.CAMERA_SCOPE).
+        # Agent cameras not linked to a server camera are superuser-only,
+        # like the server's own owner-less cameras.
+        scope_token = set_camera_scope(await _scope_for(token, user))
+        try:
+            return await call_next(request)
+        finally:
+            reset_camera_scope(scope_token)
+
+    async def _scope_for(token: str, user: dict[str, Any]) -> set[str] | None:
+        server_ids = await runtime.auth.visible_cameras(token, user)
+        if server_ids is None:
+            return None
+        return {c.camera_id for c in runtime.cfg.cameras
+                if c.opennvr_camera_id is not None
+                and int(c.opennvr_camera_id) in server_ids}
 
     # ── Interactive priority ───────────────────────────────────────
     # Bracket a discrete voice/chat turn so background detection loops
@@ -5402,11 +5449,15 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             return {"available": True, "ok": False, "events": []}
         # Map server-side camera ids back to this agent's ids/roles so the
         # card can say "the front door", not "camera 7".
-        by_srv = {int(c.opennvr_camera_id): c for c in runtime.cfg.cameras
+        by_srv = {int(c.opennvr_camera_id): c for c in runtime.visible_cameras()
                   if c.opennvr_camera_id is not None}
         rows = []
         for e in events:
             spec = by_srv.get(int(e.camera_id))
+            if spec is None and camera_scope() is not None:
+                # The store is fleet-wide (internal key); a scoped caller
+                # gets only the visits on cameras they may see.
+                continue
             rows.append({
                 "id": e.id, "label": e.label,
                 "camera_id": spec.camera_id if spec else str(e.camera_id),
@@ -5514,7 +5565,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         return {
             "cameras": [
                 {"camera_id": cam.camera_id, "role": cam.role}
-                for cam in runtime.cfg.cameras
+                for cam in runtime.visible_cameras()
             ]
         }
 
@@ -5537,7 +5588,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         return {
             "added": [{"camera_id": c.camera_id, "frame_url": c.frame_url} for c in added],
             "cameras": [
-                {"camera_id": c.camera_id, "role": c.role} for c in runtime.cfg.cameras
+                {"camera_id": c.camera_id, "role": c.role} for c in runtime.visible_cameras()
             ],
         }
 
@@ -5720,8 +5771,8 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
     async def _monitors() -> dict[str, Any]:
         """Standing monitors + any new notifications (UI polls this)."""
         return {
-            "monitors": runtime.monitors.list(),
-            "notifications": runtime.monitors.notifications(),
+            "monitors": _scoped_rules(runtime.monitors.list()),
+            "notifications": _scoped_notes(runtime.monitors.notifications()),
         }
 
     @app.post("/monitors")
@@ -5734,12 +5785,16 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         msg = await runtime._handle_create_monitor(body or {})
         if msg.startswith("ERROR:") or msg.endswith("?"):
             return JSONResponse({"error": msg}, status_code=400)
-        return JSONResponse({"message": msg, "monitors": runtime.monitors.list()}, status_code=202)
+        return JSONResponse({"message": msg,
+                             "monitors": _scoped_rules(runtime.monitors.list())},
+                            status_code=202)
 
     @app.delete("/monitors/{monitor_id}")
     async def _stop_monitor(monitor_id: int) -> JSONResponse:
         """The UI's ✕: stop AND forget — idempotent, same contract as
         DELETE /alarms/{id} (already-gone is success)."""
+        if not _rule_visible(runtime.monitors.list(), monitor_id):
+            return JSONResponse({"stopped": False, "already_gone": True})
         ok = runtime.monitors.remove(monitor_id)
         runtime.persist()
         return JSONResponse({"stopped": ok, "already_gone": not ok})
@@ -5748,10 +5803,10 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
     async def _alarms() -> dict[str, Any]:
         """Armed alarms + recent trigger events (UI polls; rings while any
         alarm is triggered)."""
-        alarms = runtime.alarms.list()
+        alarms = _scoped_rules(runtime.alarms.list())
         return {
             "alarms": alarms,
-            "events": runtime.alarms.events(),
+            "events": _scoped_notes(runtime.alarms.events()),
             # Ring only for ACTIVE, triggered alarms. list() also returns
             # disarmed ones; without the active check a stale triggered flag on a
             # disarmed alarm left the siren banner up while the panel showed
@@ -5801,7 +5856,9 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         msg = await runtime._handle_create_alarm(body or {})
         if msg.startswith("ERROR:") or msg.endswith("?"):
             return JSONResponse({"error": msg}, status_code=400)
-        return JSONResponse({"message": msg, "alarms": runtime.alarms.list()}, status_code=202)
+        return JSONResponse({"message": msg,
+                             "alarms": _scoped_rules(runtime.alarms.list())},
+                            status_code=202)
 
     @app.post("/alarms/ack")
     async def _ack_alarms(request: Request) -> JSONResponse:
@@ -5811,7 +5868,14 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         except Exception:
             body = {}
         aid = body.get("alarm_id")
-        n = runtime.alarms.acknowledge(int(aid) if aid is not None else None)
+        if aid is not None:
+            if not _rule_visible(runtime.alarms.list(), int(aid)):
+                return JSONResponse({"silenced": 0})
+            return JSONResponse({"silenced": runtime.alarms.acknowledge(int(aid))})
+        # "Silence everything" silences MY alarms — the ones on cameras I
+        # can see; someone else's yard alarm keeps ringing for them.
+        n = sum(runtime.alarms.acknowledge(int(a["id"]))
+                for a in _scoped_rules(runtime.alarms.list()))
         return JSONResponse({"silenced": n})
 
     @app.delete("/alarms/{alarm_id}")
@@ -5824,6 +5888,8 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         'couldn't remove' six times for an alarm that WAS removed —
         alarming (sic) and wrong. Deletion's contract is 'make it not
         exist', and it already doesn't."""
+        if not _rule_visible(runtime.alarms.list(), alarm_id):
+            return JSONResponse({"stopped": False, "already_gone": True})
         ok = runtime.alarms.remove(alarm_id)
         runtime.persist()
         return JSONResponse({"stopped": ok, "already_gone": not ok})
@@ -5916,7 +5982,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         if not text:
             return JSONResponse({"error": "text is required"}, status_code=400)
 
-        configured = {cam.camera_id for cam in runtime.cfg.cameras}
+        configured = {cam.camera_id for cam in runtime.visible_cameras()}
         camera_hint = None
         for part in str((body or {}).get("camera") or "").split(","):
             part = part.strip()
@@ -6036,7 +6102,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         # UI-selected camera hint: one id, a comma list, or "all". Use the
         # first concrete configured camera as the grounding default; "all"
         # or empty leaves it to the agent.
-        configured = {cam.camera_id for cam in runtime.cfg.cameras}
+        configured = {cam.camera_id for cam in runtime.visible_cameras()}
         raw_hint = request.query_params.get("camera") or ""
         camera_hint = None
         for part in raw_hint.split(","):
@@ -6238,6 +6304,9 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             if _user is None:
                 await websocket.close(code=4401)   # 4401 = auth required
                 return
+            # Same per-camera scope as the HTTP gate, for the life of the
+            # voice session (the pipeline's tool calls run in this task).
+            set_camera_scope(await _scope_for(_tok, _user))
         await websocket.accept()
         last: str | None = None
         try:
@@ -6778,13 +6847,13 @@ async def _run_conversation_turn(
     # are instant: previously they ran the full tool loop (tens of seconds on a
     # CPU model) only to have the roster answer override the result at the end.
     if _is_config_question(user_text):
-        return _roster_answer(runtime.cfg.cameras)
+        return _roster_answer(runtime.visible_cameras())
 
     messages: list[dict[str, Any]] = [
         {"role": "system", "content": runtime.build_system_prompt()}
     ]
     tools = tool_definitions if tool_definitions is not None else runtime.tool_definitions
-    cameras = [cam.camera_id for cam in runtime.cfg.cameras]
+    cameras = [cam.camera_id for cam in runtime.visible_cameras()]
     # UI-selected camera: when the user doesn't name one, bias the model
     # toward the camera the operator picked in the dropdown.
     if preferred_camera and preferred_camera in cameras:
@@ -6908,18 +6977,18 @@ async def _run_conversation_turn(
     # reasoning) but a tool ran, surface that result. For camera-roster/config
     # questions, answer deterministically — small models often just deflect
     # ("I'll check…") and there's no tool to ground them.
-    cleaned = _clean_for_speech(final, runtime.cfg.cameras)
+    cleaned = _clean_for_speech(final, runtime.visible_cameras())
     if _is_config_question(user_text):
         # Roster/config questions ("how many cameras are configured?") are
         # answered deterministically and FIRST — the model can't reliably count
         # the configured cameras and often narrates a tool it never called
         # ("…calling detect_objects to check…"). The roster is authoritative, so
         # don't let that narration through as the answer.
-        reply, source = _roster_answer(runtime.cfg.cameras), "roster"
+        reply, source = _roster_answer(runtime.visible_cameras()), "roster"
     elif cleaned and not _is_deflection(cleaned):
         reply, source = cleaned, "llm"
     elif last_tool_result:
-        reply, source = _humanize_for_speech(last_tool_result, runtime.cfg.cameras), "tool_fallback"
+        reply, source = _humanize_for_speech(last_tool_result, runtime.visible_cameras()), "tool_fallback"
     else:
         reply, source = (cleaned or "Sorry, I'm having trouble answering that right now."), "none"
 

--- a/examples/camera-agent/context.py
+++ b/examples/camera-agent/context.py
@@ -27,12 +27,75 @@ import json
 import logging
 import time
 from collections import deque
+from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Iterable
 
 from frame_sources import FrameSource, FrameSourceError
 
 logger = logging.getLogger(__name__)
+
+
+# ── Per-request camera scope (RBAC) ────────────────────────────────
+#
+# In ``auth_mode: opennvr`` every request is made by an OpenNVR user who
+# may see only SOME of the cameras this agent serves (the server's
+# per-camera assignments: ownership + CameraPermission grants). The auth
+# middleware resolves that user's visible set and stores it here for the
+# duration of the request; every roster read below — the tools' camera
+# resolver, the frame cache, the event/plate rings, the system-prompt
+# roster — filters through it, so "what's on the yard camera?" from a
+# guard who was never assigned the yard is answered "no such camera",
+# exactly as the main UI would. ``None`` = unrestricted: a superuser, a
+# background loop (alarms/monitors run for the whole fleet), or
+# ``auth_mode: none``. ContextVars follow the request into every task
+# and thread it spawns, so tools running under ``to_thread`` see it.
+CAMERA_SCOPE: ContextVar[frozenset[str] | None] = ContextVar(
+    "camera_scope", default=None)
+
+
+def set_camera_scope(scope: Iterable[str] | None):
+    """Bind the caller's visible agent-camera ids (``None`` = all).
+    Returns the token for ``reset_camera_scope``."""
+    return CAMERA_SCOPE.set(None if scope is None else frozenset(scope))
+
+
+def reset_camera_scope(token) -> None:
+    CAMERA_SCOPE.reset(token)
+
+
+def camera_scope() -> frozenset[str] | None:
+    return CAMERA_SCOPE.get()
+
+
+def camera_in_scope(camera_id: str) -> bool:
+    scope = CAMERA_SCOPE.get()
+    return scope is None or camera_id in scope
+
+
+def spawn_unscoped(coro, *, name: str | None = None) -> asyncio.Task:
+    """``asyncio.create_task`` for the agent's own BACKGROUND work.
+
+    A task inherits the context it is created in, so a monitor or alarm
+    loop started from inside a scoped request would carry that caller's
+    camera scope for its whole life — an alarm the site admin later
+    widened would keep looking at one guard's cameras. Background loops
+    watch the fleet: this clears the scope in the new task before the
+    coroutine runs (the reset touches only the new task's own context).
+    """
+    async def _run():
+        CAMERA_SCOPE.set(None)
+        return await coro
+
+    return asyncio.create_task(_run(), name=name)
+
+
+def scoped_cameras(cameras: Iterable["CameraSpec"]) -> list["CameraSpec"]:
+    """``cameras`` narrowed to the current scope (identity when unset)."""
+    scope = CAMERA_SCOPE.get()
+    if scope is None:
+        return list(cameras)
+    return [c for c in cameras if c.camera_id in scope]
 
 
 @dataclass
@@ -182,6 +245,14 @@ class CameraContext:
 
     @property
     def cameras(self) -> list[CameraSpec]:
+        """The roster as the CURRENT CALLER may see it (see CAMERA_SCOPE);
+        the full fleet outside a scoped request."""
+        return scoped_cameras(self._cameras.values())
+
+    @property
+    def all_cameras(self) -> list[CameraSpec]:
+        """The whole fleet regardless of the caller — for the agent's own
+        background work (alarms, monitors, roster reconciliation)."""
         return list(self._cameras.values())
 
     def add_camera(self, spec: CameraSpec) -> None:
@@ -190,7 +261,10 @@ class CameraContext:
         self._cameras[spec.camera_id] = spec
 
     def known_camera(self, camera_id: str) -> bool:
-        return camera_id in self._cameras
+        """Configured AND visible to the current caller. Out of scope reads
+        as unknown on purpose — a camera you were not assigned must not be
+        confirmed to exist by the error message."""
+        return camera_id in self._cameras and camera_in_scope(camera_id)
 
     def remove_camera(self, camera_id: str) -> bool:
         """Forget a camera: its spec, frame source, and cached/pinned frames.
@@ -211,6 +285,8 @@ class CameraContext:
         return True
 
     def get_camera(self, camera_id: str) -> CameraSpec | None:
+        if not camera_in_scope(camera_id):
+            return None
         return self._cameras.get(camera_id)
 
     def register_frame_source(self, camera_id: str, source: FrameSource) -> None:
@@ -231,7 +307,7 @@ class CameraContext:
         always see the real current frame — an operator pinning a
         historical frame for a question must never ring an alarm or
         freeze a monitor on it."""
-        if camera_id not in self._cameras:
+        if camera_id not in self._cameras or not camera_in_scope(camera_id):
             raise LookupError(
                 f"camera_id {camera_id!r} is not configured; "
                 f"available: {sorted(self._cameras.keys())}"
@@ -376,9 +452,10 @@ class CameraContext:
         cutoff = time.time() - max(0.0, float(window_seconds))
         rings: list[deque[EventRecord]]
         if camera_id is None:
-            rings = list(self._events.values())
+            rings = [ring for cid, ring in self._events.items()
+                     if camera_in_scope(cid)]
         else:
-            ring = self._events.get(camera_id)
+            ring = self._events.get(camera_id) if camera_in_scope(camera_id) else None
             rings = [ring] if ring else []
         out: list[EventRecord] = []
         for ring in rings:
@@ -399,7 +476,7 @@ class CameraContext:
         Used by ``camera_snapshot`` to answer count/presence questions from the
         always-on Tier-0 stream with **no new inference** — the detection already
         ran; we just read its latest result off the ring."""
-        ring = self._events.get(camera_id)
+        ring = self._events.get(camera_id) if camera_in_scope(camera_id) else None
         if not ring:
             return None
         for ev in reversed(ring):            # newest-first
@@ -430,6 +507,7 @@ class CameraContext:
             r for r in self._plates
             if r.received_at >= cutoff
             and (camera_id is None or r.camera_id == camera_id)
+            and camera_in_scope(r.camera_id)
             and (needle is None or needle in r.plate_text)
         ]
         out.sort(key=lambda r: (r.received_at, r.seq), reverse=True)
@@ -477,10 +555,18 @@ class CameraContext:
         out: list[AlertRecord] = []
         for ring in rings:
             for al in ring:
-                if al.received_at >= cutoff:
+                if al.received_at >= cutoff and _alert_in_scope(al):
                     out.append(al)
         out.sort(key=lambda a: (a.received_at, a.seq), reverse=True)
         return out
+
+
+def _alert_in_scope(alert: "AlertRecord") -> bool:
+    """An app alert about a camera is visible only to callers who may see
+    that camera; an alert about nothing in particular (empty camera_id —
+    a site-wide notice) reaches everyone. Mirrors the server's inbox."""
+    cam = (getattr(alert, "camera_id", "") or "").strip()
+    return not cam or camera_in_scope(cam)
 
 
 # ── NATS subscriber ────────────────────────────────────────────────

--- a/examples/camera-agent/monitor_host.py
+++ b/examples/camera-agent/monitor_host.py
@@ -100,6 +100,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
+from context import spawn_unscoped
 from opennvr_app_sdk.alerts import Alert, AlertDispatcher
 from opennvr_app_sdk.geometry import Tripwire, Zone
 
@@ -363,7 +364,7 @@ class MonitorHost:
 
         mon.detector = detector
         self._monitors[mid] = mon
-        mon.task = asyncio.create_task(self._loop(mon), name=f"sdk-monitor-{mid}")
+        mon.task = spawn_unscoped(self._loop(mon), name=f"sdk-monitor-{mid}")
         logger.info(
             "hosted monitor #%d started: %s %r on %s (interval %.1fs, alerts %s)",
             mid, rule, target, cams, interval_s,

--- a/examples/camera-agent/tests/test_auth_gate.py
+++ b/examples/camera-agent/tests/test_auth_gate.py
@@ -32,6 +32,9 @@ class _FakeAuth:
         self.me_calls += 1
         return USERS.get(token)
 
+    async def visible_cameras(self, token, user=None):
+        return None   # unrestricted — per-camera scope has its own tests
+
     async def device_allowed(self, device_token):
         self.device_calls += 1
         return self.device_ok

--- a/examples/camera-agent/tests/test_camera_scope.py
+++ b/examples/camera-agent/tests/test_camera_scope.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""auth_mode="opennvr": per-camera RBAC.
+
+The main server assigns cameras to users (ownership + CameraPermission
+grants). The agent honours the SAME assignment: a guard who can see the
+gate and not the yard gets the gate's roster entry, frames, events,
+plates, alarms and app alerts — and "no such camera" for the yard, from
+the HTTP routes and from the LLM's tools alike. Superusers see the
+fleet; background loops (alarms, monitors) always see the fleet."""
+from __future__ import annotations
+
+import time
+
+from fastapi.testclient import TestClient
+
+from camera_agent import AppConfig, CameraAgentRuntime, build_app
+from context import (
+    AlertRecord, CameraSpec, EventRecord, PlateRecord, camera_scope,
+    set_camera_scope, spawn_unscoped,
+)
+
+USERS = {
+    "tok-guard": {"username": "guard", "is_superuser": False, "role_name": "operator"},
+    "tok-super": {"username": "root", "is_superuser": True, "role_name": "admin"},
+    "tok-nobody": {"username": "nobody", "is_superuser": False, "role_name": "viewer"},
+}
+# Server camera ids each user may see (what GET /api/v1/cameras returns).
+SCOPES = {"tok-guard": {1}, "tok-nobody": set()}
+
+
+class _FakeAuth:
+    def __init__(self):
+        self.scope_calls = 0
+
+    async def me(self, token):
+        return USERS.get(token)
+
+    async def visible_cameras(self, token, user=None):
+        self.scope_calls += 1
+        if user and user.get("is_superuser"):
+            return None
+        return set(SCOPES.get(token, set()))
+
+    async def device_allowed(self, device_token):
+        return True
+
+    async def aclose(self):
+        pass
+
+
+def _client():
+    cfg = AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+        auth_mode="opennvr", opennvr_api_url="http://srv",
+        cameras=[
+            CameraSpec(camera_id="cam1", frame_url="http://x/1.jpg",
+                       role="the gate", opennvr_camera_id=1),
+            CameraSpec(camera_id="cam2", frame_url="http://x/2.jpg",
+                       role="the yard", opennvr_camera_id=2),
+            # A config-only camera the server does not know: superuser-only.
+            CameraSpec(camera_id="cam9", frame_url="http://x/9.jpg",
+                       role="the workshop"),
+        ],
+    )
+    rt = CameraAgentRuntime(cfg)
+    rt.auth = _FakeAuth()
+    return rt, TestClient(build_app(rt))
+
+
+def _h(tok):
+    return {"Authorization": f"Bearer {tok}"}
+
+
+def _ids(resp):
+    return sorted(c["camera_id"] for c in resp.json()["cameras"])
+
+
+# ── the roster ─────────────────────────────────────────────────────────
+
+
+def test_roster_is_the_users_assigned_cameras():
+    _, c = _client()
+    assert _ids(c.get("/cameras", headers=_h("tok-guard"))) == ["cam1"]
+    assert _ids(c.get("/cameras", headers=_h("tok-super"))) == ["cam1", "cam2", "cam9"]
+    assert _ids(c.get("/cameras", headers=_h("tok-nobody"))) == []
+
+
+def test_unassigned_camera_reads_as_unknown_not_forbidden():
+    """404, never 403: the guard must not learn the yard exists."""
+    _, c = _client()
+    assert c.get("/timeline/cam1", headers=_h("tok-guard")).status_code == 200
+    assert c.get("/timeline/cam2", headers=_h("tok-guard")).status_code == 404
+    assert c.get("/timeline/cam9", headers=_h("tok-guard")).status_code == 404
+    assert c.get("/timeline/cam2", headers=_h("tok-super")).status_code == 200
+    assert c.get("/frame/cam2", headers=_h("tok-guard")).status_code == 404
+
+
+def test_scope_is_bound_only_for_the_request():
+    """Outside a request (background alarm loops) the fleet is whole."""
+    rt, c = _client()
+    assert c.get("/cameras", headers=_h("tok-guard")).status_code == 200
+    assert camera_scope() is None
+    assert [x.camera_id for x in rt.context.cameras] == ["cam1", "cam2", "cam9"]
+
+
+# ── the rings the tools read ───────────────────────────────────────────
+
+
+def test_rings_and_prompt_roster_follow_the_scope():
+    rt, _ = _client()
+    now = time.time()
+    rt.context.record_event(EventRecord(
+        received_at=now, camera_id="cam1", adapter="tier0", summary="1 car"))
+    rt.context.record_event(EventRecord(
+        received_at=now, camera_id="cam2", adapter="tier0", summary="1 person"))
+    rt.context.record_plate(PlateRecord(
+        received_at=now, camera_id="cam2", plate_text="KA01AB1234", confidence=0.9))
+    rt.context.record_app_alert(AlertRecord(
+        received_at=now, app_id="lpr", camera_id="cam2", title="Unknown vehicle",
+        severity="high", summary="on the yard"))
+    rt.context.record_app_alert(AlertRecord(
+        received_at=now, app_id="site", camera_id="", title="Backup done",
+        severity="low", summary="site-wide notice"))
+
+    token = set_camera_scope({"cam1"})
+    try:
+        assert {e.camera_id for e in rt.context.recent_events(
+            camera_id=None, window_seconds=60)} == {"cam1"}
+        assert rt.context.recent_events(camera_id="cam2", window_seconds=60) == []
+        assert rt.context.latest_inference("cam2") is None
+        assert rt.context.recent_plates(window_seconds=60) == []
+        titles = [a.title for a in rt.context.recent_app_alerts(window_seconds=60)]
+        assert titles == ["Backup done"]          # the camera-less notice only
+        assert rt.context.known_camera("cam2") is False
+        assert rt.context.get_camera("cam2") is None
+        assert "the yard" not in rt.build_system_prompt()
+        assert "the gate" in rt.build_system_prompt()
+        # The LLM's camera resolver: "all" means all of MINE.
+        assert rt.tools._resolve_cameras({"camera_id": "all"}) == ["cam1"]
+        assert rt.tools._resolve_cameras({"camera_id": "cam2"}).startswith("ERROR")
+    finally:
+        from context import reset_camera_scope
+        reset_camera_scope(token)
+    # Unscoped again: everything is back.
+    assert len(rt.context.recent_plates(window_seconds=60)) == 1
+
+
+# ── alarms / monitors / the events feed ────────────────────────────────
+
+
+def test_alarms_and_monitors_are_per_camera(monkeypatch):
+    rt, c = _client()
+    # The superuser arms one alarm on each camera and a watch on the yard.
+    assert c.post("/alarms", headers=_h("tok-super"),
+                  json={"name": "Gate", "target": "person", "camera_ids": ["cam1"]}
+                  ).status_code == 202
+    assert c.post("/alarms", headers=_h("tok-super"),
+                  json={"name": "Yard", "target": "person", "camera_ids": ["cam2"]}
+                  ).status_code == 202
+    assert c.post("/monitors", headers=_h("tok-super"),
+                  json={"kind": "notify", "target": "car", "camera_ids": ["cam2"]}
+                  ).status_code == 202
+
+    got = c.get("/alarms", headers=_h("tok-guard")).json()
+    assert [a["name"] for a in got["alarms"]] == ["Gate"]
+    assert c.get("/monitors", headers=_h("tok-guard")).json()["monitors"] == []
+    assert len(c.get("/alarms", headers=_h("tok-super")).json()["alarms"]) == 2
+
+    # Arming on a camera you cannot see fails as "unknown camera".
+    r = c.post("/alarms", headers=_h("tok-guard"),
+               json={"name": "Sneaky", "target": "person", "camera_ids": ["cam2"]})
+    assert r.status_code == 400 and "cam2" in r.json()["error"]
+
+    # Deleting someone else's alarm is a no-op, and it is still armed.
+    yard_id = next(a["id"] for a in c.get("/alarms", headers=_h("tok-super")).json()["alarms"]
+                   if a["name"] == "Yard")
+    assert c.delete(f"/alarms/{yard_id}", headers=_h("tok-guard")).json()["stopped"] is False
+    assert len(c.get("/alarms", headers=_h("tok-super")).json()["alarms"]) == 2
+
+    # "Silence everything" silences only MY ringing alarms.
+    for a in rt.alarms._alarms.values():
+        a.triggered = True
+    assert c.post("/alarms/ack", headers=_h("tok-guard"), json={}).json()["silenced"] == 1
+    assert next(a for a in rt.alarms._alarms.values() if a.name == "Yard").triggered is True
+
+
+def test_events_feed_is_scoped():
+    rt, c = _client()
+    now = time.time()
+    rt.context.record_app_alert(AlertRecord(
+        received_at=now, app_id="lpr", camera_id="cam2", title="Yard alert",
+        severity="high", summary=""))
+    rt.context.record_app_alert(AlertRecord(
+        received_at=now, app_id="lpr", camera_id="cam1", title="Gate alert",
+        severity="high", summary=""))
+    rt.context.record_app_alert(AlertRecord(
+        received_at=now, app_id="site", camera_id="", title="Notice",
+        severity="low", summary=""))
+    titles = lambda tok: sorted(e["title"] for e in c.get("/events", headers=_h(tok)).json()["events"])
+    assert titles("tok-guard") == ["Gate alert", "Notice"]
+    assert titles("tok-nobody") == ["Notice"]
+    assert titles("tok-super") == ["Gate alert", "Notice", "Yard alert"]
+
+
+def test_scope_lookup_is_cached_per_token():
+    rt, c = _client()
+    c.get("/cameras", headers=_h("tok-guard"))
+    c.get("/cameras", headers=_h("tok-guard"))
+    # The fake counts calls; the real client caches per token (see
+    # OpennvrAuthClient.visible_cameras) — here we only assert the gate
+    # asks the auth client rather than deciding on its own.
+    assert rt.auth.scope_calls >= 1
+
+
+def test_background_work_spawned_from_a_scoped_request_sees_the_fleet():
+    """A task inherits its creator's context — an alarm loop started
+    by a guard's POST /alarms must NOT stay pinned to the guard's
+    cameras for the rest of its life."""
+    import asyncio
+
+    async def _probe():
+        return camera_scope()
+
+    async def main():
+        token = set_camera_scope({"cam1"})
+        try:
+            inherited = await asyncio.create_task(_probe())
+            cleared = await spawn_unscoped(_probe())
+        finally:
+            from context import reset_camera_scope
+            reset_camera_scope(token)
+        return inherited, cleared
+
+    inherited, cleared = asyncio.run(main())
+    assert inherited == frozenset({"cam1"})
+    assert cleared is None

--- a/examples/camera-agent/tests/test_device_firewall.py
+++ b/examples/camera-agent/tests/test_device_firewall.py
@@ -117,6 +117,9 @@ class _FakeAuth:
         return ({"username": "v", "is_superuser": False, "role_name": "viewer"}
                 if token == "tok-viewer" else None)
 
+    async def visible_cameras(self, token, user=None):
+        return None   # unrestricted — per-camera scope has its own tests
+
     async def device_allowed(self, device_token):
         self.device_calls += 1
         self.device_tokens.append(device_token)

--- a/server/routers/alerts_inbox.py
+++ b/server/routers/alerts_inbox.py
@@ -22,6 +22,12 @@ The read side of ``services/alerts_inbox.py``: the UI's alert bell polls
 every open browser goes quiet together. Acknowledge is idempotent and
 recorded with the acknowledging user — an alarm silenced at 3am should
 say by whom.
+
+Scope: an operator sees, counts and acknowledges only the alerts raised
+on cameras they may view (``services.camera_scope``); alerts with no
+camera (a site-wide notice, a test alarm) reach everyone. The alarm
+POLICY — ring modes, call/SMS/hooter actions, test alarms — is a site
+decision and superuser-only.
 """
 
 from __future__ import annotations
@@ -32,9 +38,10 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
-from core.auth import get_current_active_user
+from core.auth import get_current_active_user, get_current_superuser
 from core.database import get_db
 from models import AppAlert, SecuritySetting, User
 from services.alerts_inbox import (
@@ -49,6 +56,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/alerts-inbox", tags=["alerts-inbox"])
 
 _MAX_LIMIT = 200
+
+
+def _scope_alerts(q, scope: set[int] | None):
+    """Restrict an AppAlert query to ``scope`` (the caller's visible
+    camera ids from ``camera_scope.visible_camera_ids``).
+
+    ``AppAlert.camera_id`` is the wire handle (``cam3``) — or NULL /
+    blank for an alert about nothing in particular, which every operator
+    gets. Superusers (scope None) see the lot; a user granted no cameras
+    sees only the camera-less rows.
+    """
+    if scope is None:
+        return q
+    handles: list[str] = []
+    for cam_id in sorted(scope):
+        handles += [f"cam{cam_id}", f"cam-{cam_id}", str(cam_id)]
+    camera_less = or_(AppAlert.camera_id.is_(None), AppAlert.camera_id == "")
+    if not handles:
+        return q.filter(camera_less)
+    return q.filter(or_(camera_less,
+                        func.lower(AppAlert.camera_id).in_(handles)))
 
 
 def _row_out(a: AppAlert) -> dict:
@@ -93,7 +121,10 @@ async def list_alerts(
 ):
     """Inbox listing, newest first. ``unacked=true`` is what the bell
     polls; the full list backs the Alerts & Incidents page."""
-    q = db.query(AppAlert)
+    from services.camera_scope import visible_camera_ids
+
+    scope = visible_camera_ids(db, current_user)
+    q = _scope_alerts(db.query(AppAlert), scope)
     if unacked:
         q = q.filter(AppAlert.acknowledged_at.is_(None))
     if severity:
@@ -104,7 +135,7 @@ async def list_alerts(
         q = q.filter(AppAlert.id > after_id)
     rows = q.order_by(AppAlert.id.desc()).limit(limit).all()
     unacked_count = (
-        db.query(AppAlert.id)
+        _scope_alerts(db.query(AppAlert.id), scope)
         .filter(AppAlert.acknowledged_at.is_(None))
         .count()
     )
@@ -125,8 +156,14 @@ async def acknowledge(
     db: Session = Depends(get_db),
 ):
     """Silence alerts. Idempotent — an already-acked id is left with its
-    ORIGINAL acknowledgement (first silencer wins the audit trail)."""
-    q = db.query(AppAlert).filter(AppAlert.acknowledged_at.is_(None))
+    ORIGINAL acknowledgement (first silencer wins the audit trail).
+    Only alerts the caller can see are touched: "ack all" silences MY
+    inbox, and an id on someone else's camera is simply not found."""
+    from services.camera_scope import visible_camera_ids
+
+    q = _scope_alerts(db.query(AppAlert),
+                      visible_camera_ids(db, current_user)).filter(
+        AppAlert.acknowledged_at.is_(None))
     if payload.ids is not None:
         if not payload.ids:
             return {"acknowledged": 0}
@@ -151,7 +188,7 @@ class TestAlarmIn(BaseModel):
 @router.post("/test")
 async def fire_test_alarm(
     payload: TestAlarmIn,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_superuser),
 ):
     """Fire a synthetic alarm through the REAL ingestion path.
 
@@ -202,7 +239,7 @@ class ActionConfigIn(BaseModel):
 
 @router.get("/actions")
 async def get_alarm_actions(
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_superuser),
     db: Session = Depends(get_db),
 ):
     """Call / SMS / hooter configuration, secret masked (set/unset)."""
@@ -214,7 +251,7 @@ async def get_alarm_actions(
 @router.put("/actions")
 async def put_alarm_actions(
     payload: ActionConfigIn,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_superuser),
     db: Session = Depends(get_db),
 ):
     from services.alarm_actions import (
@@ -239,7 +276,7 @@ async def put_alarm_actions(
 
 @router.post("/actions/test")
 async def test_alarm_actions(
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_superuser),
 ):
     """Run every ENABLED action once with a synthetic alarm and return
     each action's outcome — validates Twilio credentials and the relay
@@ -292,7 +329,7 @@ class RingConfigIn(BaseModel):
 @router.put("/ring-config")
 async def put_ring_config(
     payload: RingConfigIn,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_superuser),
     db: Session = Depends(get_db),
 ):
     """Replace the ring policy. Unknown severities/modes are rejected

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -51,7 +51,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from core.auth import get_current_active_user, verify_token
+from core.auth import get_current_active_user, get_current_superuser, verify_token
 from core.database import get_db
 from core.permissions import RequirePermission
 from models import AppInstallIntent, InstalledApp, User
@@ -232,6 +232,74 @@ def validate_app_config(manifest: dict, config: dict) -> list[str]:
             errors.append(f"param '{name}' must be of type {type_name}")
 
     return errors
+
+
+def _per_camera_param_names(manifest: dict) -> set[str]:
+    return {
+        p["name"]
+        for p in (manifest.get("params") or [])
+        if isinstance(p, dict) and "name" in p and p.get("per_camera")
+    }
+
+
+def _scope_per_camera_config(manifest: dict, config: dict,
+                             scope: set[int] | None) -> dict:
+    """``config`` with every ``per_camera`` param trimmed to the camera
+    keys inside ``scope`` (None = unrestricted)."""
+    if scope is None:
+        return config
+    from services.camera_scope import in_scope
+
+    out = dict(config)
+    for name in _per_camera_param_names(manifest):
+        value = out.get(name)
+        if isinstance(value, dict):
+            out[name] = {k: v for k, v in value.items() if in_scope(scope, k)}
+    return out
+
+
+def _merge_scoped_config(manifest: dict, stored: dict, incoming: dict,
+                         manage_scope: set[int] | None) -> tuple[dict, list[str]]:
+    """Apply a NON-superuser's ``incoming`` config on top of ``stored``.
+
+    Returns ``(merged, denied)``. ``denied`` names what they may not
+    change — a site-wide (non per-camera) key whose value differs, or
+    a per-camera entry for a camera outside ``manage_scope`` that
+    differs — and a non-empty list means the write is refused whole.
+
+    Absence is NOT a change here: a per-camera key left out of the
+    payload is untouched, and within a key the caller read a config
+    trimmed to their cameras (``_scope_per_camera_config``), so a
+    camera missing from their payload is one they never saw and its
+    stored entry is kept. Only a camera they can manage is removed by
+    omission from a key they DID send — that is them erasing their own
+    zone.
+    """
+    from services.camera_scope import in_scope
+
+    per_camera = _per_camera_param_names(manifest)
+    merged = dict(stored)
+    denied: list[str] = []
+    for key in sorted(set(stored) | set(incoming)):
+        if key not in per_camera:
+            if key in incoming and incoming[key] != stored.get(key):
+                denied.append(f"'{key}' (site-wide setting)")
+            continue
+        if key not in incoming:
+            continue            # untouched: the stored entries stand
+        before = stored.get(key) if isinstance(stored.get(key), dict) else {}
+        after = incoming.get(key) if isinstance(incoming.get(key), dict) else {}
+        result = dict(before)
+        for cam in sorted(set(before) | set(after), key=str):
+            if in_scope(manage_scope, cam):
+                if cam in after:
+                    result[cam] = after[cam]
+                else:
+                    result.pop(cam, None)
+            elif cam in after and after[cam] != before.get(cam):
+                denied.append(f"'{key}' for camera '{cam}'")
+        merged[key] = result
+    return merged, denied
 
 
 # ── App URL sovereignty guard (SSRF) ───────────────────────────────
@@ -650,13 +718,13 @@ async def register_app(
 @router.post("/{app_id}/enable")
 async def enable_app(
     app_id: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_superuser),
     db: Session = Depends(get_db),
 ):
     """
     Enable an app. 404 if the app was never registered.
 
-    Requires authenticated user.
+    Superuser only — turning a site-wide app on is a site decision.
     """
     row = _get_app_or_404(db, app_id)
     row.enabled = True
@@ -676,13 +744,14 @@ async def enable_app(
 @router.post("/{app_id}/disable")
 async def disable_app(
     app_id: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_superuser),
     db: Session = Depends(get_db),
 ):
     """
     Disable an app. 404 if the app was never registered.
 
-    Requires authenticated user.
+    Superuser only — turning a site-wide app off silences it for
+    every operator's cameras, not just the caller's.
     """
     row = _get_app_or_404(db, app_id)
     row.enabled = False
@@ -719,9 +788,19 @@ async def get_app_config(
     caller. Writes stay user-JWT-only (``PUT`` below).
     """
     row = _get_app_or_404(db, app_id)
+    config = row.config_json or {}
+    if principal is not None and not principal.is_superuser:
+        # A user sees the site-wide settings (read-only for them) but
+        # only THEIR cameras' per-camera entries — a zone drawn on a
+        # camera they were never assigned is not theirs to look at.
+        from services.camera_scope import visible_camera_ids
+
+        config = _scope_per_camera_config(
+            row.manifest_json or {}, config,
+            visible_camera_ids(db, principal))
     return {
         "id": row.id,
-        "config": row.config_json or {},
+        "config": config,
         "updated_at": row.updated_at,
     }
 
@@ -745,10 +824,28 @@ async def update_app_config(
     overwritten), so ``config_json`` is the effective config and the
     registry stays the single source of truth (spec §05).
 
-    Requires authenticated user.
+    Authorization: a superuser may change anything. Any other user may
+    change ONLY the ``per_camera`` entries (zones, tripwires, per-camera
+    limits) of cameras they can manage; a site-wide key or another
+    camera's entry arriving CHANGED is a 403, and entries for cameras
+    they cannot see (trimmed from their read) are preserved. The global
+    settings of an app (its watchlists, thresholds, alarm policy) are a
+    site decision, not a per-operator one.
     """
     row = _get_app_or_404(db, app_id)
     manifest = row.manifest_json or {}
+    if not current_user.is_superuser:
+        from services.camera_scope import manageable_camera_ids
+
+        config, denied = _merge_scoped_config(
+            manifest, row.config_json or {}, config,
+            manageable_camera_ids(db, current_user))
+        if denied:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=("Only a superuser can change "
+                        + ", ".join(denied)),
+            )
     errors = validate_app_config(manifest, config)
     if errors:
         raise HTTPException(
@@ -835,6 +932,28 @@ async def invoke_app_action(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid action params: {'; '.join(errors)}",
         )
+    # An action aimed at a camera (``camera_id`` / ``camera`` param —
+    # open THIS gate, clear THIS zone) is a control on that camera:
+    # the caller must be allowed to manage it. Actions with no camera
+    # target (enroll a face, search footage) stay open to any user.
+    if not current_user.is_superuser:
+        from services.camera_scope import (
+            camera_id_from_handle, manageable_camera_ids,
+        )
+
+        scope = None
+        for key in ("camera_id", "camera"):
+            target = params.get(key)
+            if target is None:
+                continue
+            cam_id = camera_id_from_handle(target)
+            if scope is None:
+                scope = manageable_camera_ids(db, current_user)
+            if cam_id is None or cam_id not in scope:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Not permitted to control this camera",
+                )
 
     base_url = row.url.rstrip("/")
     if validate_app_url(base_url) is not None:
@@ -958,6 +1077,15 @@ async def get_app_status(
     if reachable:
         row.last_seen = datetime.now(UTC)
     db.commit()
+
+    if principal is not None and not principal.is_superuser:
+        # Live state is per-camera data (occupancy per zone, the LPR
+        # review queue, each camera's last read): a user gets their
+        # cameras' slice. The service-key path (the agent) is scoped
+        # by its own roster, and a superuser sees the site.
+        from services.camera_scope import filter_app_state, visible_camera_ids
+
+        state = filter_app_state(state, visible_camera_ids(db, principal))
 
     return {"health": health, "state": state}
 

--- a/server/routers/occupancy.py
+++ b/server/routers/occupancy.py
@@ -9,8 +9,8 @@
 
 The consumer writes samples; this router serves the Occupancy page's
 charts: a bucketed series per camera over the requested window plus
-busiest-hours-of-day over the last 7 days. Owner-scoped through the
-cameras table like every other read surface."""
+busiest-hours-of-day over the last 7 days. Scoped to the caller's
+visible cameras (owned + can_view grants) like every other read surface."""
 
 from __future__ import annotations
 
@@ -22,8 +22,9 @@ from sqlalchemy.orm import Session
 from core.database import get_db
 from core.auth import get_current_active_user
 from models import (
-    Camera, OccupancyFootfall, OccupancyHeatmap, OccupancySample, User,
+    OccupancyFootfall, OccupancyHeatmap, OccupancySample, User,
 )
+from services.camera_scope import scope_query, visible_camera_ids
 
 router = APIRouter(tags=["occupancy"])
 
@@ -32,7 +33,7 @@ def occupancy_history(
     db: Session,
     *,
     hours: int = 24,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     now: datetime | None = None,
 ) -> dict:
     """Bucketed occupancy series + busiest hours. Bucketing happens in
@@ -45,10 +46,7 @@ def occupancy_history(
     week_start = now - timedelta(days=7)
 
     q = db.query(OccupancySample).filter(OccupancySample.ts >= week_start)
-    if owner_id is not None:
-        q = q.join(Camera, Camera.id == OccupancySample.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    q = scope_query(q, OccupancySample.camera_id, scope)
 
     series: dict[int, dict[datetime, list[int]]] = {}
     hour_of_day: dict[int, list[int]] = {}
@@ -102,7 +100,7 @@ async def get_occupancy_history(
     return occupancy_history(
         db,
         hours=hours,
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
     )
 
 
@@ -111,7 +109,7 @@ def occupancy_heatmap(
     *,
     camera_id: int,
     hours: int = 24,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     now: datetime | None = None,
 ) -> dict:
     """The camera's heat grid summed over the last ``hours`` — the read
@@ -130,10 +128,7 @@ def occupancy_heatmap(
         OccupancyHeatmap.camera_id == camera_id,
         OccupancyHeatmap.hour_start >= start,
     )
-    if owner_id is not None:
-        q = q.join(Camera, Camera.id == OccupancyHeatmap.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    q = scope_query(q, OccupancyHeatmap.camera_id, scope)
     cols = rows = 0
     cells: list[int] = []
     frames = 0
@@ -180,7 +175,7 @@ async def get_occupancy_heatmap(
         db,
         camera_id=camera_id,
         hours=hours,
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
     )
 
 
@@ -188,7 +183,7 @@ def occupancy_footfall(
     db: Session,
     *,
     hours: int = 24,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     now: datetime | None = None,
 ) -> dict:
     """Entries, exits and dwell per camera over the window, as hourly
@@ -198,10 +193,7 @@ def occupancy_footfall(
     start = (now - timedelta(hours=hours)).replace(minute=0, second=0,
                                                    microsecond=0)
     q = db.query(OccupancyFootfall).filter(OccupancyFootfall.hour_start >= start)
-    if owner_id is not None:
-        q = q.join(Camera, Camera.id == OccupancyFootfall.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    q = scope_query(q, OccupancyFootfall.camera_id, scope)
     per_camera: dict[int, dict] = {}
     for row in q.order_by(OccupancyFootfall.hour_start.asc()).all():
         cam = per_camera.setdefault(row.camera_id, {
@@ -262,7 +254,7 @@ async def get_occupancy_footfall(
     return occupancy_footfall(
         db,
         hours=hours,
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
     )
 
 
@@ -270,7 +262,7 @@ def occupancy_report(
     db: Session,
     *,
     days: int = 7,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     now: datetime | None = None,
     tz_offset_minutes: int = 0,
 ) -> dict:
@@ -292,9 +284,7 @@ def occupancy_report(
     # ── occupancy samples → peak / average / busiest hour ──────────
     sq = db.query(OccupancySample).filter(OccupancySample.ts >= start,
                                           OccupancySample.ts < end)
-    if owner_id is not None:
-        sq = sq.join(Camera, Camera.id == OccupancySample.camera_id).filter(
-            Camera.owner_id == owner_id)
+    sq = scope_query(sq, OccupancySample.camera_id, scope)
     per: dict[int, dict] = {}
 
     def _cam(camera_id: int) -> dict:
@@ -322,9 +312,7 @@ def occupancy_report(
     # ── footfall rows → entries / exits / dwell, per day ──────────
     fq = db.query(OccupancyFootfall).filter(OccupancyFootfall.hour_start >= start,
                                             OccupancyFootfall.hour_start < end)
-    if owner_id is not None:
-        fq = fq.join(Camera, Camera.id == OccupancyFootfall.camera_id).filter(
-            Camera.owner_id == owner_id)
+    fq = scope_query(fq, OccupancyFootfall.camera_id, scope)
     for row in fq.all():
         hs = row.hour_start if row.hour_start.tzinfo else \
             row.hour_start.replace(tzinfo=timezone.utc)
@@ -409,6 +397,6 @@ async def get_occupancy_report(
     return occupancy_report(
         db,
         days=days,
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
         tz_offset_minutes=tz_offset_minutes,
     )

--- a/server/routers/recordings.py
+++ b/server/routers/recordings.py
@@ -325,15 +325,19 @@ def _get_or_init(db: Session, key: str, default_obj) -> SecuritySetting:
 def _can_view_camera(user: User, camera: Camera, db: Session) -> bool:
     """Camera-level view permission for recordings/playback.
 
-    Mirrors the ownership rule the camera routes enforce (superuser bypass,
-    else owner), extended with CameraPermission.can_view grants. Cameras with
-    no owner (legacy rows) stay visible to any authenticated user — matching
-    their pre-existing behaviour instead of suddenly locking them away.
+    The camera_scope rule (superuser bypass, else owner or a
+    CameraPermission.can_view grant), evaluated on the row rather than
+    through ``services.camera_scope`` because recordings outlive their
+    camera: a binned (soft-deleted) camera's history stays browsable by
+    the people who could see it, and the scope service excludes deleted
+    rows. Cameras with no owner (legacy rows) are superuser-only until an
+    owner or a grant is assigned — an unassigned camera must never be the
+    one everybody can see.
     """
     if getattr(user, "is_superuser", False):
         return True
     owner_id = getattr(camera, "owner_id", None)
-    if owner_id is None or owner_id == user.id:
+    if owner_id is not None and owner_id == user.id:
         return True
     from models import CameraPermission
 

--- a/server/routers/timeline_events.py
+++ b/server/routers/timeline_events.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import Session
 from core.auth import get_current_active_user
 from core.database import get_db, release
 from models import TimelineEvent, User
+from services.camera_scope import visible_camera_ids
 
 router = APIRouter(tags=["timeline"])
 
@@ -126,10 +127,11 @@ async def list_events(
     rows = query_events(
         db, camera_id=camera_id, label=label, source=source, plate=plate,
         has_plate=has_plate, from_=from_, to=to, limit=limit,
-        # Camera data is owner-scoped everywhere in OpenNVR; history and
-        # evidence photos are the MOST sensitive camera data, so the same
-        # rule applies here. Superusers see the fleet.
-        owner_id=None if current_user.is_superuser else current_user.id,
+        # Camera data is scoped to the caller's cameras (owned + can_view
+        # grants) everywhere in OpenNVR; history and evidence photos are
+        # the MOST sensitive camera data, so the same rule applies here.
+        # Superusers see the fleet.
+        scope=visible_camera_ids(db, current_user),
     )
     return {"events": [_serialize(e) for e in rows], "count": len(rows)}
 
@@ -291,7 +293,7 @@ async def get_plate_stats(
     return plate_stats(
         db,
         days=max(1, min(int(days), 90)),
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
     )
 
 
@@ -311,7 +313,7 @@ async def get_plate_summary(
     return plate_summary(
         db,
         plate=plate,
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
     )
 
 
@@ -350,7 +352,7 @@ async def get_plate_sessions(
         plate=plate,
         in_cameras=_parse_camera_ids(in_cameras),
         out_cameras=_parse_camera_ids(out_cameras),
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
         limit=max(1, min(int(limit), 200)),
     )
 
@@ -372,7 +374,7 @@ async def get_gate_occupancy(
         in_cameras=_parse_camera_ids(in_cameras),
         out_cameras=_parse_camera_ids(out_cameras),
         hours=max(1, min(int(hours), 24 * 7)),
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
     )
 
 
@@ -393,5 +395,5 @@ async def get_vehicle_report(
         db,
         year=year,
         month=month,
-        owner_id=None if current_user.is_superuser else current_user.id,
+        scope=visible_camera_ids(db, current_user),
     )

--- a/server/services/camera_scope.py
+++ b/server/services/camera_scope.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""The one answer to "which cameras may this user see / control?"
+
+The camera routes, streams and recordings each grew their own copy of
+the rule — some owner-only, one that also honoured CameraPermission
+grants, one that let owner-less cameras through to everyone — and the
+newer read surfaces (timeline, plates, occupancy, the alerts inbox, app
+state) either copied the owner-only version or scoped nothing at all.
+A user GRANTED a camera saw its live stream but none of its plates,
+alarms or occupancy; a user granted nothing saw every alarm on the
+site. This module is the single rule every surface calls:
+
+* **superuser** — everything.
+* **view**  — cameras the user owns, plus cameras with a
+  ``CameraPermission.can_view`` grant.
+* **manage** — cameras the user owns, plus ``can_manage`` grants.
+* **owner-less cameras** (legacy rows, ``owner_id`` NULL) are visible to
+  superusers only until an owner or a grant is assigned.
+* A soft-deleted (binned) camera stays in the scope of the people who
+  could see it: its history, plates and recordings outlive it (the
+  Deleted Cameras page relies on this), and the camera routes themselves
+  already hide binned rows from the live list.
+
+Everything is expressed as a *set of camera ids* (``None`` meaning
+"unrestricted", the superuser case) so callers can filter a query, a
+list of rows, or an app's ``/state`` dict with the same value.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from sqlalchemy.orm import Session
+
+_CAMERA_HANDLE = re.compile(r"^cam-?(\d+)$", re.IGNORECASE)
+
+
+def camera_id_from_handle(value: object) -> int | None:
+    """``"cam3"`` / ``"cam-3"`` / ``"3"`` / ``3`` → ``3``; anything else
+    → None. The bus and the apps key cameras by the platform handle,
+    the database by the integer id; this is the bridge."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.isdigit():
+        return int(text)
+    m = _CAMERA_HANDLE.match(text)
+    return int(m.group(1)) if m else None
+
+
+def _is_superuser(user) -> bool:
+    return bool(getattr(user, "is_superuser", False))
+
+
+def visible_camera_ids(db: Session, user) -> set[int] | None:
+    """Ids of every camera ``user`` may SEE — own + can_view grants,
+    binned cameras included (their history outlives them) — or ``None``
+    for a superuser (no restriction)."""
+    if user is None:
+        return set()
+    if _is_superuser(user):
+        return None
+    from models import Camera, CameraPermission
+
+    owned = db.query(Camera.id).filter(Camera.owner_id == user.id)
+    granted = (
+        db.query(Camera.id)
+        .join(CameraPermission, CameraPermission.camera_id == Camera.id)
+        .filter(CameraPermission.user_id == user.id,
+                CameraPermission.can_view == True)  # noqa: E712
+    )
+    return {row[0] for row in owned.all()} | {row[0] for row in granted.all()}
+
+
+def manageable_camera_ids(db: Session, user) -> set[int] | None:
+    """Ids of every camera ``user`` may CONTROL / configure — own +
+    can_manage grants — or ``None`` for a superuser."""
+    if user is None:
+        return set()
+    if _is_superuser(user):
+        return None
+    from models import Camera, CameraPermission
+
+    owned = db.query(Camera.id).filter(Camera.owner_id == user.id)
+    granted = (
+        db.query(Camera.id)
+        .join(CameraPermission, CameraPermission.camera_id == Camera.id)
+        .filter(CameraPermission.user_id == user.id,
+                CameraPermission.can_manage == True)  # noqa: E712
+    )
+    return {row[0] for row in owned.all()} | {row[0] for row in granted.all()}
+
+
+def can_view_camera(db: Session, user, camera_id: int) -> bool:
+    scope = visible_camera_ids(db, user)
+    return scope is None or int(camera_id) in scope
+
+
+def can_manage_camera(db: Session, user, camera_id: int) -> bool:
+    scope = manageable_camera_ids(db, user)
+    return scope is None or int(camera_id) in scope
+
+
+def in_scope(scope: set[int] | None, camera: object) -> bool:
+    """Is ``camera`` (an id, a handle, or None) inside ``scope``?
+    ``None`` scope = unrestricted. A camera that cannot be parsed is
+    OUT of scope — an unknown key must never widen what a user sees."""
+    if scope is None:
+        return True
+    cam_id = camera_id_from_handle(camera)
+    return cam_id is not None and cam_id in scope
+
+
+def scope_query(q, camera_column, scope: set[int] | None):
+    """Filter a SQLAlchemy query on ``camera_column`` to ``scope``.
+    An empty scope matches nothing (never everything)."""
+    if scope is None:
+        return q
+    if not scope:
+        return q.filter(camera_column.in_([-1]))
+    return q.filter(camera_column.in_(sorted(scope)))
+
+
+def filter_app_state(state: object, scope: set[int] | None) -> object:
+    """Strip an app's ``/state`` payload down to the caller's cameras.
+
+    Apps key per-camera state in two shapes, both handled recursively:
+    dicts whose KEYS are camera handles (``{"cam3": {...}}``), lists of
+    dicts carrying a ``camera_id`` / ``camera`` / ``id`` handle (the LPR
+    review queue, ``per_camera`` tallies) and bare handle lists
+    (``"cameras": ["cam1", "cam2"]``). Roll-up numbers computed by the app
+    (``total_people``, ``zones_over``…) cannot be re-derived here and
+    are left as they are — they are counts, not camera data. ``None``
+    scope returns the payload untouched.
+    """
+    if scope is None:
+        return state
+    if isinstance(state, dict):
+        out = {}
+        for key, value in state.items():
+            if camera_id_from_handle(key) is not None:
+                if in_scope(scope, key):
+                    out[key] = filter_app_state(value, scope)
+                continue
+            out[key] = filter_app_state(value, scope)
+        return out
+    if isinstance(state, list):
+        out_list = []
+        for item in state:
+            if isinstance(item, dict):
+                tag = next((item[k] for k in ("camera_id", "camera", "id")
+                            if k in item), None)
+                if tag is not None and _is_handle(tag) \
+                        and not in_scope(scope, tag):
+                    continue
+            elif _is_handle(item) and not in_scope(scope, item):
+                # A bare roster: ``"cameras": ["cam1", "cam2"]``.
+                continue
+            out_list.append(filter_app_state(item, scope))
+        return out_list
+    return state
+
+
+def _is_handle(value: object) -> bool:
+    """A ``camN`` handle specifically — NOT a bare integer or digit
+    string, which inside a list or an ``id`` field is as likely to be a
+    row id or a count as a camera."""
+    return isinstance(value, str) and _CAMERA_HANDLE.match(value.strip()) is not None
+
+
+def scoped_ids(scope: set[int] | None, candidates: Iterable[object]) -> list[int]:
+    """The ids among ``candidates`` (ids or handles) that fall inside
+    ``scope`` — for narrowing a caller-supplied camera list."""
+    out: list[int] = []
+    for c in candidates:
+        cam_id = camera_id_from_handle(c)
+        if cam_id is not None and (scope is None or cam_id in scope):
+            out.append(cam_id)
+    return out

--- a/server/services/timeline_service.py
+++ b/server/services/timeline_service.py
@@ -29,7 +29,8 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 
-from models import Camera, TimelineEvent
+from models import TimelineEvent
+from services.camera_scope import can_view_camera, scope_query
 
 
 def record_track_visit(
@@ -74,21 +75,19 @@ def query_events(
     from_: datetime | None = None,
     to: datetime | None = None,
     limit: int = 100,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     plate: str | None = None,
     has_plate: bool = False,
 ) -> list[TimelineEvent]:
     """Newest-first visits/alarms/alerts intersecting [from, to).
 
-    ``owner_id`` scopes results to that user's cameras — the same ownership
-    rule every camera route enforces. Pass None ONLY for superusers.
+    ``scope`` is the caller's visible camera set from
+    ``camera_scope.visible_camera_ids`` — own cameras plus can_view
+    grants. Pass None ONLY for superusers (unrestricted).
     """
     limit = max(1, min(500, limit))
     q = db.query(TimelineEvent)
-    if owner_id is not None:
-        q = q.join(Camera, Camera.id == TimelineEvent.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    q = scope_query(q, TimelineEvent.camera_id, scope)
     if camera_id is not None:
         q = q.filter(TimelineEvent.camera_id == camera_id)
     if label:
@@ -117,18 +116,16 @@ def query_events(
 
 
 def can_access_event(db: Session, event: TimelineEvent, *, user) -> bool:
-    """Ownership check for a single event — mirrors get_camera_or_403."""
-    if getattr(user, "is_superuser", False):
-        return True
-    cam = db.query(Camera).filter(Camera.id == event.camera_id).first()
-    return bool(cam and cam.owner_id == user.id)
+    """Visibility check for a single event — the camera_scope rule
+    (owner or can_view grant; superusers see everything)."""
+    return can_view_camera(db, user, event.camera_id)
 
 
 def plate_stats(
     db: Session,
     *,
     days: int = 7,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     now: datetime | None = None,
 ) -> dict:
     """Aggregates for the Vehicles page: plate reads over the last
@@ -147,10 +144,7 @@ def plate_stats(
         .filter(TimelineEvent.plate_text.isnot(None))
         .filter(TimelineEvent.started_at >= cutoff)
     )
-    if owner_id is not None:
-        base = base.join(Camera, Camera.id == TimelineEvent.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    base = scope_query(base, TimelineEvent.camera_id, scope)
 
     total = base.count()
     unique_plates = (
@@ -192,23 +186,20 @@ def plate_summary(
     db: Session,
     *,
     plate: str,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
 ) -> dict:
     """Everything the platform knows about ONE plate — the Vehicles
     page's history drill-down ("when did this car last come in?").
 
     ``plate`` is normalised the same way the producers do (upper, no
-    separators) and matched exactly; owner-scoped like ``query_events``.
+    separators) and matched exactly; scoped like ``query_events``.
     All-time on purpose: first_seen is the point of the question.
     """
     from sqlalchemy import func
 
     normalized = "".join(str(plate).split()).upper()
     base = db.query(TimelineEvent).filter(TimelineEvent.plate_text == normalized)
-    if owner_id is not None:
-        base = base.join(Camera, Camera.id == TimelineEvent.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    base = scope_query(base, TimelineEvent.camera_id, scope)
 
     total = base.count()
     first_seen, last_seen = (
@@ -243,7 +234,7 @@ def plate_sessions(
     plate: str,
     in_cameras: list[int],
     out_cameras: list[int],
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     limit: int = 50,
 ) -> dict:
     """Entry/exit pairing for ONE plate — gate in / gate out history.
@@ -268,10 +259,7 @@ def plate_sessions(
         .filter(TimelineEvent.plate_text == normalized)
         .filter(TimelineEvent.camera_id.in_(gates))
     )
-    if owner_id is not None:
-        q = q.join(Camera, Camera.id == TimelineEvent.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    q = scope_query(q, TimelineEvent.camera_id, scope)
     reads = q.order_by(TimelineEvent.started_at.asc()).all()
 
     def _row(entry, exit_) -> dict:
@@ -316,7 +304,7 @@ def gate_occupancy(
     in_cameras: list[int],
     out_cameras: list[int],
     hours: int = 24,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     now: datetime | None = None,
 ) -> dict:
     """Who is inside right now: plates whose LAST gate read within the
@@ -338,10 +326,7 @@ def gate_occupancy(
         .filter(TimelineEvent.camera_id.in_(gates))
         .filter(TimelineEvent.started_at >= cutoff)
     )
-    if owner_id is not None:
-        q = q.join(Camera, Camera.id == TimelineEvent.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    q = scope_query(q, TimelineEvent.camera_id, scope)
     last_by_plate: dict[str, TimelineEvent] = {}
     for r in q.order_by(TimelineEvent.started_at.asc()).all():
         last_by_plate[r.plate_text] = r
@@ -356,7 +341,7 @@ def vehicle_report(
     *,
     year: int,
     month: int,
-    owner_id: int | None = None,
+    scope: set[int] | None = None,
     per_plate_limit: int = 1000,
 ) -> dict:
     """One calendar month of vehicle movement, aggregated for the
@@ -382,10 +367,7 @@ def vehicle_report(
         .filter(TimelineEvent.started_at >= start)
         .filter(TimelineEvent.started_at < end)
     )
-    if owner_id is not None:
-        base = base.join(Camera, Camera.id == TimelineEvent.camera_id).filter(
-            Camera.owner_id == owner_id
-        )
+    base = scope_query(base, TimelineEvent.camera_id, scope)
 
     total = base.count()
     per_camera = [

--- a/server/tests/test_alerts_inbox.py
+++ b/server/tests/test_alerts_inbox.py
@@ -90,8 +90,10 @@ def db(monkeypatch):
     role = models.Role(name="admin")
     s.add(role)
     s.commit()
+    # A superuser: these tests exercise the inbox MECHANICS (ack, poll,
+    # ring policy). Camera scoping has its own tests further down.
     user = models.User(username="op", email="op@x", hashed_password="x",
-                       role_id=role.id)
+                       role_id=role.id, is_superuser=True)
     s.add(user)
     s.commit()
     user_id = user.id
@@ -225,6 +227,7 @@ def client(db, monkeypatch):
 
     app.dependency_overrides[get_db] = _fake_db
     app.dependency_overrides[auth_mod.get_current_active_user] = lambda: user
+    app.dependency_overrides[auth_mod.get_current_superuser] = lambda: user
     return TestClient(app), SessionLocal, user_id
 
 
@@ -425,3 +428,125 @@ def test_twilio_dispatch_shapes_the_rest_calls(client, monkeypatch):
     assert "Unknown vehicle" in sms["data"]["Body"]
     assert all(r["ok"] for r in results if r["action"].startswith("twilio"))
 
+
+
+# ── camera scope (RBAC): you get the alarms for YOUR cameras ───────
+
+
+@pytest.fixture()
+def scoped_client(db, monkeypatch):
+    """Two cameras (owner: someone else), one operator granted can_view
+    on the first only, plus a superuser — the same app, two callers."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import core.auth as auth_mod
+    from core.database import get_db
+    from routers.alerts_inbox import router
+
+    SessionLocal, admin_id = db
+    s = SessionLocal()
+    role = s.query(models.Role).first()
+    op = models.User(username="guard", email="g@x", hashed_password="x",
+                     role_id=role.id)
+    s.add(op)
+    s.commit()
+    gate = models.Camera(name="Gate", ip_address="10.0.0.1", owner_id=admin_id)
+    yard = models.Camera(name="Yard", ip_address="10.0.0.2", owner_id=admin_id)
+    s.add_all([gate, yard])
+    s.commit()
+    s.add(models.CameraPermission(user_id=op.id, camera_id=gate.id,
+                                  can_view=True, can_manage=False))
+    s.commit()
+    gate_id, yard_id = gate.id, yard.id
+    admin = s.get(models.User, admin_id)
+    s.refresh(admin)
+    s.refresh(op)
+    s.expunge(admin)
+    s.expunge(op)
+    s.close()
+
+    app = FastAPI()
+    app.include_router(router)
+
+    def _fake_db():
+        sess = SessionLocal()
+        try:
+            yield sess
+        finally:
+            sess.close()
+
+    app.dependency_overrides[get_db] = _fake_db
+    current = {"user": op}
+    app.dependency_overrides[auth_mod.get_current_active_user] = \
+        lambda: current["user"]
+
+    def _as_superuser():
+        from fastapi import HTTPException
+        if not current["user"].is_superuser:
+            raise HTTPException(status_code=403, detail="Not enough permissions")
+        return current["user"]
+
+    app.dependency_overrides[auth_mod.get_current_superuser] = _as_superuser
+    return TestClient(app), current, op, admin, gate_id, yard_id
+
+
+def test_inbox_lists_counts_and_acks_only_visible_cameras(scoped_client):
+    tc, current, op, admin, gate_id, yard_id = scoped_client
+    apply_alert(_envelope("on-gate", camera_id=f"cam{gate_id}"))
+    apply_alert(_envelope("on-yard", camera_id=f"cam{yard_id}"))
+    apply_alert(_envelope("site-wide", camera_id=None))
+
+    # The guard: the gate alarm and the camera-less notice, never the yard.
+    out = tc.get("/alerts-inbox", params={"unacked": True}).json()
+    assert sorted(a["alert_id"] for a in out["alerts"]) == ["on-gate", "site-wide"]
+    assert out["unacked_count"] == 2
+
+    # Ack-all silences MY inbox only; the yard alarm keeps ringing for
+    # whoever can see the yard.
+    assert tc.post("/alerts-inbox/ack", json={}).json() == {"acknowledged": 2}
+    current["user"] = admin
+    out = tc.get("/alerts-inbox", params={"unacked": True}).json()
+    assert [a["alert_id"] for a in out["alerts"]] == ["on-yard"]
+    assert out["unacked_count"] == 1
+
+    # An explicit id on someone else's camera is not acked (not found).
+    yard_row = out["alerts"][0]["id"]
+    current["user"] = op
+    assert tc.post("/alerts-inbox/ack",
+                   json={"ids": [yard_row]}).json() == {"acknowledged": 0}
+    assert tc.get("/alerts-inbox").json()["alerts"] and all(
+        a["alert_id"] != "on-yard" for a in tc.get("/alerts-inbox").json()["alerts"])
+
+
+def test_user_granted_nothing_sees_only_camera_less_alerts(scoped_client, db):
+    tc, current, op, admin, gate_id, yard_id = scoped_client
+    SessionLocal, _ = db
+    s = SessionLocal()
+    s.query(models.CameraPermission).delete()
+    s.commit()
+    s.close()
+    apply_alert(_envelope("on-gate", camera_id=f"cam{gate_id}"))
+    apply_alert(_envelope("notice", camera_id=""))
+    out = tc.get("/alerts-inbox").json()
+    assert [a["alert_id"] for a in out["alerts"]] == ["notice"]
+    assert out["unacked_count"] == 1
+
+
+def test_alarm_policy_is_superuser_only(scoped_client):
+    tc, current, op, admin, *_ = scoped_client
+    # The bell needs the ring policy to know HOW to ring: readable by all.
+    assert tc.get("/alerts-inbox/ring-config").status_code == 200
+    # Changing the site's alarm policy, its actions, or firing test
+    # alarms into everyone's inbox is not.
+    assert tc.put("/alerts-inbox/ring-config",
+                  json={"ring": {"low": "ping"}}).status_code == 403
+    assert tc.get("/alerts-inbox/actions").status_code == 403
+    assert tc.put("/alerts-inbox/actions",
+                  json={"min_severity": "high"}).status_code == 403
+    assert tc.post("/alerts-inbox/actions/test").status_code == 403
+    assert tc.post("/alerts-inbox/test", json={"severity": "high"}).status_code == 403
+    current["user"] = admin
+    assert tc.put("/alerts-inbox/ring-config",
+                  json={"ring": {"low": "ping"}}).status_code == 200
+    assert tc.get("/alerts-inbox/actions").status_code == 200

--- a/server/tests/test_apps_camera_scope.py
+++ b/server/tests/test_apps_camera_scope.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Camera-scope RBAC on the app registry routes.
+
+An app is site-wide, but what it KNOWS is per camera: the occupancy of
+each zone, the last plate on each gate, the polygon drawn on each
+view. A user assigned two of the site's ten cameras must get exactly
+those two cameras' slice of an app — its live state, its per-camera
+config — and must not be able to change the app's site-wide settings,
+turn it off for everyone, or drive an action at a camera that is not
+theirs. Superusers keep the whole site.
+
+Run with:
+    cd server && pytest tests/test_apps_camera_scope.py -v
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as auth_mod  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Camera, CameraPermission, InstalledApp, Role, User  # noqa: E402
+from routers import apps as apps_router  # noqa: E402
+from routers.apps import get_read_principal  # noqa: E402
+
+MANIFEST = {
+    "id": "occupancy-counting",
+    "name": "Occupancy Counting",
+    "version": "1.0.0",
+    "category": "analytics",
+    "summary": "Counts people per zone.",
+    "requires_tasks": ["object_detection"],
+    "subscribes": "opennvr.inference.>",
+    "params": [
+        {"name": "max_occupancy", "required": False, "type": "int",
+         "default": 25, "per_camera": False, "description": ""},
+        {"name": "zones", "required": False, "type": "geometry.polygon",
+         "default": None, "per_camera": True, "description": ""},
+    ],
+    "emits": [{"name": "over", "severity": "high", "description": ""}],
+    "actions": [
+        {"name": "reset", "label": "Reset a camera's count",
+         "params": [{"name": "camera_id", "required": True, "type": "str",
+                     "default": None, "per_camera": False, "description": ""}],
+         "description": ""},
+        {"name": "export", "label": "Export", "params": [], "description": ""},
+    ],
+}
+
+
+@pytest.fixture()
+def env():
+    """One app, two cameras owned by the admin, a guard granted can_view
+    on the gate and can_manage on the yard. The current caller is
+    switchable so one client speaks as either user."""
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    s = SessionLocal()
+    role = Role(name="admin")
+    s.add(role)
+    s.flush()
+    admin = User(username="admin", email="a@x", hashed_password="x",
+                 role_id=role.id, is_superuser=True)
+    guard = User(username="guard", email="g@x", hashed_password="x",
+                 role_id=role.id)
+    s.add_all([admin, guard])
+    s.flush()
+    gate = Camera(name="Gate", ip_address="10.0.0.1", owner_id=admin.id)
+    yard = Camera(name="Yard", ip_address="10.0.0.2", owner_id=admin.id)
+    lobby = Camera(name="Lobby", ip_address="10.0.0.3", owner_id=admin.id)
+    s.add_all([gate, yard, lobby])
+    s.flush()
+    s.add_all([
+        CameraPermission(user_id=guard.id, camera_id=gate.id,
+                         can_view=True, can_manage=False),
+        CameraPermission(user_id=guard.id, camera_id=yard.id,
+                         can_view=True, can_manage=True),
+    ])
+    s.add(InstalledApp(
+        id="occupancy-counting", name="Occupancy Counting", version="1.0.0",
+        url="http://occupancy:9200", manifest_json=MANIFEST, enabled=True,
+        config_json={
+            "max_occupancy": 25,
+            "zones": {f"cam{gate.id}": [[0, 0], [1, 0], [1, 1]],
+                      f"cam{yard.id}": [[0, 0], [1, 0], [1, 1]],
+                      f"cam{lobby.id}": [[0, 0], [1, 0], [1, 1]]},
+        },
+    ))
+    s.commit()
+    ids = {"gate": gate.id, "yard": yard.id, "lobby": lobby.id}
+    s.close()
+
+    app = FastAPI()
+    app.include_router(apps_router.router)
+
+    def _db():
+        sess = SessionLocal()
+        try:
+            yield sess
+        finally:
+            sess.close()
+
+    current = {"user": guard}
+
+    def _as_superuser():
+        if not current["user"].is_superuser:
+            raise HTTPException(status_code=403, detail="Not enough permissions")
+        return current["user"]
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[auth_mod.get_current_active_user] = lambda: current["user"]
+    app.dependency_overrides[auth_mod.get_current_superuser] = _as_superuser
+    app.dependency_overrides[get_read_principal] = lambda: current["user"]
+    with TestClient(app) as tc:
+        yield tc, current, admin, guard, ids
+    engine.dispose()
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def _fake_app(monkeypatch, state):
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, **kw):
+            if url.endswith("/health"):
+                return _Resp({"status": "ok", "ready": True})
+            return _Resp(state)
+
+    monkeypatch.setattr(apps_router.httpx, "AsyncClient", _Client)
+
+
+def test_status_state_is_trimmed_to_the_users_cameras(env, monkeypatch):
+    tc, current, admin, guard, ids = env
+    g, y, l = (f"cam{ids[k]}" for k in ("gate", "yard", "lobby"))
+    _fake_app(monkeypatch, {
+        "total_people": 9,
+        "cameras": {g: {"last_count": 2}, y: {"last_count": 3},
+                    l: {"last_count": 4}},
+        "gate_in_cameras": [g, l],
+        "recent": [{"camera_id": l, "plate": "AAA"},
+                   {"camera_id": g, "plate": "BBB"}],
+    })
+    state = tc.get("/apps/occupancy-counting/status").json()["state"]
+    assert set(state["cameras"]) == {g, y}
+    assert state["gate_in_cameras"] == [g]
+    assert state["recent"] == [{"camera_id": g, "plate": "BBB"}]
+    assert state["total_people"] == 9          # a roll-up, left alone
+
+    current["user"] = admin
+    state = tc.get("/apps/occupancy-counting/status").json()["state"]
+    assert set(state["cameras"]) == {g, y, l}
+
+
+def test_get_config_hides_other_cameras_per_camera_entries(env):
+    tc, current, admin, guard, ids = env
+    cfg = tc.get("/apps/occupancy-counting/config").json()["config"]
+    assert cfg["max_occupancy"] == 25               # site-wide: readable
+    assert set(cfg["zones"]) == {f"cam{ids['gate']}", f"cam{ids['yard']}"}
+    current["user"] = admin
+    cfg = tc.get("/apps/occupancy-counting/config").json()["config"]
+    assert len(cfg["zones"]) == 3
+
+
+def test_put_config_non_superuser_may_only_edit_manageable_cameras(env):
+    tc, current, admin, guard, ids = env
+    g, y, l = (f"cam{ids[k]}" for k in ("gate", "yard", "lobby"))
+    stored = tc.get("/apps/occupancy-counting/config").json()["config"]
+    # The guard reads a TRIMMED config (no lobby). The contract is
+    # "send back what you read, plus your edits on your cameras": a
+    # camera missing from the payload is one they never saw, never a
+    # deletion of its zone.
+    tri = [[0, 0], [2, 0], [2, 2]]
+
+    # Redrawing the YARD zone (can_manage) is fine.
+    ok = dict(stored, zones=dict(stored["zones"], **{y: tri}))
+    r = tc.put("/apps/occupancy-counting/config", json=ok)
+    assert r.status_code == 200, r.text
+    assert r.json()["config"]["zones"][y] == tri
+    # …and the lobby's zone (never visible to the guard) survived intact.
+    current["user"] = admin
+    full = tc.get("/apps/occupancy-counting/config").json()["config"]
+    assert l in full["zones"]
+    current["user"] = guard
+
+    # Redrawing the GATE zone (view-only) is refused.
+    bad = dict(ok, zones=dict(ok["zones"], **{g: tri}))
+    r = tc.put("/apps/occupancy-counting/config", json=bad)
+    assert r.status_code == 403 and g in r.json()["detail"]
+
+    # Changing a site-wide setting is refused.
+    bad = dict(ok, max_occupancy=99)
+    r = tc.put("/apps/occupancy-counting/config", json=bad)
+    assert r.status_code == 403 and "max_occupancy" in r.json()["detail"]
+
+    # Drawing on a camera the guard cannot even see is refused.
+    bad = dict(ok, zones=dict(ok["zones"], **{l: tri}))
+    assert tc.put("/apps/occupancy-counting/config", json=bad).status_code == 403
+
+    # A payload that leaves the per-camera key out entirely (the form
+    # field was blank) touches nothing — never "erase all my zones".
+    r = tc.put("/apps/occupancy-counting/config", json={"max_occupancy": 25})
+    assert r.status_code == 200 and r.json()["config"]["zones"][y] == tri
+
+    # The superuser changes anything.
+    current["user"] = admin
+    r = tc.put("/apps/occupancy-counting/config",
+               json=dict(full, max_occupancy=99))
+    assert r.status_code == 200 and r.json()["config"]["max_occupancy"] == 99
+
+
+def test_enable_disable_is_superuser_only(env):
+    tc, current, admin, guard, ids = env
+    assert tc.post("/apps/occupancy-counting/disable").status_code == 403
+    assert tc.post("/apps/occupancy-counting/enable").status_code == 403
+    current["user"] = admin
+    assert tc.post("/apps/occupancy-counting/disable").json()["enabled"] is False
+    assert tc.post("/apps/occupancy-counting/enable").json()["enabled"] is True
+
+
+def test_camera_targeted_action_needs_manage_on_that_camera(env, monkeypatch):
+    tc, current, admin, guard, ids = env
+    calls: list[str] = []
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            calls.append(json.get("camera_id", "-"))
+            return _Resp({"ok": True})
+
+    monkeypatch.setattr(apps_router.httpx, "AsyncClient", _Client)
+    g, y = f"cam{ids['gate']}", f"cam{ids['yard']}"
+    # yard: can_manage → allowed; gate: view-only → refused; unknown → refused.
+    assert tc.post("/apps/occupancy-counting/actions/reset",
+                   json={"camera_id": y}).status_code == 200
+    assert tc.post("/apps/occupancy-counting/actions/reset",
+                   json={"camera_id": g}).status_code == 403
+    assert tc.post("/apps/occupancy-counting/actions/reset",
+                   json={"camera_id": "cam999"}).status_code == 403
+    # An action with no camera target stays open to any user.
+    assert tc.post("/apps/occupancy-counting/actions/export",
+                   json={}).status_code == 200
+    assert calls == [y, "-"]

--- a/server/tests/test_apps_registry.py
+++ b/server/tests/test_apps_registry.py
@@ -104,7 +104,9 @@ from sqlalchemy import create_engine  # noqa: E402
 from sqlalchemy.orm import sessionmaker  # noqa: E402
 from sqlalchemy.pool import StaticPool  # noqa: E402
 
-from core.auth import create_access_token, get_current_active_user  # noqa: E402
+from core.auth import (  # noqa: E402
+    create_access_token, get_current_active_user, get_current_superuser,
+)
 from core.database import Base, get_db  # noqa: E402
 from models import AuditLog, InstalledApp, Role, User  # noqa: E402
 from routers import apps as apps_router  # noqa: E402
@@ -116,10 +118,12 @@ from routers.apps import (  # noqa: E402
 
 
 class _StubUser:
-    """Just enough of a User for the router + audit log."""
+    """Just enough of a User for the router + audit log. A superuser:
+    camera scoping has its own module (test_apps_camera_scope)."""
 
     id = 1
     username = "tester"
+    is_superuser = True
 
 
 def _make_app():
@@ -166,6 +170,7 @@ def client():
     re-proven per route."""
     app, _session_factory, engine = _make_app()
     app.dependency_overrides[get_current_active_user] = lambda: _StubUser()
+    app.dependency_overrides[get_current_superuser] = lambda: _StubUser()
     app.dependency_overrides[get_register_principal] = lambda: _StubUser()
     app.dependency_overrides[get_read_principal] = lambda: _StubUser()
 
@@ -199,6 +204,7 @@ def auth_client(monkeypatch):
     app, session_factory, engine = _make_app()
     # Operator routes stay overridden — only registration auth is real.
     app.dependency_overrides[get_current_active_user] = lambda: _StubUser()
+    app.dependency_overrides[get_current_superuser] = lambda: _StubUser()
 
     session = session_factory()
     role = Role(name="admin")

--- a/server/tests/test_occupancy_history.py
+++ b/server/tests/test_occupancy_history.py
@@ -43,6 +43,7 @@ import core.database as cdb  # noqa: E402
 import models  # noqa: E402
 import services.occupancy_event_consumer as occ  # noqa: E402
 from routers.occupancy import occupancy_history  # noqa: E402
+from services.camera_scope import visible_camera_ids  # noqa: E402
 
 NOW = datetime(2026, 8, 31, 12, 0, tzinfo=timezone.utc)
 
@@ -145,7 +146,7 @@ def test_history_buckets_and_owner_scope(db):
     _sample(s, cams["lot"], 30, hours_ago=1.0)   # bob's camera
     _sample(s, cams["hall"], 9, hours_ago=30.0)  # outside 24h window
 
-    got = occupancy_history(s, hours=48, owner_id=users["alice"].id, now=NOW)
+    got = occupancy_history(s, hours=48, scope=visible_camera_ids(s, users["alice"]), now=NOW)
     assert got["bucket_minutes"] == 60
     assert [c["camera_id"] for c in got["cameras"]] == [cams["hall"].id]
     samples = got["cameras"][0]["samples"]
@@ -161,7 +162,7 @@ def test_history_buckets_and_owner_scope(db):
 def test_history_fleet_view_and_fine_buckets(db):
     s, _users, cams = db
     _sample(s, cams["lot"], 30, hours_ago=0.1)
-    got = occupancy_history(s, hours=24, owner_id=None, now=NOW)
+    got = occupancy_history(s, hours=24, scope=None, now=NOW)
     assert got["bucket_minutes"] == 15
     assert [c["camera_id"] for c in got["cameras"]] == [cams["lot"].id]
 
@@ -202,7 +203,7 @@ def test_heatmap_deltas_sum_into_the_camera_hour(db):
     assert s.query(models.OccupancyHeatmap).count() == 2
 
     out = occupancy_heatmap(s, camera_id=cams["hall"].id, hours=24,
-                            owner_id=users["alice"].id,
+                            scope=visible_camera_ids(s, users["alice"]),
                             now=NOW + timedelta(hours=1, minutes=5))
     assert (out["cols"], out["rows"]) == (48, 27)
     assert len(out["cells"]) == 48 * 27
@@ -211,12 +212,12 @@ def test_heatmap_deltas_sum_into_the_camera_hour(db):
     # the window floors to hour boundaries (a partial current hour is
     # always included): at 14:05 a one-hour window starts at 13:00
     out1 = occupancy_heatmap(s, camera_id=cams["hall"].id, hours=1,
-                             owner_id=users["alice"].id,
+                             scope=visible_camera_ids(s, users["alice"]),
                              now=NOW + timedelta(hours=2, minutes=5))
     assert out1["cells"][5] == 1 and out1["hours_covered"] == 1
     # owner scope: bob cannot read alice's camera
     other = occupancy_heatmap(s, camera_id=cams["hall"].id, hours=24,
-                              owner_id=users["bob"].id,
+                              scope=visible_camera_ids(s, users["bob"]),
                               now=NOW + timedelta(hours=2))
     assert other["cols"] == 0 and other["cells"] == [] and other["max"] == 0
 
@@ -290,7 +291,7 @@ def test_footfall_deltas_sum_into_the_camera_hour(db):
     assert (rows[0].entries, rows[0].exits, rows[0].dwell_count) == (4, 1, 3)
     assert rows[0].dwell_seconds == 45.0 and rows[0].dwell_max_seconds == 30.0
 
-    out = occupancy_footfall(s, hours=24, owner_id=users["alice"].id,
+    out = occupancy_footfall(s, hours=24, scope=visible_camera_ids(s, users["alice"]),
                              now=NOW + timedelta(hours=1, minutes=5))
     assert out["totals"] == {"entries": 4, "exits": 3, "dwell_count": 3,
                              "dwell_avg_seconds": 15.0, "dwell_max_seconds": 30.0}
@@ -301,7 +302,7 @@ def test_footfall_deltas_sum_into_the_camera_hour(db):
     assert cam_out["hours"][0]["dwell_avg_seconds"] == 15.0
     assert cam_out["hours"][1]["dwell_avg_seconds"] is None
     # bob owns no camera with footfall
-    assert occupancy_footfall(s, hours=24, owner_id=users["bob"].id,
+    assert occupancy_footfall(s, hours=24, scope=visible_camera_ids(s, users["bob"]),
                               now=NOW + timedelta(hours=2))["cameras"] == []
 
 
@@ -338,7 +339,7 @@ def test_report_rolls_up_all_three_histories(db):
     assert occ.apply_footfall_event(_foot_envelope(
         camera=cam, ts=NOW - timedelta(days=10), entries=99)) == "applied"
 
-    out = occupancy_report(s, days=7, owner_id=users["alice"].id, now=NOW)
+    out = occupancy_report(s, days=7, scope=visible_camera_ids(s, users["alice"]), now=NOW)
     assert out["days"] == 7 and len(out["cameras"]) == 1
     c = out["cameras"][0]
     assert c["peak_occupancy"] == 9
@@ -348,7 +349,7 @@ def test_report_rolls_up_all_three_histories(db):
     assert c["busiest_hour"] == {"hour": (day1 + timedelta(hours=1)).hour, "avg": 9.0}
     # local-time bucketing: +5:30 shifts the busiest hour and can move a
     # late-evening row into the next local day
-    ist = occupancy_report(s, days=7, owner_id=users["alice"].id, now=NOW,
+    ist = occupancy_report(s, days=7, scope=visible_camera_ids(s, users["alice"]), now=NOW,
                            tz_offset_minutes=330)
     assert ist["cameras"][0]["busiest_hour"]["hour"] == \
         ((day1 + timedelta(hours=1, minutes=330)).hour)
@@ -360,4 +361,4 @@ def test_report_rolls_up_all_three_histories(db):
     assert out["totals"]["peak_camera_id"] == cams["hall"].id
     assert [d["entries"] for d in out["daily"]] == [5, 2]
     # bob sees nothing of alice's camera
-    assert occupancy_report(s, days=7, owner_id=users["bob"].id, now=NOW)["cameras"] == []
+    assert occupancy_report(s, days=7, scope=visible_camera_ids(s, users["bob"]), now=NOW)["cameras"] == []

--- a/server/tests/test_plate_stats.py
+++ b/server/tests/test_plate_stats.py
@@ -40,6 +40,7 @@ from sqlalchemy.pool import StaticPool  # noqa: E402
 
 import models  # noqa: E402
 from services.timeline_service import plate_stats  # noqa: E402
+from services.camera_scope import visible_camera_ids  # noqa: E402
 
 NOW = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
 
@@ -86,7 +87,7 @@ def db():
 
 def test_counts_window_and_uniques(db):
     s, users, cams = db
-    stats = plate_stats(s, days=7, owner_id=None, now=NOW)
+    stats = plate_stats(s, days=7, scope=None, now=NOW)
     assert stats["total_reads"] == 4            # OLD999 + plateless excluded
     assert stats["unique_plates"] == 3
     per_cam = {e["camera_id"]: e["reads"] for e in stats["per_camera"]}
@@ -97,14 +98,14 @@ def test_counts_window_and_uniques(db):
 
 def test_owner_scoping(db):
     s, users, cams = db
-    stats = plate_stats(s, days=7, owner_id=users["alice"].id, now=NOW)
+    stats = plate_stats(s, days=7, scope=visible_camera_ids(s, users["alice"]), now=NOW)
     assert stats["total_reads"] == 3            # bob's lot excluded
     assert all(e["camera_id"] != cams["lot"].id for e in stats["per_camera"])
 
 
 def test_window_days(db):
     s, users, _ = db
-    wide = plate_stats(s, days=90, owner_id=None, now=NOW)
+    wide = plate_stats(s, days=90, scope=None, now=NOW)
     assert wide["total_reads"] == 5             # OLD999 now inside
 
 
@@ -115,14 +116,14 @@ def test_plate_summary_all_time_counts_and_range(db):
     from services.timeline_service import plate_summary
 
     s, users, cams = db
-    got = plate_summary(s, plate="aaa 111", owner_id=users["alice"].id)
+    got = plate_summary(s, plate="aaa 111", scope=visible_camera_ids(s, users["alice"]))
     assert got["plate"] == "AAA111"
     assert got["total_reads"] == 2
     assert got["per_camera"] == [{"camera_id": cams["gate"].id, "reads": 2}]
     # first/last seen span the two visits (2h ago .. 1h ago)
     assert got["first_seen"] < got["last_seen"]
     # ALL-time: the 30-day-old read of another plate is still visible
-    old = plate_summary(s, plate="OLD999", owner_id=users["alice"].id)
+    old = plate_summary(s, plate="OLD999", scope=visible_camera_ids(s, users["alice"]))
     assert old["total_reads"] == 1
 
 
@@ -132,11 +133,11 @@ def test_plate_summary_owner_scoped_and_unknown_plate(db):
     s, users, _cams = db
     # bob's camera read is invisible to alice…
     assert plate_summary(s, plate="CCC333",
-                         owner_id=users["alice"].id)["total_reads"] == 0
-    # …and visible fleet-wide (owner_id=None = superuser)
-    assert plate_summary(s, plate="CCC333", owner_id=None)["total_reads"] == 1
+                         scope=visible_camera_ids(s, users["alice"]))["total_reads"] == 0
+    # …and visible fleet-wide (scope=None = superuser)
+    assert plate_summary(s, plate="CCC333", scope=None)["total_reads"] == 1
     # A plate never seen: zeroes, not an error.
-    none = plate_summary(s, plate="ZZ00XX", owner_id=None)
+    none = plate_summary(s, plate="ZZ00XX", scope=None)
     assert none == {"plate": "ZZ00XX", "total_reads": 0,
                     "first_seen": None, "last_seen": None, "per_camera": []}
 
@@ -158,7 +159,7 @@ def test_plate_sessions_pairs_in_and_out(db):
     got = plate_sessions(
         s, plate="AAA111",
         in_cameras=[cams["gate"].id], out_cameras=[cams["yard"].id],
-        owner_id=users["alice"].id)
+        scope=visible_camera_ids(s, users["alice"]))
     assert got["inside_now"] is False
     assert len(got["sessions"]) == 2  # newest first
     closed = got["sessions"][0]
@@ -178,7 +179,7 @@ def test_plate_sessions_open_session_means_inside(db):
     got = plate_sessions(
         s, plate="AAA111",
         in_cameras=[cams["gate"].id], out_cameras=[cams["yard"].id],
-        owner_id=users["alice"].id)
+        scope=visible_camera_ids(s, users["alice"]))
     # No OUT reads in the base fixture: latest entry is still open.
     assert got["inside_now"] is True
     assert got["sessions"][0]["exited_at"] is None
@@ -201,7 +202,7 @@ def test_gate_occupancy_counts_last_direction(db):
     s.commit()
     got = gate_occupancy(
         s, in_cameras=[cams["gate"].id], out_cameras=[cams["yard"].id],
-        hours=24, owner_id=users["alice"].id, now=NOW)
+        hours=24, scope=visible_camera_ids(s, users["alice"]), now=NOW)
     assert got == {"inside": 1, "plates": ["AAA111"]}
 
 
@@ -210,7 +211,7 @@ def test_gate_occupancy_needs_both_directions(db):
 
     s, users, cams = db
     assert gate_occupancy(s, in_cameras=[cams["gate"].id], out_cameras=[],
-                          owner_id=users["alice"].id) == {"inside": 0, "plates": []}
+                          scope=visible_camera_ids(s, users["alice"])) == {"inside": 0, "plates": []}
 
 
 # ── vehicle_report (the printable monthly report) ───────────────────
@@ -223,7 +224,7 @@ def test_vehicle_report_month_window_and_rollups(db):
     # Fixture reads are around NOW (2026-08-29): AAA111 ×2 on gate,
     # BBB222 on yard, CCC333 on bob's lot, OLD999 ~30 days back
     # (2026-07-30 — the PREVIOUS month), plus a plateless row.
-    got = vehicle_report(s, year=2026, month=8, owner_id=None)
+    got = vehicle_report(s, year=2026, month=8, scope=None)
     assert got["total_reads"] == 4          # OLD999 + plateless excluded
     assert got["unique_plates"] == 3
     plates = {p["plate"]: p for p in got["per_plate"]}
@@ -233,7 +234,7 @@ def test_vehicle_report_month_window_and_rollups(db):
     assert plates["AAA111"]["first_seen"] < plates["AAA111"]["last_seen"]
     assert sum(d["reads"] for d in got["per_day"]) == 4
     # July catches the old read.
-    july = vehicle_report(s, year=2026, month=7, owner_id=None)
+    july = vehicle_report(s, year=2026, month=7, scope=None)
     assert {p["plate"] for p in july["per_plate"]} == {"OLD999"}
 
 
@@ -241,6 +242,6 @@ def test_vehicle_report_owner_scoped(db):
     from services.timeline_service import vehicle_report
 
     s, users, _cams = db
-    got = vehicle_report(s, year=2026, month=8, owner_id=users["alice"].id)
+    got = vehicle_report(s, year=2026, month=8, scope=visible_camera_ids(s, users["alice"]))
     assert {p["plate"] for p in got["per_plate"]} == {"AAA111", "BBB222"}
     assert got["total_reads"] == 3

--- a/server/tests/test_recordings_playback_authz.py
+++ b/server/tests/test_recordings_playback_authz.py
@@ -97,9 +97,13 @@ def test_owner_sees_own_camera():
     assert _can_view_camera(FakeUser(5, ), FakeCamera(9, owner_id=5), db)
 
 
-def test_null_owner_camera_visible_to_any_user():
+def test_null_owner_camera_is_superuser_only():
+    # An unassigned (legacy) camera must never be the one everybody
+    # can see: no owner, no grant → hidden until an admin assigns it.
     db = FakeSession(cameras=[], grant_result=None)
-    assert _can_view_camera(FakeUser(5), FakeCamera(9, owner_id=None), db)
+    assert not _can_view_camera(FakeUser(5), FakeCamera(9, owner_id=None), db)
+    assert _can_view_camera(FakeUser(1, superuser=True),
+                            FakeCamera(9, owner_id=None), db)
 
 
 def test_non_owner_without_grant_denied():
@@ -116,11 +120,11 @@ def test_non_owner_with_grant_allowed():
 
 def test_viewable_filters_out_foreign_cameras():
     mine = FakeCamera(1, owner_id=5)
-    shared = FakeCamera(2, owner_id=None)   # legacy null-owner: visible
+    orphan = FakeCamera(2, owner_id=None)   # legacy null-owner: superuser-only
     foreign = FakeCamera(3, owner_id=99)    # not mine, no grant: hidden
-    db = FakeSession(cameras=[mine, shared, foreign], grant_result=None)
+    db = FakeSession(cameras=[mine, orphan, foreign], grant_result=None)
     got = {c.id for c in _viewable_cameras(db, FakeUser(5))}
-    assert got == {1, 2}
+    assert got == {1}
 
 
 def test_viewable_superuser_sees_all():

--- a/server/tests/test_timeline_events.py
+++ b/server/tests/test_timeline_events.py
@@ -192,11 +192,11 @@ def test_query_scoped_to_owners_cameras(db):
     _visit(db, start_min=1)                       # mine
     _visit(db, start_min=2, cam=other_cam.id)     # theirs
 
-    owner_id = db.query(Camera).filter(Camera.id == db.cam_id).first().owner_id
-    mine = query_events(db, owner_id=owner_id)
+    mine = query_events(db, scope={db.cam_id})
     assert [r.camera_id for r in mine] == [db.cam_id]
     fleet = query_events(db)                      # superuser path (no scope)
     assert len(fleet) == 2
+    assert query_events(db, scope=set()) == []    # granted nothing → nothing
 
 
 def test_can_access_event_mirrors_ownership(db):


### PR DESCRIPTION
…mera agent

Camera assignments (ownership + CameraPermission grants) only scoped the camera list, streams and recordings. The alerts inbox rang every alarm on the site for every user, app /status and per-camera config were fleet-wide, and timeline/plates/occupancy used an owner-only rule that hid a granted camera's history from the user it was granted to.

One rule, services/camera_scope: owned + can_view to see, owned + can_manage to control, superusers everything, owner-less cameras superuser-only. Applied to timeline_service (+ evidence routes), occupancy history/heatmap/footfall/report, recordings (owner-less no longer visible to all), the alerts inbox (list/count/ack scoped; camera-less alerts for everyone; ring policy, actions and test alarms superuser-only), and the app registry (/status state filtered, per-camera config entries trimmed to visible cameras, non-superusers may edit only per-camera geometry on cameras they manage, enable/disable superuser-only, camera-targeted actions need can_manage).

The camera-agent example resolves the caller's visible cameras from the server in auth_mode opennvr and binds them as a per-request ContextVar consulted by the roster, frame cache, event/plate/alert rings, prompt roster, the tools' camera resolver, alarms/monitors and the events feed. Background loops keep the whole fleet.

UI hides the site-wide controls (alarm policy, vehicle register and watchlists, occupancy thresholds, app enable/disable and site-wide params) from non-superusers; enforcement is server-side.