### PR TITLE
Gate camera creation on cameras.manage; opt-in self-registration; lis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **Self-service ways into the camera scope closed.** With per-camera
+  RBAC as the boundary, two routes let a user widen it themselves:
+  `POST /cameras/` made any active user the OWNER of the camera it
+  added (and an owner sees that camera everywhere), and
+  `POST /auth/register` minted a viewer account for anyone who could
+  reach the box. Adding a camera now requires the seeded
+  `cameras.manage` permission (operator/admin roles hold it, viewers do
+  not; superusers implicitly), and self-registration is off unless
+  `PUBLIC_REGISTRATION_ENABLED=true` (`/auth/check-setup` reports
+  `registration_open`). New `GET /cameras/{id}/permissions` lists a
+  camera's grants (owner first) so assignments can be audited, not only
+  written.
 - **Missing authorization on the IP-keyed ONVIF routes** (CWE-862 /
   CWE-639). `/connect` and every `/camera/{ip}/...` route (profiles,
   stream URI, PTZ move/stop/presets, clock) checked only that the IP lay

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -315,6 +315,12 @@ class Settings(BaseSettings):
     # a separate reconciler applies it. See docs/APPS_INSTALL.md.
     apps_install_enabled: bool = False
 
+    # Self-service sign-up (``POST /auth/register`` → a viewer account).
+    # Off by default: an NVR's users are created by its administrator
+    # (``POST /users``), and an open sign-up door on a LAN-exposed box is
+    # an account for anyone who can reach it. Opt in for kiosk/demo use.
+    public_registration_enabled: bool = False
+
     # Logging settings
     log_level: str = "INFO"  # DEBUG, INFO, WARNING, ERROR, CRITICAL
     log_file_enabled: bool = True

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -81,7 +81,9 @@ async def check_first_time_setup(db: Session = Depends(get_db)):
             setup_required=True, username=admin_user.username
         )
 
-    return FirstTimeSetupCheckResponse(setup_required=False)
+    return FirstTimeSetupCheckResponse(
+        setup_required=False,
+        registration_open=bool(settings.public_registration_enabled))
 
 
 @router.post("/first-time-setup", response_model=FirstTimeSetupResponse)
@@ -165,7 +167,14 @@ async def first_time_setup(
 async def register_user(
     payload: UserRegister, db: Session = Depends(get_db), request: Request = None
 ):
-    """Public registration for viewer role by default."""
+    """Self-service registration (viewer role). Off unless the operator
+    opted in with ``PUBLIC_REGISTRATION_ENABLED`` — accounts on an NVR
+    are otherwise the administrator's to create (``POST /users``)."""
+    if not settings.public_registration_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="Self-service registration is disabled on this server; "
+                   "ask an administrator for an account")
     viewer = db.query(Role).filter(Role.name == "viewer").first()
     if not viewer:
         raise HTTPException(status_code=400, detail="Viewer role is not set up")

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -31,7 +31,7 @@ from core.auth import get_current_active_user, get_current_superuser
 from core.config import settings
 from core.database import get_db
 from core.logging_config import camera_logger
-from core.permissions import get_camera_or_403
+from core.permissions import RequirePermission, get_camera_or_403
 from models import (
     Camera,
     CameraConfig,
@@ -46,6 +46,7 @@ from schemas import (
     CameraHardDeleteRequest,
     CameraList,
     CameraPermissionAssign,
+    CameraPermissionEntry,
     CameraPermissionResponse,
     CameraResponse,
     CameraUpdate,
@@ -275,6 +276,15 @@ def _check_duplicate_ips(db: Session, user_id: int, cam: Camera):
         )
 
 
+#: Adding a camera makes the caller its OWNER — and an owner sees that
+#: camera everywhere (timeline, alerts, apps). Left open to any active
+#: user, "add a camera" was a self-service way to widen one's own scope.
+#: ``cameras.manage`` is the seeded permission the operator role holds
+#: and the viewer role does not (scripts/init_db.py), and the one the
+#: UI already keys its Add Camera button on.
+require_cameras_manage = RequirePermission("cameras.manage")
+
+
 @router.post("/", response_model=CameraResponse)
 async def create_camera(
     camera_create: CameraCreate,
@@ -283,10 +293,11 @@ async def create_camera(
         description="Add the camera even when its IP or RTSP URL matches an existing one.",
     ),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_cameras_manage),
     request: Request = None,
 ):
