### PR TITLE
Per-app credentials: register mints an app key; internal reads scoped…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **Every app gets its own credential.** SDK apps used to boot with the
+  deployment's `INTERNAL_API_KEY` and could read every camera and every
+  other app's config and live state. `POST /apps/register` now mints an
+  app-scoped key (`oak_<app-id>_…`), returned once and persisted by the
+  SDK (`OPENNVR_APP_KEY_FILE` / `OPENNVR_APP_KEY`); with it an app reads
+  only its own config/status and only the cameras the operator assigned
+  to it (its manifest `provides` in `Camera.assignments`; every camera
+  when none is assigned). The pipeline's write routes refuse app keys.
+  Superusers rotate (`POST /apps/{id}/key/rotate`) or revoke
+  (`DELETE /apps/{id}/key`) without touching the site key. The register
+  exchange also carries `sdk_version` and returns
+  `registry.{server_version, api_version, min_sdk_version}`; the SDK
+  warns when it is older than the server supports. See
+  `docs/APP_CREDENTIALS.md`. SDK: `discover_cameras`, `cameras_for_skill`,
+  `AppCredentials` are now top-level exports.
 - **Writes that any signed-in user could make now require the seeded
   permission.** Creating/editing/deleting AI models and starting or
   stopping their inference (`/ai-model-management`) need `byom.manage`;

--- a/docs/APP_CREDENTIALS.md
+++ b/docs/APP_CREDENTIALS.md
@@ -1,0 +1,69 @@
+# App credentials — every app gets its own key
+
+**Status:** shipped (server `api_version` 1.1, SDK ≥ 0.2.0).
+
+Until this change every SDK app booted with the deployment's
+`INTERNAL_API_KEY` — the same secret the detect-pipeline and KAI-C hold.
+Any app could therefore read every camera, every other app's config and
+live state, and revoking one app meant rotating the key for the whole
+stack. That is acceptable for the platform's own components and wrong for
+a catalog of third-party apps.
+
+## The model
+
+| Credential | Who holds it | What it opens |
+|---|---|---|
+| **App key** `oak_<app-id>_<32 hex>` | one installed app | its own `GET /apps/{id}/config` and `/status`, re-registering itself, and the internal door (`/internal/camera-agent/cameras`, `/events`, evidence, `/recordings/frame`) **for its own camera roster** |
+| **Site key** `INTERNAL_API_KEY` | platform components (detect-pipeline, KAI-C, the OpenNVR Agent) and bootstrap | everything the internal door serves, unscoped; the pipeline's write routes |
+| **User JWT** | people | the operator API, per-camera RBAC applied |
+
+An app's **roster** is the cameras the operator assigned to it on the
+camera settings page (`Camera.assignments[].skill` naming one of the
+app's manifest `provides`, or the app id). When no camera names the app,
+it sees every camera — the additive rule of
+[CAMERA_ASSIGNMENTS.md](CAMERA_ASSIGNMENTS.md), the same rule the SDK's
+`cameras_for_skill` applies client-side, now enforced where the frames are
+handed out.
+
+## The handshake
+
+1. The app boots holding only the site key (`OPENNVR_INTERNAL_API_KEY`)
+   and registers: `POST /api/v1/apps/register` with
+   `{"url", "manifest", "sdk_version", "wants_key": true}`.
+2. Core mints the app key, stores its SHA-256, and returns the key **once**
+   in the response (`api_key`) alongside a compatibility line
+   (`registry: {server_version, api_version, min_sdk_version}`).
+3. The SDK persists it (`OPENNVR_APP_KEY_FILE`, default `.opennvr/app.key`
+   under the working directory — mount a volume there, or set
+   `OPENNVR_APP_KEY` outright) and sends it on every core call from then
+   on: the config poll, camera discovery, the events store.
+4. On a later boot the app registers **with its own key**; nothing new is
+   minted. If the key was lost (fresh container, no volume) the app
+   registers with the site key and `wants_key` again — the old key is
+   invalidated, a new one issued. If core answers 401 to the app key
+   (rotated or revoked by an administrator) the SDK discards it and
+   bootstraps again at the next registration.
+
+An app never needs to know any of this: `Detector` / `FrameApp` /
+`AlertSubscriber` do it inside `register_with_opennvr()`. Apps that build
+their own clients take headers from `opennvr_app_sdk.AppCredentials`
+(`.headers()` / `.token()`) so a rotation lands everywhere at once.
+
+## Operating it
+
+* `POST /api/v1/apps/{id}/key/rotate` (superuser) — new key, returned once;
+  the old one stops working immediately.
+* `DELETE /api/v1/apps/{id}/key` (superuser) — revoke; the app can no
+  longer read its config or its roster until it re-registers with the
+  site key.
+* `GET /api/v1/apps` shows `has_api_key` / `api_key_issued_at` per app; the
+  key itself is never readable back.
+* Audit rows: `app.register` carries `key_issued` and `sdk_version`;
+  `app.key.rotate` / `app.key.revoke` name the administrator.
+
+## Version negotiation
+
+The register response's `registry.min_sdk_version` is the oldest SDK the
+server still speaks to; the SDK logs a warning (never fails) when it is
+older. `api_version` is bumped on any change to the register / config /
+state / actions shapes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Start here. Pick the row that matches what you're doing.
 - **[CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md)** — publish an app to the catalog.
 - **[APP_SURFACES.md](APP_SURFACES.md)** — the surfaces (config, state, actions) an app exposes.
 - **[APPS_INSTALL.md](APPS_INSTALL.md)** — one-click install design (desired-state + reconciler).
+- **[APP_CREDENTIALS.md](APP_CREDENTIALS.md)** — per-app keys: the register handshake, roster scoping, rotate/revoke.
 
 ## Build on the AI layer
 - **[AI_ADAPTER_CONTRACT.md](AI_ADAPTER_CONTRACT.md)** — the REST/WebSocket wire spec adapters implement.

--- a/docs/TWO_DOORS.md
+++ b/docs/TWO_DOORS.md
@@ -207,9 +207,11 @@ both the catalog and the agent.
 
 On the server, this is one thin seam: `GET /api/v1/apps` and
 `GET /apps/{id}/status` accept the deployment's `X-Internal-Api-Key` (a
-read-only service principal, constant-time compared) as an alternative to a
-user JWT, exactly like `POST /apps/register` already does — while
-enable/disable/config **remain user-JWT-only**. The agent's registry client
+read-only service principal, constant-time compared) or an app's own key
+(see [APP_CREDENTIALS.md](APP_CREDENTIALS.md)) as an alternative to a user
+JWT, exactly like `POST /apps/register` already does — while enable/disable
+are **superuser-only** and `PUT /config` is superuser-only apart from the
+per-camera entries of cameras the caller may manage (per-camera RBAC). The agent's registry client
 is cached (60s TTL, negative-cached) and never raises: an unreachable or
 unconfigured registry degrades to a graceful "couldn't reach the app
 registry" message and simply omits the per-app skill entries, never a crash.

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -53,6 +53,13 @@ from .manifest import Action, AlertType, AppManifest, Param, StateView
 from .state import KeyedState, StateRecord, keyed_state
 from .domain_events import DomainEventPublisher, domain_envelope, domain_subject
 from .events import EventsClient, StoredEvent
