### PR TITLE
Users API: is_superuser flag (MFA-gated), last-superuser guard; wire …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **Writes that any signed-in user could make now require the seeded
+  permission.** Creating/editing/deleting AI models and starting or
+  stopping their inference (`/ai-model-management`) need `byom.manage`;
+  granting, revoking or approving an adapter's permission keys
+  (`/ai-models/adapters/{name}/permissions/*`) need `ai.manage`; editing
+  or deleting a camera needs `cameras.manage` on top of ownership. The
+  admin role holds all of these (`scripts/init_db.py`); superusers
+  implicitly.
 - **Self-service ways into the camera scope closed.** With per-camera
   RBAC as the boundary, two routes let a user widen it themselves:
   `POST /cameras/` made any active user the OWNER of the camera it
@@ -54,6 +62,14 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Superusers can be created and managed through the API.**
+  `POST /users` and `PUT /users/{id}` accept `is_superuser`; creating,
+  promoting or demoting a superuser requires the caller's TOTP code in
+  `X-MFA-Code` (like delete). You cannot demote yourself, and the last
+  active superuser cannot be demoted, deactivated or deleted. Until now
+  the first-time-setup admin was the only superuser a deployment could
+  have without a database edit. The Users page gains the checkbox.
+
 - **Occupancy heatmap.** The occupancy app bins where watched entities
   stand (foot point of every detection) into a per-camera grid and ships
   sparse deltas as `occupancy.heatmap.v1`; core sums them per camera-hour
@@ -76,6 +92,12 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the vehicle movement report.
 
 ### Fixed
+
+- `PUT /users/me` was unreachable for non-superusers (declared after
+  `PUT /users/{user_id}`, which captured it and demanded superuser), and
+  its "strip admin-only fields" logic wrote NULL into `is_active` /
+  `role_id` instead of dropping them — `{"is_active": false}` locked the
+  caller out of their own account.
 
 - **The occupancy app now applies its configuration.** It never overrode
   the SDK's live-config hook, so thresholds saved on the Occupancy page

--- a/app/src/services/userService.ts
+++ b/app/src/services/userService.ts
@@ -22,8 +22,12 @@ export const userService = {
   // Users
   getUsers: (params: Record<string, any> = {}) => api.get('/api/v1/users/', { params }),
   getUser: (userId: number) => api.get(`/api/v1/users/${userId}`),
-  updateUser: (userId: number, payload: any) => api.put(`/api/v1/users/${userId}`, payload),
-  createUser: (payload: any) => api.post('/api/v1/users/', payload),
+  // Changing is_superuser (or creating a superuser) is MFA-gated like
+  // delete: pass the caller's current TOTP code and it rides X-MFA-Code.
+  updateUser: (userId: number, payload: any, mfaCode?: string) =>
+    api.put(`/api/v1/users/${userId}`, payload, mfaCode ? { headers: { 'X-MFA-Code': mfaCode } } : undefined),
+  createUser: (payload: any, mfaCode?: string) =>
+    api.post('/api/v1/users/', payload, mfaCode ? { headers: { 'X-MFA-Code': mfaCode } } : undefined),
   // Deleting or reactivating a user requires the caller's current TOTP code (X-MFA-Code).
   deleteUser: (userId: number, mfaCode: string) => api.delete(`/api/v1/users/${userId}`, { headers: { 'X-MFA-Code': mfaCode } }),
   activateUser: (userId: number, mfaCode: string) => api.post(`/api/v1/users/${userId}/activate`, undefined, { headers: { 'X-MFA-Code': mfaCode } }),

--- a/app/src/views/settings/UsersManager.tsx
+++ b/app/src/views/settings/UsersManager.tsx
@@ -41,6 +41,7 @@ type UserForm = {
   password?: string
   role_id: number
   is_active?: boolean
+  is_superuser?: boolean
 }
 
 type Role = {
@@ -67,7 +68,10 @@ export function UsersManager() {
   const [confirmAction, setConfirmAction] = useState<{ kind: 'delete' | 'activate'; user: User } | null>(null)
   const [mfaCode, setMfaCode] = useState('')
 
-  const [form, setForm] = useState<UserForm>({ username: '', email: '', password: '', role_id: 1, first_name: '', last_name: '' })
+  const [form, setForm] = useState<UserForm>({ username: '', email: '', password: '', role_id: 1, first_name: '', last_name: '', is_superuser: false })
+  // TOTP code for the MFA-gated writes inside the create/edit dialogs
+  // (creating a superuser, promoting or demoting one).
+  const [formMfaCode, setFormMfaCode] = useState('')
   const [roles, setRoles] = useState<Role[]>([])
 
   const canAdmin = !!me?.is_superuser
@@ -94,7 +98,7 @@ export function UsersManager() {
     })()
   }, [canAdmin, skip, limit, activeOnly])
 
