### PR TITLE
Forward the operator's identity to apps (X-OpenNVR-User); SDK current…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,16 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Apps know who is asking.** Core now attaches `X-OpenNVR-User` — a
+  60-second JWT naming the operator (id, username, superuser flag, the
+  camera ids they may view and manage), signed with the SHA-256 of the
+  app's own key — to every proxied `GET /apps/{id}/ui` and
+  `POST /apps/{id}/actions/{name}`. The SDK verifies it (stdlib only)
+  and exposes `current_user()` / `self.current_user` inside `ui_html()`
+  and `on_action()`, with `can_see()` / `can_manage()` / `visible()`
+  helpers, so an app renders per user and refuses actions on cameras
+  the caller may not control without a login of its own. Absent or
+  invalid → `None`, never partial trust. `docs/APP_SURFACES.md` §5.
 - **Superusers can be created and managed through the API.**
   `POST /users` and `PUT /users/{id}` accept `is_superuser`; creating,
   promoting or demoting a superuser requires the caller's TOTP code in

--- a/docs/APP_CREDENTIALS.md
+++ b/docs/APP_CREDENTIALS.md
@@ -67,3 +67,13 @@ The register response's `registry.min_sdk_version` is the oldest SDK the
 server still speaks to; the SDK logs a warning (never fails) when it is
 older. `api_version` is bumped on any change to the register / config /
 state / actions shapes.
+
+## User identity for your app
+
+The same key hash is the shared secret behind `X-OpenNVR-User`: on every
+proxied `/ui` view and action, core attaches a 60-second HS256 token
+naming the operator (id, username, superuser flag, the camera ids they
+may view and manage). The SDK verifies it against `sha256(app key)` and
+exposes it as `current_user()` — see
+[APP_SURFACES.md](APP_SURFACES.md#who-is-asking-current_user). No key
+issued → no identity forwarded.

--- a/docs/APP_SURFACES.md
+++ b/docs/APP_SURFACES.md
@@ -196,6 +196,47 @@ terms stay out of the log). The agent can *read* your state and *relay*
 your alerts; it can never *act* on your app. Design your actions
 assuming an authenticated human is on the other end — because one is.
 
+### Who is asking: `current_user()`
+
+The proxy tells you **which** human. Core signs the caller's identity
+for your app (`X-OpenNVR-User`, a 60-second JWT over the SHA-256 of
+your app key — see [APP_CREDENTIALS.md](APP_CREDENTIALS.md)) on every
+`/ui` view and every action, and the SDK verifies it before your code
+runs. Inside `ui_html()` and `on_action()`:
+
+```python
+from opennvr_app_sdk import current_user
+
+def on_action(self, name, params):
+    user = current_user()            # or self.current_user
+    if user is None:                 # older core / no app key yet
+        raise ValueError("no operator identity")
+    if not user.can_manage(params["camera_id"]):
+        raise ValueError("not permitted on that camera")   # → 400
+    ...
+
+def ui_html(self):
+    user = self.current_user
+    cams = user.visible(self.cameras) if user else []
+    ...
+```
+
+`UserContext` carries `user_id`, `username`, `is_superuser`, `cameras`
+(ids the user may *view*, `None` = every camera), `manage` (ids they may
+*control*), and `purpose` (`"ui"` / `"action"`). Per-camera RBAC is
+enforced by core on its own routes; this is how your app applies the
+same assignment to what *it* shows and does. A token that fails any
+check is treated as absent — never trusted partially.
+
+Two things also changed on the proxies since this section was first
+written: enabling/disabling an app is **superuser-only**, and
+`PUT /apps/{id}/config` accepts only per-camera entries (zones,
+tripwires) from a non-superuser, for cameras they manage — the
+site-wide params of your manifest are an administrator's to change.
+`GET /apps/{id}/status` returns a non-superuser only their cameras'
+slice of your `/state`, keyed by the `camN` handles the SDK already
+uses.
+
 ## 6. "What if I really need custom UI?"
 
 You don't ship one — that's the platform bet that keeps a community

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -60,6 +60,7 @@ from .cameras import (
     full_frame_polygon,
 )
 from .credentials import AppCredentials, auth_headers