-    """Create a new camera.
+    """Create a new camera. Requires the ``cameras.manage`` permission
+    (superusers hold it implicitly).
 
     When no RTSP URL is supplied but credentials are, the server derives it
     from the IP + credentials (ONVIF direct-connect, then vendor RTSP
@@ -1705,6 +1716,39 @@ def assign_camera_permission(
     except Exception:
         pass
     return perm
+
+
+@router.get("/{camera_id}/permissions", response_model=list[CameraPermissionEntry])
+def list_camera_permissions(
+    camera_id: int,
+    camera: Camera = Depends(get_camera_or_403),
+    db: Session = Depends(get_db),
+):
+    """Every grant on a camera — who may view it, who may manage it —
+    with the owner listed first. Owner or superuser (the same gate as
+    assigning); the assignment API was write-only before this, so an
+    admin could grant but never audit."""
+    rows = (
+        db.query(CameraPermission, User.username)
+        .join(User, User.id == CameraPermission.user_id)
+        .filter(CameraPermission.camera_id == camera.id)
+        .order_by(User.username.asc())
+        .all()
+    )
+    out: list[CameraPermissionEntry] = []
+    if camera.owner_id is not None:
+        owner = db.query(User).filter(User.id == camera.owner_id).first()
+        out.append(CameraPermissionEntry(
+            user_id=camera.owner_id, username=owner.username if owner else None,
+            can_view=True, can_manage=True, is_owner=True))
+    for perm, username in rows:
+        if perm.user_id == camera.owner_id:
+            continue
+        out.append(CameraPermissionEntry(
+            user_id=perm.user_id, username=username,
+            can_view=bool(perm.can_view), can_manage=bool(perm.can_manage),
+            is_owner=False))
+    return out
 
 
 @router.delete("/{camera_id}/permissions/{user_id}")

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -548,6 +548,17 @@ class RolePermissionsSet(BaseModel):
     permission_ids: list[int]
 
 
+class CameraPermissionEntry(BaseModel):
+    """One row of ``GET /cameras/{id}/permissions``: a grant, or the
+    owner (who holds every right implicitly)."""
+
+    user_id: int
+    username: str | None = None
+    can_view: bool
+    can_manage: bool
+    is_owner: bool = False
+
+
 class CameraPermissionResponse(BaseModel):
     """Schema for camera permission response."""
 
@@ -653,6 +664,9 @@ class FirstTimeSetupResponse(BaseModel):
 class FirstTimeSetupCheckResponse(BaseModel):
     setup_required: bool
     username: str | None = None
+    # Whether ``POST /auth/register`` (self-service viewer accounts) is
+    # open on this deployment — the login page shows the link only then.
+    registration_open: bool = False
 
 
 class CameraResponse(CameraBase):

--- a/server/tests/test_camera_create_permission.py
+++ b/server/tests/test_camera_create_permission.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Closing the self-service doors into the camera scope.
+
+Per-camera RBAC (PR #399) makes "which cameras can this user see" the
+security boundary — and two routes let a user widen it themselves:
+``POST /cameras/`` (any active user became the OWNER of the camera it
+added) and ``POST /auth/register`` (anyone reaching the box could mint
+a viewer account). Adding a camera now requires the seeded
+``cameras.manage`` permission, self-registration is off unless the
+operator opts in, and the assignment API gains the read it lacked:
+``GET /cameras/{id}/permissions``.
+
+Run with:
+    cd server && pytest tests/test_camera_create_permission.py -v
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules["core.logging_config"] = _lm
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as core_auth  # noqa: E402
+from core.config import settings  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Camera, CameraPermission, Permission, Role, RolePermission, User  # noqa: E402
+from routers import auth as auth_router  # noqa: E402
+from routers import cameras as cameras_router  # noqa: E402
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setattr(core_auth, "auth_logger", _L(), raising=False)
+    monkeypatch.setattr(cameras_router, "camera_logger", _L(), raising=False)
+    monkeypatch.setattr(auth_router, "auth_logger", _L(), raising=False)
+
+    eng = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                        poolclass=StaticPool)
+    Base.metadata.create_all(eng)
+    SessionLocal = sessionmaker(bind=eng, expire_on_commit=False)
+
+    db = SessionLocal()
+    manage = Permission(name="cameras.manage", description="")
+    viewer_role = Role(name="viewer", description="")
+    operator_role = Role(name="operator", description="")
+    db.add_all([manage, viewer_role, operator_role])
+    db.flush()
+    db.add(RolePermission(role_id=operator_role.id, permission_id=manage.id))
+
+    def user(name, role, superuser=False):
+        u = User(username=name, email=f"{name}@x", hashed_password="x",
+                 is_active=True, is_superuser=superuser, password_set=True,
+                 role_id=role.id)
+        db.add(u)
+        db.flush()
+        return u
+
+    viewer = user("viewer", viewer_role)
+    operator = user("operator", operator_role)
+    admin = user("admin", viewer_role, superuser=True)
+    db.commit()
+    # Role/permissions are lazy relationships; load them while attached.
+    for u in (viewer, operator, admin):
+        db.refresh(u)
+        _ = [p.name for p in (u.role.permissions or [])]
+        db.expunge(u)
+    db.close()
+
+    app = FastAPI()
+    app.include_router(cameras_router.router, prefix="/api/v1")
+    app.include_router(auth_router.router, prefix="/api/v1")
+
+    def _db():
+        s = SessionLocal()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    current = {"user": viewer}
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[core_auth.get_current_active_user] = lambda: current["user"]
+    with TestClient(app) as tc:
+        yield tc, current, {"viewer": viewer, "operator": operator, "admin": admin}, SessionLocal
+
+
+CAMERA = {"name": "Gate", "ip_address": "10.0.0.7", "port": 554,
+          "rtsp_url": "rtsp://10.0.0.7/stream"}
+
+
+def test_adding_a_camera_needs_cameras_manage(env, monkeypatch):
+    tc, current, users, _ = env
+    # The create path provisions the stream — keep it out of the test.
+    import services.camera_service as cs
+
+    async def _create(db, camera_create, owner_id):
+        cam = Camera(name=camera_create.name, ip_address=camera_create.ip_address,
+                     port=camera_create.port, rtsp_url=camera_create.rtsp_url,
+                     owner_id=owner_id, is_active=True)
+        db.add(cam)
+        db.commit()
+        db.refresh(cam)
+        return cam
+
+    monkeypatch.setattr(cs.CameraService, "create_camera", staticmethod(_create))
+
+    r = tc.post("/api/v1/cameras/", json=CAMERA)
+    assert r.status_code == 403 and "cameras.manage" in r.json()["detail"]
+
+    current["user"] = users["operator"]
+    r = tc.post("/api/v1/cameras/", json=CAMERA)
+    assert r.status_code == 200, r.text
+    assert r.json()["owner_id"] == users["operator"].id
+
+    current["user"] = users["admin"]          # superusers hold it implicitly
+    assert tc.post("/api/v1/cameras/", json=dict(CAMERA, ip_address="10.0.0.8"),
+                   params={"force": "true"}).status_code == 200
+
+
+def test_route_is_gated_structurally():
+    """The gate must be the dependency itself, not a check that a later
+    refactor could route around."""
+    route = next(r for r in cameras_router.router.routes
+                 if r.path == "/cameras/" and "POST" in r.methods)
+    names = {d.call.__name__ for d in route.dependant.dependencies}
+    assert "require_permission[cameras.manage]" in names
+
+
+def test_list_camera_permissions(env):
+    tc, current, users, SessionLocal = env
+    s = SessionLocal()
+    cam = Camera(name="Yard", ip_address="10.0.0.9", port=554,
+                 owner_id=users["operator"].id, is_active=True)
+    s.add(cam)
+    s.flush()
+    s.add(CameraPermission(user_id=users["viewer"].id, camera_id=cam.id,
+                           can_view=True, can_manage=False))
+    s.commit()
+    cam_id = cam.id
+    s.close()
+
+    # A stranger to the camera cannot enumerate its grants (403 from the
+    # same owner-or-superuser gate that assigning uses).
+    current["user"] = users["viewer"]
+    assert tc.get(f"/api/v1/cameras/{cam_id}/permissions").status_code == 403
+
+    current["user"] = users["operator"]
+    rows = tc.get(f"/api/v1/cameras/{cam_id}/permissions").json()
+    assert rows[0] == {"user_id": users["operator"].id, "username": "operator",
+                       "can_view": True, "can_manage": True, "is_owner": True}
+    assert rows[1] == {"user_id": users["viewer"].id, "username": "viewer",
+                       "can_view": True, "can_manage": False, "is_owner": False}
+
+    current["user"] = users["admin"]
+    assert len(tc.get(f"/api/v1/cameras/{cam_id}/permissions").json()) == 2
+
+
+def test_self_registration_is_opt_in(env, monkeypatch):
+    tc, *_ = env
+    body = {"username": "walkin", "email": "guest@example.com", "password": "Correct-Horse-Battery-9"}
+    monkeypatch.setattr(settings, "public_registration_enabled", False)
+    r = tc.post("/api/v1/auth/register", json=body)
+    assert r.status_code == 403 and "administrator" in r.json()["detail"]
+    assert tc.post("/api/v1/auth/check-setup").json()["registration_open"] is False
+
+    monkeypatch.setattr(settings, "public_registration_enabled", True)
+    assert tc.post("/api/v1/auth/check-setup").json()["registration_open"] is True
+    r = tc.post("/api/v1/auth/register", json=body)
+    assert r.status_code == 200, r.text
+    assert r.json()["username"] == "walkin"

--- a/server/tests/test_camera_delete_deactivate.py
+++ b/server/tests/test_camera_delete_deactivate.py
@@ -60,7 +60,7 @@ import core.auth as core_auth  # noqa: E402
 import services.camera_identity as camera_identity  # noqa: E402
 from core.auth import create_access_token, get_password_hash  # noqa: E402
 from core.database import Base, get_db  # noqa: E402
-from models import Camera, Role, User  # noqa: E402
+from models import Camera, Permission, Role, RolePermission, User  # noqa: E402
 from routers import cameras as cameras_router  # noqa: E402
 from services.mediamtx_admin_service import MediaMtxAdminService  # noqa: E402
 from services.mediamtx_startup_service import MediaMtxStartupService  # noqa: E402
@@ -133,6 +133,12 @@ def env(monkeypatch):
     role = Role(name="admin", description="test role")
     db.add(role)
     db.flush()
+    # Adding a camera is gated on cameras.manage (the seeded operator/admin
+    # permission) — the owner here is a plain user, so give the role that.
+    manage = Permission(name="cameras.manage", description="")
+    db.add(manage)
+    db.flush()
+    db.add(RolePermission(role_id=role.id, permission_id=manage.id))
     owner = User(
         username="owner",
         email="owner@example.com",


### PR DESCRIPTION
…t camera grants

Per-camera RBAC makes "which cameras can this user see" the boundary, and two routes let a user move it: POST /cameras/ made any active user the owner of the camera it added, and POST /auth/register created a viewer account for anyone reaching the server.

- POST /cameras/ requires the seeded cameras.manage permission (the operator/admin roles hold it, viewer does not, superusers implicitly) via RequirePermission — the same gate the UI's Add Camera button keys on.
- POST /auth/register is disabled unless PUBLIC_REGISTRATION_ENABLED; /auth/check-setup reports registration_open for the login page.
- GET /cameras/{id}/permissions lists a camera's grants with the owner first (owner-or-superuser, like assigning) — the assignment API had no read.