-  const resetForm = () => setForm({ username: '', email: '', password: '', role_id: 1, first_name: '', last_name: '' })
+  const resetForm = () => { setForm({ username: '', email: '', password: '', role_id: 1, first_name: '', last_name: '', is_superuser: false }); setFormMfaCode('') }
 
   const onCreate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -109,8 +113,9 @@ export function UsersManager() {
         first_name: form.first_name || null,
         last_name: form.last_name || null,
         is_active: true,
+        is_superuser: !!form.is_superuser,
       }
-      await apiService.createUser(payload)
+      await apiService.createUser(payload, form.is_superuser ? formMfaCode.trim() : undefined)
       setShowCreateDialog(false)
       resetForm()
       // refresh
@@ -138,9 +143,11 @@ export function UsersManager() {
         role_id: Number(form.role_id),
         is_active: form.is_active,
       }
+      const superuserChanged = !!form.is_superuser !== !!editing.is_superuser
+      if (superuserChanged) payload.is_superuser = !!form.is_superuser
       // Remove undefined fields
       Object.keys(payload).forEach((k) => payload[k] === undefined && delete payload[k])
-      await apiService.updateUser(editing.id, payload)
+      await apiService.updateUser(editing.id, payload, superuserChanged ? formMfaCode.trim() : undefined)
       setShowEditDialog(false)
       setEditing(null)
       resetForm()
@@ -188,7 +195,9 @@ export function UsersManager() {
       last_name: u.last_name || '',
       role_id: u.role_id,
       is_active: u.is_active,
+      is_superuser: u.is_superuser,
     })
+    setFormMfaCode('')
     setShowEditDialog(true)
   }
 
@@ -262,11 +271,20 @@ export function UsersManager() {
                       {roles.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
                     </select>
                   </label>
+                  <label className="flex items-center gap-2 mt-5 text-sm" title="A superuser holds every permission and sees every camera, regardless of role">
+                    <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_superuser} onChange={(e) => setForm({ ...form, is_superuser: e.target.checked })} /> Superuser
+                  </label>
+                  {form.is_superuser && (
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-[var(--text-dim)]">Your MFA code * (required to create a superuser)</span>
+                      <input className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm font-mono" inputMode="numeric" maxLength={6} value={formMfaCode} onChange={(e) => setFormMfaCode(e.target.value.replace(/\D/g, ''))} required />
+                    </label>
+                  )}
                 </div>
               </div>
               <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
                 <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setShowCreateDialog(false); resetForm(); setError(null) }}>Cancel</button>
-                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading}>{loading ? 'Creating...' : 'Create User'}</button>
+                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading || (!!form.is_superuser && formMfaCode.length !== 6)}>{loading ? 'Creating...' : 'Create User'}</button>
               </div>
             </form>
           </div>
@@ -317,11 +335,20 @@ export function UsersManager() {
                   <label className="flex items-center gap-2 mt-5 text-sm" title={me?.id === editing.id ? 'You cannot deactivate your own account' : !editing.is_active ? 'Use the Activate button to reactivate (requires MFA code)' : undefined}>
                     <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_active} onChange={(e) => setForm({ ...form, is_active: e.target.checked })} disabled={me?.id === editing.id || !editing.is_active} /> Active
                   </label>
+                  <label className="flex items-center gap-2 mt-5 text-sm" title={me?.id === editing.id ? 'You cannot change your own superuser status' : 'A superuser holds every permission and sees every camera, regardless of role'}>
+                    <input type="checkbox" className="accent-[var(--accent)]" checked={!!form.is_superuser} onChange={(e) => setForm({ ...form, is_superuser: e.target.checked })} disabled={me?.id === editing.id} /> Superuser
+                  </label>
+                  {!!form.is_superuser !== !!editing.is_superuser && (
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-[var(--text-dim)]">Your MFA code * (required to {form.is_superuser ? 'promote' : 'demote'})</span>
+                      <input className="bg-[var(--bg-2)] border border-neutral-700 px-3 py-2 text-sm font-mono" inputMode="numeric" maxLength={6} value={formMfaCode} onChange={(e) => setFormMfaCode(e.target.value.replace(/\D/g, ''))} required />
+                    </label>
+                  )}
                 </div>
               </div>
               <div className="flex items-center justify-end gap-2 p-4 border-t border-neutral-700">
                 <button type="button" className="px-4 py-2 text-sm border border-neutral-600 hover:bg-[var(--panel-2)]" onClick={() => { setShowEditDialog(false); setEditing(null); resetForm(); setError(null) }}>Cancel</button>