+from .usercontext import UserContext, current_user
 from .tier0 import (
     BestFrameClient,
     Tier0Snapshot,
@@ -122,6 +123,9 @@ __all__ = [
     "full_frame_polygon",
     "AppCredentials",
     "auth_headers",
+    # The operator behind a /ui view or an action (X-OpenNVR-User)
+    "UserContext",
+    "current_user",
     # Frame-app plumbing
     "FrameSource",
     "KaiCClient",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
@@ -78,6 +78,11 @@ import httpx
 
 from ._version import __version__ as _sdk_version
 from .credentials import AppCredentials
+from .usercontext import (
+    USER_CONTEXT_HEADER, bind_user, signing_secret, unbind_user,
+    verify_user_context,
+)
+from .usercontext import current_user as _current_user
 
 logger = logging.getLogger(__name__)
 
@@ -126,12 +131,15 @@ class _ContractRequestHandler(BaseHTTPRequestHandler):
         # HTML route — core proxies /api/v1/apps/{id}/ui here. Optional
         # (apps opt in via a ui callable); everything else stays JSON.
         if path == "/ui" and getattr(self.server, "ui", None) is not None:
+            bound = bind_user(self._user_context())
             try:
                 html = self.server.ui()
             except Exception:
                 logger.exception("contract /ui failed")
                 self._send_json(500, {"error": "internal error"})
                 return
+            finally:
+                unbind_user(bound)
             payload = str(html).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -200,6 +208,7 @@ class _ContractRequestHandler(BaseHTTPRequestHandler):
             # same "bad body" class, and it must not kill the handler.
             self._send_json(400, {"error": f"bad action body: {exc}"})
             return
+        bound = bind_user(self._user_context())
         try:
             result = action(name, params)
         except KeyError:
@@ -212,7 +221,18 @@ class _ContractRequestHandler(BaseHTTPRequestHandler):
             logger.exception("action %s failed", name)
             self._send_json(500, {"error": "internal error"})
             return
+        finally:
+            unbind_user(bound)
         self._send_json(200, result if result is not None else {})
+
+    def _user_context(self):
+        """The operator core says is behind this request (verified
+        against this app's key), or None — see usercontext.py."""
+        secret_for = getattr(self.server, "user_secret", None)
+        secret = secret_for() if callable(secret_for) else None
+        return verify_user_context(
+            self.headers.get(USER_CONTEXT_HEADER), secret,
+            audience=getattr(self.server, "app_id", None))
 
     def _send_json(self, status: int, body: Any) -> None:
         payload = json.dumps(body).encode("utf-8")
@@ -237,6 +257,10 @@ class _ContractHTTPServer(ThreadingHTTPServer):
     action_token: "str | None"
     # Optional GET /ui HTML renderer (RFC-0002 Phase 4). None = no UI.
     ui: "Callable[[], str] | None"
+    # Verifies X-OpenNVR-User: () -> the signing secret (sha256 of the
+    # app key) or None, plus the manifest id the token must be for.
+    user_secret: "Callable[[], str | None] | None"
+    app_id: "str | None"
 
 
 class ContractServer:
@@ -257,6 +281,8 @@ class ContractServer:
         action: "Callable[[str, dict[str, Any]], Any] | None" = None,
         action_token: "str | None" = None,
         ui: "Callable[[], str] | None" = None,
+        user_secret: "Callable[[], str | None] | None" = None,
+        app_id: "str | None" = None,
         host: str = "0.0.0.0",
         port: int = 0,
     ) -> None:
@@ -266,6 +292,8 @@ class ContractServer:
         self._action = action
         self._action_token = action_token
         self._ui = ui
+        self._user_secret = user_secret
+        self._app_id = app_id
         self._server: _ContractHTTPServer | None = None
         self._thread: threading.Thread | None = None
 
@@ -286,6 +314,8 @@ class ContractServer:
         server.action = self._action
         server.action_token = self._action_token
         server.ui = self._ui
+        server.user_secret = self._user_secret
+        server.app_id = self._app_id
         self._server = server
         self._thread = threading.Thread(
             target=server.serve_forever,
@@ -387,6 +417,14 @@ class ContractMixin:
         in the catalog."""
         raise KeyError(name)
 
+    @property
+    def current_user(self):
+        """The operator behind the ``/ui`` view or action being served
+        (:class:`opennvr_app_sdk.UserContext`), or ``None`` when core
+        forwarded no identity. Valid only inside ``ui_html()`` /
+        ``on_action()``; ``None`` elsewhere."""
+        return _current_user()
+
     def _dispatch_action(self, name: str, params: dict[str, Any]) -> Any:
         """Gate + dispatch: only manifest-DECLARED actions reach
         on_action — an undeclared name 404s even if a handler would
@@ -426,6 +464,11 @@ class ContractMixin:
             action_token=action_token,
             # Apps opt into the /ui surface by defining ui_html() -> str.
             ui=getattr(self, "ui_html", None),
+            # X-OpenNVR-User (who is viewing / acting) is signed with the
+            # sha256 of our app key; resolved per request so a key
+            # issued after start-up is honoured.
+            user_secret=lambda: signing_secret(self.credentials.app_key),
+            app_id=getattr(self.manifest, "id", None) if self.manifest else None,
             host=bind_host,
             port=int(port),
         )

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/usercontext.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/usercontext.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Who is asking — the operator behind a ``/ui`` view or an action.
+
+Core authenticates the person, then forwards their identity to the app
+in ``X-OpenNVR-User``: a short-lived HS256 JWT signed with the SHA-256
+of this app's own key (see ``credentials.py``) — a secret both sides
+hold and never exchange. Inside ``ui_html()`` and ``on_action()`` an
+app reads it with :func:`current_user`::
+
+    def on_action(self, name, params):
+        user = current_user()
+        if user is None or not user.can_see(params["camera_id"]):
+            raise ValueError("not your camera")
+
+``None`` means core sent no context (an older core, no app key issued
+yet, or a caller that is not the OpenNVR proxy). Verification is
+stdlib-only; a token that fails any check is treated as absent, never
+trusted partially.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+logger = logging.getLogger("opennvr.app.user")
+
+USER_CONTEXT_HEADER = "X-OpenNVR-User"
+_LEEWAY_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class UserContext:
+    user_id: int
+    username: str
+    is_superuser: bool = False
+    #: Camera ids (server-side ints) the user may VIEW; ``None`` = all.
+    cameras: frozenset[int] | None = None
+    #: Camera ids the user may MANAGE (control / configure); ``None`` = all.
+    manage: frozenset[int] | None = None
+    #: ``"ui"`` for a dashboard view, ``"action"`` for an invoked action.
+    purpose: str = ""
+    raw: dict = field(default_factory=dict, compare=False, repr=False)
+
+    def can_see(self, camera) -> bool:
+        """``camera`` as an int id or a ``camN`` handle."""
+        return self.cameras is None or _camera_id(camera) in self.cameras
+
+    def can_manage(self, camera) -> bool:
+        return self.manage is None or _camera_id(camera) in self.manage
+
+    def visible(self, camera_ids) -> list:
+        """Filter a list of ids/handles down to what this user may see."""
+        return [c for c in camera_ids if self.can_see(c)]
+
+
+def _camera_id(value) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    text = str(value).strip().lower()
+    if text.startswith("cam-"):
+        text = text[4:]
+    elif text.startswith("cam"):
+        text = text[3:]
+    return int(text) if text.isdigit() else None
+
+
+_CURRENT: ContextVar[UserContext | None] = ContextVar("opennvr_user", default=None)
+
+
+def current_user() -> UserContext | None:
+    """The operator behind the request being served, or ``None``."""
+    return _CURRENT.get()
+
+
+def bind_user(user: UserContext | None):
+    return _CURRENT.set(user)
+
+
+def unbind_user(token) -> None:
+    _CURRENT.reset(token)
+
+
+def signing_secret(app_key: str | None) -> str | None:
+    """What core signs with: the SHA-256 hex of the app's key."""
+    if not app_key:
+        return None
+    return hashlib.sha256(app_key.encode("utf-8")).hexdigest()
+
+
+def _b64url_decode(text: str) -> bytes:
+    pad = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(text + pad)
+
+
+def verify_user_context(token: str | None, secret: str | None, *,
+                        audience: str | None = None,
+                        now: float | None = None) -> UserContext | None:
+    """Verify an ``X-OpenNVR-User`` value. Any failure → ``None``."""
+    if not token or not secret:
+        return None
+    try:
+        header_b64, payload_b64, sig_b64 = token.split(".")
+        header = json.loads(_b64url_decode(header_b64))
+        if header.get("alg") != "HS256":
+            return None
+        expected = hmac.new(secret.encode("utf-8"),
+                            f"{header_b64}.{payload_b64}".encode("ascii"),
+                            hashlib.sha256).digest()
+        if not hmac.compare_digest(expected, _b64url_decode(sig_b64)):
+            return None
+        claims = json.loads(_b64url_decode(payload_b64))
+    except Exception:  # noqa: BLE001 — malformed = absent
+        return None
+    if claims.get("iss") != "opennvr":
+        return None
+    if audience is not None and claims.get("aud") != audience:
+        return None
+    clock = time.time() if now is None else now
+    exp = claims.get("exp")
+    if not isinstance(exp, (int, float)) or clock > float(exp) + _LEEWAY_SECONDS:
+        return None
+    try:
+        user_id = int(claims["sub"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    cams = claims.get("cameras")
+    manage = claims.get("manage")
+    return UserContext(
+        user_id=user_id,
+        username=str(claims.get("username") or ""),
+        is_superuser=bool(claims.get("is_superuser")),
+        cameras=None if cams is None else frozenset(int(c) for c in cams),
+        manage=None if manage is None else frozenset(int(c) for c in manage),
+        purpose=str(claims.get("purpose") or ""),
+        raw=claims,
+    )

--- a/sdk/opennvr-app-sdk/tests/test_usercontext.py
+++ b/sdk/opennvr-app-sdk/tests/test_usercontext.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""X-OpenNVR-User: the operator's identity and camera scope reach the
+app's /ui and actions, verified against the app's own key."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import httpx
+import pytest
+
+from opennvr_app_sdk import (
+    AlertDispatcher, AppManifest, Action, ContractServer, Detector,
+    StdoutChannel, UserContext, current_user,
+)
+from opennvr_app_sdk import usercontext as uc
+
+APP_KEY = "oak_my-app_" + "a" * 32
+SECRET = hashlib.sha256(APP_KEY.encode()).hexdigest()
+
+
+def _b64(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def mint(claims: dict, secret: str = SECRET) -> str:
+    """What core does (jose HS256), spelled out with the stdlib."""
+    head = _b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    body = _b64(json.dumps(claims).encode())
+    sig = hmac.new(secret.encode(), f"{head}.{body}".encode(), hashlib.sha256).digest()
+    return f"{head}.{body}.{_b64(sig)}"
+
+
+def _claims(**over):
+    now = int(time.time())
+    base = {"iss": "opennvr", "aud": "my-app", "sub": "7", "username": "guard",
+            "is_superuser": False, "cameras": [1, 3], "manage": [3],
+            "purpose": "action", "iat": now, "exp": now + 60}
+    base.update(over)
+    return base
+
+
+# ── verification ───────────────────────────────────────────────────────
+
+
+def test_valid_token_yields_the_user_and_scope():
+    u = uc.verify_user_context(mint(_claims()), SECRET, audience="my-app")
+    assert u == UserContext(user_id=7, username="guard", cameras=frozenset({1, 3}),
+                            manage=frozenset({3}), purpose="action")
+    assert u.can_see("cam1") and u.can_see(3) and not u.can_see("cam-2")
+    assert u.can_manage("cam3") and not u.can_manage("cam1")
+    assert u.visible(["cam1", "cam2", "cam3"]) == ["cam1", "cam3"]
+
+
+def test_superuser_sees_everything():
+    u = uc.verify_user_context(mint(_claims(is_superuser=True, cameras=None, manage=None)),
+                               SECRET)
+    assert u.is_superuser and u.cameras is None and u.can_see(999) and u.can_manage(999)
+
+
+@pytest.mark.parametrize("bad", [
+    lambda: mint(_claims(), secret="wrong"),
+    lambda: mint(_claims(exp=int(time.time()) - 120)),
+    lambda: mint(_claims(aud="other-app")),
+    lambda: mint(_claims(iss="someone")),
+    lambda: mint(_claims(sub="not-an-int")),
+    lambda: "garbage",
+    lambda: "",
+])
+def test_anything_wrong_means_no_user(bad):
+    assert uc.verify_user_context(bad(), SECRET, audience="my-app") is None
+
+
+def test_no_secret_means_no_user():
+    assert uc.verify_user_context(mint(_claims()), None) is None
+    assert uc.signing_secret(None) is None and uc.signing_secret(APP_KEY) == SECRET
+
+
+# ── through the contract server ───────────────────────────────────────
+
+
+MANIFEST = AppManifest(
+    id="my-app", name="My App", version="1.0.0", category="test", summary="t",
+    requires_tasks=[], subscribes="opennvr.inference.>", has_ui=True,
+    actions=[Action("reset", "Reset", params=[])],
+)
+
+
+class _App(Detector):
+    manifest = MANIFEST
+
+    def on_detections(self, camera_id, detections, event):
+        pass
+
+    def ui_html(self) -> str:
+        u = self.current_user
+        return f"<p>{u.username if u else 'anonymous'}</p>"
+
+    def on_action(self, name, params):
+        u = current_user()
+        return {"by": u.username if u else None,
+                "sees_cam2": bool(u and u.can_see("cam2"))}
+
+
+@pytest.fixture
+def served(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENNVR_APP_KEY", APP_KEY)
+    monkeypatch.delenv("OPENNVR_INTERNAL_API_KEY", raising=False)
+    from types import SimpleNamespace
+    cfg = SimpleNamespace(contract_port=0, contract_bind_host="127.0.0.1",
+                          nats_url="nats://x", nats_token=None, opennvr_token=None)
+    app = _App(cfg, AlertDispatcher([StdoutChannel()]))
+    server = app.start_contract_server()
+    try:
+        yield f"http://127.0.0.1:{server.port}"
+    finally:
+        app.stop_contract_server()
+
+
+def test_ui_and_actions_see_the_forwarded_user(served):
+    tok = mint(_claims(purpose="ui"))
+    assert httpx.get(f"{served}/ui", headers={"X-OpenNVR-User": tok}).text == "<p>guard</p>"
+    assert httpx.get(f"{served}/ui").text == "<p>anonymous</p>"
+    r = httpx.post(f"{served}/actions/reset", json={},
+                   headers={"X-OpenNVR-User": mint(_claims())})
+    assert r.json() == {"by": "guard", "sees_cam2": False}
+    # A forged token (wrong secret) is simply "no user".
+    r = httpx.post(f"{served}/actions/reset", json={},
+                   headers={"X-OpenNVR-User": mint(_claims(), secret="x")})
+    assert r.json() == {"by": None, "sees_cam2": False}
+    # Nothing leaks between requests.
+    assert current_user() is None

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -1050,6 +1050,12 @@ async def invoke_app_action(
         if settings.internal_api_key
         else {}
     )
+    # Who is invoking, and which cameras they may see/manage — signed
+    # for this app (services/app_user_context.py) so it can render or
+    # refuse per user without a login of its own.
+    from services.app_user_context import user_context_headers
+
+    headers.update(user_context_headers(db, row, current_user, purpose="action"))
     async with httpx.AsyncClient(timeout=ACTION_PROXY_TIMEOUT_S) as client:
         try:
             resp = await client.post(
@@ -1477,9 +1483,14 @@ async def get_app_ui(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="App URL is blocked by policy.",
         )
+    # The viewer's identity and camera scope travel with the request
+    # (signed for this app) so the page can be per-user.
+    from services.app_user_context import user_context_headers
+
+    headers = user_context_headers(db, row, current_user, purpose="ui")
     try:
         async with httpx.AsyncClient(timeout=STATUS_PROBE_TIMEOUT_S) as client:
-            resp = await client.get(f"{base_url}/ui")
+            resp = await client.get(f"{base_url}/ui", headers=headers)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/server/services/app_user_context.py
+++ b/server/services/app_user_context.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Who is asking? — user identity forwarded to an app.
+
+Core authenticates the operator on ``GET /apps/{id}/ui`` and
+``POST /apps/{id}/actions/{name}`` and then calls the app, which until
+now saw only the deployment key: no user, no camera scope. An app could
+not draw a per-user page or refuse an action on a camera the caller may
+not touch, and the camera-agent example re-implemented login just to
+find out who it was talking to.
+
+The proxies now attach ``X-OpenNVR-User``: a short-lived (60 s) HS256
+JWT describing the caller — id, username, superuser flag, the camera
+ids they may VIEW (``null`` = every camera) and MANAGE, and the purpose
+(``ui`` / ``action``). It is signed with the app's ``api_key_hash``:
+the SHA-256 of the app's own key, which the app can compute from the
+key it holds and core already stores — a per-app shared secret with
+nothing new to provision. No key issued → no context is forwarded
+(the app behaves as before).
+
+The SDK verifies it in ``opennvr_app_sdk.usercontext`` and exposes
+``current_user()`` inside ``ui_html()`` / ``on_action()``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from jose import jwt
+from sqlalchemy.orm import Session
+
+USER_CONTEXT_HEADER = "X-OpenNVR-User"
+USER_CONTEXT_TTL_SECONDS = 60
+ISSUER = "opennvr"
+
+
+def mint_user_context(db: Session, row, user, *, purpose: str) -> str | None:
+    """The signed ``X-OpenNVR-User`` value for ``user`` calling ``row``
+    (an InstalledApp), or ``None`` when the app holds no key yet."""
+    secret = getattr(row, "api_key_hash", None)
+    if not secret:
+        return None
+    from services.camera_scope import manageable_camera_ids, visible_camera_ids
+
+    view = visible_camera_ids(db, user)
+    manage = manageable_camera_ids(db, user)
+    now = datetime.now(UTC)
+    claims = {
+        "iss": ISSUER,
+        "aud": row.id,
+        "sub": str(user.id),
+        "username": user.username,
+        "is_superuser": bool(getattr(user, "is_superuser", False)),
+        "cameras": None if view is None else sorted(view),
+        "manage": None if manage is None else sorted(manage),
+        "purpose": purpose,
+        "iat": now,
+        "exp": now + timedelta(seconds=USER_CONTEXT_TTL_SECONDS),
+    }
+    return jwt.encode(claims, secret, algorithm="HS256")
+
+
+def user_context_headers(db: Session, row, user, *, purpose: str) -> dict[str, str]:
+    token = mint_user_context(db, row, user, purpose=purpose)
+    return {USER_CONTEXT_HEADER: token} if token else {}

--- a/server/tests/test_app_credentials.py
+++ b/server/tests/test_app_credentials.py
@@ -261,3 +261,120 @@ def test_app_roster_resolution_unit():
     plain, digest = app_keys.mint_key("x-app")
     assert plain.startswith("oak_x-app_") and digest == app_keys.hash_key(plain)
     assert app_keys.looks_like_app_key(plain) and not app_keys.looks_like_app_key(SITE_KEY)
+
+
+# ── user identity forwarded to the app (X-OpenNVR-User) ────────────────
+
+
+def test_ui_and_action_proxies_forward_a_signed_user_context(env, monkeypatch):
+    """Core signs the caller's identity + camera scope with the app's
+    key hash; the SDK verifies with sha256(app key). Both halves here."""
+    import sys
+
+    tc, ids, SessionLocal = env
+    key = _register(tc, _site()).json()["api_key"]
+    s = SessionLocal()
+    row = s.get(InstalledApp, "loitering-detection")
+    row.manifest_json = {**row.manifest_json, "has_ui": True,
+                         "actions": [{"name": "reset", "label": "Reset", "params": []}]}
+    row.enabled = True
+    s.commit()
+    s.close()
+
+    seen: dict[str, dict] = {}
+
+    class _Resp:
+        status_code = 200
+        content = b"<p>ok</p>"
+
+        def json(self):
+            return {"ok": True}
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, headers=None, **kw):
+            seen["ui"] = dict(headers or {})
+            return _Resp()
+
+        async def post(self, url, json=None, headers=None, **kw):
+            seen["action"] = dict(headers or {})
+            return _Resp()
+
+    monkeypatch.setattr(apps_router.httpx, "AsyncClient", _Client)
+    # A plain (non-superuser) operator granted the gate camera only.
+    s = SessionLocal()
+    from models import CameraPermission
+    guard = User(username="guard", email="g@x", hashed_password="x",
+                 role_id=s.query(Role).first().id, is_active=True)
+    s.add(guard)
+    s.flush()
+    s.add(CameraPermission(user_id=guard.id, camera_id=ids["gate"], can_view=True))
+    s.commit()
+    s.refresh(guard)
+    s.expunge(guard)
+    s.close()
+    tc.app.dependency_overrides[auth_mod.get_current_active_user] = lambda: guard
+
+    assert tc.get("/apps/loitering-detection/ui").status_code == 200
+    assert tc.post("/apps/loitering-detection/actions/reset", json={}).status_code == 200
+
+    # Verify exactly as the SDK does (stdlib HS256 over sha256(app key)).
+    sdk_path = str(REPO_ROOT / "sdk" / "opennvr-app-sdk")
+    if sdk_path not in sys.path:
+        sys.path.insert(0, sdk_path)
+    from opennvr_app_sdk.usercontext import signing_secret, verify_user_context
+
+    ui = verify_user_context(seen["ui"]["X-OpenNVR-User"], signing_secret(key),
+                             audience="loitering-detection")
+    assert ui is not None and ui.username == "guard" and ui.purpose == "ui"
+    assert ui.cameras == frozenset({ids["gate"]}) and ui.manage == frozenset()
+    act = verify_user_context(seen["action"]["X-OpenNVR-User"], signing_secret(key),
+                              audience="loitering-detection")
+    assert act is not None and act.purpose == "action" and act.user_id == guard.id
+    # Signed for THIS app: another app's secret does not verify it.
+    assert verify_user_context(seen["ui"]["X-OpenNVR-User"],
+                               signing_secret("oak_other_" + "0" * 32)) is None
+
+
+def test_no_app_key_means_no_user_context(env, monkeypatch):
+    tc, ids, SessionLocal = env
+    _register(tc, _site())
+    s = SessionLocal()
+    row = s.get(InstalledApp, "loitering-detection")
+    row.manifest_json = {**row.manifest_json, "has_ui": True}
+    app_keys.revoke_key(row)
+    s.commit()
+    s.close()
+    seen = {}
+
+    class _Resp:
+        status_code = 200
+        content = b"<p>ok</p>"
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, headers=None, **kw):
+            seen["ui"] = dict(headers or {})
+            return _Resp()
+
+    monkeypatch.setattr(apps_router.httpx, "AsyncClient", _Client)
+    admin = SessionLocal().query(User).filter_by(username="admin").one()
+    tc.app.dependency_overrides[auth_mod.get_current_active_user] = lambda: admin
+    assert tc.get("/apps/loitering-detection/ui").status_code == 200
+    assert "X-OpenNVR-User" not in seen["ui"]


### PR DESCRIPTION
…_user()

Core authenticated the person on GET /apps/{id}/ui and POST /apps/{id}/actions/{name} and then called the app with nothing about them: an app could not render per user or refuse an action on a camera the caller may not touch, and the camera-agent example re-implemented login just to learn who it was talking to.

The proxies now attach X-OpenNVR-User: a 60-second HS256 JWT with the user's id, username, superuser flag, the camera ids they may view (null = all) and manage, and the purpose (ui/action) — signed with the app's api_key_hash, the sha256 of the key the app already holds, so there is a per-app shared secret with nothing new to provision. No key issued → nothing forwarded.

SDK: usercontext.py verifies it (stdlib HMAC, exp/iss/aud checked; any failure = no user), the contract server binds it for the duration of the /ui or action call, and apps read current_user() / self.current_user with can_see / can_manage / visible helpers. UserContext and current_user are package exports.

Docs: APP_SURFACES.md §5 gains "Who is asking" and the RBAC corrections for enable/disable, config and status; APP_CREDENTIALS.md links it.