### PR TITLE
Catalog & commerce contract: pricing/entitlement in manifest and inde…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,20 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Apps can be sold.** The manifest and the App Store index carry
+  `pricing` (free | paid | subscription | contact), `price_note` and
+  `entitlement` (none | license_key); the catalog shows the badge on
+  cards and listings. A licensed app cannot be enabled until an
+  administrator enters a key (`PUT /apps/{id}/license`, encrypted at
+  rest, never returned) **and the app itself accepts it** — core calls
+  the app's `POST /entitlement/verify` (SDK: override
+  `ContractMixin.verify_license` → `Entitlement`) and records the
+  verdict (status, plan, expiry, message, limits), re-delivered on the
+  app's config poll as `self.entitlement`. Re-check and forget routes;
+  402 on enable with the reason. Index entries may also be
+  `kind: external` — a third-party listing that links out
+  (`external_url`) with "Learn more" instead of Install; the validator
+  understands both kinds. `docs/APP_SURFACES.md` §5b.
 - **One platform client for apps.** `opennvr_app_sdk.OpenNVR` wraps
   everything an app reads from core and KAI-C — the camera roster,
   current snapshots, recordings (list / playback URL / frame at an

--- a/app/src/services/appsService.ts
+++ b/app/src/services/appsService.ts
@@ -28,6 +28,12 @@ export const appsService = {
   // the skill each installed app provides (status + published events).
   getSkills: () => api.get('/api/v1/skills'),
   enableApp: (id: string) => api.post(`/api/v1/apps/${id}/enable`),
+  // Licensed apps (manifest entitlement: license_key): store a key and
+  // have the app verify it; re-check; forget it. Superuser only.
+  setAppLicense: (id: string, licenseKey: string) =>
+    api.put(`/api/v1/apps/${id}/license`, { license_key: licenseKey }),
+  verifyAppLicense: (id: string) => api.post(`/api/v1/apps/${id}/license/verify`),
+  clearAppLicense: (id: string) => api.delete(`/api/v1/apps/${id}/license`),
   disableApp: (id: string) => api.post(`/api/v1/apps/${id}/disable`),
   updateAppConfig: (id: string, config: Record<string, any>) =>
     api.put(`/api/v1/apps/${id}/config`, config),

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -95,6 +95,35 @@ export type AppManifest = {
   // Vertical capabilities this app provides ("vehicles", "occupancy")
   // — first-class pages in the main nav light up per capability.
   provides?: string[]
+  // Commerce: free | paid | subscription | contact, a human price line,
+  // and whether enabling needs a licence key the app verifies.
+  pricing?: 'free' | 'paid' | 'subscription' | 'contact'
+  price_note?: string
+  entitlement?: 'none' | 'license_key'
+}
+
+// The platform's record of a licensed app's key (never the key itself)
+// and the app's own verdict on it — GET /apps and the config poll.
+export type Entitlement = {
+  mode: 'none' | 'license_key'
+  status: 'none' | 'unverified' | 'valid' | 'invalid'
+  plan?: string | null
+  expires_at?: string | null
+  message?: string
+  limits?: Record<string, any>
+  checked_at?: string | null
+  has_license_key: boolean
+}
+
+/** A small pricing badge for cards and listings; nothing for free apps. */
+function PricingBadge({ pricing, note }: { pricing?: string; note?: string }) {
+  if (!pricing || pricing === 'free') return null
+  const label = pricing === 'contact' ? 'contact for pricing' : pricing
+  return (
+    <Badge variant="neutral" title={note || undefined}>
+      {label}{note ? ` · ${note}` : ''}
+    </Badge>
+  )
 }
 
 /** Resolve an external ui_url for THIS browser: apps rarely know their
@@ -123,6 +152,7 @@ export type RegisteredApp = {
   last_seen?: string | null
   manifest?: AppManifest | null
   config?: Record<string, any> | null
+  entitlement?: Entitlement | null
 }
 
 export type AppStatusResp = {
@@ -138,11 +168,19 @@ type IndexApp = {
   summary?: string
   category: string
   version: string
-  image?: string
+  // "installable" (image + compose service) or "external" (a listing
+  // that links out — no Install button, a "Learn more" link instead).
+  kind?: 'installable' | 'external'
+  external_url?: string | null
+  pricing?: 'free' | 'paid' | 'subscription' | 'contact'
+  price_note?: string
+  entitlement?: 'none' | 'license_key'
+  author?: string
+  image?: string | null
   requires_tasks?: string[]
   emits?: string[]
   docs_url?: string
-  install?: { compose?: string; command?: string }
+  install?: { compose?: string; command?: string } | null
   installed: boolean
   enabled: boolean | null
 }
@@ -1064,6 +1102,84 @@ function skillStatusVariant(status: SkillEntry['status']): BadgeVariant {
   }
 }
 
+/** The licence line on a licensed app's card: status, plan, expiry, the
+ * app's own message; and, for administrators, the key entry itself. The
+ * key is sent once and never read back. */
+function LicensePanel({ app, isAdmin }: { app: RegisteredApp; isAdmin: boolean }) {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useSnackbar()
+  const [key, setKey] = useState('')
+  const ent = app.entitlement
+  const status = ent?.status ?? 'none'
+  const variant: BadgeVariant =
+    status === 'valid' ? 'success' : status === 'invalid' ? 'destructive' : 'warning'
+  const label =
+    status === 'valid'
+      ? `licensed${ent?.plan ? ` · ${ent.plan}` : ''}${ent?.expires_at ? ` · until ${ent.expires_at.slice(0, 10)}` : ''}`
+      : status === 'invalid'
+        ? 'licence rejected'
+        : status === 'unverified'
+          ? 'licence not yet verified'
+          : 'licence required'
+  const set = useMutation({
+    mutationFn: () => apiService.setAppLicense(app.id, key.trim()),
+    onSuccess: (res: any) => {
+      queryClient.invalidateQueries({ queryKey: ['apps'] })
+      setKey('')
+      const e = res?.data?.entitlement
+      if (e?.status === 'valid') showSuccess(`${app.name}: licence accepted`)
+      else showError(`${app.name}: ${e?.message || 'licence not accepted'}`)
+    },
+    onError: (e) => showError(extractApiError(e, 'Could not store the licence key.')),
+  })
+  const verify = useMutation({
+    mutationFn: () => apiService.verifyAppLicense(app.id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['apps'] }),
+    onError: (e) => showError(extractApiError(e, 'Could not re-verify the licence.')),
+  })
+  const clear = useMutation({
+    mutationFn: () => apiService.clearAppLicense(app.id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['apps'] }),
+    onError: (e) => showError(extractApiError(e, 'Could not clear the licence key.')),
+  })
+  return (
+    <div className="rounded border border-[var(--border)] p-2 space-y-2">
+      <div className="flex items-center gap-2 flex-wrap text-xs">
+        <Badge variant={variant}>{label}</Badge>
+        {ent?.message && status !== 'valid' && (
+          <span className="text-[var(--text-dim)]">{ent.message}</span>
+        )}
+        {ent?.limits && Object.keys(ent.limits).length > 0 && (
+          <span className="text-[var(--text-dim)]">
+            {Object.entries(ent.limits).map(([k, v]) => `${k}: ${String(v)}`).join(' · ')}
+          </span>
+        )}
+      </div>
+      {isAdmin && (
+        <div className="flex items-center gap-2">
+          <input
+            className="flex-1 px-2 py-1 text-sm font-mono rounded border border-[var(--border)] bg-[var(--bg-2)] text-[var(--text)]"
+            placeholder={ent?.has_license_key ? 'replace licence key…' : 'licence key'}
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <Button variant="outline" onClick={() => set.mutate()} disabled={!key.trim() || set.isPending}>
+            {set.isPending ? 'Verifying…' : 'Save & verify'}
+          </Button>
+          {ent?.has_license_key && (
+            <>
+              <Button variant="ghost" onClick={() => verify.mutate()} disabled={verify.isPending}>Re-check</Button>
+              <Button variant="ghost" onClick={() => clear.mutate()} disabled={clear.isPending}>Forget</Button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function AppCard({ app, tasks, skill, onConfigure }: { app: RegisteredApp; tasks: Set<string>; skill?: SkillEntry; onConfigure: () => void }) {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
@@ -1096,6 +1212,9 @@ function AppCard({ app, tasks, skill, onConfigure }: { app: RegisteredApp; tasks
   })
 
   const uninstallStatus = useInstallStatusPoll(app.id, uninstallPollActive)
+  // A licensed app cannot be enabled until the app has accepted a key.
+  const needsLicense =
+    app.manifest?.entitlement === 'license_key' && app.entitlement?.status !== 'valid'
 
   // Same opt-in + RBAC gating as install: a 403 degrades to an inline note
   // (fail-closed) rather than an error toast, since the operator may have
@@ -1142,12 +1261,17 @@ function AppCard({ app, tasks, skill, onConfigure }: { app: RegisteredApp; tasks
         </Link>
         <Badge variant="info">{app.category}</Badge>
         <span className="text-xs text-[var(--text-dim)]">v{app.version}</span>
+        <PricingBadge pricing={app.manifest?.pricing} note={app.manifest?.price_note} />
         <div className="ml-auto">
           <AppStatusChip appId={app.id} />
         </div>
       </CardHeader>
       <CardContent className="space-y-3 text-sm">
         <div className="text-[var(--text-dim)]">{app.manifest?.summary || 'No summary provided.'}</div>
+
+        {app.manifest?.entitlement === 'license_key' && (
+          <LicensePanel app={app} isAdmin={isAdmin} />
+        )}
 
         {/* RFC-0002 Phase 1: the skill this app provides, as the platform
             registry sees it — same derivation the agent's panel renders,
@@ -1185,7 +1309,8 @@ function AppCard({ app, tasks, skill, onConfigure }: { app: RegisteredApp; tasks
           <Button
             variant={app.enabled ? 'default' : 'primary'}
             onClick={() => toggleMutation.mutate()}
-            disabled={toggleMutation.isPending}
+            disabled={toggleMutation.isPending || (!app.enabled && needsLicense)}
+            title={!app.enabled && needsLicense ? 'Enter a licence key the app accepts first' : undefined}
             aria-pressed={app.enabled}
           >
             {toggleMutation.isPending ? 'Working…' : app.enabled ? 'Disable' : 'Enable'}
@@ -1386,9 +1511,12 @@ function AvailableAppCard({ app, tasks, onInstall }: { app: IndexApp; tasks: Set
         <CardTitle>{app.name}</CardTitle>
         <Badge variant="info">{app.category}</Badge>
         <span className="text-xs text-[var(--text-dim)]">v{app.version}</span>
+        <PricingBadge pricing={app.pricing} note={app.price_note} />
+        {app.kind === 'external' && <Badge variant="neutral">third-party</Badge>}
       </CardHeader>
       <CardContent className="space-y-3 text-sm">
         <div className="text-[var(--text-dim)]">{app.summary || 'No summary provided.'}</div>
+        {app.author && <div className="text-xs text-[var(--text-dim)]">by {app.author}</div>}
 
         {requires.length > 0 && (
           <div>
@@ -1401,9 +1529,17 @@ function AvailableAppCard({ app, tasks, onInstall }: { app: IndexApp; tasks: Set
         )}
 
         <div className="flex items-center gap-2 pt-1">
-          <Button variant="primary" onClick={onInstall}>
-            <Download size={14} /> Install
-          </Button>
+          {app.kind === 'external' && app.external_url ? (
+            <a href={app.external_url} target="_blank" rel="noreferrer">
+              <Button variant="primary">
+                <ExternalLink size={14} /> Learn more
+              </Button>
+            </a>
+          ) : (
+            <Button variant="primary" onClick={onInstall}>
+              <Download size={14} /> Install
+            </Button>
+          )}
           {app.docs_url && (
             <a
               href={app.docs_url}

--- a/docs/APP_SURFACES.md
+++ b/docs/APP_SURFACES.md
@@ -237,6 +237,54 @@ site-wide params of your manifest are an administrator's to change.
 slice of your `/state`, keyed by the `camN` handles the SDK already
 uses.
 
+## 5b. Selling your app: pricing and licences
+
+Three manifest fields turn a listing into a product:
+
+```python
+AppManifest(
+    ...,
+    pricing="subscription",           # free | paid | subscription | contact
+    price_note="$29 / camera / year", # the human line under the badge
+    entitlement="license_key",        # none | license_key
+)
+```
+
+`pricing` and `price_note` are display only — the catalog shows the
+badge on your card and on your App Store listing (the index entry
+mirrors them; a listing can also be `kind: external` and link out to
+where you distribute the app). `entitlement: license_key` is the gate:
+an administrator enters a key in the catalog, core stores it encrypted
+and asks **your app** whether it is valid, and refuses to enable the
+app until you say yes. You decide what a key means:
+
+```python
+from opennvr_app_sdk import Entitlement
+
+class MyApp(Detector):
+    manifest = AppManifest(..., entitlement="license_key")
+
+    def verify_license(self, license_key: str) -> Entitlement:
+        claims = my_signature_check(license_key)          # or call your licence server
+        if claims is None:
+            return Entitlement(valid=False, message="unknown or tampered key")
+        return Entitlement(valid=True, plan=claims.plan,
+                           expires_at=claims.expires, limits={"cameras": claims.cameras})
+
+    def on_entitlement_update(self, entitlement):        # optional
+        self.max_cameras = entitlement.get("limits", {}).get("cameras")
+```
+
+Core calls `POST /entitlement/verify` on your contract port (site-key
+gated like actions), records the verdict — status, plan, expiry,
+message, limits — shows it to the administrator, and re-delivers it on
+your live config poll as `self.entitlement` so you can feature-gate
+yourself. Re-verification runs on every key change and on demand
+(`POST /apps/{id}/license/verify`); an app that is unreachable when
+asked keeps its previous verdict, so a restart never silently
+un-licenses a site. Core never sees your licence logic and never
+returns the key to anyone.
+
 ## 6. "What if I really need custom UI?"
 
 You don't ship one — that's the platform bet that keeps a community

--- a/docs/apps-index-entry.template.yml
+++ b/docs/apps-index-entry.template.yml
@@ -21,6 +21,21 @@
                                    #   forensics | integration. Reuse an existing one.
   version: "1.0.0"                 # REQUIRED. Matches AppManifest.version. QUOTE IT — a bare 1.0 parses as a YAML float and the validator rejects it.
 
+  # ── Kind & commerce (all OPTIONAL; defaults shown) ──────────────────
+  kind: installable                # installable (image + compose service below) or
+                                   #   external: a listing that links out — your app is
+                                   #   distributed elsewhere; the catalog shows "Learn more"
+                                   #   and never offers Install. External entries carry
+                                   #   external_url (https://) and NO image / install block.
+  # external_url: https://example.com/my-app
+  pricing: free                    # free | paid | subscription | contact — the badge on the card.
+  price_note: ""                   # The human line under it: "$29 / camera / year".
+  entitlement: none                # none | license_key. license_key = an administrator enters
+                                   #   a key in the catalog, core asks YOUR app to verify it
+                                   #   (ContractMixin.verify_license) and refuses to enable the
+                                   #   app until it says yes. Mirror these three in AppManifest.
+  author: ""                       # Shown as "by <author>" on the listing.
+
   image: ghcr.io/<you>/my-app:latest   # REQUIRED. Well-formed ref — ghcr.io/... or
                                        #   opennvr/... . This is the canonical pull ref
                                        #   the one-click installer deploys.

--- a/scripts/validate_apps_index.py
+++ b/scripts/validate_apps_index.py
@@ -334,8 +334,35 @@ def validate_entry(
     if not isinstance(entry, dict):
         return [f"{label}: not a mapping (got {type(entry).__name__})"], warnings
 
+    # kind: "installable" (default — image + compose service) or
+    # "external" (a link-out listing: no image, no install, an https
+    # external_url). Commerce fields mirror the manifest.
+    kind = entry.get("kind", "installable")
+    if kind not in ("installable", "external"):
+        errors.append(f"{label}: kind must be 'installable' or 'external' (got {kind!r})")
+        kind = "installable"
+    external = kind == "external"
+    if external:
+        ext = entry.get("external_url")
+        if not isinstance(ext, str) or not ext.startswith("https://"):
+            errors.append(f"{label}: external entries need an https:// external_url")
+        for forbidden in ("install", "image", "build_context", "image_digest"):
+            if entry.get(forbidden):
+                errors.append(
+                    f"{label}: external entries must not carry '{forbidden}' — "
+                    "a listing that links out is never installed by the reconciler")
+    pricing = entry.get("pricing", "free")
+    if pricing not in ("free", "paid", "subscription", "contact"):
+        errors.append(f"{label}: pricing must be free | paid | subscription | contact")
+    if entry.get("entitlement", "none") not in ("none", "license_key"):
+        errors.append(f"{label}: entitlement must be none | license_key")
+    if pricing != "free" and not entry.get("price_note"):
+        warnings.append(f"{label}: pricing is '{pricing}' but price_note is empty")
+
     # Required fields present + non-empty.
-    for field in REQUIRED_FIELDS:
+    required = tuple(f for f in REQUIRED_FIELDS
+                     if not (external and f in ("image", "install")))
+    for field in required:
         if field not in entry:
             errors.append(f"{label}: missing required field '{field}'")
         elif field != "requires_tasks" and not entry[field]:
@@ -377,7 +404,9 @@ def validate_entry(
         # docker-compose.apps.yml — an entry without a service block
         # there fails on install for EVERY user (review finding: 8 of 10
         # original entries were uninstallable exactly this way).
-        if overlay_services is not None and app_id not in overlay_services:
+        if external:
+            pass   # nothing to install; the service-block contract does not apply
+        elif overlay_services is not None and app_id not in overlay_services:
             errors.append(
                 f"{label}: id '{app_id}' has no service block in "
                 "docker-compose.apps.yml — the entry is uninstallable. "
@@ -465,7 +494,9 @@ def validate_entry(
 
     # install: compose + command both present, non-empty, and SAFE.
     install = entry.get("install")
-    if not isinstance(install, dict):
+    if external:
+        pass   # no install block by construction (checked above)
+    elif not isinstance(install, dict):
         errors.append(f"{label}: install must be a mapping with compose + command")
     else:
         compose = install.get("compose")

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -36,7 +36,7 @@ from .alerts import (
 )
 from .alert_subscriber import AlertSubscriber, AlertSubscriberRunner, alert_app
 from .config import load_yaml, require
-from .contract import ContractServer
+from .contract import ContractServer, Entitlement
 from .detector import AppRunner, Detector, app
 from .frame_app import FrameApp, FrameSource, KaiCClient, KaiCError
 from .frame_sources import (
@@ -49,7 +49,9 @@ from .frame_sources import (
     dict_frame_source,
 )
 from .geometry import Point, Tripwire, Zone, bbox_center
-from .manifest import Action, AlertType, AppManifest, Param, StateView
+from .manifest import (
+    ENTITLEMENT_MODES, PRICING_MODELS, Action, AlertType, AppManifest, Param, StateView,
+)
 from .state import KeyedState, StateRecord, keyed_state
 from .domain_events import DomainEventPublisher, domain_envelope, domain_subject
 from .events import EventsClient, StoredEvent
@@ -105,6 +107,9 @@ __all__ = [
     "DEFAULT_ALERT_SUBJECT_PREFIX",
     # Manifest
     "AppManifest",
+    "PRICING_MODELS",
+    "ENTITLEMENT_MODES",
+    "Entitlement",
     "Param",
     "AlertType",
     "StateView",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/contract.py
@@ -71,6 +71,7 @@ import os
 import socket
 import threading
 import time
+from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Callable
 
@@ -104,6 +105,33 @@ CONFIG_POLL_TIMEOUT_SECONDS = 5.0
 # Content-Length from forcing an arbitrary-size read into memory on this
 # (internal-network) surface.
 ACTION_BODY_MAX_BYTES = 8 * 1024 * 1024
+
+@dataclass(frozen=True)
+class Entitlement:
+    """A licence verdict from :meth:`ContractMixin.verify_license`."""
+
+    valid: bool
+    plan: str = ""
+    expires_at: str | None = None      # ISO 8601, or None = no expiry
+    message: str = ""                  # shown to the administrator
+    #: Optional limits the app wants the catalog to display ("2 cameras").
+    limits: dict[str, Any] = field(default_factory=dict)
+
+
+def _entitlement_dict(verdict: Any) -> dict[str, Any]:
+    if isinstance(verdict, Entitlement):
+        return {"valid": bool(verdict.valid), "plan": verdict.plan,
+                "expires_at": verdict.expires_at, "message": verdict.message,
+                "limits": dict(verdict.limits)}
+    if isinstance(verdict, dict):
+        return {"valid": bool(verdict.get("valid")),
+                "plan": str(verdict.get("plan") or ""),
+                "expires_at": verdict.get("expires_at"),
+                "message": str(verdict.get("message") or ""),
+                "limits": dict(verdict.get("limits") or {})}
+    return {"valid": bool(verdict), "plan": "", "expires_at": None,
+            "message": "", "limits": {}}
+
 
 # Captured at import so the contract counters keep reading the REAL
 # clock even when an app's tests monkeypatch ``time.monotonic`` to
@@ -173,6 +201,9 @@ class _ContractRequestHandler(BaseHTTPRequestHandler):
         bad params its ValueError → 400, anything else a 500. The
         server itself never interprets action semantics."""
         path = self.path.split("?", 1)[0].rstrip("/")
+        if path == "/entitlement/verify":
+            self._verify_entitlement()
+            return
         action = getattr(self.server, "action", None)
         if action is None or not path.startswith("/actions/"):
             self._send_json(404, {"error": f"unknown path {path!r}"})
@@ -225,6 +256,38 @@ class _ContractRequestHandler(BaseHTTPRequestHandler):
             unbind_user(bound)
         self._send_json(200, result if result is not None else {})
 
+    def _verify_entitlement(self) -> None:
+        """``POST /entitlement/verify`` — core asks whether a licence key
+        the administrator entered is valid for this app. Key-gated like
+        actions; the verdict comes from ``ContractMixin.verify_license``."""
+        verifier = getattr(self.server, "license_verifier", None)
+        if verifier is None:
+            self._send_json(404, {"error": "this app has no licence verifier"})
+            return
+        expected_token = getattr(self.server, "action_token", None)
+        if expected_token:
+            import hmac
+
+            presented = self.headers.get("X-Internal-Api-Key") or ""
+            if not hmac.compare_digest(str(presented), str(expected_token)):
+                self._send_json(401, {"error": "requires X-Internal-Api-Key"})
+                return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length) if 0 < length <= 64 * 1024 else b"{}"
+            body = json.loads(raw.decode("utf-8") or "{}")
+            key = str((body or {}).get("license_key") or "")
+        except (ValueError, RecursionError) as exc:
+            self._send_json(400, {"error": f"bad body: {exc}"})
+            return
+        try:
+            verdict = verifier(key)
+        except Exception:
+            logger.exception("verify_license raised")
+            self._send_json(500, {"error": "internal error"})
+            return
+        self._send_json(200, _entitlement_dict(verdict))
+
     def _user_context(self):
         """The operator core says is behind this request (verified
         against this app's key), or None — see usercontext.py."""
@@ -261,6 +324,8 @@ class _ContractHTTPServer(ThreadingHTTPServer):
     # app key) or None, plus the manifest id the token must be for.
     user_secret: "Callable[[], str | None] | None"
     app_id: "str | None"
+    # POST /entitlement/verify: (license_key) -> Entitlement | dict.
+    license_verifier: "Callable[[str], Any] | None"
 
 
 class ContractServer:
@@ -283,6 +348,7 @@ class ContractServer:
         ui: "Callable[[], str] | None" = None,
         user_secret: "Callable[[], str | None] | None" = None,
         app_id: "str | None" = None,
+        license_verifier: "Callable[[str], Any] | None" = None,
         host: str = "0.0.0.0",
         port: int = 0,
     ) -> None:
@@ -294,6 +360,7 @@ class ContractServer:
         self._ui = ui
         self._user_secret = user_secret
         self._app_id = app_id
+        self._license_verifier = license_verifier
         self._server: _ContractHTTPServer | None = None
         self._thread: threading.Thread | None = None
 
@@ -316,6 +383,7 @@ class ContractServer:
         server.ui = self._ui
         server.user_secret = self._user_secret
         server.app_id = self._app_id
+        server.license_verifier = self._license_verifier
         self._server = server
         self._thread = threading.Thread(
             target=server.serve_forever,
@@ -417,6 +485,38 @@ class ContractMixin:
         in the catalog."""
         raise KeyError(name)
 
+    # ── Entitlement (licensed apps) ─────────────────────────────────
+
+    #: What core last told us about our licence (the live config poll
+    #: delivers it): ``{"status", "plan", "expires_at", "message"}`` or
+    #: ``None`` before the first poll. Status is "none" (the manifest
+    #: declares no entitlement), "unverified", "valid" or "invalid".
+    entitlement: dict[str, Any] | None = None
+
+    def verify_license(self, license_key: str) -> "Entitlement | dict[str, Any]":
+        """Override in a licensed app (``manifest.entitlement ==
+        "license_key"``): decide whether ``license_key`` is valid for
+        THIS deployment — check a signature, call your licence server,
+        compare a hash — and return an :class:`Entitlement`. Core calls
+        this through ``POST /entitlement/verify`` when an administrator
+        enters the key and on every re-check; it never sees your
+        logic, only the verdict. The default answers "valid" for apps
+        that declare no entitlement and "invalid" otherwise, so a
+        licensed app that forgets to override cannot be enabled by
+        accident."""
+        mode = getattr(self.manifest, "entitlement", "none") if self.manifest else "none"
+        if mode == "none":
+            return Entitlement(valid=True, plan="free")
+        return Entitlement(
+            valid=False,
+            message="this app declares license_key entitlement but does not "
+                    "implement verify_license()")
+
+    def on_entitlement_update(self, entitlement: dict[str, Any]) -> None:
+        """Optional hook — called from the config poll whenever core's
+        view of the licence changes (a key entered, a verdict flipping,
+        an expiry). Feature-gate on ``self.entitlement`` here."""
+
     @property
     def current_user(self):
         """The operator behind the ``/ui`` view or action being served
@@ -469,6 +569,7 @@ class ContractMixin:
             # issued after start-up is honoured.
             user_secret=lambda: signing_secret(self.credentials.app_key),
             app_id=getattr(self.manifest, "id", None) if self.manifest else None,
+            license_verifier=self.verify_license,
             host=bind_host,
             port=int(port),
         )
@@ -656,6 +757,17 @@ class ContractMixin:
             return
         if not isinstance(config, dict):
             return
+        # The licence verdict rides the same poll (registry stores it).
+        try:
+            ent = response.json().get("entitlement")
+        except Exception:  # noqa: BLE001
+            ent = None
+        if isinstance(ent, dict) and ent != self.entitlement:
+            self.entitlement = ent
+            try:
+                self.on_entitlement_update(dict(ent))
+            except Exception:
+                logger.exception("on_entitlement_update raised")
         if config == self._applied_config:
             return
         self._applied_config = config

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
@@ -33,6 +33,11 @@ def _type_name(t: Any) -> str:
     return str(t)
 
 
+#: Manifest ``pricing`` values the catalog understands.
+PRICING_MODELS = frozenset({"free", "paid", "subscription", "contact"})
+#: Manifest ``entitlement`` values: how enabling is gated.
+ENTITLEMENT_MODES = frozenset({"none", "license_key"})
+
 @dataclass
 class Param:
     """One typed, declarative config knob.
@@ -251,7 +256,28 @@ class AppManifest:
     # as a "contact" action. Empty = no contact surface shown.
     contact: str = ""
 
+    # ── Commerce (the catalog's pricing badge and the licence gate) ─
+    # ``pricing``: "free" (default) | "paid" | "subscription" | "contact".
+    # ``price_note``: the human line under the badge — "$29 / camera /
+    # year", "free for 2 cameras". ``entitlement``: how the platform
+    # decides the app may be enabled — "none" (default: always) or
+    # "license_key": an administrator enters a key in the catalog, core
+    # asks the app to verify it (``ContractMixin.verify_license``) and
+    # refuses to enable the app until the app says the key is valid.
+    # The verdict is the app's — core stores the key (encrypted) and
+    # the verdict, and re-delivers both on the live config poll.
+    pricing: str = "free"
+    price_note: str = ""
+    entitlement: str = "none"
+
     def __post_init__(self) -> None:
+        if self.pricing not in PRICING_MODELS:
+            raise ValueError(
+                f"pricing must be one of {sorted(PRICING_MODELS)}, got {self.pricing!r}")
+        if self.entitlement not in ENTITLEMENT_MODES:
+            raise ValueError(
+                f"entitlement must be one of {sorted(ENTITLEMENT_MODES)}, "
+                f"got {self.entitlement!r}")
         if self.ui_mode not in ("internal", "external"):
             raise ValueError(
                 f"ui_mode must be 'internal' or 'external', got {self.ui_mode!r}"
@@ -289,4 +315,7 @@ class AppManifest:
             "license": self.license,
             "use_cases": list(self.use_cases),
             "contact": self.contact,
+            "pricing": self.pricing,
+            "price_note": self.price_note,
+            "entitlement": self.entitlement,
         }

--- a/sdk/opennvr-app-sdk/tests/test_entitlement.py
+++ b/sdk/opennvr-app-sdk/tests/test_entitlement.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Commerce fields on the manifest and the licence-verification hook."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from opennvr_app_sdk import (
+    AlertDispatcher, AppManifest, Detector, Entitlement, StdoutChannel,
+)
+from opennvr_app_sdk import contract as contract_mod
+
+
+def _manifest(**over):
+    base = dict(id="paid-app", name="Paid", version="1.0.0", category="test",
+                summary="t", requires_tasks=[], subscribes="opennvr.inference.>")
+    base.update(over)
+    return AppManifest(**base)
+
+
+def test_manifest_commerce_fields_default_and_validate():
+    free = _manifest()
+    assert free.pricing == "free" and free.entitlement == "none"
+    d = free.to_dict()
+    assert (d["pricing"], d["price_note"], d["entitlement"]) == ("free", "", "none")
+    paid = _manifest(pricing="subscription", price_note="$29 / camera / year",
+                     entitlement="license_key")
+    assert paid.to_dict()["entitlement"] == "license_key"
+    with pytest.raises(ValueError, match="pricing"):
+        _manifest(pricing="donationware")
+    with pytest.raises(ValueError, match="entitlement"):
+        _manifest(entitlement="honor-system")
+
+
+class _Free(Detector):
+    manifest = _manifest(id="free-app")
+
+    def on_detections(self, *a):
+        pass
+
+
+class _Licensed(Detector):
+    manifest = _manifest(pricing="paid", entitlement="license_key")
+    updates: list = []
+
+    def on_detections(self, *a):
+        pass
+
+    def verify_license(self, license_key):
+        if license_key == "GOOD-KEY":
+            return Entitlement(valid=True, plan="pro", expires_at="2027-01-01",
+                               limits={"cameras": 8})
+        return Entitlement(valid=False, message="unknown key")
+
+    def on_entitlement_update(self, entitlement):
+        self.updates.append(entitlement)
+
+
+class _Forgot(Detector):
+    manifest = _manifest(id="forgot", entitlement="license_key")
+
+    def on_detections(self, *a):
+        pass
+
+
+def _serve(cls, monkeypatch):
+    monkeypatch.setenv("OPENNVR_INTERNAL_API_KEY", "site")
+    cfg = SimpleNamespace(contract_port=0, contract_bind_host="127.0.0.1",
+                          nats_url="nats://x", nats_token=None, opennvr_token=None)
+    app = cls(cfg, AlertDispatcher([StdoutChannel()]))
+    server = app.start_contract_server()
+    return app, f"http://127.0.0.1:{server.port}"
+
+
+def test_default_verdicts(monkeypatch):
+    free, _ = _serve(_Free, monkeypatch)
+    assert free.verify_license("anything").valid is True
+    forgot, _ = _serve(_Forgot, monkeypatch)
+    v = forgot.verify_license("anything")
+    assert v.valid is False and "verify_license" in v.message
+
+
+def test_verify_route_is_key_gated_and_returns_the_verdict(monkeypatch):
+    app, base = _serve(_Licensed, monkeypatch)
+    try:
+        h = {"X-Internal-Api-Key": "site"}
+        assert httpx.post(f"{base}/entitlement/verify", json={"license_key": "x"}).status_code == 401
+        r = httpx.post(f"{base}/entitlement/verify", json={"license_key": "GOOD-KEY"}, headers=h)
+        assert r.json() == {"valid": True, "plan": "pro", "expires_at": "2027-01-01",
+                            "message": "", "limits": {"cameras": 8}}
+        r = httpx.post(f"{base}/entitlement/verify", json={"license_key": "BAD"}, headers=h)
+        assert r.json()["valid"] is False and r.json()["message"] == "unknown key"
+    finally:
+        app.stop_contract_server()
+
+
+def test_config_poll_delivers_the_entitlement(monkeypatch):
+    app, _ = _serve(_Licensed, monkeypatch)
+    app.stop_contract_server()
+    _Licensed.updates = []
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"config": {"a": 1},
+                    "entitlement": {"status": "valid", "plan": "pro",
+                                    "expires_at": "2027-01-01", "message": ""}}
+
+    monkeypatch.setattr(contract_mod.httpx, "get", lambda *a, **k: _Resp())
+    app._config_poll_once("http://core/api/v1/apps/paid-app/config", {})
+    assert app.entitlement["status"] == "valid"
+    assert _Licensed.updates == [app.entitlement]
+    # Unchanged verdict → no second hook call.
+    app._config_poll_once("http://core/api/v1/apps/paid-app/config", {})
+    assert len(_Licensed.updates) == 1

--- a/server/migrations/versions/d7f3a2c9e1b4_add_app_entitlements.py
+++ b/server/migrations/versions/d7f3a2c9e1b4_add_app_entitlements.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""add installed_apps licence + entitlement columns
+
+Revision ID: d7f3a2c9e1b4
+Revises: c4e7a9d1f2b3
+Create Date: 2026-09-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d7f3a2c9e1b4"
+down_revision = "c4e7a9d1f2b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("installed_apps") as b:
+        b.add_column(sa.Column("license_key_encrypted", sa.Text(), nullable=True))
+        b.add_column(sa.Column("entitlement_status", sa.String(16), nullable=False,
+                               server_default="none"))
+        b.add_column(sa.Column("entitlement_plan", sa.String(100), nullable=True))
+        b.add_column(sa.Column("entitlement_expires_at", sa.DateTime(timezone=True),
+                               nullable=True))
+        b.add_column(sa.Column("entitlement_message", sa.String(500), nullable=True))
+        b.add_column(sa.Column("entitlement_limits", sa.JSON(), nullable=True))
+        b.add_column(sa.Column("entitlement_checked_at", sa.DateTime(timezone=True),
+                               nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("installed_apps") as b:
+        for col in ("entitlement_checked_at", "entitlement_limits",
+                    "entitlement_message", "entitlement_expires_at",
+                    "entitlement_plan", "entitlement_status",
+                    "license_key_encrypted"):
+            b.drop_column(col)

--- a/server/models.py
+++ b/server/models.py
@@ -1098,6 +1098,18 @@ class InstalledApp(Base):
     # platform components (detect-pipeline, KAI-C, the agent).
     api_key_hash = Column(String(64), nullable=True, index=True)
     api_key_issued_at = Column(DateTime(timezone=True), nullable=True)
+    # Licensed apps (manifest ``entitlement: license_key``): the key the
+    # administrator entered, Fernet-encrypted at rest and never returned;
+    # and the app's own verdict on it (services/app_entitlements.py).
+    # status: none | unverified | valid | invalid.
+    license_key_encrypted = Column(Text, nullable=True)
+    entitlement_status = Column(String(16), nullable=False, default="none",
+                                server_default="none")
+    entitlement_plan = Column(String(100), nullable=True)
+    entitlement_expires_at = Column(DateTime(timezone=True), nullable=True)
+    entitlement_message = Column(String(500), nullable=True)
+    entitlement_limits = Column(JSON, nullable=True)
+    entitlement_checked_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -47,7 +47,7 @@ import httpx
 import yaml
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -60,6 +60,9 @@ from services.app_keys import (
     resolve_app_key, revoke_key,
 )
 from services.audit_service import write_audit_log
+from services.app_entitlements import (
+    entitlement_view, may_enable, store_license_key, verify_with_app,
+)
 
 # The one-click install/uninstall endpoints require this RBAC permission
 # (in addition to the APPS_INSTALL_ENABLED opt-in). Reused as a FastAPI
@@ -113,20 +116,46 @@ class IndexEntry(BaseModel):
     summary: str
     category: str
     version: str
-    image: str
+    # "installable" (default): a shipped image + compose service the
+    # one-click installer applies. "external": a listing that links out
+    # — a third-party app distributed elsewhere; the catalog shows
+    # "Learn more" and never offers Install.
+    kind: str = "installable"
+    image: str | None = None
+    external_url: str | None = None
+    # Commerce, mirroring the manifest: free | paid | subscription |
+    # contact, a human price line, and whether enabling needs a licence.
+    pricing: str = "free"
+    price_note: str = ""
+    entitlement: str = "none"
+    author: str = ""
     requires_tasks: list[str] = []
     # RFC-0002 Phase 3 (decision 7): KAI-C adapters that must be
     # provisioned with the app; the reconciler ups + refcounts them.
     requires_adapters: list[str] = []
     emits: list[str] = []
     docs_url: str
-    install: InstallSpec
+    install: InstallSpec | None = None
     build_context: str | None = None
     # Optional sha256 digest the reconciler pins the image to. When
     # present, the one-click installer deploys ``image@sha256:...`` for
     # supply-chain integrity; when absent, the reconciler logs a loud
     # "UNPINNED — dev only" warning. Not for production without a digest.
     image_digest: str | None = None
+
+    @model_validator(mode="after")
+    def _shape_by_kind(self) -> "IndexEntry":
+        if self.kind not in ("installable", "external"):
+            raise ValueError("kind must be 'installable' or 'external'")
+        if self.kind == "installable" and (not self.image or self.install is None):
+            raise ValueError("installable entries need image + install")
+        if self.kind == "external" and not (self.external_url or "").startswith("https://"):
+            raise ValueError("external entries need an https:// external_url")
+        if self.pricing not in ("free", "paid", "subscription", "contact"):
+            raise ValueError("pricing must be free | paid | subscription | contact")
+        if self.entitlement not in ("none", "license_key"):
+            raise ValueError("entitlement must be none | license_key")
+        return self
 
 
 @lru_cache(maxsize=1)
@@ -559,6 +588,8 @@ def _serialize_app(row: InstalledApp) -> dict[str, Any]:
         # Credential state only — the key itself is returned once, at issue.
         "has_api_key": bool(row.api_key_hash),
         "api_key_issued_at": row.api_key_issued_at,
+        # Licence verdict (never the key) — services/app_entitlements.py.
+        "entitlement": entitlement_view(row),
     }
 
 
@@ -638,14 +669,20 @@ async def get_apps_index(
                 "summary": entry.summary,
                 "category": entry.category,
                 "version": entry.version,
+                "kind": entry.kind,
                 "image": entry.image,
+                "external_url": entry.external_url,
+                "pricing": entry.pricing,
+                "price_note": entry.price_note,
+                "entitlement": entry.entitlement,
+                "author": entry.author,
                 "requires_tasks": entry.requires_tasks,
                 "emits": entry.emits,
                 "docs_url": entry.docs_url,
                 "install": {
                     "compose": entry.install.compose,
                     "command": entry.install.command,
-                },
+                } if entry.install is not None else None,
                 "installed": row is not None,
                 "enabled": bool(row.enabled) if row is not None else None,
             }
@@ -786,8 +823,14 @@ async def enable_app(
     Enable an app. 404 if the app was never registered.
 
     Superuser only — turning a site-wide app on is a site decision.
+    A licensed app (manifest ``entitlement: license_key``) also needs
+    a key the app has accepted — 402 otherwise, with the reason.
     """
     row = _get_app_or_404(db, app_id)
+    allowed, reason = may_enable(row)
+    if not allowed:
+        raise HTTPException(status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                            detail=f"Cannot enable '{app_id}': {reason}")
     row.enabled = True
     db.commit()
     db.refresh(row)
@@ -864,6 +907,9 @@ async def get_app_config(
         "id": row.id,
         "config": config,
         "updated_at": row.updated_at,
+        # The licence verdict rides the live config poll so the app can
+        # feature-gate itself (ContractMixin.entitlement).
+        "entitlement": entitlement_view(row),
     }
 
 
@@ -1087,6 +1133,65 @@ async def invoke_app_action(
         )
 
 
+class LicenseIn(BaseModel):
+    license_key: str
+
+
+@router.put("/{app_id}/license")
+async def put_app_license(
+    app_id: str,
+    payload: LicenseIn,
+    current_user: User = Depends(get_current_superuser),
+    db: Session = Depends(get_db),
+):
+    """Store a licence key (encrypted, never returned) and ask the app
+    to verify it. Superuser only. Returns the verdict; enabling the app
+    is refused until it is ``valid``."""
+    row = _get_app_or_404(db, app_id)
+    key = payload.license_key.strip()
+    if not key or len(key) > 2000:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="license_key must be 1..2000 characters")
+    store_license_key(row, key)
+    db.commit()
+    view = await verify_with_app(row)
+    db.commit()
+    write_audit_log(db, action="app.license.set", user_id=current_user.id,
+                    entity_type="app", entity_id=app_id,
+                    details={"status": view["status"], "plan": view["plan"]})
+    return {"id": app_id, "entitlement": view}
+
+
+@router.post("/{app_id}/license/verify")
+async def verify_app_license(
+    app_id: str,
+    current_user: User = Depends(get_current_superuser),
+    db: Session = Depends(get_db),
+):
+    """Re-ask the app about the stored key (after a renewal, or when the
+    app was down when the key was entered)."""
+    row = _get_app_or_404(db, app_id)
+    view = await verify_with_app(row)
+    db.commit()
+    return {"id": app_id, "entitlement": view}
+
+
+@router.delete("/{app_id}/license")
+async def delete_app_license(
+    app_id: str,
+    current_user: User = Depends(get_current_superuser),
+    db: Session = Depends(get_db),
+):
+    """Forget the key. A licensed app that is enabled stays enabled
+    until it is next toggled — revoking a key is not an outage."""
+    row = _get_app_or_404(db, app_id)
+    store_license_key(row, None)
+    db.commit()
+    write_audit_log(db, action="app.license.clear", user_id=current_user.id,
+                    entity_type="app", entity_id=app_id)
+    return {"id": app_id, "entitlement": entitlement_view(row)}
+
+
 @router.post("/{app_id}/key/rotate")
 async def rotate_app_key(
     app_id: str,
@@ -1250,6 +1355,14 @@ def _index_entry_or_404(app_id: str) -> IndexEntry:
         )
     for entry in entries:
         if entry.id == app_id:
+            if entry.kind != "installable":
+                # A link-out listing has no image and no compose service:
+                # nothing for the reconciler to apply.
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"App '{app_id}' is an external listing — install it "
+                           f"from {entry.external_url}",
+                )
             return entry
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,

--- a/server/services/app_entitlements.py
+++ b/server/services/app_entitlements.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Licensed apps — the platform side of ``manifest.entitlement``.
+
+An app that declares ``entitlement: license_key`` cannot be enabled
+until an administrator enters a licence key AND the app itself says
+the key is valid. Core is deliberately not the judge: it stores the key
+(Fernet-encrypted, never returned), asks the app over its contract
+surface (``POST {app}/entitlement/verify``, site-key gated like
+actions) and records the verdict — status, plan, expiry, message,
+limits. The verdict rides the app's live config poll so the app can
+feature-gate itself, and the catalog shows it to the administrator.
+
+Free apps (``entitlement: none``) have status ``none`` and are never
+asked. Re-verification happens on every key change and on demand
+(``POST /apps/{id}/license/verify``); an app that is unreachable when
+asked keeps its previous verdict with a message, so a restart never
+silently un-licenses a site.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from sqlalchemy.orm import Session
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+VERIFY_TIMEOUT_S = 10.0
+STATUSES = ("none", "unverified", "valid", "invalid")
+
+
+def entitlement_mode(row) -> str:
+    manifest = row.manifest_json if isinstance(row.manifest_json, dict) else {}
+    mode = str(manifest.get("entitlement") or "none")
+    return mode if mode in ("none", "license_key") else "none"
+
+
+def requires_license(row) -> bool:
+    return entitlement_mode(row) == "license_key"
+
+
+def entitlement_view(row) -> dict[str, Any]:
+    """What the catalog, the app and ``GET /apps`` see — never the key."""
+    return {
+        "mode": entitlement_mode(row),
+        "status": row.entitlement_status or "none",
+        "plan": row.entitlement_plan,
+        "expires_at": row.entitlement_expires_at.isoformat()
+        if row.entitlement_expires_at else None,
+        "message": row.entitlement_message or "",
+        "limits": row.entitlement_limits or {},
+        "checked_at": row.entitlement_checked_at.isoformat()
+        if row.entitlement_checked_at else None,
+        "has_license_key": bool(row.license_key_encrypted),
+    }
+
+
+def may_enable(row) -> tuple[bool, str]:
+    """Whether the app may be switched on, and why not."""
+    if not requires_license(row):
+        return True, ""
+    if row.entitlement_status == "valid":
+        expires = row.entitlement_expires_at
+        if expires is not None and expires.tzinfo is None:
+            expires = expires.replace(tzinfo=UTC)   # SQLite hands back naive
+        if expires is not None and expires < datetime.now(UTC):
+            return False, "the licence has expired"
+        return True, ""
+    if not row.license_key_encrypted:
+        return False, "this app requires a licence key — enter one in the catalog"
+    return False, (row.entitlement_message
+                   or "the app has not accepted the licence key")
+
+
+def _vault():
+    from services.credential_vault_service import CredentialVaultService
+
+    return CredentialVaultService(settings)
+
+
+def store_license_key(row, license_key: str | None) -> None:
+    """Set (encrypted) or clear the key; the verdict resets to
+    unverified / none until the app is asked."""
+    if license_key:
+        row.license_key_encrypted = _vault().encrypt_token(license_key.strip())
+        row.entitlement_status = "unverified"
+    else:
+        row.license_key_encrypted = None
+        row.entitlement_status = "none"
+    row.entitlement_plan = None
+    row.entitlement_expires_at = None
+    row.entitlement_message = None
+    row.entitlement_limits = None
+    row.entitlement_checked_at = None
+
+
+def _stored_key(row) -> str | None:
+    if not row.license_key_encrypted:
+        return None
+    try:
+        return _vault().decrypt_token(row.license_key_encrypted)
+    except Exception:  # noqa: BLE001
+        logger.error("app %s: stored licence key could not be decrypted", row.id)
+        return None
+
+
+async def verify_with_app(row) -> dict[str, Any]:
+    """Ask the app; record and return its verdict.
+
+    Transport failure keeps the previous status (an unreachable app is
+    not an invalid licence) and records the failure in ``message``.
+    """
+    now = datetime.now(UTC)
+    if not requires_license(row):
+        row.entitlement_status = "none"
+        row.entitlement_checked_at = now
+        return entitlement_view(row)
+    key = _stored_key(row)
+    if not key:
+        row.entitlement_status = "none"
+        row.entitlement_message = "no licence key stored"
+        row.entitlement_checked_at = now
+        return entitlement_view(row)
+    headers = ({"X-Internal-Api-Key": settings.internal_api_key}
+               if settings.internal_api_key else {})
+    try:
+        async with httpx.AsyncClient(timeout=VERIFY_TIMEOUT_S) as client:
+            resp = await client.post(f"{row.url.rstrip('/')}/entitlement/verify",
+                                     json={"license_key": key}, headers=headers)
+        if resp.status_code != 200:
+            raise RuntimeError(f"HTTP {resp.status_code}: {resp.text[:200]}")
+        verdict = resp.json()
+        if not isinstance(verdict, dict):
+            raise RuntimeError("non-object verdict")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("app %s: licence verification unreachable: %s", row.id, exc)
+        if row.entitlement_status in ("none", "unverified"):
+            row.entitlement_status = "unverified"
+        row.entitlement_message = f"could not reach the app to verify: {exc}"[:500]
+        row.entitlement_checked_at = now
+        return entitlement_view(row)
+
+    row.entitlement_status = "valid" if verdict.get("valid") else "invalid"
+    row.entitlement_plan = (str(verdict.get("plan") or "")[:100]) or None
+    row.entitlement_message = (str(verdict.get("message") or "")[:500]) or None
+    limits = verdict.get("limits")
+    row.entitlement_limits = limits if isinstance(limits, dict) else None
+    expires = verdict.get("expires_at")
+    row.entitlement_expires_at = None
+    if isinstance(expires, str) and expires:
+        try:
+            dt = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+            row.entitlement_expires_at = dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+        except ValueError:
+            pass
+    row.entitlement_checked_at = now
+    return entitlement_view(row)

--- a/server/tests/test_app_credentials.py
+++ b/server/tests/test_app_credentials.py
@@ -23,6 +23,7 @@ import os
 import secrets
 import sys
 import types as _types
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
@@ -475,3 +476,141 @@ def test_app_state_is_per_app_and_bounded(platform):
                   json="x" * (256 * 1024 + 1)).status_code == 413
     assert tc.delete("/internal/app/state/cooldown", headers=_app(key)).json()["deleted"] is True
     assert tc.delete("/internal/app/state/cooldown", headers=_app(key)).json()["deleted"] is False
+
+
+# ── licensed apps (services/app_entitlements.py) ───────────────────────
+
+
+def _licensed_manifest():
+    m = _manifest("paid-app", provides=("paid",))
+    m.update({"pricing": "subscription", "price_note": "$29 / camera / year",
+              "entitlement": "license_key"})
+    return m
+
+
+@pytest.fixture
+def licensed(env, monkeypatch):
+    """A registered licensed app whose /entitlement/verify is a fake:
+    GOOD-KEY → valid (plan pro, expires 2099), anything else → invalid,
+    and the app can be made unreachable."""
+    tc, ids, SessionLocal = env
+    tc.post("/apps/register", headers=_site(),
+            json={"url": "http://paid:9200", "manifest": _licensed_manifest()})
+    calls: list[dict] = []
+    state = {"reachable": True}
+
+    class _Resp:
+        def __init__(self, body, code=200):
+            self._b, self.status_code, self.text = body, code, ""
+
+        def json(self):
+            return self._b
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json=None, headers=None, **kw):
+            if not state["reachable"]:
+                raise ConnectionError("down")
+            calls.append({"url": url, "json": json, "headers": headers})
+            key = (json or {}).get("license_key")
+            if key == "GOOD-KEY":
+                return _Resp({"valid": True, "plan": "pro", "expires_at": "2099-01-01T00:00:00Z",
+                              "message": "", "limits": {"cameras": 8}})
+            return _Resp({"valid": False, "message": "unknown key"})
+
+        async def get(self, url, **kw):
+            return _Resp({"status": "ok", "ready": True})
+
+    import services.app_entitlements as ent
+    monkeypatch.setattr(ent.httpx, "AsyncClient", _Client)
+    return tc, SessionLocal, calls, state
+
+
+def test_licensed_app_cannot_be_enabled_without_an_accepted_key(licensed):
+    tc, SessionLocal, calls, state = licensed
+    r = tc.post("/apps/paid-app/enable")
+    assert r.status_code == 402 and "licence key" in r.json()["detail"]
+    view = tc.get("/apps", headers=_site()).json()
+    rows = view["apps"] if isinstance(view, dict) else view
+    row = next(a for a in rows if a["id"] == "paid-app")
+    assert row["entitlement"]["mode"] == "license_key"
+    assert row["entitlement"]["status"] == "none" and not row["entitlement"]["has_license_key"]
+
+    # A rejected key: stored, verdict invalid, still cannot enable.
+    r = tc.put("/apps/paid-app/license", json={"license_key": "BAD"})
+    assert r.status_code == 200 and r.json()["entitlement"]["status"] == "invalid"
+    assert r.json()["entitlement"]["message"] == "unknown key"
+    assert tc.post("/apps/paid-app/enable").status_code == 402
+    # The key went to the app over the site-key-gated verify route, and
+    # is never readable back.
+    assert calls[-1]["url"] == "http://paid:9200/entitlement/verify"
+    assert calls[-1]["json"] == {"license_key": "BAD"}
+    assert "X-Internal-Api-Key" in calls[-1]["headers"]
+    assert "BAD" not in tc.get("/apps", headers=_site()).text
+
+    # The right key: valid, and enabling works.
+    r = tc.put("/apps/paid-app/license", json={"license_key": "GOOD-KEY"})
+    ent = r.json()["entitlement"]
+    assert ent["status"] == "valid" and ent["plan"] == "pro"
+    assert ent["limits"] == {"cameras": 8} and ent["expires_at"].startswith("2099")
+    assert tc.post("/apps/paid-app/enable").json()["enabled"] is True
+    # Stored encrypted, not in the clear.
+    s = SessionLocal()
+    row = s.get(InstalledApp, "paid-app")
+    assert row.license_key_encrypted and "GOOD-KEY" not in row.license_key_encrypted
+    s.close()
+
+
+def test_unreachable_app_keeps_its_last_verdict(licensed):
+    tc, SessionLocal, calls, state = licensed
+    tc.put("/apps/paid-app/license", json={"license_key": "GOOD-KEY"})
+    state["reachable"] = False
+    r = tc.post("/apps/paid-app/license/verify")
+    ent = r.json()["entitlement"]
+    assert ent["status"] == "valid" and "could not reach" in ent["message"]
+    assert tc.post("/apps/paid-app/enable").status_code == 200
+    # Clearing the key resets everything.
+    assert tc.delete("/apps/paid-app/license").json()["entitlement"]["status"] == "none"
+
+
+def test_free_apps_are_never_asked(licensed):
+    tc, SessionLocal, calls, state = licensed
+    key = _register(tc, _site()).json()["api_key"]          # loitering (free)
+    assert tc.post("/apps/loitering-detection/enable").status_code == 200
+    assert calls == []
+    # The verdict rides the app's config poll.
+    body = tc.get("/apps/loitering-detection/config", headers=_app(key)).json()
+    assert body["entitlement"]["mode"] == "none" and body["entitlement"]["status"] == "none"
+
+
+def test_index_external_listing_is_not_installable(monkeypatch, env):
+    tc, *_ = env
+    entry = apps_router.IndexEntry(
+        id="acme-lpr", name="Acme LPR", summary="s", category="vehicles", version="2.0",
+        kind="external", external_url="https://acme.example/opennvr", docs_url="https://d",
+        pricing="paid", price_note="$99", entitlement="license_key", author="Acme")
+    monkeypatch.setattr(apps_router, "_load_apps_index", lambda: [entry])
+    monkeypatch.setattr(apps_router, "_require_install_enabled", lambda: None)
+    admin = SimpleNamespace(id=1, username="admin", is_superuser=True)
+    tc.app.dependency_overrides[apps_router.require_apps_install] = lambda: admin
+    tc.app.dependency_overrides[auth_mod.get_current_active_user] = lambda: admin
+    listing = tc.get("/apps/index", headers=_site()).json()["apps"][0]
+    assert listing["kind"] == "external" and listing["install"] is None
+    assert listing["pricing"] == "paid" and listing["external_url"].startswith("https://acme")
+    r = tc.post("/apps/index/acme-lpr/install")
+    assert r.status_code == 400 and "external listing" in r.json()["detail"]
+    with pytest.raises(ValueError):
+        apps_router.IndexEntry(id="x", name="x", summary="s", category="c", version="1",
+                               kind="external", external_url="http://insecure", docs_url="d")
+    with pytest.raises(ValueError):
+        apps_router.IndexEntry(id="x", name="x", summary="s", category="c", version="1",
+                               docs_url="d")          # installable without image/install
+

--- a/server/tests/test_apps_index.py
+++ b/server/tests/test_apps_index.py
@@ -245,8 +245,9 @@ def test_index_returns_all_entries(client):
 
 def test_index_response_shape_matches_contract(client):
     """The per-app shape is exactly the frontend contract:
-    {id, name, summary, category, version, image, requires_tasks[],
-     emits[], docs_url, install{compose,command}, installed, enabled}.
+    {id, name, summary, category, version, kind, image, external_url,
+     pricing, price_note, entitlement, author, requires_tasks[], emits[],
+     docs_url, install{compose,command}, installed, enabled}.
     build_context is index-only and must NOT leak into the response."""
     app = next(
         a
@@ -258,6 +259,12 @@ def test_index_response_shape_matches_contract(client):
         "name",
         "summary",
         "category",
+        "kind",
+        "external_url",
+        "pricing",
+        "price_note",
+        "entitlement",
+        "author",
         "version",
         "image",
         "requires_tasks",


### PR DESCRIPTION
…x, app-verified licences, external listings

Nothing in the app contract said whether an app costs money or how a site proves it may run one; selling apps or models had no seam.

Manifest + index: pricing (free | paid | subscription | contact), price_note, entitlement (none | license_key); the index also gains kind (installable | external), external_url and author. External entries link out ("Learn more"), are never installed by the reconciler (400 on install), and the validator checks both kinds.

Licences: PUT /apps/{id}/license stores the key Fernet-encrypted (never returned), then asks the app — POST {app}/entitlement/verify, site-key gated like actions — and records its verdict: status (none | unverified | valid | invalid), plan, expiry, message, limits. POST /apps/{id}/enable answers 402 with the reason until the verdict is valid; POST …/license/verify re-checks, DELETE …/license forgets. An unreachable app keeps its last verdict. The verdict rides GET /apps/{id}/config so the app can feature-gate itself. InstalledApp columns via migration d7f3a2c9e1b4.

SDK: Entitlement dataclass, ContractMixin.verify_license (default: valid for entitlement none, invalid for a licensed app that forgot to override) served at POST /entitlement/verify, self.entitlement + on_entitlement_update from the config poll; PRICING_MODELS / ENTITLEMENT_MODES exported and validated on the manifest.

UI: pricing badge on installed cards and listings, third-party badge and Learn-more link for external entries, a licence panel (status, plan, expiry, message, limits; key entry / re-check / forget for superusers), Enable disabled until the licence is accepted.