-                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading}>{loading ? 'Updating...' : 'Update User'}</button>
+                <button type="submit" className="px-4 py-2 text-sm bg-[var(--accent)] text-white disabled:opacity-50" disabled={loading || (!!form.is_superuser !== !!editing.is_superuser && formMfaCode.length !== 6)}>{loading ? 'Updating...' : 'Update User'}</button>
               </div>
             </form>
           </div>

--- a/server/routers/ai_model_management.py
+++ b/server/routers/ai_model_management.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from core.auth import get_current_active_user
+from core.permissions import RequirePermission
 from core.database import get_db
 from models import AIModel, Camera, CameraConfig, User
 from services.audit_service import write_audit_log
@@ -33,6 +34,13 @@ from services.inference_manager import get_inference_manager
 from services.storage_service import storage_service
 
 router = APIRouter(prefix="/ai-model-management", tags=["ai-model-management"])
+
+#: Creating, editing, deleting a model and starting/stopping its
+#: inference are site-wide changes to what the NVR runs — the seeded
+#: ``byom.manage`` ("Manage custom AI models") permission, which the
+#: admin role holds and operator/viewer do not. Reads stay open to any
+#: active user.
+require_byom_manage = RequirePermission("byom.manage")
 
 
 # Pydantic schemas
@@ -82,7 +90,7 @@ class AIModelResponse(BaseModel):
 @router.post("", response_model=AIModelResponse)
 async def create_ai_model(
     model_data: AIModelCreate,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_byom_manage),
     db: Session = Depends(get_db),
 ):
     """Create a new AI model configuration."""
@@ -295,7 +303,7 @@ async def get_ai_model(
 async def update_ai_model(
     model_id: int,
     model_data: AIModelUpdate,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_byom_manage),
     db: Session = Depends(get_db),
 ):
     """Update an AI model configuration."""
@@ -359,7 +367,7 @@ async def update_ai_model(
 @router.delete("/{model_id}")
 async def delete_ai_model(
     model_id: int,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_byom_manage),
     db: Session = Depends(get_db),
 ):
     """Delete an AI model configuration."""
@@ -420,7 +428,7 @@ RETIRED_LIVE_INFERENCE_DETAIL = (
 @router.post("/{model_id}/start-inference")
 async def start_inference(
     model_id: int,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_byom_manage),
     db: Session = Depends(get_db),
 ):
     """RETIRED: returns 410 Gone with the migration pointer.
@@ -443,7 +451,7 @@ async def start_inference(
 @router.post("/{model_id}/stop-inference")
 async def stop_inference(
     model_id: int,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_byom_manage),
     db: Session = Depends(get_db),
 ):
     """Stop background inference for a model."""

--- a/server/routers/ai_models.py
+++ b/server/routers/ai_models.py
@@ -37,6 +37,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from core.auth import get_current_active_user, get_current_superuser
+from core.permissions import RequirePermission
 from core.database import get_db
 from core.logging_config import main_logger
 from models import AIDetectionResult, User
@@ -44,6 +45,11 @@ from services.audit_service import write_audit_log
 from services.kai_c_service import get_kai_c_service
 
 router = APIRouter(prefix="/ai-models", tags=["ai-models"])
+
+#: Granting / revoking an adapter's permission keys is governance over
+#: what the AI layer may touch (§8 / §11) — the seeded ``ai.manage``
+#: permission (admin role), not any signed-in user.
+require_ai_manage = RequirePermission("ai.manage")
 
 
 # Request/Response schemas
@@ -562,7 +568,7 @@ async def get_adapter_permissions(
 async def grant_adapter_permissions(
     adapter_name: str,
     request: PermissionKeysRequest,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_ai_manage),
     db: Session = Depends(get_db),
 ):
     """Grant permission keys for an adapter (§8 / §11). Governance
