### PR TITLE
docs: the developer program, the compatibility promise, and two refer…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,6 @@ data/net-hints/
 # KAI-C runtime adapter-registration receipts (#371) — machine state,
 # never source. In Docker this lives on the opennvr_kai_c_state volume.
 kai-c-state/
+
+# make sdk-docs output (generated, see docs/SDK_REFERENCE.md)
+sdk/opennvr-app-sdk/docs/api/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,19 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The developer program is written down.** `docs/DEVELOPER_PROGRAM.md`
+  is the deal for third-party developers — no fee, your licence, the
+  platform surface in one table, and a **compatibility promise** for the
+  app-registry contract (versioned `api_version`, `min_sdk_version` moves
+  only for misbehaviour, additive event schemas, deprecations announced a
+  minor release ahead) now pinned by `server/tests/test_registry_contract.py`.
+  New references: `docs/SDK_REFERENCE.md` (every public
+  `opennvr_app_sdk` name, by task) and `docs/PLATFORM_API.md` (the
+  operator API: users incl. superusers + MFA, roles and the permission
+  catalogue, cameras, assignments, per-camera access, apps and licences).
+  `make sdk-docs` renders the SDK docstrings with pdoc.
+  `FIRST_DETECTOR.md` and `CONTRIBUTING_APPS.md` cover the app key, the
+  `OpenNVR()` client, and paid / external listings.
 - **Apps can be sold.** The manifest and the App Store index carry
   `pricing` (free | paid | subscription | contact), `price_note` and
   `entitlement` (none | license_key); the catalog shows the badge on

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 PY ?= python3
 
-.PHONY: help secrets secrets-env check-secrets sync-agent-tasks validate-apps-index
+.PHONY: help secrets secrets-env check-secrets sync-agent-tasks validate-apps-index sdk-docs
 
 help:
 	@echo "OpenNVR Makefile targets:"
@@ -21,6 +21,8 @@ help:
 	@echo "                           camera-agent bundle (keeps the parity test green)."
 	@echo "  make validate-apps-index Validate server/config/apps_index.yml (App"
 	@echo "                           Store submission gate — run before opening a PR)."
+	@echo "  make sdk-docs            Render the App SDK's public API (docstrings) to"
+	@echo "                           sdk/opennvr-app-sdk/docs/api/ with pdoc."
 
 # --------------------------------------------------------------------------
 # make sync-agent-tasks