+from .cameras import (
+    cameras_for_skill,
+    discover_cameras,
+    filter_cameras_for_skill,
+    full_frame_polygon,
+)
+from .credentials import AppCredentials, auth_headers
 from .tier0 import (
     BestFrameClient,
     Tier0Snapshot,
@@ -63,7 +70,7 @@ from .tier0 import (
     snapshot_from_event,
 )
 
-__version__ = "0.2.0"
+from ._version import __version__  # noqa: E402
 
 __all__ = [
     # Domain events (producing side of docs/EVENT_CONTRACTS.md)
@@ -108,6 +115,13 @@ __all__ = [
     # Config helpers
     "load_yaml",
     "require",
+    # Cameras (roster + per-camera assignment) and the app's credential
+    "discover_cameras",
+    "cameras_for_skill",
+    "filter_cameras_for_skill",
+    "full_frame_polygon",
+    "AppCredentials",
+    "auth_headers",
     # Frame-app plumbing
     "FrameSource",
     "KaiCClient",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Single source of the SDK version (pyproject mirrors it)."""
+__version__ = "0.2.0"

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/cameras.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/cameras.py
@@ -30,7 +30,6 @@ regardless of its real resolution.
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
 logger = logging.getLogger("opennvr_app_sdk.cameras")
@@ -44,12 +43,14 @@ CAMERAS_PATH = "/api/v1/internal/camera-agent/cameras"
 
 
 def internal_api_key(explicit: str | None = None) -> str | None:
-    """The stack's internal key: an explicit value wins, else the
-    ``OPENNVR_INTERNAL_API_KEY`` env var the app overlays already set."""
-    if explicit:
-        return explicit
-    key = (os.getenv("OPENNVR_INTERNAL_API_KEY") or "").strip()
-    return key or None
+    """The credential to present: the app's OWN key when it has one
+    (issued at registration — see ``credentials.py``), else an explicit
+    value, else the ``OPENNVR_INTERNAL_API_KEY`` env var the app
+    overlays set. With an app key core returns only the cameras the
+    operator assigned to this app."""
+    from .credentials import AppCredentials
+
+    return AppCredentials(explicit).token()
 
 
 def discover_cameras(

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
@@ -76,6 +76,9 @@ from typing import Any, Callable
 
 import httpx
 
+from ._version import __version__ as _sdk_version
+from .credentials import AppCredentials
+
 logger = logging.getLogger(__name__)
 
 # Budget for the one-shot registration POST at boot. Tight on purpose:
@@ -465,21 +468,18 @@ class ContractMixin:
             return False
 
         host = getattr(self.cfg, "contract_host", None) or socket.gethostname()
+        creds = self.credentials
         payload = {
             "url": f"http://{host}:{int(port)}",
             "manifest": self.manifest_snapshot(),
+            "sdk_version": _sdk_version,
+            # No key of our own yet: register with the site key and ask
+            # core to mint one (returned once, then persisted).
+            "wants_key": not creds.has_app_key,
         }
-        headers: dict[str, str] = {}
-        token = getattr(self.cfg, "opennvr_token", None) or os.environ.get(
-            "OPENNVR_INTERNAL_API_KEY"
-        )
-        if token:
-            # Both header shapes: the registry's register route accepts
-            # a user JWT (Authorization: Bearer) or the deployment's
-            # INTERNAL_API_KEY (X-Internal-Api-Key) — sending both lets
-            # one config key work against either credential kind.
-            headers["Authorization"] = f"Bearer {token}"
-            headers["X-Internal-Api-Key"] = str(token)
+        # Both header shapes: one value works as an app key, the site's
+        # INTERNAL_API_KEY, or a user JWT — see credentials.py.
+        headers: dict[str, str] = creds.headers()
         endpoint = f"{str(opennvr_url).rstrip('/')}/api/v1/apps/register"
         try:
             response = httpx.post(
@@ -504,13 +504,48 @@ class ContractMixin:
                 response.status_code,
                 response.text[:200],
             )
+            if response.status_code == 401 and creds.has_app_key:
+                # Our key was rotated or revoked: drop it so the next
+                # attempt bootstraps with the site key and asks anew.
+                creds.invalidate()
             return False
         logger.info(
             "registered with OpenNVR app registry: %s as %s",
             endpoint,
             payload["url"],
         )
+        self._absorb_registration(response)
         return True
+
+    @property
+    def credentials(self) -> AppCredentials:
+        """The app's credential (app key, else site key) — shared by the
+        register call, the config poll and any client built from it."""
+        creds = getattr(self, "_credentials", None)
+        if creds is None:
+            creds = AppCredentials(getattr(self.cfg, "opennvr_token", None))
+            self._credentials = creds
+        return creds
+
+    def _absorb_registration(self, response) -> None:
+        """Take what the registry hands back: an issued app key (once)
+        and the compatibility line."""
+        try:
+            body = response.json()
+        except Exception:  # noqa: BLE001
+            return
+        if not isinstance(body, dict):
+            return
+        key = body.get("api_key")
+        if isinstance(key, str) and key:
+            self.credentials.adopt(key)
+        registry = body.get("registry") or {}
+        min_sdk = registry.get("min_sdk_version") if isinstance(registry, dict) else None
+        if min_sdk and _version_tuple(_sdk_version) < _version_tuple(str(min_sdk)):
+            logger.warning(
+                "OpenNVR %s requires opennvr-app-sdk >= %s (this app runs %s) — "
+                "upgrade the SDK; some registry features will not work",
+                registry.get("server_version", "?"), min_sdk, _sdk_version)
 
     # ── Live config delivery (registry poll, spec §05) ─────────────
 
@@ -545,17 +580,12 @@ class ContractMixin:
         app_id = getattr(self.manifest, "id", None) if self.manifest else None
         if not opennvr_url or not app_id:
             return None
-        headers: dict[str, str] = {}
-        token = getattr(self.cfg, "opennvr_token", None) or os.environ.get(
-            "OPENNVR_INTERNAL_API_KEY"
-        )
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-            headers["X-Internal-Api-Key"] = str(token)
         url = (
             f"{str(opennvr_url).rstrip('/')}/api/v1/apps/{app_id}/config"
         )
-        return url, headers
+        # Headers are re-read on every tick (see _config_poll_once) so a
+        # key issued after the poll started is picked up.
+        return url, self.credentials.headers()
 
     def _config_poll_once(self, url: str, headers: dict[str, str]) -> None:
         """One poll tick. Never raises — every failure is a debug log
@@ -563,7 +593,7 @@ class ContractMixin:
         try:
             response = httpx.get(
                 url,
-                headers=headers,
+                headers=self.credentials.headers() or headers,
                 timeout=CONFIG_POLL_TIMEOUT_SECONDS,
                 trust_env=False,
             )
@@ -643,3 +673,19 @@ __all__ = [
     "REGISTER_TIMEOUT_SECONDS",
     "CONFIG_POLL_DEFAULT_SECONDS",
 ]
+
+
+def _version_tuple(text: str) -> tuple[int, ...]:
+    """``"0.2.0"`` → ``(0, 2, 0)``; non-numeric tails are ignored."""
+    out: list[int] = []
+    for part in str(text).split("."):
+        digits = ""
+        for ch in part:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        if not digits:
+            break
+        out.append(int(digits))
+    return tuple(out)

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/credentials.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/credentials.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The credential an app presents to OpenNVR core — and where it lives.
+
+An app has, in order of preference:
+
+1. **its own app key** (``oak_<app-id>_…``), minted by core the first
+   time the app registers and handed back once. It authenticates the
+   app *as itself*: its own config and live state, the cameras the
+   operator assigned to it, nothing else. Persisted to a small file
+   (``OPENNVR_APP_KEY_FILE``, default ``.opennvr/app.key`` under the
+   working directory — mount a volume there to survive restarts) or
+   supplied outright by the operator in ``OPENNVR_APP_KEY``;
+2. the deployment's **site key** (``OPENNVR_INTERNAL_API_KEY`` or the
+   config's ``opennvr_token``) — the bootstrap credential: an app that
+   holds no key of its own registers with it and asks core for one
+   (``wants_key``), after which every call switches to the app key.
+
+Every SDK client that talks to core (registration, the config poll,
+camera discovery, the events store) takes its headers from
+:func:`auth_headers` so a rotation lands everywhere at once.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger("opennvr.app.credentials")
+
+APP_KEY_PREFIX = "oak_"
+DEFAULT_KEY_FILE = ".opennvr/app.key"
+
+
+def key_file() -> Path:
+    return Path(os.environ.get("OPENNVR_APP_KEY_FILE") or DEFAULT_KEY_FILE)
+
+
+def stored_app_key() -> str | None:
+    """The persisted app key, if any (env ``OPENNVR_APP_KEY`` wins)."""
+    env = (os.environ.get("OPENNVR_APP_KEY") or "").strip()
+    if env:
+        return env
+    try:
+        text = key_file().read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return text or None
+
+
+def store_app_key(key: str) -> bool:
+    """Persist a freshly issued key (0600). ``False`` when the location
+    is not writable — the app keeps working from memory for this run
+    and asks for a new key next boot."""
+    path = key_file()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(key.strip() + "\n", encoding="utf-8")
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except OSError as exc:
+        logger.warning(
+            "could not persist the app key to %s (%s) — set "
+            "OPENNVR_APP_KEY_FILE to a writable path or mount a volume; "
+            "the app will request a fresh key on every start", path, exc)
+        return False
+    return True
+
+
+def forget_app_key() -> None:
+    """Drop the persisted key (after a 401 — it was rotated or revoked)."""
+    try:
+        key_file().unlink()
+    except OSError:
+        pass
+
+
+def site_key(explicit: str | None = None) -> str | None:
+    """The deployment's ``INTERNAL_API_KEY`` as this app knows it."""
+    if explicit:
+        return str(explicit)
+    key = (os.environ.get("OPENNVR_INTERNAL_API_KEY") or "").strip()
+    return key or None
+
+
+def is_app_key(value: str | None) -> bool:
+    return bool(value) and str(value).startswith(APP_KEY_PREFIX)
+
+
+class AppCredentials:
+    """Resolve, remember and rotate the app's credential.
+
+    ``explicit`` is the config's ``opennvr_token`` (either kind).
+    """
+
+    def __init__(self, explicit: str | None = None) -> None:
+        self._explicit = str(explicit) if explicit else None
+        self._app_key: str | None = None
+        if is_app_key(self._explicit):
+            self._app_key = self._explicit
+        else:
+            self._app_key = stored_app_key()
+
+    @property
+    def app_key(self) -> str | None:
+        return self._app_key
+
+    @property
+    def has_app_key(self) -> bool:
+        return bool(self._app_key)
+
+    def token(self) -> str | None:
+        """What to send: the app key when we have one, else the site key."""
+        return self._app_key or site_key(
+            None if is_app_key(self._explicit) else self._explicit)
+
+    def headers(self) -> dict[str, str]:
+        """Both header shapes core accepts, so one value works whether
+        it is an app key, the site key or a user JWT."""
+        tok = self.token()
+        if not tok:
+            return {}
+        return {"Authorization": f"Bearer {tok}", "X-Internal-Api-Key": tok}
+
+    def adopt(self, key: str) -> None:
+        """A key just issued by core: use it from now on and persist it."""
+        self._app_key = key.strip()
+        store_app_key(self._app_key)
+        logger.info("app key issued by OpenNVR — using it for every core call")
+
+    def invalidate(self) -> None:
+        """Core refused our app key (rotated/revoked): fall back to the
+        site key so the next registration can ask for a new one."""
+        if self._app_key:
+            logger.warning("OpenNVR rejected the app key — discarding it; "
+                           "will request a new one at next registration")
+        self._app_key = None
+        forget_app_key()
+
+
+def auth_headers(explicit: str | None = None) -> dict[str, str]:
+    """One-shot helper for clients that don't hold an AppCredentials."""
+    return AppCredentials(explicit).headers()

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/events.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/events.py
@@ -64,10 +64,15 @@ class StoredEvent:
 class EventsClient:
     """Query visits and fetch their evidence photos from core."""
 
-    def __init__(self, core_url: str, api_key: str | None, *,
+    def __init__(self, core_url: str, api_key: str | None = None, *,
                  http_get: HttpGetH | None = None) -> None:
         self._base = core_url.rstrip("/")
-        self._headers = {"X-Internal-Api-Key": api_key} if api_key else {}
+        # The app's own key when it has one (scoped to its cameras), else
+        # the explicit/site key — see credentials.py.
+        from .credentials import AppCredentials
+
+        key = AppCredentials(api_key).token()
+        self._headers = {"X-Internal-Api-Key": key} if key else {}
         self._get = http_get or _default_http_get
 
     async def search(

--- a/sdk/opennvr-app-sdk/tests/test_contract.py
+++ b/sdk/opennvr-app-sdk/tests/test_contract.py
@@ -208,6 +208,10 @@ def test_registration_posts_url_manifest_and_auth_headers(monkeypatch):
     assert call["json"] == {
         "url": "http://loitering:9200",
         "manifest": MANIFEST.to_dict(),
+        # Negotiation + credential bootstrap (credentials.py): the SDK
+        # states its version and, holding no app key yet, asks for one.
+        "sdk_version": contract_mod._sdk_version,
+        "wants_key": True,
     }
     # One token, both header shapes: the registry's register route
     # accepts a user JWT (bearer) or the deployment's INTERNAL_API_KEY

--- a/sdk/opennvr-app-sdk/tests/test_credentials.py
+++ b/sdk/opennvr-app-sdk/tests/test_credentials.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""credentials.py + the registration handshake: an app bootstraps with
+the site key, is issued its own key once, persists it, sends it from
+then on, and falls back when core rejects it."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from opennvr_app_sdk import (
+    AlertDispatcher, AppCredentials, AppManifest, Detector, StdoutChannel,
+    contract as contract_mod,
+)
+from opennvr_app_sdk import credentials as creds_mod
+from opennvr_app_sdk.cameras import internal_api_key
+
+
+@pytest.fixture(autouse=True)
+def _isolated_key_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENNVR_APP_KEY_FILE", str(tmp_path / "app.key"))
+    monkeypatch.delenv("OPENNVR_APP_KEY", raising=False)
+    monkeypatch.delenv("OPENNVR_INTERNAL_API_KEY", raising=False)
+    yield
+
+
+def test_site_key_until_an_app_key_is_issued(monkeypatch):
+    monkeypatch.setenv("OPENNVR_INTERNAL_API_KEY", "site-secret")
+    c = AppCredentials()
+    assert not c.has_app_key and c.token() == "site-secret"
+    assert c.headers() == {"Authorization": "Bearer site-secret",
+                           "X-Internal-Api-Key": "site-secret"}
+    c.adopt("oak_my-app_" + "a" * 32)
+    assert c.has_app_key and c.token().startswith("oak_my-app_")
+    # Persisted: a fresh resolver (next boot) finds it, and every client
+    # that builds headers from the credential now sends the app key.
+    assert AppCredentials().token() == c.token()
+    assert internal_api_key() == c.token()
+    assert creds_mod.key_file().stat().st_mode & 0o777 == 0o600
+
+
+def test_env_app_key_and_explicit_app_key_win(monkeypatch):
+    monkeypatch.setenv("OPENNVR_INTERNAL_API_KEY", "site-secret")
+    monkeypatch.setenv("OPENNVR_APP_KEY", "oak_x_" + "b" * 32)
+    assert AppCredentials().token() == "oak_x_" + "b" * 32
+    assert AppCredentials("oak_y_" + "c" * 32).token() == "oak_y_" + "c" * 32
+    # An explicit non-app token is treated as the site key.
+    monkeypatch.delenv("OPENNVR_APP_KEY")
+    assert AppCredentials("cfg-site").token() == "cfg-site"
+
+
+def test_invalidate_drops_the_key_and_falls_back(monkeypatch):
+    monkeypatch.setenv("OPENNVR_INTERNAL_API_KEY", "site-secret")
+    c = AppCredentials()
+    c.adopt("oak_my-app_" + "d" * 32)
+    c.invalidate()
+    assert c.token() == "site-secret" and not creds_mod.key_file().exists()
+
+
+# ── the handshake through register_with_opennvr ────────────────────────
+
+MANIFEST = AppManifest(id="my-app", name="My App", version="1.0.0",
+                       category="test", summary="t", requires_tasks=[],
+                       subscribes="opennvr.inference.>")
+
+
+class _App(Detector):
+    manifest = MANIFEST
+
+    def on_detections(self, camera_id, detections, event):
+        pass
+
+
+class _FakePost:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, url, *, json=None, headers=None, timeout=None, trust_env=None):
+        self.calls.append({"json": json, "headers": headers or {}})
+        status, body = self.responses.pop(0)
+        return SimpleNamespace(status_code=status, text="", json=lambda: body)
+
+
+def _app():
+    cfg = SimpleNamespace(opennvr_url="http://core:8080", contract_port=9200,
+                          contract_host="my-app", opennvr_token="site-secret",
+                          nats_url="nats://x", nats_token=None)
+    return _App(cfg, AlertDispatcher([StdoutChannel()]))
+
+
+def test_registration_adopts_the_issued_key_then_uses_it(monkeypatch):
+    fake = _FakePost([
+        (200, {"id": "my-app", "api_key": "oak_my-app_" + "e" * 32,
+               "registry": {"server_version": "0.1.4", "api_version": "1.1",
+                            "min_sdk_version": "0.2.0"}}),
+        (200, {"id": "my-app"}),
+    ])
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    app = _app()
+    assert app.register_with_opennvr() is True
+    first = fake.calls[0]
+    assert first["headers"]["X-Internal-Api-Key"] == "site-secret"
+    assert first["json"]["wants_key"] is True
+    # Second boot-time registration: our own key, no request for a new one.
+    assert app.register_with_opennvr() is True
+    second = fake.calls[1]
+    assert second["headers"]["X-Internal-Api-Key"] == "oak_my-app_" + "e" * 32
+    assert second["json"]["wants_key"] is False
+    # …and the config poll sends the same key.
+    url, headers = app._config_poll_target()
+    assert url.endswith("/api/v1/apps/my-app/config")
+    assert headers["X-Internal-Api-Key"] == "oak_my-app_" + "e" * 32
+
+
+def test_rejected_app_key_is_discarded_for_the_next_attempt(monkeypatch):
+    creds_mod.store_app_key("oak_my-app_" + "f" * 32)
+    fake = _FakePost([(401, {"detail": "Invalid or revoked app key"}),
+                      (200, {"id": "my-app", "api_key": "oak_my-app_" + "1" * 32})])
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    app = _app()
+    assert app.register_with_opennvr() is False
+    assert fake.calls[0]["headers"]["X-Internal-Api-Key"].startswith("oak_")
+    # Next attempt bootstraps with the site key and asks anew.
+    assert app.register_with_opennvr() is True
+    assert fake.calls[1]["headers"]["X-Internal-Api-Key"] == "site-secret"
+    assert fake.calls[1]["json"]["wants_key"] is True
+    assert app.credentials.token() == "oak_my-app_" + "1" * 32
+
+
+def test_old_sdk_is_warned_not_broken(monkeypatch, caplog):
+    fake = _FakePost([(200, {"id": "my-app",
+                             "registry": {"server_version": "9.0.0",
+                                          "min_sdk_version": "99.0.0"}})])
+    monkeypatch.setattr(contract_mod.httpx, "post", fake)
+    with caplog.at_level("WARNING"):
+        assert _app().register_with_opennvr() is True
+    assert any("requires opennvr-app-sdk >= 99.0.0" in r.message for r in caplog.records)

--- a/server/migrations/versions/b3d26b58dc7e_add_installed_app_api_key.py
+++ b/server/migrations/versions/b3d26b58dc7e_add_installed_app_api_key.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""add installed_apps.api_key_hash / api_key_issued_at (per-app credentials)
+
+Revision ID: b3d26b58dc7e
+Revises: ff88aa99bb00
+Create Date: 2026-09-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b3d26b58dc7e"
+down_revision = "ff88aa99bb00"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("installed_apps",
+                  sa.Column("api_key_hash", sa.String(64), nullable=True))
+    op.add_column("installed_apps",
+                  sa.Column("api_key_issued_at", sa.DateTime(timezone=True),
+                            nullable=True))
+    op.create_index("ix_installed_apps_api_key_hash", "installed_apps",
+                    ["api_key_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_installed_apps_api_key_hash", table_name="installed_apps")
+    op.drop_column("installed_apps", "api_key_issued_at")
+    op.drop_column("installed_apps", "api_key_hash")

--- a/server/models.py
+++ b/server/models.py
@@ -1090,6 +1090,14 @@ class InstalledApp(Base):
     # registered | ok | unreachable
     status = Column(String(20), nullable=False, default="registered")
     last_seen = Column(DateTime(timezone=True), nullable=True)
+    # The app's OWN credential (services/app_keys.py): SHA-256 of the
+    # ``oak_…`` key minted at registration and handed back exactly once.
+    # NULL = no key issued (a pre-credential registration, or revoked).
+    # With it the app reads only its own config/status and its own
+    # camera roster; the deployment's INTERNAL_API_KEY stays for
+    # platform components (detect-pipeline, KAI-C, the agent).
+    api_key_hash = Column(String(64), nullable=True, index=True)
+    api_key_issued_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -55,6 +55,10 @@ from core.auth import get_current_active_user, get_current_superuser, verify_tok
 from core.database import get_db
 from core.permissions import RequirePermission
 from models import AppInstallIntent, InstalledApp, User
+from services.app_keys import (
+    AppPrincipal, issue_key, looks_like_app_key,
+    resolve_app_key, revoke_key,
+)
 from services.audit_service import write_audit_log
 
 # The one-click install/uninstall endpoints require this RBAC permission
@@ -405,13 +409,42 @@ def get_register_principal(
     x_internal_api_key: str | None = Header(default=None, alias="X-Internal-Api-Key"),
     credentials: HTTPAuthorizationCredentials | None = Depends(_optional_bearer),
     db: Session = Depends(get_db),
-) -> User | None:
+) -> User | AppPrincipal | None:
     """Authenticate a registration call.
 
     Returns the ``User`` for the JWT path, or ``None`` for the
     service-key path (audit-logged as the ``app-sdk`` service
     identity). Raises 401 when neither credential is valid.
     """
+    return _service_or_user_principal(x_internal_api_key, credentials, db)
+
+
+def _service_or_user_principal(
+    x_internal_api_key: str | None,
+    credentials: HTTPAuthorizationCredentials | None,
+    db: Session,
+) -> User | AppPrincipal | None:
+    """Shared body of the two service-capable principals.
+
+    Three credential kinds, checked in this order:
+
+    * an **app key** (``oak_…``, in either header) → :class:`AppPrincipal`
+      for that app — it may read its own registry rows and re-register;
+    * the deployment's ``INTERNAL_API_KEY`` → ``None`` (platform
+      service identity, unscoped);
+    * a user JWT → the ``User``.
+    """
+    bearer = credentials.credentials if credentials is not None else None
+    for candidate in (x_internal_api_key, bearer):
+        if looks_like_app_key(candidate):
+            row = resolve_app_key(db, candidate)
+            if row is not None:
+                return AppPrincipal(app_id=row.id)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or revoked app key",
+            )
+
     if x_internal_api_key is not None:
         expected = _internal_api_key()
         if expected and secrets.compare_digest(x_internal_api_key, expected):
@@ -443,16 +476,25 @@ def get_register_principal(
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Provide a bearer token or X-Internal-Api-Key",
+        detail="Provide a bearer token, an app key, or X-Internal-Api-Key",
         headers={"WWW-Authenticate": "Bearer"},
     )
+
+
+def _own_app_only(principal, app_id: str) -> None:
+    """An app key reads ITS OWN registry rows and nothing else."""
+    if isinstance(principal, AppPrincipal) and principal.app_id != app_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="An app key may only access its own app",
+        )
 
 
 def get_read_principal(
     x_internal_api_key: str | None = Header(default=None, alias="X-Internal-Api-Key"),
     credentials: HTTPAuthorizationCredentials | None = Depends(_optional_bearer),
     db: Session = Depends(get_db),
-) -> User | None:
+) -> User | AppPrincipal | None:
     """Authenticate a READ-ONLY registry call (``GET /apps`` and
     ``GET /apps/{id}/status``).
 
@@ -470,40 +512,8 @@ def get_read_principal(
     stay strictly ``get_current_active_user`` (register additionally
     accepts the key via :func:`get_register_principal`).
     """