@@ -597,7 +603,7 @@ async def grant_adapter_permissions(
 async def revoke_adapter_permissions(
     adapter_name: str,
     request: PermissionKeysRequest,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_ai_manage),
     db: Session = Depends(get_db),
 ):
     """Revoke permission keys for an adapter (§8 / §11). Revoking any
@@ -631,7 +637,7 @@ async def revoke_adapter_permissions(
 @router.post("/adapters/{adapter_name}/permissions/approve-all")
 async def approve_all_adapter_permissions(
     adapter_name: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_ai_manage),
     db: Session = Depends(get_db),
 ):
     """Grant every declared permission key for an adapter — the operator

--- a/server/routers/cameras.py
+++ b/server/routers/cameras.py
@@ -997,7 +997,7 @@ async def update_camera(
     camera_update: CameraUpdate,
     camera: Camera = Depends(get_camera_or_403),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_cameras_manage),
     request: Request = None,
 ):
     """Update camera information (owner or superuser).
@@ -1443,7 +1443,7 @@ async def delete_camera(
     camera_id: int,
     camera: Camera = Depends(get_camera_or_403),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(require_cameras_manage),
     request: Request = None,
 ):
     """Delete a camera (irreversible soft delete).

--- a/server/routers/users.py
+++ b/server/routers/users.py
@@ -34,14 +34,30 @@ from utils.mfa_guard import require_mfa_code
 router = APIRouter(prefix="/users", tags=["users"])
 
 
+def _active_superusers(db: Session, *, excluding: int | None = None) -> int:
+    q = db.query(User).filter(User.is_superuser == True,  # noqa: E712
+                              User.is_active == True)  # noqa: E712
+    if excluding is not None:
+        q = q.filter(User.id != excluding)
+    return q.count()
+
+
 @router.post("/", response_model=UserResponse)
 def create_user(
     user_create: UserCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_superuser),
     request: Request = None,
+    mfa_code: str | None = Header(None, alias="X-MFA-Code"),
 ):
-    """Create a new user (superuser only)."""
+    """Create a new user (superuser only).
+
+    ``is_superuser: true`` creates another superuser — the API's most
+    privileged write (every permission, every camera), so it takes the
+    caller's current TOTP code in ``X-MFA-Code`` like delete does.
+    """
+    if user_create.is_superuser:
+        _require_mfa_code(current_user, mfa_code)
     user = UserService.create_user(db=db, user_create=user_create)
     try:
         write_audit_log(
@@ -54,6 +70,7 @@ def create_user(
                 "username": user.username,
                 "email": user.email,
                 "role_id": user.role_id,
+                "is_superuser": bool(user.is_superuser),
             },
             ip=request.client.host if request and request.client else None,
             user_agent=request.headers.get("user-agent") if request else None,
@@ -108,6 +125,55 @@ def get_current_user_permissions(
     return {"permissions": [], "is_superuser": False}
 
 
+# NOTE: registered BEFORE the ``/{user_id}`` routes on purpose. Starlette
+# matches in declaration order, and ``PUT /users/me`` declared after
+# ``PUT /users/{user_id}`` was captured by the latter — its superuser
+# dependency ran first, so every non-superuser's own profile edit was
+# a 403 (and a superuser's became a 422 on ``user_id="me"``).
+@router.put("/me", response_model=UserResponse)
+def update_current_user(
+    user_update: UserUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+    request: Request = None,
+):
+    """Update current user information (profile fields only)."""
+    # Drop the fields only an administrator may set — role, active flag,
+    # superuser — rather than nulling them: a nulled field is still "set"
+    # to Pydantic, so the old ``x = None`` dance wrote NULL into the row
+    # (``{"is_active": false}`` locked the caller out of their own
+    # account, ``{"role_id": 1}`` hit the NOT NULL constraint).
+    user_update = UserUpdate(**user_update.model_dump(
+        exclude_unset=True, exclude={"role_id", "is_active", "is_superuser"}))
+
+    user = UserService.update_user(
+        db=db, user_id=current_user.id, user_update=user_update
+    )
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    try:
+        write_audit_log(
+            db,
+            action="user.update",
+            user_id=current_user.id,
+            entity_type="user",
+            entity_id=current_user.id,
+            details={
+                "self_update": True,
+                "updated_fields": [
+                    k for k in user_update.dict(exclude_unset=True).keys()
+                ],
+            },
+            ip=request.client.host if request and request.client else None,
+            user_agent=request.headers.get("user-agent") if request else None,
+        )
+    except Exception as e:
+        main_logger.warning(f"Failed to write audit log (self user.update): {e}")
+    return user
+
+
 @router.get("/{user_id}", response_model=UserResponse)
 def get_user(
     user_id: int,
@@ -130,14 +196,43 @@ def update_user(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_superuser),
     request: Request = None,
+    mfa_code: str | None = Header(None, alias="X-MFA-Code"),
 ):
-    """Update user information (superuser only)."""
+    """Update user information (superuser only).
+
+    Changing ``is_superuser`` (promote or demote) requires the caller's
+    current TOTP code in ``X-MFA-Code``; you cannot demote yourself, and
+    the last active superuser cannot be demoted or deactivated.
+    """
     # Deactivating yourself is the same lockout as self-deletion (issue #176).
     if user_id == current_user.id and user_update.is_active is False:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="You cannot deactivate your own account.",
         )
+    if user_update.is_superuser is not None:
+        target = db.query(User).filter(User.id == user_id).first()
+        if target is not None and bool(target.is_superuser) != user_update.is_superuser:
+            _require_mfa_code(current_user, mfa_code)
+            if not user_update.is_superuser:
+                if user_id == current_user.id:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="You cannot remove your own superuser status.",
+                    )
+                if _active_superusers(db, excluding=user_id) == 0:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Cannot demote the last active superuser.",
+                    )
+    if user_update.is_active is False:
+        target = db.query(User).filter(User.id == user_id).first()
+        if target is not None and target.is_superuser \
+                and _active_superusers(db, excluding=user_id) == 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot deactivate the last active superuser.",
+            )
     # Reactivation is MFA-gated via /users/{id}/activate; without this guard
     # the plain update would be a bypass around that check.
     if user_update.is_active is True:
@@ -199,6 +294,14 @@ def delete_user(
 
     _require_mfa_code(current_user, mfa_code)
 
+    target = db.query(User).filter(User.id == user_id).first()
+    if target is not None and target.is_superuser and target.is_active \
+            and _active_superusers(db, excluding=user_id) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete the last active superuser.",
+        )
+
     success = UserService.delete_user(db=db, user_id=user_id)
     if not success:
         raise HTTPException(
@@ -256,48 +359,4 @@ def activate_user(
         )
     except Exception as e:
         main_logger.warning(f"Failed to write audit log (user.activate): {e}")
-    return user
-
-
-@router.put("/me", response_model=UserResponse)
-def update_current_user(
-    user_update: UserUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
-    request: Request = None,
-):
-    """Update current user information."""
-    # Remove fields that regular users shouldn't be able to update
-    if user_update.role_id is not None:
-        user_update.role_id = None
-    if user_update.is_active is not None:
-        user_update.is_active = None
-    if user_update.is_superuser is not None:
-        user_update.is_superuser = None
-
-    user = UserService.update_user(
-        db=db, user_id=current_user.id, user_update=user_update
-    )
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
-        )
-    try:
-        write_audit_log(
-            db,
-            action="user.update",
-            user_id=current_user.id,
-            entity_type="user",
-            entity_id=current_user.id,
-            details={
-                "self_update": True,
-                "updated_fields": [
-                    k for k in user_update.dict(exclude_unset=True).keys()
-                ],
-            },
-            ip=request.client.host if request and request.client else None,
-            user_agent=request.headers.get("user-agent") if request else None,
-        )
-    except Exception as e:
-        main_logger.warning(f"Failed to write audit log (self user.update): {e}")
     return user

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -186,6 +186,11 @@ class UserCreate(UserBase):
 
     password: str = Field(..., min_length=8)
     role_id: int
+    # Only ``POST /users`` (superuser) honours this; self-registration
+    # never passes it. A superuser holds every permission and sees every
+    # camera, so minting one is the most privileged write in the API —
+    # the route requires the caller's current TOTP code for it.
+    is_superuser: bool = False
 
     @field_validator("password")
     @classmethod
@@ -361,6 +366,11 @@ class UserUpdate(BaseModel):
     last_name: str | None = Field(None, max_length=50)
     is_active: bool | None = None
     role_id: int | None = None
