### PR TITLE
chore: confine core.* module purges, retry buildx setup, drop handles…

### DIFF
--- a/.github/workflows/app-images-smoke.yml
+++ b/.github/workflows/app-images-smoke.yml
@@ -72,6 +72,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        id: buildx1
+        uses: docker/setup-buildx-action@v3
+        # Setup pulls moby/buildkit from Docker Hub, which has 502'd
+        # PR runs unrelated to the change under test (there is no
+        # non-Hub mirror to pin). One retry absorbs the transient.
+        continue-on-error: true
+      - name: Set up Docker Buildx (retry)
+        if: steps.buildx1.outcome == 'failure'
         uses: docker/setup-buildx-action@v3
 
       # Build only (no push, load into the local daemon so the smoke
@@ -199,6 +207,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        id: buildx2
+        uses: docker/setup-buildx-action@v3
+        # Setup pulls moby/buildkit from Docker Hub, which has 502'd
+        # PR runs unrelated to the change under test (there is no
+        # non-Hub mirror to pin). One retry absorbs the transient.
+        continue-on-error: true
+      - name: Set up Docker Buildx (retry)
+        if: steps.buildx2.outcome == 'failure'
         uses: docker/setup-buildx-action@v3
 
       - name: Build ${{ matrix.app }} image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,21 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Test suites no longer leak swapped `core.*` modules into each
+  other.** `server/tests/conftest.py` snapshots the `core` namespace of
+  `sys.modules` per test module and restores it, so a suite that purges
+  `core.config` to re-validate `Settings` (`test_m1b`, `test_m1c`) no
+  longer leaves later modules monkeypatching a stale `settings` object
+  — the pass-alone / fail-in-suite 401s.
+- **App-images CI retries the Buildx setup once.** Docker Hub 502s while
+  pulling `moby/buildkit` failed PR runs unrelated to the change; there
+  is no non-Hub mirror to pin, so the setup step is `continue-on-error`
+  with a single retry.
+- **camera-agent `/health` no longer lists camera handles.** The open
+  health probe now reports `camera_count`; the roster stays behind the
+  authenticated `/cameras` route and the contract `/state` door the App
+  Catalog scopes per viewer.
+
 - `PUT /users/me` was unreachable for non-superusers (declared after
   `PUT /users/{user_id}`, which captured it and demanded superuser), and
   its "strip admin-only fields" logic wrote NULL into `is_active` /

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -5259,7 +5259,12 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
     async def _health() -> dict[str, Any]:
         return {
             "status": "ok",
-            "cameras": [cam.camera_id for cam in runtime.cfg.cameras],
+            # A count, not the handles: /health is an OPEN path on a port
+            # the demo UI publishes, and the roster is what /cameras
+            # (authenticated, per-user) is for. /state — the contract
+            # door the App Catalog proxies and scopes per viewer — still
+            # carries the handle list, like every SDK app's does.
+            "camera_count": len(runtime.cfg.cameras),
             # The tools actually ADVERTISED to the LLM (honours enabled_tools),
             # not every registered handler (test-report #4).
             "tools": [t["function"]["name"] for t in runtime.tool_definitions],

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Suite-wide isolation for the ``core.*`` module objects.
+
+Every test module is imported at collection time, so a module-level
+``from core.config import settings`` binds the object that exists
+*then*. A few suites (``test_m1b_mediamtx_hardening``,
+``test_m1c_transport_probe``) later purge ``core`` and ``core.*`` from
+``sys.modules`` to re-validate ``Settings`` against a fresh
+environment. From that point on, any code that resolves the module
+lazily — ``routers.apps._internal_api_key`` doing
+``from core.config import settings`` at call time — sees a NEW
+``settings`` object, while the test module's monkeypatch landed on
+the OLD one. The symptom is a test that passes alone and fails in the
+full run with a 401 (``test_registry_contract`` found it; several
+suites carry private work-arounds for the same thing, e.g.
+``test_camera_settings._stable_core_env``).
+
+This fixture snapshots the ``core`` namespace of ``sys.modules``
+before each test module runs and restores it afterwards, so a purge
+is confined to the module that asked for it. Per-module scope, not
+per-test: a module that purges expects its own later tests to keep
+the fresh objects.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+_NAMESPACE = ("core",)
+
+
+def _is_core(name: str) -> bool:
+    return any(name == ns or name.startswith(ns + ".") for ns in _NAMESPACE)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _restore_core_modules():
+    before = {k: v for k, v in sys.modules.items() if _is_core(k)}
+    yield
+    for k in [k for k in sys.modules if _is_core(k)]:
+        if k not in before:
+            del sys.modules[k]
+    sys.modules.update(before)


### PR DESCRIPTION
… from agent /health

Three small debts the last few PRs surfaced:

- server/tests/conftest.py: test_m1b / test_m1c purge core and core.* from sys.modules to re-validate Settings against a fresh env. Any code that resolves core.config lazily afterwards sees a NEW settings object while earlier-collected test modules monkeypatch the OLD one — tests that pass alone and 401 in the full run. A module-scoped autouse fixture snapshots the core namespace and restores it, so a purge is confined to the module that asked for it. Verified with the registry-contract test minus its private work-around: 5/9 fail without the conftest after m1b+m1c, all pass with it.
- app-images-smoke: Docker Hub 502s while pulling moby/buildkit have failed PR runs unrelated to the change; there is no non-Hub mirror to pin and the action ignores mirror config during setup, so the step is continue-on-error with one retry.
- camera-agent /health: an open path on a published port listed every camera handle. It now reports camera_count; the roster stays behind the authenticated /cameras route and the contract /state door the App Catalog scopes per viewer (unchanged, like every SDK app's).