@@ -103,3 +105,14 @@ sys.exit('server/.env still contains placeholder values:') if errs else print('s
 # See docs/CONTRIBUTING_APPS.md.
 validate-apps-index:
 	@$(PY) scripts/validate_apps_index.py
+
+# --------------------------------------------------------------------------
+# make sdk-docs
+# --------------------------------------------------------------------------
+# Generated HTML is not committed; docs/SDK_REFERENCE.md is the hand-written
+# index and the docstrings are the reference. Needs uv (uses a throwaway
+# pdoc install).
+sdk-docs:
+	@cd sdk/opennvr-app-sdk && uv run --with pdoc --python 3.12 \
+		pdoc opennvr_app_sdk -o docs/api --docformat restructuredtext
+	@echo "→ sdk/opennvr-app-sdk/docs/api/index.html"

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -39,6 +39,17 @@ So your entry earns trust by being reviewable: the image is pinned, the
 declared tasks are real, the manifest matches, and there are no secrets in
 the file. The rest of this guide is how to satisfy that.
 
+**Paid and external listings are welcome.** OpenNVR takes no fee and
+processes no payments; a paid app is your product, and its licence is
+checked by *your* code. Two extra fields cover it — `pricing` /
+`price_note` for the badge the catalog shows, `entitlement: license_key`
+if the administrator must enter a key before the app can be enabled. An
+app you distribute yourself lists as `kind: external` with an
+`external_url`: the catalog shows the card and a **Learn more** link
+and never installs it. The rules and the reasoning are in
+[`docs/DEVELOPER_PROGRAM.md`](DEVELOPER_PROGRAM.md); the licence hook
+in [`docs/APP_SURFACES.md` §5b](APP_SURFACES.md).
+
 ---
 
 ## 1. Build your app on the App SDK
@@ -224,18 +235,31 @@ index entry plus your app under `examples/<id>/` — one topic per PR.
 - **No secrets.** The compose block uses `${VAR}` placeholders only; no
   literal key ever lands in the file.
 - **The app self-registers.** On boot your app calls `POST /apps/register`
-  with the deployment's `INTERNAL_API_KEY` and appears in the catalog — so
-  "installed" actually means "running and registered".
+  with the deployment's `INTERNAL_API_KEY`, is issued its own key, and
+  appears in the catalog — so "installed" actually means "running and
+  registered".
+- **Pricing is honest.** `pricing` is one of `free` / `paid` /
+  `subscription` / `contact`; `price_note` is short and factual ("$49
+  one-time", "per camera, monthly") and names no third party. A `paid` or
+  `subscription` app that gates features declares `entitlement:
+  license_key` and implements `verify_license` — a reviewer will try
+  enabling it without a key and expect a 402.
+- **External listings link somewhere real.** `kind: external` needs an
+  https `external_url` under your control and an `author`; the
+  validator rejects an install block on an external entry.
 
 Once merged, your app is browsable in every OpenNVR deployment's App Catalog
 and installable via the copy-paste command (always) or one click (where the
-operator has opted in). If yours is a first-party example, your name goes
-on it.
+operator has opted in). Community apps are showcased in the project README
+and the release notes — say a line about yours in the PR. If yours is a
+first-party example, your name goes on it.
 
 ---
 
 ## Related reading
 
+- [`docs/DEVELOPER_PROGRAM.md`](DEVELOPER_PROGRAM.md) — the deal for
+  third-party developers: no fee, your licence, the compatibility promise.
 - [`docs/FIRST_DETECTOR.md`](FIRST_DETECTOR.md) — the on-ramp: scaffold a
   runnable app with the generator, fill in the rule, get its tests green, run
   it against the stack — then land here to publish it.

--- a/docs/DEVELOPER_PROGRAM.md
+++ b/docs/DEVELOPER_PROGRAM.md
@@ -1,0 +1,125 @@
+# Build on OpenNVR — the developer program
+
+OpenNVR is a self-hosted AI video platform. **Everything an app needs
+is already running**: the cameras and their streams, Tier-0 detection
+on every frame, an inference layer with pluggable models, an event
+bus, an evidence store, an alert inbox that rings operators, users and
+per-camera permissions, and a catalog every deployment opens. You
+write the part that is yours — the rule, the model, the workflow — and
+the platform does the rest.
+
+This page is the deal. The technical on-ramp starts at
+[FIRST_DETECTOR.md](FIRST_DETECTOR.md).
+
+## The deal, in five lines
+
+1. **You keep 100%.** OpenNVR takes no fee, processes no payments and
+   never sees your licence logic. A paid app is *your* product, sold on
+   *your* terms, verified by *your* code (`verify_license`), listed in
+   every deployment's catalog for free.
+2. **Your code stays yours.** The SDK, the wire formats and the
+   contracts are **Apache-2.0**. Ship your app under any licence,
+   closed included. Only OpenNVR itself is AGPL — and you never link
+   against it. See [LICENSING.md](LICENSING.md).
+3. **We don't break you.** The registry contract is versioned and the
+   [compatibility promise](#the-compatibility-promise) below is tested
+   in CI against every core change.
+4. **You get the platform, not plumbing.** One client object
+   ([APP_PLATFORM.md](APP_PLATFORM.md)) covers cameras, frames,
+   inference, recordings, history, alerts, durable state and events.
+   No NATS, no HTTP, no SQL of your own.
+5. **You get distribution.** A listing in the curated index appears in
+   the App Catalog of every OpenNVR install — installable from your
+   image, or a `kind: external` link to wherever you sell it.
+
+## What the platform gives you
+
+| You need | The platform provides | Read |
+|---|---|---|
+| Cameras assigned to your app, with frames | `OpenNVR().cameras()`, `.snapshot()`; roster scoped by the operator's assignments | [APP_PLATFORM.md](APP_PLATFORM.md) |
+| Detections without running a model | `Detector` archetype on the Tier-0 stream — zero GPU cost | [FIRST_DETECTOR.md](FIRST_DETECTOR.md) |
+| Your own model | KAI-C adapters (`AI_ADAPTER_CONTRACT.md`), `nvr.ai.infer()` / `.stream()` | [AI_ADAPTER_CONTRACT.md](AI_ADAPTER_CONTRACT.md) |
+| Alerts that reach a human | `AlertDispatcher` → the operator inbox, bell, Twilio/webhook actions | [APP_SURFACES.md](APP_SURFACES.md) |
+| Events other apps can build on, and theirs | `DomainEventPublisher` / `DomainEventSubscriber` | [EVENT_CONTRACTS.md](EVENT_CONTRACTS.md) |
+| History, evidence photos, recordings | `nvr.timeline`, `nvr.recordings(cam)` | [APP_PLATFORM.md](APP_PLATFORM.md) |
+| State that survives restarts | `nvr.state` (per-app key/value in core) | [APP_PLATFORM.md](APP_PLATFORM.md) |
+| An identity and a scope | Per-app key issued at registration; only your cameras, only your rows | [APP_CREDENTIALS.md](APP_CREDENTIALS.md) |
+| Who is using your app | `current_user()` inside `/ui` and actions — id, name, cameras they may see | [APP_SURFACES.md](APP_SURFACES.md) |
+| A UI, a config form, operator actions | Declared in the manifest; the catalog renders them | [APP_SURFACES.md](APP_SURFACES.md) |
+| A storefront and a licence gate | `pricing`, `price_note`, `entitlement` + `verify_license` | [APP_SURFACES.md](APP_SURFACES.md#5b-selling-your-app-pricing-and-licences) |
+| The operator API (users, roles, cameras, assignments) | `/api/v1/*`, Swagger at `/docs` | [PLATFORM_API.md](PLATFORM_API.md) |
+
+## How to ship
+
+1. **Scaffold** — `python3 scripts/create_opennvr_app.py my-app --task object_detection`
+   gives you a compiling app with a test; fill in one method.
+2. **Run it against a stack** — `OPENNVR_URL` + the site key to
+   bootstrap; the app is issued its own key on first registration and
+   uses it from then on.
+3. **Make it a product** — manifest `params` (config form),
+   `state_schema` (live views), `actions` (operator verbs), `has_ui`
+   (a dashboard), `pricing` / `entitlement` if you sell it.
+4. **List it** — build and digest-pin your image and append one entry
+   to `server/config/apps_index.yml` ([CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md));
+   or, if you distribute it yourself, a `kind: external` entry that
+   links to you.
+
+## Paid apps and models
+
+Paid listings are welcome and expected. The rules are short:
+
+* OpenNVR **takes no fee** and **does not process payments**. Selling,
+  invoicing and licence issuance happen on your side.
+* A licensed app declares `entitlement: license_key`. The
+  administrator enters the key in the catalog; core stores it
+  encrypted and asks **your app** whether it is valid. You return the
+  verdict — plan, expiry, limits. Core enforces it (the app cannot be
+  enabled until you say yes) and never returns the key to anyone.
+* Models are sold the same way: ship them inside your app image or as
+  a KAI-C adapter, gate them with the same licence hook.
+* The catalog shows your `pricing` badge and `price_note` verbatim.
+  Keep the note factual; the platform quotes no prices of its own.
+* First-party apps in this repository stay free.
+
+## The compatibility promise
+
+Apps are an investment; the platform must not spend it.
+
+* **The registry contract is versioned.** `POST /apps/register` returns
+  `registry.api_version` (semver-style `MAJOR.MINOR`) and
+  `registry.min_sdk_version`. Additive changes bump MINOR; a breaking
+  change to the register / config / state / actions / entitlement
+  shapes bumps MAJOR and is announced in the changelog one minor
+  release ahead.
+* **Old SDKs keep working.** `min_sdk_version` only moves when an older
+  SDK would *misbehave*, never merely because it lacks a feature, and
+  the SDK logs a warning rather than failing when it is behind.
+* **Event contracts are additive.** Domain-event schemas
+  (`plate.recognized.v1`, …) gain fields; a changed field is a new
+  `vN` subject ([EVENT_CONTRACTS.md](EVENT_CONTRACTS.md)).
+* **It is tested.** `server/tests/test_registry_contract.py` pins the
+  response shapes and the version relationship; the example apps run
+  against every core PR in CI (`.github/workflows/ci.yml`), so an app
+  that passes today keeps passing.
+* **Deprecations are loud.** A field or route on its way out is marked
+  in the response, in the docs and in the changelog for at least two
+  minor releases before removal.
+
+## Getting seen
+
+* Every install shows your listing; the catalog groups by category and
+  shows the pricing badge and author.
+* Community apps are showcased in the project README and release
+  notes — open your listing PR and say a line about it.
+* Verified-developer badges, featured rows and install counts are on
+  the roadmap ([ROADMAP.md](ROADMAP.md)); the index fields they need
+  (`author`, `kind`) already exist.
+
+## Getting help
+
+* Questions and design threads: GitHub Discussions.
+* Bugs in the SDK or the contract: an issue tagged `sdk`.
+* Something you need the platform to expose: an issue tagged
+  `platform-api` — the rule of this project is that anything an
+  example app needs from core goes into the SDK first, so a real
+  third-party need is the strongest case there is.

--- a/docs/FIRST_DETECTOR.md
+++ b/docs/FIRST_DETECTOR.md
@@ -157,6 +157,27 @@ Uncomment the `contract_port` / `opennvr_url` block in `config.yml` (the
 generator ships it commented) to turn the contract surface + catalog
 self-registration on.
 
+On first registration core issues the app **its own key** (`oak_…`),
+which the SDK stores and uses from then on — the site key in
+`config.yml` is only for bootstrap ([APP_CREDENTIALS.md](APP_CREDENTIALS.md)).
+With that key, `OpenNVR()` gives the rule everything else it might
+want from the platform — the cameras assigned to it, a snapshot, past
+events, a place to keep state across restarts — without touching NATS
+or HTTP yourself:
+
+```python
+from opennvr_app_sdk import OpenNVR
+
+nvr = OpenNVR()                       # OPENNVR_URL + the app's key
+for cam in nvr.cameras():             # only cameras assigned to this app
+    last = nvr.state.get(f"seen:{cam.handle}")
+    jpeg = nvr.snapshot(cam)
+```
+
+The full client is in [APP_PLATFORM.md](APP_PLATFORM.md); inside `/ui`
+and actions, `current_user()` tells you who is asking and which cameras
+they may see ([APP_SURFACES.md §5](APP_SURFACES.md)).
+
 ## 5. Publish to the App Store (2 min to start)
 
 An operator installs apps from the **App Catalog**. Getting yours there
@@ -194,6 +215,13 @@ either door can actually open — is [`docs/TWO_DOORS.md`](TWO_DOORS.md).
 
 ## Related reading
 
+- [`docs/DEVELOPER_PROGRAM.md`](DEVELOPER_PROGRAM.md) — the deal: what
+  the platform gives you, selling apps and models, the compatibility
+  promise.
+- [`docs/SDK_REFERENCE.md`](SDK_REFERENCE.md) — every public SDK name,
+  by task; [`docs/APP_PLATFORM.md`](APP_PLATFORM.md) — the `OpenNVR`
+  client; [`docs/APP_CREDENTIALS.md`](APP_CREDENTIALS.md) — the app's
+  own key.
 - [`docs/APP_SURFACES.md`](APP_SURFACES.md) — **the next step after this
   guide**: make your app a full citizen — agent skill, live config,
   state views, and action forms, all declared, no frontend.

--- a/docs/PLATFORM_API.md
+++ b/docs/PLATFORM_API.md
@@ -1,0 +1,161 @@
+# The operator API — provisioning OpenNVR from code
+
+Everything the web UI does goes through `/api/v1/*`, so everything the
+UI does can be scripted: creating users and roles, adding cameras,
+assigning skills, granting per-camera access, installing and licensing
+apps. This page is the map. The full, always-current reference is the
+generated Swagger UI at **`/docs`** on any running stack (`/redoc` for
+the reading version, `/openapi.json` for tooling).
+
+Two other doors exist and are *not* this page:
+
+* **Apps** talk to core with their own key through the SDK's
+  `OpenNVR()` client — [APP_PLATFORM.md](APP_PLATFORM.md). They do not
+  hold user credentials.
+* **The OpenNVR Agent** (camera-agent) and adapters use the internal
+  key on `/internal/*` — [TWO_DOORS.md](TWO_DOORS.md).
+
+## 1. Authenticating
+
+| Step | Route | Notes |
+|---|---|---|
+| Is this a fresh install? | `POST /auth/check-setup` | Returns `needs_setup`, `registration_open` |
+| First administrator | `POST /auth/first-time-setup` | One-shot, needs the setup token printed by `init_db` |
+| Log in | `POST /auth/login` (form) / `POST /auth/login-json` | Returns access + refresh JWTs; MFA-enrolled users pass the TOTP too |
+| Refresh / log out | `POST /auth/refresh`, `POST /auth/logout` | |
+| Who am I | `GET /auth/me`, `GET /users/me/permissions` | The second one is what the UI uses to hide controls |
+| MFA | `POST /auth/mfa/setup`, `/mfa/verify`, `/mfa/disable` | |
+
+Send `Authorization: Bearer <access token>` on every other call.
+
+`POST /auth/register` — self-registration — is **closed by default**
+(403). An operator opens it with the `public_registration_enabled`
+setting; self-registered users get the default role and can never be
+superusers by that path.
+
+## 2. Users, roles, permissions
+
+### Users — `/users`
+
+| | Route | Who |
+|---|---|---|
+| Create | `POST /users/` | superuser (`users.manage`) |
+| List / read | `GET /users/`, `GET /users/{id}` | `users.view` |
+| Update | `PUT /users/{id}` | superuser; `PUT /users/me` for yourself |
+| Deactivate / reactivate | `DELETE /users/{id}`, `POST /users/{id}/activate` | superuser |
+
+`UserCreate` / `UserUpdate` carry `is_superuser`. Minting or promoting
+a superuser, or demoting one, requires the **caller's current TOTP
+code in the `X-MFA-Code` header** — a superuser sees every camera and
+holds every permission, so it is the most privileged write in the API.
+The last active superuser cannot be demoted, deactivated or deleted.
+
+```bash
+curl -X POST $NVR/api/v1/users/ -H "Authorization: Bearer $TOK" \
+     -H "X-MFA-Code: 123456" -H "Content-Type: application/json" \
+     -d '{"username":"ops","email":"ops@example.com","password":"…",
+          "role_id":2,"is_superuser":false}'
+```
+
+### Roles and the permission catalogue — `/roles`, `/permissions`
+
+Roles are named bundles of permissions; `init_db` seeds `admin`,
+`operator` and `viewer`. `GET /permissions/` lists the catalogue,
+`PUT /permissions/roles/{role_id}` sets a role's bundle, `POST /roles/`
+creates a new role.
+
+The catalogue is `resource.action` strings. The ones that gate what a
+developer or integrator usually needs:
+
+| Permission | Gates |
+|---|---|
+| `cameras.view` / `cameras.manage` | Read cameras / create, update, delete cameras and their assignments |
+| `recordings.view` / `recordings.manage` | Playback / retention and deletion |
+| `live.view` | Live streams |
+| `alerts.view` / `alerts.manage` | The inbox / acknowledging and policy |
+| `ai.view` / `ai.manage` | Adapters and models / configuring them, granting adapter permissions |
+| `byom.manage` | Uploading and managing custom models |
+| `apps.install` | One-click install of catalog apps (superuser still enables them) |
+| `users.view` / `users.manage`, `roles.view` / `roles.manage`, `permissions.manage` | Identity administration |
+| `settings.view` / `settings.manage` | Site settings |
+| `audit.view`, `compliance.view` | Read the audit log / compliance reports |
+| `network.*`, `onvif.discover`, `firmware.*`, `integrations.*`, `cloud.*`, `byok.manage` | The corresponding admin pages |
+
+A superuser implicitly holds every permission.
+
+## 3. Cameras — `/cameras`
+
+| | Route | Who |
+|---|---|---|
+| Create | `POST /cameras/` | `cameras.manage`; the creator becomes the camera's **owner** |
+| List / read | `GET /cameras/`, `GET /cameras/{id}` | scoped — see below |
+| Update / delete | `PUT /cameras/{id}`, `DELETE /cameras/{id}` | owner, `can_manage` grantee, or superuser |
+| Discover | `GET /cameras/by-ip/{ip}`, `POST /cameras/{id}/test-connection`, `POST /cameras/{id}/probe-transport` | |
+| Streams | `GET /cameras/{id}/stream/urls`, `GET /cameras/{id}/snapshot`, PTZ routes | |
+| Skills | `GET /cameras/assignable-skills`; `assignments` on create/update | `cameras.manage` |
+
+### Assignments — what a camera *does*
+
+`assignments` is a list of `{"skill": "...", "labels": [...]?}` (max 8,
+one per skill). A skill is an open vocabulary
+(`license_plate_recognition`, `occupancy_counting`, `loitering`, …).
+Assignments are how an operator points an app at a camera: an app's
+roster is every camera assigned a skill the app `provides` (or the app
+id itself) — [CAMERA_ASSIGNMENTS.md](CAMERA_ASSIGNMENTS.md),
+[APP_CREDENTIALS.md](APP_CREDENTIALS.md).
+
+### Per-camera access — who may *see* a camera
+
+Every camera has an owner; other users see it only through a grant.
+
+| | Route |
+|---|---|
+| Grant / update | `POST /cameras/{id}/permissions` — `{"user_id", "can_view", "can_manage"}` |
+| List grants | `GET /cameras/{id}/permissions` |
+| Revoke | `DELETE /cameras/{id}/permissions/{user_id}` |
+| Check | `GET /cameras/{id}/permissions/check` |
+
+Owner or superuser may grant. The scope this produces is applied
+everywhere a camera appears — timeline, recordings, occupancy, alerts,
+app config and state — and is forwarded to apps as the signed user
+context ([APP_SURFACES.md §5](APP_SURFACES.md)). Superusers see all
+cameras; owner-less cameras are superuser-only.
+
+## 4. Apps and licences — `/apps`
+
+| | Route | Who |
+|---|---|---|
+| Catalog (curated index, merged with installed state) | `GET /apps/index` | any user |
+| Install / uninstall a listing | `POST /apps/index/{id}/install`, `/uninstall`, `GET …/install-status` | `apps.install` |
+| Installed apps | `GET /apps` | any user (scoped) |
+| Enable / disable | `POST /apps/{id}/enable`, `/disable` | superuser — enable returns **402** while a licensed app has no valid key |
+| Config | `GET/PUT /apps/{id}/config` | read: any user (own cameras only) / write: superuser or camera manager for per-camera keys |
+| Live status, UI, actions | `GET /apps/{id}/status`, `GET /apps/{id}/ui`, `POST /apps/{id}/actions/{name}` | user context forwarded |
+| Licence key | `PUT /apps/{id}/license`, `POST /apps/{id}/license/verify`, `DELETE /apps/{id}/license` | superuser; the key is stored encrypted and never returned |
+| App credential | `POST /apps/{id}/key/rotate`, `DELETE /apps/{id}/key` | superuser |
+
+Apps register *themselves* (`POST /apps/register`) with the SDK — an
+operator never calls that. `kind: external` listings in the index are
+links, not installs (400 on install).
+
+## 5. Everything else
+
+Recordings (`/recordings`), the timeline (`/events`), occupancy
+(`/occupancy`), the alerts inbox (`/alerts-inbox`), AI models and
+adapters (`/ai-models`, `/ai-model-management`, `/skills`),
+integrations, network and firewall, audit logs (`/audit-logs`),
+compliance, cloud — all under `/api/v1`, all in `/docs`, all subject to
+the same permission catalogue and camera scope.
+
+## Conventions
+
+* JSON in, JSON out; errors are `{"detail": "..."}` with the HTTP
+  status carrying the meaning (401 unauthenticated, 403 forbidden, 404
+  not found *or* not visible to you, 402 licence required, 409 conflict).
+* IDs are integers for users, roles and cameras; strings for apps and
+  adapters.
+* Timestamps are RFC 3339 / ISO 8601, UTC.
+* Every write is audited (`GET /audit-logs`).
+* Breaking changes to operator routes follow the same rule as the app
+  contract: announced in `CHANGELOG.md` one minor release ahead
+  ([DEVELOPER_PROGRAM.md](DEVELOPER_PROGRAM.md#the-compatibility-promise)).

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,12 +13,15 @@ Start here. Pick the row that matches what you're doing.
 
 ## Contribute
 - **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — PR flow, conventions, running tests.
+- **[DEVELOPER_PROGRAM.md](DEVELOPER_PROGRAM.md)** — **start here if you are building an app**: what the platform gives you, paid apps, the compatibility promise.
 - **[FIRST_DETECTOR.md](FIRST_DETECTOR.md)** — write your first detector app in ~15 minutes.
 - **[CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md)** — publish an app to the catalog.
 - **[APP_SURFACES.md](APP_SURFACES.md)** — the surfaces (config, state, actions) an app exposes.
 - **[APPS_INSTALL.md](APPS_INSTALL.md)** — one-click install design (desired-state + reconciler).
 - **[APP_CREDENTIALS.md](APP_CREDENTIALS.md)** — per-app keys: the register handshake, roster scoping, rotate/revoke.
 - **[APP_PLATFORM.md](APP_PLATFORM.md)** — the `OpenNVR` client: cameras, snapshots, recordings, timeline, AI, alerts, durable state, domain-event consumption.
+- **[SDK_REFERENCE.md](SDK_REFERENCE.md)** — index of every public `opennvr_app_sdk` name, by task.
+- **[PLATFORM_API.md](PLATFORM_API.md)** — the operator API: users (incl. superusers + MFA), roles and the permission catalogue, cameras, assignments, per-camera access, apps and licences.
 
 ## Build on the AI layer
 - **[AI_ADAPTER_CONTRACT.md](AI_ADAPTER_CONTRACT.md)** — the REST/WebSocket wire spec adapters implement.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -272,6 +272,11 @@ to a release window. Pull requests and design discussions are welcome.
 - **Edge co-processor integration.** Coral / TensorRT / Hailo adapter
   variants beyond the ONNX-only adapters that ship in v0.1.
 - **Native Kubernetes operator** for Helm-chart deployments at scale.
+- **App Catalog for developers** (see `docs/DEVELOPER_PROGRAM.md`):
+  a verified-developer badge on listings, a featured row, install
+  counts (opt-in, aggregate) and a community showcase. The index
+  fields these need — `author`, `kind`, `pricing` — already ship;
+  the catalog UI and the review policy behind the badge do not yet.
 
 ## How to influence the roadmap
 
@@ -298,6 +303,12 @@ Discussion and a migration path will ship alongside.
    events. The federated-AI roadmap item (v0.3) is opt-in by design and
    will land with the same posture.
 4. **Honest CHANGELOG.** Breaking changes get a major-version bump.
+5. **The app-registry contract is versioned and tested.** What an SDK
+   app reads from `POST /apps/register`, `/config` and `/status` does
+   not change shape without an `api_version` bump, and `min_sdk_version`
+   only moves when an old SDK would misbehave —
+   `docs/DEVELOPER_PROGRAM.md` § *The compatibility promise*, pinned by
+   `server/tests/test_registry_contract.py`.
    We're 0.x — bumps are cheaper here than at 1.x — but the policy
    stays the same when we cross 1.0.
 

--- a/docs/SDK_REFERENCE.md
+++ b/docs/SDK_REFERENCE.md
@@ -1,0 +1,145 @@
+# `opennvr_app_sdk` — public API index
+
+The SDK is the *only* import a vision app needs. This page is the map
+of what it exports (`opennvr_app_sdk.__all__`), grouped by what you
+are trying to do; the docstrings in the source are the reference for
+each name and `make sdk-docs` renders them to HTML. Concepts and
+walkthroughs live in [FIRST_DETECTOR.md](FIRST_DETECTOR.md),
+[APP_PLATFORM.md](APP_PLATFORM.md), [APP_SURFACES.md](APP_SURFACES.md)
+and [APP_CREDENTIALS.md](APP_CREDENTIALS.md).
+
+Version: `opennvr_app_sdk.__version__` (`0.3.0`). Licence: Apache-2.0.
+
+```bash
+pip install opennvr-app-sdk            # or: uv add opennvr-app-sdk
+pip install "opennvr-app-sdk[nats]"    # + NATS client for the subscribe loops
+```
+
+## Pick an archetype — the class you subclass
+
+| Archetype | Subclass | Implement | Run with | Source of frames/events |
+|---|---|---|---|---|
+| **Detector** | `Detector` | `on_detections(camera_id, detections, event) -> Iterable[Alert]` | `app(MyDetector).run()` | Tier-0 / adapter inference events on NATS — no model of your own |
+| **FrameApp** | `FrameApp` | `on_frame(camera_id, jpeg) -> Iterable[Alert]` | `app(MyApp).run()` | Frames you pull; you call inference via `KaiCClient` or `nvr.ai` |
+| **DomainEventSubscriber** | `DomainEventSubscriber` | `subscriptions = [...]`, `on_event(DomainEvent)` | `domain_event_app(MyApp).run()` | Domain events (`plate.recognized.v1`, …) other apps publish |
+| **AlertSubscriber** | `AlertSubscriber` | `on_alert(alert, subject)` | `alert_app(MySub).run()` | `opennvr.alerts.*` — relays, SIEM bridges |
+
+All four mix in `ContractMixin`, which gives every app the registry
+contract for free: `/health`, `/state`, `/manifest`, `/actions/{name}`,
+`/entitlement/verify` served by `ContractServer`; registration with
+core (`register_with_opennvr`); live config (`on_config_update`,
+`start_config_poll`); credentials (`credentials`); the calling user
+(`current_user`); and licensing (`verify_license`,
+`on_entitlement_update`, `entitlement`). Optional hooks to override:
+`setup()`, `state_snapshot()`, `health_snapshot()`, `on_action(name,
+params)`.
+
+Runners: `AppRunner`, `AlertSubscriberRunner` (what `app()` /
+`alert_app()` / `domain_event_app()` return; `.run(argv)` parses the
+CLI, loads config, wires signals).
+
+## Describe the app — the manifest
+
+| Name | Purpose |
+|---|---|
+| `AppManifest` | Identity + schema: `id`, `name`, `version`, `category`, `summary`, `requires_tasks`, `requires_adapters`, `requires_scopes`, `provides`, `subscribes`, `params`, `emits`, `state_schema`, `actions`, `has_ui` / `ui_mode` / `ui_url`, `description`, `author`, `website`, `license`, `use_cases`, `contact`, `pricing`, `price_note`, `entitlement` |
+| `Param` | One config field the catalog renders (`key`, `type`, `default`, `per_camera`, …) |
+| `AlertType` | One kind of alert the app `emits` |
+| `StateView` | One live view of `/state` the catalog renders (`state_schema`) |
+| `Action` | One operator verb the catalog offers (`POST /actions/{name}`) |
+| `PRICING_MODELS` | `free`, `paid`, `subscription`, `contact` |
+| `ENTITLEMENT_MODES` | `none`, `license_key` |
+| `Entitlement` | What `verify_license` returns: `valid`, `plan`, `expires_at`, `message`, `limits` |
+
+## Talk to the platform — `OpenNVR`
+
+```python
+from opennvr_app_sdk import OpenNVR
+nvr = OpenNVR()                      # OPENNVR_URL + the app's own key
+```
+
+| Name | Purpose |
+|---|---|
+| `OpenNVR(url=None, *, token=None, kaic_url=None, timeout=…)` | The client; everything below hangs off it |
+| `.cameras() -> list[Camera]`, `.camera(x)` | The app's roster (only cameras assigned to it) |
+| `.snapshot(camera) -> bytes \| None` | Current JPEG |
+| `.recordings(camera)` → `RecordingsAPI` | `.list(start, end)`, `.url(start, duration)`, `.frame_at(at)` |
+| `.timeline` → `TimelineAPI` | `.search(camera=, label=, …)`, `.evidence(event_id)`, `.plate_stats()`, `.plate_summary()`, `.plate_sessions()` |
+| `.alerts` → `AlertsAPI` | `.inbox(unacked=, limit=, after_id=)` — what this app raised, and whether anyone acknowledged it |
+| `.state` → `StateAPI` | `.get`, `.set`, `.delete`, `.items(prefix)` — durable per-app key/value in core |
+| `.ai` → `AIAPI` | `.capabilities()`, `.infer(adapter, jpeg, task=…)`, `.stream(adapter, camera_id=…)` |
+| `Camera` | `id`, `handle` (`camN`), `name`, `role`, `frame_url`, `assignments`; `.has_skill(s)` |
+| `Recording` | `start`, `duration` |
+| `PlatformError` | Raised by writes; reads degrade to `None` / `[]` and log |
+| `InferStream` | The WebSocket inference session behind `nvr.ai.stream()`; `open()`, `infer(jpeg)`, `close()`, context-manager |
+
+Lower-level helpers that predate the client and remain public:
+`discover_cameras(url)`, `cameras_for_skill(...)`,
+`filter_cameras_for_skill(...)`, `full_frame_polygon()`, `EventsClient`
+/ `StoredEvent` (async event search), `KaiCClient` / `KaiCError`
+(direct KAI-C HTTP), and the Tier-0 helpers `Tier0Snapshot`,
+`snapshot_from_event`, `tier0_to_detections`, `is_tier0_subject`,
+`describe_counts`, `BestFrameClient`, `make_best_frame_fetch`.
+
+## Raise alerts
+
+| Name | Purpose |
+|---|---|
+| `Alert` | `title`, `description`, `camera_id`, `severity` (`low`/`medium`/`high`/`critical`), `evidence`, `tags`, `correlation_id`; `.to_wire()` |
+| `AlertSource`, `set_default_source(...)` | Who raised it (app id/name/version) — set once at startup |
+| `AlertDispatcher`, `build_dispatcher(webhook_url=…, nats_alerts_url=…)` | Fan-out: `StdoutChannel` always, `WebhookChannel` and `NatsAlertChannel` opt-in |
+| `alert_subject(alert)`, `DEFAULT_ALERT_SUBJECT_PREFIX` | The NATS subject an alert lands on (`opennvr.alerts.<severity>.<camera>`) |
+| `AlertChannel` | Protocol for your own channel: `send(alert) -> bool` |
+
+Alerts published on NATS reach the operator inbox, the bell and the
+alarm actions without any further code.
+
+## Publish and consume domain events
+
+| Name | Purpose |
+|---|---|
+| `DomainEventPublisher` | `.publish(schema, camera_id, payload)` on `opennvr.events.<schema>.<camera>` |
+| `domain_envelope(...)`, `domain_subject(schema, camera_id)` | The wire helpers |
+| `DomainEvent` | Parsed envelope: `id`, `schema`, `camera_id`, `ts`, `payload`, `producer`, `correlation_id`, `subject` |
+| `DomainEventSubscriber`, `domain_event_app`, `parse_domain_event` | The consuming archetype (above) |
+
+Schemas and their payloads: [EVENT_CONTRACTS.md](EVENT_CONTRACTS.md).
+
+## Identity
+
+| Name | Purpose |
+|---|---|
+| `AppCredentials`, `auth_headers()` | The app's own key (`OPENNVR_APP_KEY`, or `.opennvr/app.key`), falling back to the site key only to bootstrap |
+| `UserContext`, `current_user()` | Inside `/ui` and `/actions/*`: the user core forwarded — `id`, `username`, `is_superuser`, `.can_see(cam)`, `.can_manage(cam)`, `.visible(ids)` |
+
+## Rules — geometry and state
+
+| Name | Purpose |
+|---|---|
+| `Zone` (`.contains`, `.from_config`), `Tripwire` (`.side`, `.crossing`), `Point`, `bbox_center(bbox, w, h)` | Polygons and lines in frame coordinates; `from_config` reads what the catalog's zone editor stored |
+| `KeyedState`, `StateRecord`, `keyed_state(ttl=…)` | Per-key TTL memory for dwell/cooldown/tracking rules; `Detector.keyed_state(ttl)` is the shortcut |
+
+## Frames (FrameApp)
+
+| Name | Purpose |
+|---|---|
+| `FrameSource` | Protocol: `get_frame(camera_id) -> bytes \| None` |
+| `build_frame_source(camera_id=, url=)` | `rtsp://`, `http(s)://` snapshot, or `file://` from one URL |
+| `HttpSnapshotSource`, `FileFrameSource`, `CameraFrameSource`, `DictFrameSource`, `dict_frame_source(...)`, `FrameSourceError` | The concrete sources and the mapping wrapper |
+
+Prefer `nvr.snapshot(camera)` (server-side capture, no RTSP in your
+container) unless you need full frame rate.
+
+## Config
+
+`load_yaml(path)`, `require(cfg, key)` — the two helpers the runners
+use; pass your own `load_config` to `app()` for anything richer.
+
+## Stability
+
+Every name above is covered by the
+[compatibility promise](DEVELOPER_PROGRAM.md#the-compatibility-promise):
+removals and signature changes are announced a minor release ahead and
+the deprecated name keeps working, with a warning, until then. Names
+starting with `_` and modules not re-exported from the package root
+are internal.

--- a/server/tests/test_registry_contract.py
+++ b/server/tests/test_registry_contract.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""The app-registry contract — the compatibility promise, pinned.
+
+docs/DEVELOPER_PROGRAM.md tells third-party developers that the shapes
+the SDK reads from ``POST /apps/register``, ``GET /apps/{id}/config``
+and ``GET /apps/{id}/status`` do not change under them without an
+``API_VERSION`` bump, and that an SDK at ``MIN_SDK_VERSION`` keeps
+working. This file is where that promise is enforced:
+
+* every key the released SDK reads is present, with the type it expects;
+* ``API_VERSION`` and ``MIN_SDK_VERSION`` are well-formed and the SDK in
+  this repository satisfies its own server's minimum;
+* the SDK's constants agree with the server's.
+
+If a change here is deliberate, bump ``API_VERSION`` in
+``routers/apps.py`` and say so in CHANGELOG.md — that is the whole
+process.
+
+Run with:
+    cd server && pytest tests/test_registry_contract.py -v
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017
+
+import os
+import re
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+sys.path.insert(0, str(REPO_ROOT / "sdk" / "opennvr-app-sdk"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+SITE_KEY = secrets.token_urlsafe(48)
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ["INTERNAL_API_KEY"] = SITE_KEY
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as auth_mod  # noqa: E402
+from core.config import settings  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Role, User  # noqa: E402
+from routers import apps as apps_router  # noqa: E402
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+API_VER = re.compile(r"^\d+\.\d+$")
+
+
+def _vt(text: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in text.split("."))
+
+
+def _manifest(**over):
+    m = {"id": "contract-probe", "name": "Contract Probe", "version": "1.0.0",
+         "category": "perimeter", "summary": "", "requires_tasks": [],
+         "subscribes": "opennvr.inference.>", "params": [], "emits": [],
+         "provides": ["probe"]}
+    m.update(over)
+    return m
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setattr(settings, "internal_api_key", SITE_KEY, raising=False)
+    # The router resolves ``core.config.settings`` lazily; an earlier test
+    # module may have swapped the module object in sys.modules, so patch
+    # whichever one the router will see now, too.
+    live_cfg = sys.modules.get("core.config")
+    if live_cfg is not None and getattr(live_cfg, "settings", None) is not settings:
+        monkeypatch.setattr(live_cfg.settings, "internal_api_key", SITE_KEY, raising=False)
+    monkeypatch.setenv("INTERNAL_API_KEY", SITE_KEY)
+    monkeypatch.setattr(auth_mod, "auth_logger", _L(), raising=False)
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    s = SessionLocal()
+    role = Role(name="admin")
+    s.add(role)
+    s.flush()
+    admin = User(username="admin", email="a@x", hashed_password="x",
+                 role_id=role.id, is_superuser=True, is_active=True)
+    s.add(admin)
+    s.commit()
+    s.close()
+
+    app = FastAPI()
+    app.include_router(apps_router.router)
+
+    def _db():
+        sess = SessionLocal()
+        try:
+            yield sess
+        finally:
+            sess.close()
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[auth_mod.get_current_superuser] = lambda: admin
+    with TestClient(app) as tc:
+        yield tc
+
+
+def _site():
+    return {"X-Internal-Api-Key": SITE_KEY}
+
+
+# ── versions ────────────────────────────────────────────────────────────
+
+
+def test_version_constants_are_well_formed():
+    assert API_VER.match(apps_router.API_VERSION), apps_router.API_VERSION
+    assert SEMVER.match(apps_router.MIN_SDK_VERSION), apps_router.MIN_SDK_VERSION
+
+
+def test_the_sdk_in_this_repo_satisfies_its_own_server():
+    """A developer who pins the SDK shipped with a release must be able
+    to register against that release."""
+    from opennvr_app_sdk._version import __version__ as sdk_version
+
+    assert SEMVER.match(sdk_version), sdk_version
+    assert _vt(sdk_version) >= _vt(apps_router.MIN_SDK_VERSION), (
+        f"SDK {sdk_version} is older than the server's MIN_SDK_VERSION "
+        f"{apps_router.MIN_SDK_VERSION}; ship the SDK first")
+
+
+def test_min_sdk_never_moves_past_what_the_examples_pin():
+    """The example apps and the template are the reference SDK users;
+    if they pin an SDK below the server minimum, CI would break for
+    exactly the reason we promise it will not."""
+    import tomllib
+
+    pins = []
+    for pyproject in [*REPO_ROOT.glob("examples/*/pyproject.toml"),
+                      REPO_ROOT / "templates" / "opennvr-app" / "pyproject.toml"]:
+        if not pyproject.exists():
+            continue
+        data = tomllib.loads(pyproject.read_text())
+        for dep in data.get("project", {}).get("dependencies", []):
+            m = re.match(r"opennvr[-_]app[-_]sdk\s*>=\s*(\d+\.\d+\.\d+)", dep)
+            if m:
+                pins.append((pyproject.parent.name, m.group(1)))
+    for name, pin in pins:
+        assert _vt(pin) >= _vt(apps_router.MIN_SDK_VERSION), (
+            f"{name} pins opennvr-app-sdk>={pin}, below MIN_SDK_VERSION")
+
+
+# ── response shapes the SDK reads ───────────────────────────────────────
+
+#: key → accepted types. Removing a key or changing its type is a
+#: MAJOR bump of API_VERSION. Adding keys is free (MINOR).
+REGISTER_KEYS = {
+    "id": (str,), "name": (str,), "category": (str,), "version": (str,),
+    "url": (str,), "enabled": (bool,), "status": (str,),
+    "last_seen": (str, type(None)), "manifest": (dict,), "config": (dict,),
+    "has_api_key": (bool,), "api_key_issued_at": (str, type(None)),
+    "entitlement": (dict,), "registry": (dict,),
+}
+REGISTRY_KEYS = {"server_version": (str,), "api_version": (str,),
+                 "min_sdk_version": (str,)}
+ENTITLEMENT_KEYS = {
+    "mode": (str,), "status": (str,), "plan": (str, type(None)),
+    "expires_at": (str, type(None)), "message": (str,), "limits": (dict,),
+    "checked_at": (str, type(None)), "has_license_key": (bool,),
+}
+CONFIG_KEYS = {"id": (str,), "config": (dict,), "updated_at": (str, type(None)),
+               "entitlement": (dict,)}
+STATUS_KEYS = {"health": (dict,), "state": (dict, list, type(None))}
+
+
+def _assert_shape(body: dict, spec: dict, where: str):
+    for key, types in spec.items():
+        assert key in body, f"{where}: missing '{key}'"
+        assert isinstance(body[key], types), (
+            f"{where}: '{key}' is {type(body[key]).__name__}, expected {types}")
+
+
+def test_register_response_shape(env):
+    r = env.post("/apps/register",
+                 json={"url": "http://probe:9200", "manifest": _manifest(),
+                       "sdk_version": apps_router.MIN_SDK_VERSION, "wants_key": True},
+                 headers=_site())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    _assert_shape(body, REGISTER_KEYS, "register")
+    _assert_shape(body["registry"], REGISTRY_KEYS, "register.registry")
+    _assert_shape(body["entitlement"], ENTITLEMENT_KEYS, "register.entitlement")
+    assert body["registry"]["api_version"] == apps_router.API_VERSION
+    assert body["registry"]["min_sdk_version"] == apps_router.MIN_SDK_VERSION
+    # The key is returned exactly once, in the clear, under this name.
+    assert isinstance(body["api_key"], str) and body["api_key"].startswith("oak_")
+    # A free app is enable-able out of the box.
+    assert body["entitlement"]["mode"] == "none"
+    assert body["entitlement"]["status"] == "none"
+
+
+def test_old_sdk_is_warned_not_refused(env):
+    """A too-old SDK still registers; the response says what it should
+    upgrade to. Refusing would strand every deployed app on upgrade."""
+    r = env.post("/apps/register",
+                 json={"url": "http://probe:9200", "manifest": _manifest(),
+                       "sdk_version": "0.0.1"},
+                 headers=_site())
+    assert r.status_code == 200, r.text
+    assert r.json()["registry"]["min_sdk_version"] == apps_router.MIN_SDK_VERSION
+
+
+def test_register_without_sdk_fields_still_works(env):
+    """Pre-0.2 SDKs send only url + manifest."""
+    r = env.post("/apps/register",
+                 json={"url": "http://probe:9200", "manifest": _manifest()},
+                 headers=_site())
+    assert r.status_code == 200, r.text
+    _assert_shape(r.json(), REGISTER_KEYS, "register(legacy)")
+
+
+def test_config_and_status_response_shapes(env):
+    key = env.post("/apps/register",
+                   json={"url": "http://probe:9200", "manifest": _manifest()},
+                   headers=_site()).json()["api_key"]
+    app = {"X-Internal-Api-Key": key}
+
+    cfg = env.get("/apps/contract-probe/config", headers=app)
+    assert cfg.status_code == 200, cfg.text
+    _assert_shape(cfg.json(), CONFIG_KEYS, "config")
+    _assert_shape(cfg.json()["entitlement"], ENTITLEMENT_KEYS, "config.entitlement")
+
+    st = env.get("/apps/contract-probe/status", headers=app)
+    assert st.status_code == 200, st.text
+    _assert_shape(st.json(), STATUS_KEYS, "status")
+    assert "status" in st.json()["health"]     # "unreachable" here — still the shape
+
+
+def test_licensed_app_contract(env):
+    """The entitlement keys an app's ``verify_license`` verdict is
+    mapped onto, and the 402 an operator sees before a valid key."""
+    r = env.post("/apps/register",
+                 json={"url": "http://probe:9200",
+                       "manifest": _manifest(pricing="paid",
+                                             entitlement="license_key")},
+                 headers=_site())
+    assert r.status_code == 200, r.text
+    ent = r.json()["entitlement"]
+    assert ent["mode"] == "license_key" and ent["has_license_key"] is False
+    en = env.post("/apps/contract-probe/enable")
+    assert en.status_code == 402, en.text
+
+
+def test_sdk_constants_match_the_server():
+    """The SDK ships the same field names it reads from the wire —
+    catching a rename on either side before a release."""
+    from opennvr_app_sdk import manifest as sdk_manifest
+    from services import app_entitlements
+
+    assert set(sdk_manifest.ENTITLEMENT_MODES) >= {"none", "license_key"}
+    assert set(sdk_manifest.PRICING_MODELS) >= {"free", "paid"}
+    # The server maps the app's verdict onto these — the SDK's
+    # Entitlement dataclass carries the same names.
+    from opennvr_app_sdk.contract import Entitlement
+
+    for field in ("valid", "plan", "expires_at", "message", "limits"):
+        assert field in Entitlement.__dataclass_fields__, field
+    assert callable(app_entitlements.entitlement_view)

--- a/templates/opennvr-app/README.md
+++ b/templates/opennvr-app/README.md
@@ -45,6 +45,19 @@ dwell timer (`opennvr_app_sdk.state.keyed_state`), a confidence gate, a
 time-of-day window. The [`loitering-detection`](../../examples/loitering-detection)
 example is a full worked state machine to copy from.
 
+When the rule needs more than the event in hand — the cameras assigned
+to this app, a snapshot, past events, state that survives a restart —
+use the platform client instead of talking to core yourself:
+
+```python
+from opennvr_app_sdk import OpenNVR
+nvr = OpenNVR()                       # OPENNVR_URL + the app's own key
+nvr.cameras(); nvr.snapshot(camera_id); nvr.state.get("last_seen")
+```
+
+See [`docs/APP_PLATFORM.md`](../../docs/APP_PLATFORM.md) and the index in
+[`docs/SDK_REFERENCE.md`](../../docs/SDK_REFERENCE.md).
+
 ## Layout
 
 ```


### PR DESCRIPTION
…ences

Third-party developers had the pieces (SDK, per-app keys, platform client, entitlements) but no page that says what the deal is. This adds:

- docs/DEVELOPER_PROGRAM.md — the deal in five lines (no fee, your licence, we don't break you, the platform not plumbing, distribution), the platform surface as one table, how to ship, paid apps and models, the compatibility promise, getting seen, getting help.
- server/tests/test_registry_contract.py — pins the register / config / status response shapes and the entitlement keys the SDK reads, checks API_VERSION / MIN_SDK_VERSION are well-formed, that the SDK in this repo satisfies its own server's minimum, that an old SDK is warned not refused, and that a licensed app returns 402 on enable without a key. This is what makes the promise a test rather than a sentence.
- docs/SDK_REFERENCE.md — every public opennvr_app_sdk name, grouped by task (archetypes, manifest, OpenNVR client, alerts, domain events, identity, geometry/state, frames, config), with the stability rule.
- docs/PLATFORM_API.md — the operator API for provisioning from code: auth and registration setting, users (is_superuser + X-MFA-Code, last superuser guard), roles and the permission catalogue, cameras, assignments, per-camera access, apps and licences, conventions.
- make sdk-docs renders the SDK docstrings with pdoc into sdk/opennvr-app-sdk/docs/api/ (gitignored; the index is hand-written).
- FIRST_DETECTOR.md gains the app key and the OpenNVR() client in §4; CONTRIBUTING_APPS.md covers paid / external listings and the reviewer checks for pricing and entitlement; docs/README.md, the template README, ROADMAP.md (catalog-for-developers items, contract commitment) and CHANGELOG.md are updated to match.