-    if x_internal_api_key is not None:
-        expected = _internal_api_key()
-        if expected and secrets.compare_digest(x_internal_api_key, expected):
-            return None  # service identity
-        # A service sends its one token as BOTH headers (it can't know
-        # which kind the operator provisioned) — a non-matching key
-        # only fails the request when there's no bearer to fall back to.
-        if credentials is None:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid internal API key",
-            )
+    return _service_or_user_principal(x_internal_api_key, credentials, db)
 
-    if credentials is not None:
-        token_data = verify_token(credentials.credentials)
-        if token_data is not None:
-            user = (
-                db.query(User)
-                .filter(User.username == token_data.username)
-                .first()
-            )
-            if user is not None and user.is_active:
-                return user
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Provide a bearer token or X-Internal-Api-Key",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
 
 
 # ── Request schemas / serialization ────────────────────────────────
@@ -514,6 +524,23 @@ class AppRegisterRequest(BaseModel):
 
     url: str
     manifest: dict[str, Any]
+    # The SDK's own version, for the compatibility line in the response
+    # and the audit row. Optional: older SDKs send nothing.
+    sdk_version: str | None = None
+    # "I hold no app key" — an app booting without a persisted key (no
+    # volume, first run) registers with the site key and asks for one;
+    # the registry (re)issues it. An app registering WITH its own key
+    # never gets a new one back.
+    wants_key: bool = False
+
+
+#: The app-registry contract version the SDK negotiates against, and
+#: the oldest SDK this server still speaks to. Bump API_VERSION on any
+#: change to the register/config/state/actions shapes; bump
+#: MIN_SDK_VERSION only when an old SDK would misbehave, not merely
+#: miss a feature.
+API_VERSION = "1.1"
+MIN_SDK_VERSION = "0.2.0"
 
 
 def _serialize_app(row: InstalledApp) -> dict[str, Any]:
@@ -529,6 +556,9 @@ def _serialize_app(row: InstalledApp) -> dict[str, Any]:
         "last_seen": row.last_seen,
         "manifest": row.manifest_json,
         "config": row.config_json or {},
+        # Credential state only — the key itself is returned once, at issue.
+        "has_api_key": bool(row.api_key_hash),
+        "api_key_issued_at": row.api_key_issued_at,
     }
 
 
@@ -650,6 +680,8 @@ async def register_app(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Manifest is missing required fields: {', '.join(missing)}",
         )
+    # An app key registers only the app it was minted for.
+    _own_app_only(principal, str(manifest["id"]))
 
     url_error = validate_app_url(request.url)
     if url_error is not None:
@@ -672,26 +704,38 @@ async def register_app(
     row.manifest_json = manifest
     row.status = "registered"
     row.last_seen = datetime.now(UTC)
+    # Per-app credential: issued on first registration, and re-issued
+    # whenever the app registers with the SITE key (or a user) and says
+    # it holds no key of its own (a fresh container with no persisted
+    # key). An app presenting its own key keeps it. Audited below.
+    issued_key: str | None = None
+    if not isinstance(principal, AppPrincipal) and (
+            created or not row.api_key_hash or request.wants_key):
+        issued_key = issue_key(db, row)
     db.commit()
     db.refresh(row)
 
+    actor_user = principal if isinstance(principal, User) else None
+    registered_by = (
+        f"user:{principal.username}" if isinstance(principal, User)
+        else f"app:{principal.app_id}" if isinstance(principal, AppPrincipal)
+        else "service:internal-api-key"
+    )
     write_audit_log(
         db,
         action="app.register",
         # Service-key registrations have no user row; the actor is
         # recorded in details instead so the audit trail stays whole.
-        user_id=principal.id if principal is not None else None,
+        user_id=actor_user.id if actor_user is not None else None,
         entity_type="app",
         entity_id=app_id,
         details={
             "created": created,
             "url": row.url,
             "version": row.version,
-            "registered_by": (
-                f"user:{principal.username}"
-                if principal is not None
-                else "service:internal-api-key"
-            ),
+            "sdk_version": request.sdk_version,
+            "registered_by": registered_by,
+            "key_issued": issued_key is not None,
         },
     )
     # RFC-0002 Phase 5: event-scope grants. v1 policy is grant-on-
@@ -707,12 +751,29 @@ async def register_app(
             write_audit_log(
                 db,
                 action="app.scope_granted",
-                user_id=principal.id if principal is not None else None,
+                user_id=actor_user.id if actor_user is not None else None,
                 entity_type="app",
                 entity_id=app_id,
                 details={"scope": scope.strip(), "policy": "grant-on-registration"},
             )
-    return _serialize_app(row)
+    out = _serialize_app(row)
+    out["registry"] = _registry_info()
+    if issued_key is not None:
+        # The only time the key exists in the clear. The SDK persists it.
+        out["api_key"] = issued_key
+    return out
+
+
+def _registry_info() -> dict[str, Any]:
+    try:
+        from main import __version__ as server_version  # noqa: PLC0415
+    except Exception:  # noqa: BLE001 — tests import the router alone
+        server_version = "unknown"
+    return {
+        "server_version": server_version,
+        "api_version": API_VERSION,
+        "min_sdk_version": MIN_SDK_VERSION,
+    }
 
 
 @router.post("/{app_id}/enable")
@@ -787,9 +848,10 @@ async def get_app_config(
     ``X-Internal-Api-Key``): the app itself is the intended service
     caller. Writes stay user-JWT-only (``PUT`` below).
     """
+    _own_app_only(principal, app_id)
     row = _get_app_or_404(db, app_id)
     config = row.config_json or {}
-    if principal is not None and not principal.is_superuser:
+    if isinstance(principal, User) and not principal.is_superuser:
         # A user sees the site-wide settings (read-only for them) but
         # only THEIR cameras' per-camera entries — a zone drawn on a
         # camera they were never assigned is not theirs to look at.
@@ -1019,6 +1081,41 @@ async def invoke_app_action(
         )
 
 
+@router.post("/{app_id}/key/rotate")
+async def rotate_app_key(
+    app_id: str,
+    current_user: User = Depends(get_current_superuser),
+    db: Session = Depends(get_db),
+):
+    """Mint a NEW app key and return it once; the old one stops working
+    immediately. Superuser only. Hand the value to the app's operator
+    (``OPENNVR_APP_KEY``), or restart the app with the site key and it
+    asks for one itself (``wants_key``)."""
+    row = _get_app_or_404(db, app_id)
+    plain = issue_key(db, row)
+    db.commit()
+    write_audit_log(db, action="app.key.rotate", user_id=current_user.id,
+                    entity_type="app", entity_id=app_id)
+    return {"id": app_id, "api_key": plain,
+            "api_key_issued_at": row.api_key_issued_at}
+
+
+@router.delete("/{app_id}/key")
+async def revoke_app_key(
+    app_id: str,
+    current_user: User = Depends(get_current_superuser),
+    db: Session = Depends(get_db),
+):
+    """Revoke the app's key: it can no longer read its config, its
+    roster, or re-register with that key. Superuser only."""
+    row = _get_app_or_404(db, app_id)
+    revoke_key(row)
+    db.commit()
+    write_audit_log(db, action="app.key.revoke", user_id=current_user.id,
+                    entity_type="app", entity_id=app_id)
+    return {"id": app_id, "has_api_key": False}
+
+
 @router.get("/{app_id}/status")
 async def get_app_status(
     app_id: str,
@@ -1042,6 +1139,7 @@ async def get_app_status(
     (``X-Internal-Api-Key``) — a service reads live app state to relay
     it; see :func:`get_read_principal`. Read only.
     """
+    _own_app_only(principal, app_id)
     row = _get_app_or_404(db, app_id)
     base_url = row.url.rstrip("/")
 
@@ -1078,7 +1176,7 @@ async def get_app_status(
         row.last_seen = datetime.now(UTC)
     db.commit()
 
-    if principal is not None and not principal.is_superuser:
+    if isinstance(principal, User) and not principal.is_superuser:
         # Live state is per-camera data (occupancy per zone, the LPR
         # review queue, each camera's last read): a user gets their
         # cameras' slice. The service-key path (the agent) is scoped

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -24,6 +24,9 @@ from sqlalchemy.orm import Session
 from core.config import settings
 from core.database import get_db, release
 from models import Camera, SecuritySetting
+from services.app_keys import (
+    AppPrincipal, app_camera_ids, looks_like_app_key, resolve_app_key,
+)
 from services.stream_service import _build_stream_name
 
 logger = logging.getLogger(__name__)
@@ -34,8 +37,25 @@ router = APIRouter(prefix="/internal/camera-agent", tags=["internal-camera-agent
 def _require_internal_key(
     x_internal_api_key: str | None = Header(default=None, alias="X-Internal-Api-Key"),
     x_internal_api_key_alt: str | None = Header(default=None, alias="X-Internal-API-Key"),
-) -> None:
+    db: Session = Depends(get_db),
+):
+    """Authenticate an internal-door call.
+
+    Returns ``None`` for the deployment's ``INTERNAL_API_KEY`` (a platform
+    component — unscoped), or an :class:`services.app_keys.AppPrincipal`
+    for an app presenting its own key (``oak_…`` — scoped to the app's
+    camera roster on the read routes below, refused on the pipeline's
+    write routes). 401 otherwise.
+    """
     supplied = x_internal_api_key or x_internal_api_key_alt
+    if looks_like_app_key(supplied):
+        row = resolve_app_key(db, supplied)
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid or revoked app key",
+            )
+        return AppPrincipal(app_id=row.id)
     expected = settings.internal_api_key
     # Constant-time compare to avoid leaking the key via response timing.
     if not expected or not supplied or not secrets.compare_digest(str(supplied), str(expected)):
@@ -43,6 +63,28 @@ def _require_internal_key(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="invalid internal api key",
         )
+    return None
+
+
+def _platform_only(principal) -> None:
+    """The pipeline's write routes and platform config: site key only."""
+    if isinstance(principal, AppPrincipal):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="this route is for platform components, not apps",
+        )
+
+
+def _app_roster(db: Session, principal) -> set[int] | None:
+    """Camera ids an app principal may read (None = unrestricted)."""
+    if not isinstance(principal, AppPrincipal):
+        return None
+    from models import InstalledApp
+
+    row = db.query(InstalledApp).filter(InstalledApp.id == principal.app_id).first()
+    if row is None:
+        return set()
+    return app_camera_ids(db, row)
 
 
 class TrackEventIn(BaseModel):
@@ -73,7 +115,7 @@ class TrackEventIn(BaseModel):
 async def ingest_track_event(
     payload: TrackEventIn,
     background: BackgroundTasks,
-    _: None = Depends(_require_internal_key),
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
 ):
     """Canonical-store ingest (RFC-0001 C1): persist a visit + its evidence.
@@ -83,6 +125,7 @@ async def ingest_track_event(
     content-addresses to the same file; duplicate rows are tolerated and
     cheap to de-dup at query time via (camera_id, track_id, started_at).
     """
+    _platform_only(principal)
     camera = db.query(Camera).filter(Camera.id == payload.camera_id).first()
     if camera is None:
         raise HTTPException(status_code=404, detail="unknown camera_id")
@@ -383,12 +426,13 @@ async def run_early_plate_attempt(
 async def ingest_plate_attempt(
     payload: PlateAttemptIn,
     background: BackgroundTasks,
-    _: None = Depends(_require_internal_key),
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
 ):
     """Accept one early plate attempt (multi-frame OCR). The OCR runs
     in the background — this endpoint only validates and queues, so the
     Tier-0 poster thread never waits on an inference."""
+    _platform_only(principal)
     camera = db.query(Camera).filter(Camera.id == payload.camera_id).first()
     if camera is None:
         raise HTTPException(status_code=404, detail="unknown camera_id")
@@ -421,7 +465,7 @@ async def internal_list_events(
     from_: datetime | None = Query(default=None, alias="from"),
     to: datetime | None = None,
     limit: int = 100,
-    _: None = Depends(_require_internal_key),
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
 ):
     """Event-store read for trusted internal components (the camera agents).
@@ -432,8 +476,10 @@ async def internal_list_events(
     """
     from services.timeline_service import query_events
 
+    # An app key sees its own roster's visits only (site key: the fleet).
     rows = query_events(db, camera_id=camera_id, label=label, plate=plate,
-                        from_=from_, to=to, limit=limit)
+                        from_=from_, to=to, limit=limit,
+                        scope=_app_roster(db, principal))
     return {
         "events": [
             {
@@ -462,7 +508,7 @@ async def internal_list_events(
 @router.get("/events/{event_id}/evidence")
 async def internal_event_evidence(
     event_id: int,
-    _: None = Depends(_require_internal_key),
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
 ):
     """The visit's best-frame JPEG, for agent-side face match / VLM looks."""
@@ -472,6 +518,9 @@ async def internal_event_evidence(
     from services.evidence_store import resolve_evidence
 
     e = db.query(TimelineEvent).filter(TimelineEvent.id == event_id).first()
+    roster = _app_roster(db, principal)
+    if e is not None and roster is not None and int(e.camera_id) not in roster:
+        e = None   # 404, not 403: another app's camera is not confirmed to exist
     if e is None or not e.evidence_path:
         raise HTTPException(status_code=404, detail="no evidence")
     path = resolve_evidence(e.evidence_path)
@@ -483,7 +532,7 @@ async def internal_event_evidence(
 @router.get("/events/{event_id}/scene-evidence")
 async def internal_event_scene_evidence(
     event_id: int,
-    _: None = Depends(_require_internal_key),
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
 ):
     """The whole frame behind the best crop — a wider look for the VLM path.
@@ -497,6 +546,9 @@ async def internal_event_scene_evidence(
     from services.evidence_store import resolve_evidence
 
     e = db.query(TimelineEvent).filter(TimelineEvent.id == event_id).first()
+    roster = _app_roster(db, principal)
+    if e is not None and roster is not None and int(e.camera_id) not in roster:
+        e = None   # 404, not 403: another app's camera is not confirmed to exist
     if e is None or not e.scene_evidence_path:
         raise HTTPException(status_code=404, detail="no scene evidence")
     path = resolve_evidence(e.scene_evidence_path)
@@ -512,7 +564,7 @@ _VALID_GATE_MODES = ("off", "shadow", "enforce")
 
 @router.get("/detect-config")
 async def get_detect_config(
-    _: None = Depends(_require_internal_key),
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
 ):
     """Effective Tier-0 gate override for the detect-pipeline.
@@ -521,6 +573,7 @@ async def get_detect_config(
     flips shadow->enforce in the UI; the pipeline applies it live, no
     redeploy). ``gate_mode: null`` means "no override — follow your env".
     """
+    _platform_only(principal)
     row = (
         db.query(SecuritySetting)
         .filter(SecuritySetting.key == GATE_MODE_KEY)
@@ -563,8 +616,9 @@ def _mint_mediamtx_jwt() -> str | None:
         return None
 
 
-@router.get("/cameras", dependencies=[Depends(_require_internal_key)])
+@router.get("/cameras")
 def list_camera_agent_sources(
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
     x_detect_hwaccel: str | None = Header(default=None, alias="X-Detect-Hwaccel"),
 ) -> dict[str, object]:
@@ -602,6 +656,13 @@ def list_camera_agent_sources(
         .order_by(Camera.id.asc())
         .all()
     )
+    # An app key gets the cameras the operator assigned to it (every
+    # camera when none is assigned — the additive rule); the site key
+    # gets the fleet. Same rule the SDK's cameras_for_skill applies
+    # client-side, now enforced where the frames are handed out.
+    roster = _app_roster(db, principal)
+    if roster is not None:
+        cameras = [c for c in cameras if int(c.id) in roster]
     out: list[dict[str, object]] = []
     for cam in cameras:
         stream_name = _build_stream_name(
@@ -699,7 +760,7 @@ def list_camera_agent_sources(
 async def internal_recording_frame(
     camera_id: int = Query(..., description="Camera ID"),
     at: str = Query(..., description="Wall-clock instant (ISO 8601)"),
-    _: None = Depends(_require_internal_key),
+    principal=Depends(_require_internal_key),
     db: Session = Depends(get_db),
 ):
     """One JPEG from recorded footage at a past instant, for the agent's
@@ -719,6 +780,9 @@ async def internal_recording_frame(
     if at_dt.tzinfo is None:
         at_dt = at_dt.replace(tzinfo=UTC)
 
+    roster = _app_roster(db, principal)
+    if roster is not None and int(camera_id) not in roster:
+        raise HTTPException(status_code=404, detail="no recording at that time")
     job = _resolve_frame_job(db, camera_id, at_dt)
     if job is None:
         raise HTTPException(status_code=404, detail="no recording at that time")

--- a/server/services/app_keys.py
+++ b/server/services/app_keys.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Per-app credentials — one key per installed app, instead of the site key.
+
+Every SDK app used to boot with the deployment's ``INTERNAL_API_KEY``:
+the same secret the detect-pipeline and KAI-C hold. Any app therefore
+read every camera, every app's config and live state, and revoking one
+app meant rotating the key for the whole stack. That is fine for the
+platform's own components and wrong for a catalog of third-party apps.
+
+The model here:
+
+* ``POST /apps/register`` mints an **app key** the first time an app
+  registers (or whenever the app says it has none — ``wants_key``), and
+  returns it exactly once. Format ``oak_<app-id>_<32 hex>`` — the id is
+  in the clear so a key can be routed to its row without a table scan;
+  the secret half is what is hashed (SHA-256) and stored.
+* Presenting an app key authenticates AS THAT APP: it may read its own
+  config and status, register itself again, and read the platform's
+  internal camera/event routes **for its own roster** (the cameras the
+  operator assigned it — ``Camera.assignments[].skill == app id`` —
+  or every camera when no assignment names it, the additive rule of
+  docs/CAMERA_ASSIGNMENTS.md). Never another app's config, never the
+  detect-pipeline's write routes.
+* A superuser can rotate or revoke a key from the registry; the site
+  key keeps working for platform components and for onboarding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+KEY_PREFIX = "oak_"
+_KEY_RE = re.compile(r"^oak_([A-Za-z0-9][A-Za-z0-9._-]{0,99})_([0-9a-f]{32})$")
+
+
+@dataclass(frozen=True)
+class AppPrincipal:
+    """The caller is an installed app, authenticated by its own key."""
+
+    app_id: str
+    #: Keeps ``principal.is_superuser`` checks in the registry routes
+    #: honest without isinstance games everywhere: an app is never one.
+    is_superuser: bool = False
+
+
+def looks_like_app_key(value: str | None) -> bool:
+    return bool(value) and str(value).startswith(KEY_PREFIX)
+
+
+def hash_key(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+def mint_key(app_id: str) -> tuple[str, str]:
+    """``(plain, sha256)`` for a fresh key bound to ``app_id``."""
+    plain = f"{KEY_PREFIX}{app_id}_{secrets.token_hex(16)}"
+    return plain, hash_key(plain)
+
+
+def issue_key(db: Session, row) -> str:
+    """Mint, store the hash on the InstalledApp row, return the plain key
+    (the only time it exists in the clear). Caller commits."""
+    plain, digest = mint_key(row.id)
+    row.api_key_hash = digest
+    row.api_key_issued_at = datetime.now(UTC)
+    return plain
+
+
+def revoke_key(row) -> None:
+    row.api_key_hash = None
+    row.api_key_issued_at = None
+
+
+def resolve_app_key(db: Session, supplied: str | None):
+    """The InstalledApp a presented key belongs to, or ``None``.
+
+    Constant-time on the hash compare; the app id parsed from the key is
+    only a lookup hint — the stored hash is what authenticates."""
+    if not supplied:
+        return None
+    m = _KEY_RE.match(str(supplied).strip())
+    if not m:
+        return None
+    from models import InstalledApp
+
+    row = db.query(InstalledApp).filter(InstalledApp.id == m.group(1)).first()
+    if row is None or not row.api_key_hash:
+        return None
+    if not secrets.compare_digest(row.api_key_hash, hash_key(str(supplied).strip())):
+        return None
+    return row
+
+
+def app_skills(row) -> set[str]:
+    """The skill names an app answers to in ``Camera.assignments``: what
+    its manifest ``provides`` (``license_plate_recognition``) plus its id
+    in both spellings (``license-plate-recognition`` / ``_``)."""
+    manifest = row.manifest_json or {}
+    skills = {str(s) for s in (manifest.get("provides") or []) if s}
+    skills.add(row.id)
+    skills.add(row.id.replace("-", "_"))
+    return skills
+
+
+def app_camera_ids(db: Session, row) -> set[int] | None:
+    """Cameras the operator assigned to this app (``assignments[].skill``
+    in :func:`app_skills`), or ``None`` = every camera when no assignment
+    names it — the additive rule of docs/CAMERA_ASSIGNMENTS.md, exactly
+    as ``cameras_for_skill`` in the SDK reads it."""
+    from models import Camera
+
+    skills = app_skills(row)
+    rows = (
+        db.query(Camera.id, Camera.assignments)
+        .filter(Camera.deleted_at.is_(None))
+        .all()
+    )
+    named: set[int] = set()
+    for cam_id, assignments in rows:
+        for entry in assignments or []:
+            if isinstance(entry, dict) and entry.get("skill") in skills:
+                named.add(int(cam_id))
+                break
+    return named or None

--- a/server/tests/test_app_credentials.py
+++ b/server/tests/test_app_credentials.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Per-app credentials (services/app_keys.py).
+
+Every SDK app used to boot with the deployment's INTERNAL_API_KEY and
+could therefore read every camera, every app's config and live state.
+Now ``POST /apps/register`` mints the app its own ``oak_…`` key, returned
+once; with it the app reads only its own registry rows and only the
+cameras the operator assigned to it, and a superuser can rotate or
+revoke it without touching the site key.
+
+Run with:
+    cd server && pytest tests/test_app_credentials.py -v
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+SITE_KEY = secrets.token_urlsafe(48)
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ["INTERNAL_API_KEY"] = SITE_KEY
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as auth_mod  # noqa: E402
+from core.config import settings  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Camera, InstalledApp, Role, TimelineEvent, User  # noqa: E402
+from routers import apps as apps_router  # noqa: E402
+from routers import internal_camera_agent as internal_router  # noqa: E402
+from services import app_keys  # noqa: E402
+
+
+def _manifest(app_id="loitering-detection", provides=("loitering",)):
+    return {"id": app_id, "name": app_id.title(), "version": "1.0.0",
+            "category": "perimeter", "summary": "", "requires_tasks": [],
+            "subscribes": "opennvr.inference.>", "params": [], "emits": [],
+            "provides": list(provides)}
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setattr(settings, "internal_api_key", SITE_KEY, raising=False)
+    monkeypatch.setattr(settings, "inference_use_mediamtx_tap", False, raising=False)
+    monkeypatch.setattr(auth_mod, "auth_logger", _L(), raising=False)
+
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    s = SessionLocal()
+    role = Role(name="admin")
+    s.add(role)
+    s.flush()
+    admin = User(username="admin", email="a@x", hashed_password="x",
+                 role_id=role.id, is_superuser=True, is_active=True)
+    s.add(admin)
+    s.flush()
+    gate = Camera(name="Gate", ip_address="10.0.0.1", owner_id=admin.id, is_active=True,
+                  rtsp_url="rtsp://10.0.0.1/s", assignments=[{"skill": "loitering"}])
+    yard = Camera(name="Yard", ip_address="10.0.0.2", owner_id=admin.id, is_active=True,
+                  rtsp_url="rtsp://10.0.0.2/s",
+                  assignments=[{"skill": "license_plate_recognition"}])
+    lobby = Camera(name="Lobby", ip_address="10.0.0.3", owner_id=admin.id, is_active=True,
+                   rtsp_url="rtsp://10.0.0.3/s")
+    s.add_all([gate, yard, lobby])
+    s.flush()
+    from datetime import datetime, timezone
+    for cam in (gate, yard):
+        s.add(TimelineEvent(camera_id=cam.id, source="tier0", event_type="track",
+                            label="person", started_at=datetime.now(timezone.utc)))
+    s.commit()
+    ids = {"gate": gate.id, "yard": yard.id, "lobby": lobby.id}
+    s.close()
+
+    app = FastAPI()
+    app.include_router(apps_router.router)
+    app.include_router(internal_router.router)
+
+    def _db():
+        sess = SessionLocal()
+        try:
+            yield sess
+        finally:
+            sess.close()
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[auth_mod.get_current_superuser] = lambda: admin
+    with TestClient(app) as tc:
+        yield tc, ids, SessionLocal
+
+
+def _site():
+    return {"X-Internal-Api-Key": SITE_KEY}
+
+
+def _app(key):
+    return {"X-Internal-Api-Key": key}
+
+
+def _register(tc, headers, **kw):
+    body = {"url": "http://loitering:9200", "manifest": _manifest(), **kw}
+    return tc.post("/apps/register", json=body, headers=headers)
+
+
+# ── issuing ─────────────────────────────────────────────────────────────
+
+
+def test_first_registration_mints_a_key_once(env):
+    tc, _, SessionLocal = env
+    r = _register(tc, _site(), sdk_version="0.2.0")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    key = body["api_key"]
+    assert key.startswith("oak_loitering-detection_") and body["has_api_key"] is True
+    assert body["registry"]["api_version"] and body["registry"]["min_sdk_version"]
+    # Stored hashed, never in the clear.
+    s = SessionLocal()
+    row = s.get(InstalledApp, "loitering-detection")
+    assert row.api_key_hash == app_keys.hash_key(key) and key not in str(row.__dict__)
+    s.close()
+    # Re-registering with the SITE key and no wants_key: the key stands,
+    # and is NOT returned again.
+    r = _register(tc, _site())
+    assert r.status_code == 200 and "api_key" not in r.json()
+    # Re-registering with its OWN key: accepted, nothing minted.
+    r = _register(tc, _app(key))
+    assert r.status_code == 200 and "api_key" not in r.json()
+    assert r.json()["has_api_key"] is True
+    s = SessionLocal()
+    assert s.get(InstalledApp, "loitering-detection").api_key_hash == app_keys.hash_key(key)
+    s.close()
+
+
+def test_wants_key_reissues_and_invalidates_the_old_one(env):
+    tc, *_ = env
+    old = _register(tc, _site()).json()["api_key"]
+    new = _register(tc, _site(), wants_key=True).json()["api_key"]
+    assert new != old
+    assert tc.get("/apps/loitering-detection/config", headers=_app(new)).status_code == 200
+    assert tc.get("/apps/loitering-detection/config", headers=_app(old)).status_code == 401
+
+
+def test_an_app_key_cannot_register_or_read_another_app(env):
+    tc, *_ = env
+    key = _register(tc, _site()).json()["api_key"]
+    other = {"url": "http://lpr:9200", "manifest": _manifest("license-plate-recognition")}
+    assert tc.post("/apps/register", json=other, headers=_site()).status_code == 200
+    r = tc.post("/apps/register", json=other, headers=_app(key))
+    assert r.status_code == 403
+    assert tc.get("/apps/license-plate-recognition/config", headers=_app(key)).status_code == 403
+    assert tc.get("/apps/license-plate-recognition/status", headers=_app(key)).status_code == 403
+    # Its own: fine (status probes the app URL; unreachable degrades, not 4xx).
+    assert tc.get("/apps/loitering-detection/config", headers=_app(key)).status_code == 200
+    assert tc.get("/apps/loitering-detection/status", headers=_app(key)).status_code == 200
+
+
+def test_garbage_and_revoked_keys_are_401(env):
+    tc, *_ = env
+    key = _register(tc, _site()).json()["api_key"]
+    assert tc.get("/apps/loitering-detection/config",
+                  headers=_app("oak_loitering-detection_" + "0" * 32)).status_code == 401
+    assert tc.get("/apps/loitering-detection/config",
+                  headers=_app("oak_nonsense")).status_code == 401
+    assert tc.delete("/apps/loitering-detection/key").json()["has_api_key"] is False
+    assert tc.get("/apps/loitering-detection/config", headers=_app(key)).status_code == 401
+    # The site key still works for the platform.
+    assert tc.get("/apps/loitering-detection/config", headers=_site()).status_code == 200
+
+
+def test_rotate_returns_a_fresh_key(env):
+    tc, *_ = env
+    old = _register(tc, _site()).json()["api_key"]
+    new = tc.post("/apps/loitering-detection/key/rotate").json()["api_key"]
+    assert new != old
+    assert tc.get("/apps/loitering-detection/config", headers=_app(old)).status_code == 401
+    assert tc.get("/apps/loitering-detection/config", headers=_app(new)).status_code == 200
+
+
+# ── the internal door, scoped to the app's roster ──────────────────────
+
+
+def test_internal_cameras_and_events_follow_the_apps_assignments(env):
+    tc, ids, _ = env
+    key = _register(tc, _site()).json()["api_key"]
+    # Gate is assigned "loitering" (this app's `provides`); yard and lobby are not.
+    cams = tc.get("/internal/camera-agent/cameras", headers=_app(key)).json()["cameras"]
+    assert [int(c["open_nvr_camera_id"]) for c in cams] == [ids["gate"]]
+    # The site key sees the fleet.
+    cams = tc.get("/internal/camera-agent/cameras", headers=_site()).json()["cameras"]
+    assert sorted(int(c["open_nvr_camera_id"]) for c in cams) == sorted(ids.values())
+    # Events likewise.
+    ev = tc.get("/internal/camera-agent/events", headers=_app(key)).json()["events"]
+    assert {e["camera_id"] for e in ev} == {ids["gate"]}
+    ev = tc.get("/internal/camera-agent/events", headers=_site()).json()["events"]
+    assert {e["camera_id"] for e in ev} == {ids["gate"], ids["yard"]}
+
+
+def test_unassigned_app_sees_the_fleet_additive_rule(env):
+    """No camera names this app → no restriction declared → everything
+    (docs/CAMERA_ASSIGNMENTS.md, same as the SDK's cameras_for_skill)."""
+    tc, ids, _ = env
+    body = {"url": "http://occ:9200", "manifest": _manifest("occupancy-counting", ("occupancy",))}
+    key = tc.post("/apps/register", json=body, headers=_site()).json()["api_key"]
+    cams = tc.get("/internal/camera-agent/cameras", headers=_app(key)).json()["cameras"]
+    assert sorted(int(c["open_nvr_camera_id"]) for c in cams) == sorted(ids.values())
+
+
+def test_pipeline_write_routes_refuse_app_keys(env):
+    tc, ids, _ = env
+    key = _register(tc, _site()).json()["api_key"]
+    r = tc.post("/internal/camera-agent/events", headers=_app(key), json={
+        "camera_id": ids["gate"], "label": "person",
+        "started_at": "2026-09-05T10:00:00+00:00"})
+    assert r.status_code == 403
+    assert tc.get("/internal/camera-agent/detect-config", headers=_app(key)).status_code == 403
+
+
+def test_app_roster_resolution_unit():
+    """The skill names an app answers to: `provides` + its id both ways."""
+    row = _types.SimpleNamespace(id="license-plate-recognition",
+                                 manifest_json={"provides": ["license_plate_recognition"]})
+    assert app_keys.app_skills(row) == {"license_plate_recognition",
+                                        "license-plate-recognition"}
+    plain, digest = app_keys.mint_key("x-app")
+    assert plain.startswith("oak_x-app_") and digest == app_keys.hash_key(plain)
+    assert app_keys.looks_like_app_key(plain) and not app_keys.looks_like_app_key(SITE_KEY)


### PR DESCRIPTION
… to the app's roster

Every SDK app booted with the deployment's INTERNAL_API_KEY — the same secret the detect-pipeline and KAI-C hold — so any app could read every camera and every other app's config and live state, and revoking one app meant rotating the key for the stack.

Server:
- InstalledApp.api_key_hash / api_key_issued_at (migration b3d26b58dc7e).
- POST /apps/register mints an oak_<app-id>_… key on first registration or when the app says wants_key (no persisted key); returned once in the response with registry.{server_version, api_version, min_sdk_version}. Request carries sdk_version. Audited.
- App keys authenticate as AppPrincipal on the registry and internal doors: own config/status/register only (403 for another app); /internal/camera-agent cameras, events, evidence and recordings/frame are filtered to the app's roster (Camera.assignments naming the manifest's provides or app id; unrestricted when none — the additive rule); the pipeline's write routes and detect-config refuse app keys.
- POST /apps/{id}/key/rotate and DELETE /apps/{id}/key (superuser).

SDK:
- credentials.AppCredentials: app key (OPENNVR_APP_KEY / key file, default .opennvr/app.key) preferred over the site key; headers() used by registration, the config poll, discover_cameras and EventsClient. register_with_opennvr sends sdk_version + wants_key, adopts and persists an issued key, discards a rejected one, warns when older than min_sdk_version.
- cameras.* and AppCredentials exported from the package root; __version__ moved to _version.py.

docs/APP_CREDENTIALS.md; TWO_DOORS.md corrected for the RBAC gates.