+    # Promote/demote. Superuser-only route; changing it requires the
+    # caller's TOTP code (X-MFA-Code) like delete/reactivate, and the
+    # last active superuser can never be demoted (nor can you demote
+    # yourself) — a site with no superuser has no way back.
+    is_superuser: bool | None = None
 
 
 class CameraAssignment(BaseModel):

--- a/server/services/user_service.py
+++ b/server/services/user_service.py
@@ -68,6 +68,7 @@ class UserService:
                     password_set=True,  # Normal user creation has password set
                     mfa_enabled=False,  # User enrolls TOTP at first login (MFA wall)
                     role_id=user_create.role_id,
+                    is_superuser=bool(getattr(user_create, "is_superuser", False)),
                 )
                 db.add(db_user)
                 db.flush()

--- a/server/tests/test_ai_models_adapter_permissions.py
+++ b/server/tests/test_ai_models_adapter_permissions.py
@@ -102,6 +102,10 @@ GRANT_RESULT = {**VIEW, "approval_status": "approved", "granted": ["gpu"],
 class _StubUser:
     id = 1
     username = "tester"
+    # Grant/revoke/approve-all are gated on ai.manage (superusers hold
+    # every permission); the gate itself is covered structurally in
+    # test_user_superuser_flag.py — these tests exercise the proxying.
+    is_superuser = True
 
 
 class _StubKaiCService:

--- a/server/tests/test_camera_edit_reprovision.py
+++ b/server/tests/test_camera_edit_reprovision.py
@@ -68,7 +68,7 @@ import services.camera_identity as camera_identity  # noqa: E402
 from core.auth import create_access_token, get_password_hash  # noqa: E402
 from core.config import settings  # noqa: E402
 from core.database import Base, get_db  # noqa: E402
-from models import Camera, CameraConfig, Role, User  # noqa: E402
+from models import Camera, CameraConfig, Permission, Role, RolePermission, User  # noqa: E402
 from routers import cameras as cameras_router  # noqa: E402
 from services.mediamtx_admin_service import MediaMtxAdminService  # noqa: E402
 from services.mediamtx_startup_service import MediaMtxStartupService  # noqa: E402
@@ -147,6 +147,11 @@ def env(monkeypatch):
     role = Role(name="admin", description="test role")
     db.add(role)
     db.flush()
+    # Editing a camera is gated on cameras.manage as well as ownership.
+    manage = Permission(name="cameras.manage", description="")
+    db.add(manage)
+    db.flush()
+    db.add(RolePermission(role_id=role.id, permission_id=manage.id))
     owner = User(
         username="owner",
         email="owner@example.com",

--- a/server/tests/test_user_superuser_flag.py
+++ b/server/tests/test_user_superuser_flag.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""``is_superuser`` on the users API, and the seeded permission
+catalogue wired to the writes that were open to any signed-in user.
+
+Until now ``is_superuser`` was a database column with no API: the
+first-time-setup admin was the only superuser a deployment could ever
+have without a SQL edit. ``POST /users`` and ``PUT /users/{id}`` now
+carry the flag, MFA-gated like delete, with the last active superuser
+protected from demotion, deactivation and deletion.
+
+Run with:
+    cd server && pytest tests/test_user_superuser_flag.py -v
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pyotp
+import pytest
+from cryptography.fernet import Fernet
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_superuser_flag_test.db")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as core_auth  # noqa: E402
+from core.auth import create_access_token, get_password_hash  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Role, User  # noqa: E402
+from routers import ai_model_management as aimm_router  # noqa: E402
+from routers import ai_models as ai_router  # noqa: E402
+from routers import cameras as cameras_router  # noqa: E402
+from routers import users as users_router  # noqa: E402
+
+PASSWORD = "Str0ng!passw0rd"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setattr(core_auth, "auth_logger", _L(), raising=False)
+    monkeypatch.setattr(users_router, "main_logger", _L(), raising=False)
+
+    eng = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                        poolclass=StaticPool)
+    Base.metadata.create_all(eng)
+    session_factory = sessionmaker(bind=eng)
+
+    app = FastAPI()
+    app.include_router(users_router.router, prefix="/api/v1")
+
+    def _get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _get_db
+
+    db = session_factory()
+    role = Role(name="admin", description="test role")
+    db.add(role)
+    db.flush()
+    hashed = get_password_hash(PASSWORD)
+    secret = pyotp.random_base32()
+    root = User(username="root", email="root@example.com", hashed_password=hashed,
+                is_active=True, is_superuser=True, password_set=True,
+                mfa_enabled=True, role_id=role.id)
+    root.mfa_secret = secret
+    plain = User(username="plain", email="plain@example.com", hashed_password=hashed,
+                 is_active=True, is_superuser=False, password_set=True, role_id=role.id)
+    db.add_all([root, plain])
+    db.commit()
+    client = TestClient(app)
+    try:
+        yield _types.SimpleNamespace(client=client, db=db, root=root, plain=plain,
+                                     role=role, secret=secret)
+    finally:
+        db.close()
+
+
+def _auth(username):
+    return {"Authorization": f"Bearer {create_access_token({'sub': username})}"}
+
+
+def _code(env):
+    return pyotp.TOTP(env.secret).now()
+
+
+# ── create ─────────────────────────────────────────────────────────────
+
+
+def test_create_superuser_needs_mfa_and_sets_the_flag(env):
+    body = {"username": "second", "email": "second@example.com",
+            "password": PASSWORD, "role_id": env.role.id, "is_superuser": True}
+    r = env.client.post("/api/v1/users/", json=body, headers=_auth("root"))
+    assert r.status_code == 401 and "MFA" in r.json()["detail"]   # no code
+
+    r = env.client.post("/api/v1/users/", json=body,
+                        headers={**_auth("root"), "X-MFA-Code": _code(env)})
+    assert r.status_code == 200, r.text
+    assert r.json()["is_superuser"] is True
+    env.db.expire_all()
+    assert env.db.query(User).filter_by(username="second").one().is_superuser is True
+
+
+def test_create_plain_user_needs_no_mfa_and_defaults_to_not_superuser(env):
+    body = {"username": "third", "email": "third@example.com",
+            "password": PASSWORD, "role_id": env.role.id}
+    r = env.client.post("/api/v1/users/", json=body, headers=_auth("root"))
+    assert r.status_code == 200, r.text
+    assert r.json()["is_superuser"] is False
+
+
+# ── promote / demote ───────────────────────────────────────────────────
+
+
+def test_promote_and_demote_are_mfa_gated(env):
+    url = f"/api/v1/users/{env.plain.id}"
+    assert env.client.put(url, json={"is_superuser": True},
+                          headers=_auth("root")).status_code == 401
+    r = env.client.put(url, json={"is_superuser": True},
+                       headers={**_auth("root"), "X-MFA-Code": _code(env)})
+    assert r.status_code == 200 and r.json()["is_superuser"] is True
+    # Sending the flag UNCHANGED is not a promotion — no code needed.
+    assert env.client.put(url, json={"is_superuser": True, "first_name": "P"},
+                          headers=_auth("root")).status_code == 200
+    r = env.client.put(url, json={"is_superuser": False},
+                       headers={**_auth("root"), "X-MFA-Code": _code(env)})
+    assert r.status_code == 200 and r.json()["is_superuser"] is False
+
+
+def test_cannot_demote_yourself(env):
+    r = env.client.put(f"/api/v1/users/{env.root.id}", json={"is_superuser": False},
+                       headers={**_auth("root"), "X-MFA-Code": _code(env)})
+    assert r.status_code == 400 and "own superuser" in r.json()["detail"]
+
+
+def test_last_superuser_is_protected(env):
+    # Promote plain so root is no longer the only one, then try to take
+    # the LAST one out via the three doors: demote, deactivate, delete.
+    env.client.put(f"/api/v1/users/{env.plain.id}", json={"is_superuser": True},
+                   headers={**_auth("root"), "X-MFA-Code": _code(env)})
+    # Demote root (as plain, now a superuser): fine — plain remains.
+    env.db.expire_all()
+    plain = env.db.get(User, env.plain.id)
+    plain.mfa_enabled = True
+    plain.mfa_secret = env.secret
+    env.db.commit()
+    r = env.client.put(f"/api/v1/users/{env.root.id}", json={"is_superuser": False},
+                       headers={**_auth("plain"), "X-MFA-Code": _code(env)})
+    assert r.status_code == 200, r.text
+    # Now plain is the last: root (a plain user now) cannot act; plain
+    # cannot demote or deactivate itself; and re-promoting root then
+    # deleting plain works only because root remains.
+    assert env.client.put(f"/api/v1/users/{env.root.id}", json={"is_superuser": True},
+                          headers={**_auth("root"), "X-MFA-Code": _code(env)}
+                          ).status_code == 403
+    r = env.client.put(f"/api/v1/users/{env.plain.id}", json={"is_superuser": False},
+                       headers={**_auth("plain"), "X-MFA-Code": _code(env)})
+    assert r.status_code == 400
+    r = env.client.put(f"/api/v1/users/{env.plain.id}", json={"is_active": False},
+                       headers=_auth("plain"))
+    assert r.status_code == 400
+    # Deleting the only OTHER superuser when it would leave none: refused.
+    env.client.put(f"/api/v1/users/{env.root.id}", json={"is_superuser": True},
+                   headers={**_auth("plain"), "X-MFA-Code": _code(env)})
+    env.db.expire_all()
+    env.db.get(User, env.plain.id).is_superuser = False
+    env.db.commit()
+    # plain is no longer a superuser, root is the last: plain can't call,
+    # and root cannot be deleted by anyone as the last superuser.
+    r = env.client.delete(f"/api/v1/users/{env.root.id}",
+                          headers={**_auth("plain"), "X-MFA-Code": _code(env)})
+    assert r.status_code == 403
+
+
+def test_self_update_cannot_touch_admin_fields_or_null_them(env):
+    """PUT /users/me used to NULL role/active/superuser instead of
+    dropping them — {"is_active": false} locked the caller out."""
+    r = env.client.put("/api/v1/users/me",
+                       json={"is_active": False, "is_superuser": True,
+                             "role_id": 999, "first_name": "Still"},
+                       headers=_auth("plain"))
+    assert r.status_code == 200, r.text
+    env.db.expire_all()
+    u = env.db.get(User, env.plain.id)
+    assert (u.first_name, u.is_active, u.is_superuser, u.role_id) == \
+        ("Still", True, False, env.role.id)
+
+
+# ── seeded catalogue wired to the open writes ──────────────────────────
+
+
+def _gate_names(router, path, method):
+    route = next(r for r in router.routes if r.path == path and method in r.methods)
+    return {d.call.__name__ for d in route.dependant.dependencies}
+
+
+@pytest.mark.parametrize("path,method,perm", [
+    ("/ai-model-management", "POST", "byom.manage"),
+    ("/ai-model-management/{model_id}", "PUT", "byom.manage"),
+    ("/ai-model-management/{model_id}", "DELETE", "byom.manage"),
+    ("/ai-model-management/{model_id}/start-inference", "POST", "byom.manage"),
+    ("/ai-model-management/{model_id}/stop-inference", "POST", "byom.manage"),
+])
+def test_model_management_writes_need_byom_manage(path, method, perm):
+    assert f"require_permission[{perm}]" in _gate_names(aimm_router.router, path, method)
+
+
+@pytest.mark.parametrize("path", [
+    "/ai-models/adapters/{adapter_name}/permissions/grant",
+    "/ai-models/adapters/{adapter_name}/permissions/revoke",
+    "/ai-models/adapters/{adapter_name}/permissions/approve-all",
+])
+def test_adapter_governance_needs_ai_manage(path):
+    assert "require_permission[ai.manage]" in _gate_names(ai_router.router, path, "POST")
+
+
+@pytest.mark.parametrize("method", ["PUT", "DELETE"])
+def test_camera_edit_and_delete_need_cameras_manage(method):
+    names = _gate_names(cameras_router.router, "/cameras/{camera_id}", method)
+    assert "require_permission[cameras.manage]" in names
+    assert "get_camera_or_403" in names       # ownership still required too


### PR DESCRIPTION
…seeded permissions to open writes

is_superuser was a database column with no API — the first-time-setup admin was the only superuser a deployment could have without a SQL edit. POST /users and PUT /users/{id} now accept it. Creating, promoting or demoting a superuser requires the caller's TOTP code (X-MFA-Code) like delete; you cannot demote yourself; the last active superuser cannot be demoted, deactivated or deleted. Users page gains the checkbox and the MFA prompt.

Fixes found on the way: PUT /users/me was declared after PUT /users/{user_id} and so was captured by it (403 for every non-superuser editing their own profile), and its admin-field stripping set fields to None instead of dropping them, writing NULL into is_active / role_id.

Seeded permissions (scripts/init_db.py) now gate writes that were open to any signed-in user: byom.manage on AI model create/update/delete and inference start/stop; ai.manage on adapter permission grant/revoke/approve-all; cameras.manage (plus ownership) on camera edit/delete.