### PR TITLE
feat(sdk): AsyncOpenNVR — the platform client for apps on an event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **SDK 0.4.0: an async platform client.** `opennvr_app_sdk.aio.AsyncOpenNVR`
+  is `OpenNVR` `await`-ed — same methods, arguments, return types and
+  degrade/raise rules — for apps that serve a `/ui`, run on
+  FastAPI/Starlette, or drive an agent loop that must never block. It
+  shares the route paths, KAI-C request builder and response parsers
+  with the sync client and a parity test pins the two surfaces
+  together; `http_client=` shares an existing `httpx.AsyncClient`.
+  `ai.stream()` has no async form yet. The OpenNVR Agent's KAI-C
+  capabilities probe now rides it. See `docs/APP_PLATFORM.md`.
+
 ### Security
 
 - **Every app gets its own credential.** SDK apps used to boot with the

--- a/docs/APP_PLATFORM.md
+++ b/docs/APP_PLATFORM.md
@@ -1,6 +1,6 @@
 # The app platform client — `opennvr_app_sdk.OpenNVR`
 
-**Status:** shipped (SDK ≥ 0.3.0, server `api_version` 1.2).
+**Status:** shipped (SDK ≥ 0.3.0, server `api_version` 1.2; async client SDK ≥ 0.4.0).
 
 Everything a vision app needs from the platform, behind one object that
 already holds the app's credential ([APP_CREDENTIALS.md](APP_CREDENTIALS.md))
@@ -53,6 +53,33 @@ Cameras are accepted as a `Camera`, an int id, or a `camN` / `cam-N`
 handle everywhere. Reads return `None` / `[]` and log when the platform
 is unreachable (an app must not die to a blip); writes raise
 `PlatformError` so a lost state write is never silent.
+
+## On an event loop: `opennvr_app_sdk.aio.AsyncOpenNVR`
+
+The sync client is right for a detector loop. An app that serves a
+`/ui` page, a FastAPI/Starlette service, or an agent loop that must
+never block gets the same surface `await`-ed — same method names,
+arguments, return types and degrade/raise rules, sharing the route
+paths, request builders and parsers with the sync client (a parity test
+in the SDK keeps the two identical):
+
+```python
+from opennvr_app_sdk.aio import AsyncOpenNVR
+
+async with AsyncOpenNVR() as nvr:                 # or AsyncOpenNVR(http_client=pool)
+    for cam in await nvr.cameras():
+        jpeg = await nvr.snapshot(cam)
+        result = await nvr.ai.infer("yolov8", jpeg, task="object_detection",
+                                    camera_id=cam.handle)
+    await nvr.state.set("last_seen", {"cam1": 12.5})
+    recent = await nvr.timeline.search(camera="cam1", limit=5)
+```
+
+Pass `http_client=` to share one `httpx.AsyncClient` (a FastAPI
+lifespan pool, a test transport); the client then leaves it open. The
+one gap: `ai.stream()` (a blocking WebSocket session) has no async form
+yet — call `ai.infer()` per frame from async code. The OpenNVR Agent's
+capabilities probe is the first consumer.
 
 ## Durable state
 

--- a/docs/SDK_REFERENCE.md
+++ b/docs/SDK_REFERENCE.md
@@ -8,7 +8,7 @@ walkthroughs live in [FIRST_DETECTOR.md](FIRST_DETECTOR.md),
 [APP_PLATFORM.md](APP_PLATFORM.md), [APP_SURFACES.md](APP_SURFACES.md)
 and [APP_CREDENTIALS.md](APP_CREDENTIALS.md).
 
-Version: `opennvr_app_sdk.__version__` (`0.3.0`). Licence: Apache-2.0.
+Version: `opennvr_app_sdk.__version__` (`0.4.0`). Licence: Apache-2.0.
 
 ```bash
 pip install opennvr-app-sdk            # or: uv add opennvr-app-sdk
@@ -72,6 +72,7 @@ nvr = OpenNVR()                      # OPENNVR_URL + the app's own key
 | `Recording` | `start`, `duration` |
 | `PlatformError` | Raised by writes; reads degrade to `None` / `[]` and log |
 | `InferStream` | The WebSocket inference session behind `nvr.ai.stream()`; `open()`, `infer(jpeg)`, `close()`, context-manager |
+| `AsyncOpenNVR` (`opennvr_app_sdk.aio`) | The same client `await`-ed, for FastAPI/agent loops: `await nvr.cameras()`, `await nvr.state.set(...)`, `async with`; `http_client=` shares a pool; no `ai.stream()` yet |
 
 Lower-level helpers that predate the client and remain public:
 `discover_cameras(url)`, `cameras_for_skill(...)`,

--- a/examples/camera-agent/adapter_clients.py
+++ b/examples/camera-agent/adapter_clients.py
@@ -218,7 +218,8 @@ class KaicCapabilitiesClient(_ReusableClientMixin):
         ttl_seconds: float = 60.0,
         timeout_seconds: float = 5.0,
     ) -> None:
-        self._url = f"{kaic_url.rstrip('/')}/api/v1/ai/capabilities"
+        self._kaic_url = kaic_url.rstrip("/")
+        self._url = f"{self._kaic_url}/api/v1/ai/capabilities"
         self._api_key = api_key
         self._ttl = ttl_seconds
         self._timeout = timeout_seconds
@@ -252,12 +253,15 @@ class KaicCapabilitiesClient(_ReusableClientMixin):
         # to one attempt per TTL (negative caching).
         self._fetched_at = now
         try:
-            headers = {}
-            if self._api_key:
-                headers["X-Internal-Api-Key"] = self._api_key
-            resp = await self._client().get(self._url, headers=headers)
-            resp.raise_for_status()
-            data = resp.json()
+            # The fetch itself is the SDK's (opennvr_app_sdk.aio) — same
+            # route, header and degrade rule every async app gets; this
+            # class keeps only the agent-side TTL cache and the parse.
+            from opennvr_app_sdk.aio import AsyncAIAPI
+
+            data = await AsyncAIAPI(self._kaic_url, self._api_key or None,
+                                    self._timeout, client=self._client()).capabilities()
+            if data is None:
+                raise RuntimeError("capabilities unavailable")
             tasks: set[str] = set()
             gpu: dict[str, bool] = {}
             adapters = data.get("adapters") or {}

--- a/examples/camera-agent/tests/test_skills_live_capabilities.py
+++ b/examples/camera-agent/tests/test_skills_live_capabilities.py
@@ -52,6 +52,8 @@ class _StubCaps:
 
 
 class _FakeResponse:
+    status_code = 200
+
     def __init__(self, payload: dict) -> None:
         self._payload = payload
 

--- a/examples/camera-agent/uv.lock
+++ b/examples/camera-agent/uv.lock
@@ -942,7 +942,7 @@ wheels = [
 
 [[package]]
 name = "opennvr-app-sdk"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../sdk/opennvr-app-sdk" }
 dependencies = [
     { name = "httpx" },

--- a/examples/intrusion-detection/uv.lock
+++ b/examples/intrusion-detection/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "opennvr-app-sdk"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../sdk/opennvr-app-sdk" }
 dependencies = [
     { name = "httpx" },

--- a/examples/package-delivery/uv.lock
+++ b/examples/package-delivery/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "opennvr-app-sdk"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../sdk/opennvr-app-sdk" }
 dependencies = [
     { name = "httpx" },

--- a/examples/smart-doorbell/uv.lock
+++ b/examples/smart-doorbell/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "opennvr-app-sdk"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../sdk/opennvr-app-sdk" }
 dependencies = [
     { name = "httpx" },

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -64,6 +64,7 @@ from .cameras import (
 from .credentials import AppCredentials, auth_headers
 from .usercontext import UserContext, current_user
 from .client import OpenNVR, Camera, Recording, PlatformError
+from .aio import AsyncOpenNVR
 from .infer_stream import InferStream
 from .domain_subscriber import (
     DomainEvent, DomainEventSubscriber, domain_event_app, parse_domain_event,
@@ -138,6 +139,7 @@ __all__ = [
     "current_user",
     # The platform client (everything an app reads from core / KAI-C)
     "OpenNVR",
+    "AsyncOpenNVR",
     "Camera",
     "Recording",
     "PlatformError",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2026 OpenNVR
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Single source of the SDK version (pyproject mirrors it)."""
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/aio.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/aio.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""``AsyncOpenNVR`` — the platform client for apps that live on an
+event loop.
+
+The sync :class:`~opennvr_app_sdk.OpenNVR` is right for a detector
+loop. An app with a ``/ui`` page, a FastAPI/Starlette service, or a
+voice/agent loop that must never block would have to push every
+platform call through ``asyncio.to_thread`` — the OpenNVR Agent ended
+up writing its own async clients instead. This module is the same
+surface, ``await``-ed::
+
+    from opennvr_app_sdk.aio import AsyncOpenNVR
+
+    async with AsyncOpenNVR() as nvr:
+        for cam in await nvr.cameras():
+            jpeg = await nvr.snapshot(cam)
+            det = await nvr.ai.infer("yolov8", jpeg, task="object_detection")
+        await nvr.state.set("last_seen", {"cam1": 12.5})
+        recent = await nvr.timeline.search(camera="cam1", limit=5)
+
+Method names, arguments, return types and error behaviour are those
+of the sync client — reads degrade to ``None`` / ``[]`` and log,
+writes raise :class:`PlatformError` — and both share the same route
+paths, request builders and response parsers (``client.py``,
+``frame_app.build_infer_request``), so they cannot drift. The one
+difference: ``ai.stream()`` (a blocking WebSocket session) has no
+async form yet; use ``ai.infer()`` per frame from async code.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from typing import Any, Iterable
+
+import httpx
+
+from .client import (
+    DEFAULT_TIMEOUT, Camera, PlatformError, Recording, _camera_id, _iso,
+    parse_cameras, parse_recordings, parse_state_items, query_string,
+)
+from .credentials import AppCredentials
+from .frame_app import KaiCError, build_infer_request
+
+logger = logging.getLogger("opennvr.app.client.aio")
+
+__all__ = ["AsyncOpenNVR", "Camera", "Recording", "PlatformError"]
+
+
+class _AsyncHttp:
+    def __init__(self, base: str, creds: AppCredentials, timeout: float,
+                 client: httpx.AsyncClient | None = None) -> None:
+        self.base = base.rstrip("/")
+        self.creds = creds
+        self.timeout = timeout
+        self._owns = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout, trust_env=False)
+
+    def headers(self) -> dict[str, str]:
+        return self.creds.headers()
+
+    async def get(self, path: str, **params) -> httpx.Response:
+        return await self._client.get(f"{self.base}{path}{query_string(params)}",
+                                      headers=self.headers())
+
+    async def get_json(self, path: str, **params) -> Any | None:
+        try:
+            r = await self.get(path, **params)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("OpenNVR GET %s failed: %s", path, exc)
+            return None
+        if r.status_code >= 400:
+            logger.warning("OpenNVR GET %s → HTTP %d", path, r.status_code)
+            return None
+        try:
+            return r.json()
+        except ValueError:
+            return None
+
+    async def get_bytes(self, path: str, **params) -> bytes | None:
+        try:
+            r = await self.get(path, **params)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("OpenNVR GET %s failed: %s", path, exc)
+            return None
+        return r.content if r.status_code == 200 else None
+
+    async def put_json(self, path: str, body: Any, **params) -> Any:
+        url = f"{self.base}{path}{query_string(params)}"
+        try:
+            r = await self._client.put(url, json=body, headers=self.headers())
+        except Exception as exc:  # noqa: BLE001
+            raise PlatformError(f"PUT {path} failed: {exc}") from exc
+        if r.status_code >= 400:
+            raise PlatformError(f"PUT {path} → HTTP {r.status_code}: {r.text[:200]}")
+        return r.json()
+
+    async def delete(self, path: str, **params) -> Any:
+        url = f"{self.base}{path}{query_string(params)}"
+        try:
+            r = await self._client.delete(url, headers=self.headers())
+        except Exception as exc:  # noqa: BLE001
+            raise PlatformError(f"DELETE {path} failed: {exc}") from exc
+        if r.status_code >= 400:
+            raise PlatformError(f"DELETE {path} → HTTP {r.status_code}")
+        return r.json()
+
+    async def aclose(self) -> None:
+        if self._owns:
+            await self._client.aclose()
+
+
+# ── Sub-APIs ────────────────────────────────────────────────────────
+
+
+class AsyncRecordingsAPI:
+    def __init__(self, http: _AsyncHttp, camera_id: int) -> None:
+        self._http = http
+        self._cam = camera_id
+
+    async def list(self, start: datetime | str | None = None,
+                   end: datetime | str | None = None) -> list[Recording]:
+        return parse_recordings(await self._http.get_json(
+            f"/api/v1/internal/app/recordings/{self._cam}",
+            start=_iso(start), end=_iso(end)))
+
+    async def url(self, start: datetime | str, duration: float) -> str | None:
+        body = await self._http.get_json(
+            f"/api/v1/internal/app/recordings/{self._cam}/url",
+            start=_iso(start), duration=duration)
+        return (body or {}).get("url")
+
+    async def frame_at(self, at: datetime | str) -> bytes | None:
+        return await self._http.get_bytes(
+            "/api/v1/internal/camera-agent/recordings/frame",
+            camera_id=self._cam, at=_iso(at))
+
+
+class AsyncTimelineAPI:
+    def __init__(self, http: _AsyncHttp) -> None:
+        self._http = http
+
+    async def search(self, *, camera=None, label: str | None = None,
+                     plate: str | None = None, start=None, end=None,
+                     limit: int = 50) -> list[dict] | None:
+        body = await self._http.get_json(
+            "/api/v1/internal/camera-agent/events",
+            camera_id=None if camera is None else _camera_id(camera),
+            label=label, plate=plate, limit=limit,
+            **{"from": _iso(start), "to": _iso(end)})
+        return None if body is None else list(body.get("events") or [])
+
+    async def evidence(self, event_id: int, *, scene: bool = False) -> bytes | None:
+        suffix = "scene-evidence" if scene else "evidence"
+        return await self._http.get_bytes(
+            f"/api/v1/internal/camera-agent/events/{int(event_id)}/{suffix}")
+
+    async def plate_stats(self, days: int = 7) -> dict | None:
+        return await self._http.get_json("/api/v1/internal/app/plates/stats", days=days)
+
+    async def plate_summary(self, plate: str) -> dict | None:
+        return await self._http.get_json("/api/v1/internal/app/plates/summary", plate=plate)
+
+    async def plate_sessions(self, plate: str, *, in_cameras: Iterable = (),
+                             out_cameras: Iterable = (), limit: int = 50) -> dict | None:
+        return await self._http.get_json(
+            "/api/v1/internal/app/plates/sessions", plate=plate, limit=limit,
+            in_cameras=",".join(str(_camera_id(c)) for c in in_cameras),
+            out_cameras=",".join(str(_camera_id(c)) for c in out_cameras))
+
+
+class AsyncAlertsAPI:
+    def __init__(self, http: _AsyncHttp) -> None:
+        self._http = http
+
+    async def inbox(self, *, unacked: bool = False, limit: int = 50,
+                    after_id: int | None = None) -> list[dict]:
+        body = await self._http.get_json("/api/v1/internal/app/alerts",
+                                         unacked="true" if unacked else None,
+                                         limit=limit, after_id=after_id)
+        return list((body or {}).get("alerts") or [])
+
+
+class AsyncStateAPI:
+    def __init__(self, http: _AsyncHttp) -> None:
+        self._http = http
+
+    async def get(self, key: str, default: Any = None) -> Any:
+        body = await self._http.get_json(f"/api/v1/internal/app/state/{key}")
+        return default if body is None else body.get("value", default)
+
+    async def set(self, key: str, value: Any) -> None:
+        await self._http.put_json(f"/api/v1/internal/app/state/{key}", value)
+
+    async def delete(self, key: str) -> bool:
+        body = await self._http.delete(f"/api/v1/internal/app/state/{key}")
+        return bool(body.get("deleted"))
+
+    async def items(self, prefix: str = "") -> dict[str, Any]:
+        return parse_state_items(await self._http.get_json(
+            "/api/v1/internal/app/state", prefix=prefix or None))
+
+
+class AsyncAIAPI:
+    """KAI-C: adapters that exist, and running one on a frame."""
+
+    def __init__(self, kaic_url: str | None, api_key: str | None,
+                 timeout: float, client: httpx.AsyncClient | None = None) -> None:
+        self._base = (kaic_url or "").rstrip("/")
+        self._key = api_key
+        self._timeout = timeout
+        self._owns = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout, trust_env=False)
+
+    async def capabilities(self) -> dict | None:
+        if not self._base:
+            return None
+        headers = {"X-Internal-Api-Key": self._key} if self._key else {}
+        try:
+            r = await self._client.get(f"{self._base}/api/v1/ai/capabilities",
+                                       headers=headers)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("KAI-C capabilities failed: %s", exc)
+            return None
+        return r.json() if r.status_code == 200 else None
+
+    async def infer(self, adapter: str, jpeg: bytes, *, task: str,
+                    camera_id: str | None = None, params: dict | None = None,
+                    correlation_id: str | None = None) -> dict:
+        """One inference call; raises :class:`KaiCError` on transport
+        failure or a non-200, exactly like the sync client."""
+        if not self._base:
+            raise PlatformError("KAI-C is not configured (KAIC_URL)")
+        url, headers, body = build_infer_request(
+            self._base, adapter, jpeg, task=task, api_key=self._key,
+            camera_id=None if camera_id is None else str(camera_id),
+            params=params, correlation_id=correlation_id)
+        try:
+            r = await self._client.post(url, json=body, headers=headers)
+        except Exception as exc:  # noqa: BLE001
+            raise KaiCError(f"KAI-C unreachable at {url}: {exc}") from exc
+        if r.status_code != 200:
+            raise KaiCError(f"KAI-C returned HTTP {r.status_code}: {r.text[:200]}")
+        return r.json()
+
+    async def aclose(self) -> None:
+        if self._owns:
+            await self._client.aclose()
+
+
+# ── The client ──────────────────────────────────────────────────────
+
+
+class AsyncOpenNVR:
+    """The async twin of :class:`opennvr_app_sdk.OpenNVR`; same
+    arguments and environment fallbacks. Pass ``http_client`` to share
+    one ``httpx.AsyncClient`` (a FastAPI app's lifespan pool, a test
+    transport); the client then does not close it."""
+
+    def __init__(self, url: str | None = None, *, token: str | None = None,
+                 kaic_url: str | None = None, kaic_api_key: str | None = None,
+                 timeout: float = DEFAULT_TIMEOUT,
+                 http_client: httpx.AsyncClient | None = None) -> None:
+        base = url or os.environ.get("OPENNVR_URL") or ""
+        if not base:
+            raise ValueError("AsyncOpenNVR(url=...) or OPENNVR_URL is required")
+        self.credentials = AppCredentials(token)
+        self._http = _AsyncHttp(base, self.credentials, timeout, http_client)
+        kaic = kaic_url or os.environ.get("KAIC_URL") or os.environ.get("OPENNVR_KAIC_URL")
+        self.ai = AsyncAIAPI(kaic, kaic_api_key or os.environ.get("KAIC_API_KEY")
+                             or os.environ.get("OPENNVR_INTERNAL_API_KEY"),
+                             timeout, http_client)
+        self.timeline = AsyncTimelineAPI(self._http)
+        self.alerts = AsyncAlertsAPI(self._http)
+        self.state = AsyncStateAPI(self._http)
+
+    @property
+    def url(self) -> str:
+        return self._http.base
+
+    async def cameras(self) -> list[Camera]:
+        return parse_cameras(await self._http.get_json(
+            "/api/v1/internal/camera-agent/cameras"))
+
+    async def camera(self, camera) -> Camera | None:
+        want = _camera_id(camera)
+        return next((c for c in await self.cameras() if c.id == want), None)
+
+    async def snapshot(self, camera) -> bytes | None:
+        return await self._http.get_bytes(
+            f"/api/v1/internal/app/cameras/{_camera_id(camera)}/snapshot")
+
+    def recordings(self, camera) -> AsyncRecordingsAPI:
+        return AsyncRecordingsAPI(self._http, _camera_id(camera))
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+        await self.ai.aclose()
+
+    async def __aenter__(self) -> "AsyncOpenNVR":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.aclose()

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/client.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/client.py
@@ -92,6 +92,44 @@ class Recording:
     raw: dict = field(default_factory=dict, compare=False, repr=False)
 
 
+# ── Response parsers shared with the async client (aio.py) ──────────
+
+
+def parse_cameras(body: Any) -> list[Camera]:
+    """``GET /internal/camera-agent/cameras`` → roster."""
+    out: list[Camera] = []
+    for row in (body or {}).get("cameras") or []:
+        if not isinstance(row, dict):
+            continue
+        try:
+            cid = int(row.get("open_nvr_camera_id") or _camera_id(row.get("camera_id")))
+        except (TypeError, ValueError):
+            continue
+        out.append(Camera(
+            id=cid, handle=str(row.get("camera_id") or f"cam{cid}"),
+            name=str(row.get("name") or f"Camera {cid}"),
+            role=str(row.get("role") or ""),
+            frame_url=str(row.get("frame_url") or ""),
+            assignments=list(row.get("assignments") or []), raw=row))
+    return out
+
+
+def parse_recordings(body: Any) -> list[Recording]:
+    rows = (body or {}).get("recordings") or []
+    return [Recording(start=str(r.get("start", "")),
+                      duration=float(r.get("duration", 0) or 0), raw=r)
+            for r in rows if isinstance(r, dict)]
+
+
+def parse_state_items(body: Any) -> dict[str, Any]:
+    return {r["key"]: r["value"] for r in (body or {}).get("items") or []}
+
+
+def query_string(params: dict[str, Any]) -> str:
+    clean = {k: v for k, v in params.items() if v is not None}
+    return f"?{urlencode(clean)}" if clean else ""
+
+
 class _Http:
     """The client's one HTTP session: base URL + the app's headers,
     re-read per request so a key issued after start-up is honoured."""
@@ -106,9 +144,8 @@ class _Http:
         return self.creds.headers()
 
     def get(self, path: str, **params) -> httpx.Response:
-        clean = {k: v for k, v in params.items() if v is not None}
-        url = f"{self.base}{path}" + (f"?{urlencode(clean)}" if clean else "")
-        return self._client.get(url, headers=self.headers())
+        return self._client.get(f"{self.base}{path}{query_string(params)}",
+                                headers=self.headers())
 
     def get_json(self, path: str, **params) -> Any | None:
         try:
@@ -133,8 +170,7 @@ class _Http:
         return r.content if r.status_code == 200 else None
 
     def put_json(self, path: str, body: Any, **params) -> Any:
-        clean = {k: v for k, v in params.items() if v is not None}
-        url = f"{self.base}{path}" + (f"?{urlencode(clean)}" if clean else "")
+        url = f"{self.base}{path}{query_string(params)}"
         try:
             r = self._client.put(url, json=body, headers=self.headers())
         except Exception as exc:  # noqa: BLE001
@@ -144,8 +180,7 @@ class _Http:
         return r.json()
 
     def delete(self, path: str, **params) -> Any:
-        clean = {k: v for k, v in params.items() if v is not None}
-        url = f"{self.base}{path}" + (f"?{urlencode(clean)}" if clean else "")
+        url = f"{self.base}{path}{query_string(params)}"
         try:
             r = self._client.delete(url, headers=self.headers())
         except Exception as exc:  # noqa: BLE001
@@ -171,10 +206,7 @@ class RecordingsAPI:
         body = self._http.get_json(
             f"/api/v1/internal/app/recordings/{self._cam}",
             start=_iso(start), end=_iso(end))
-        rows = (body or {}).get("recordings") or []
-        return [Recording(start=str(r.get("start", "")),
-                          duration=float(r.get("duration", 0) or 0), raw=r)
-                for r in rows if isinstance(r, dict)]
+        return parse_recordings(body)
 
     def url(self, start: datetime | str, duration: float) -> str | None:
         body = self._http.get_json(
@@ -259,7 +291,7 @@ class StateAPI:
 
     def items(self, prefix: str = "") -> dict[str, Any]:
         body = self._http.get_json("/api/v1/internal/app/state", prefix=prefix or None)
-        return {r["key"]: r["value"] for r in (body or {}).get("items") or []}
+        return parse_state_items(body)
 
 
 class AIAPI:
@@ -356,22 +388,7 @@ class OpenNVR:
         """The roster core assigned to this app (every active camera
         when the operator assigned none). ``[]`` when core can't be
         reached — log it; never guess."""
-        body = self._http.get_json("/api/v1/internal/camera-agent/cameras")
-        out: list[Camera] = []
-        for row in (body or {}).get("cameras") or []:
-            if not isinstance(row, dict):
-                continue
-            try:
-                cid = int(row.get("open_nvr_camera_id") or _camera_id(row.get("camera_id")))
-            except (TypeError, ValueError):
-                continue
-            out.append(Camera(
-                id=cid, handle=str(row.get("camera_id") or f"cam{cid}"),
-                name=str(row.get("name") or f"Camera {cid}"),
-                role=str(row.get("role") or ""),
-                frame_url=str(row.get("frame_url") or ""),
-                assignments=list(row.get("assignments") or []), raw=row))
-        return out
+        return parse_cameras(self._http.get_json("/api/v1/internal/camera-agent/cameras"))
 
     def camera(self, camera) -> Camera | None:
         want = _camera_id(camera)

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/frame_app.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/frame_app.py
@@ -57,6 +57,33 @@ class KaiCError(Exception):
     via the correlation_id we sent)."""
 
 
+def build_infer_request(
+    base_url: str, adapter_name: str, frame_bytes: bytes, *, task: str,
+    api_key: str | None = None, camera_id: str | None = None,
+    params: dict[str, Any] | None = None, correlation_id: str | None = None,
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """``(url, headers, json body)`` for one KAI-C inference call — the
+    one wire shape both the sync :class:`KaiCClient` and the async
+    client (``aio.py``) send, so they cannot drift."""
+    url = f"{base_url.rstrip('/')}/api/v1/infer/{adapter_name}"
+    headers = {
+        "X-Correlation-Id": correlation_id or f"app-{uuid.uuid4().hex[:12]}",
+    }
+    if api_key:
+        headers["X-Internal-Api-Key"] = api_key
+    # Body shape matches the server's build_infer_payload:
+    # {"frame_b64", "task", "camera_id", **params} — adapters read
+    # task + params, KAI-C reads camera_id for NATS subject + audit.
+    body: dict[str, Any] = {
+        "task": task,
+        "frame_b64": base64.b64encode(frame_bytes).decode("ascii"),
+        **(params or {}),
+    }
+    if camera_id is not None:
+        body["camera_id"] = str(camera_id)
+    return url, headers, body
+
+
 class KaiCClient:
     """Tiny client for KAI-C's ``POST /api/v1/infer/{adapter}``.
 
@@ -106,22 +133,10 @@ class KaiCClient:
         probe. Raises :class:`KaiCError` on transport failure or
         non-200; the frame loop catches and decides whether to alert /
         skip / abort."""
-        url = f"{self._base_url}/api/v1/infer/{self._adapter_name}"
-        headers = {
-            "X-Correlation-Id": correlation_id or f"app-{uuid.uuid4().hex[:12]}",
-        }
-        if self._api_key:
-            headers["X-Internal-Api-Key"] = self._api_key
-        # Body shape matches the server's build_infer_payload:
-        # {"frame_b64", "task", "camera_id", **params} — adapters read
-        # task + params, KAI-C reads camera_id for NATS subject + audit.
-        body = {
-            "task": task,
-            "frame_b64": base64.b64encode(frame_bytes).decode("ascii"),
-            **(params or {}),
-        }
-        if camera_id is not None:
-            body["camera_id"] = str(camera_id)
+        url, headers, body = build_infer_request(
+            self._base_url, self._adapter_name, frame_bytes, task=task,
+            api_key=self._api_key, camera_id=camera_id, params=params,
+            correlation_id=correlation_id)
         try:
             response = self._client.post(url, json=body, headers=headers)
         except Exception as exc:

--- a/sdk/opennvr-app-sdk/pyproject.toml
+++ b/sdk/opennvr-app-sdk/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "opennvr-app-sdk"
-version = "0.3.0"
+version = "0.4.0"
 description = "Shared SDK for OpenNVR monitoring apps: §11.5 alert dispatch, zone geometry, keyed TTL state, app manifests, and the Detector / FrameApp base loops."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/sdk/opennvr-app-sdk/tests/test_aio.py
+++ b/sdk/opennvr-app-sdk/tests/test_aio.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``AsyncOpenNVR`` — the async twin of the platform client: the same
+routes with the app key, the same degrade/raise rules, and a parity
+check so the two surfaces cannot drift apart."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from opennvr_app_sdk import OpenNVR, PlatformError, Recording
+from opennvr_app_sdk.aio import (
+    AsyncAIAPI, AsyncAlertsAPI, AsyncOpenNVR, AsyncRecordingsAPI,
+    AsyncStateAPI, AsyncTimelineAPI,
+)
+from opennvr_app_sdk.client import (
+    AIAPI, AlertsAPI, RecordingsAPI, StateAPI, TimelineAPI,
+)
+from opennvr_app_sdk.frame_app import KaiCError
+from test_client import APP_KEY, _FakeCore
+
+
+class _FakeKaiC(BaseHTTPRequestHandler):
+    log: list[dict] = []
+
+    def _reply(self, status, body):
+        raw = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):  # noqa: N802
+        self.log.append({"path": self.path, "key": self.headers.get("X-Internal-Api-Key")})
+        if self.path == "/api/v1/ai/capabilities":
+            return self._reply(200, {"adapters": {"yolov8": {"tasks_advertised": ["object_detection"]}}})
+        return self._reply(404, {})
+
+    def do_POST(self):  # noqa: N802
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)))
+        self.log.append({"path": self.path, "body": body,
+                         "corr": self.headers.get("X-Correlation-Id")})
+        if self.path.endswith("/broken"):
+            return self._reply(500, {"detail": "boom"})
+        return self._reply(200, {"result": {"detections": [{"label": "person"}]},
+                                 "inference_ms": 3})
+
+    def log_message(self, *a):
+        pass
+
+
+@pytest.fixture
+def stack(monkeypatch):
+    monkeypatch.setenv("OPENNVR_APP_KEY", APP_KEY)
+    monkeypatch.delenv("OPENNVR_INTERNAL_API_KEY", raising=False)
+    _FakeCore.log, _FakeCore.state, _FakeKaiC.log = [], {}, []
+    core = ThreadingHTTPServer(("127.0.0.1", 0), _FakeCore)
+    kaic = ThreadingHTTPServer(("127.0.0.1", 0), _FakeKaiC)
+    for s in (core, kaic):
+        threading.Thread(target=s.serve_forever, daemon=True).start()
+    try:
+        yield (f"http://127.0.0.1:{core.server_address[1]}",
+               f"http://127.0.0.1:{kaic.server_address[1]}")
+    finally:
+        core.shutdown()
+        kaic.shutdown()
+
+
+def test_cameras_snapshot_recordings(stack):
+    core, _ = stack
+
+    async def go():
+        async with AsyncOpenNVR(core) as nvr:
+            cams = await nvr.cameras()
+            assert [c.id for c in cams] == [1, 2] and cams[0].has_skill("loitering")
+            assert (await nvr.camera("cam2")).name == "Yard"
+            assert await nvr.camera(99) is None
+            assert await nvr.snapshot(cams[0]) == b"\xff\xd8jpeg"
+            assert await nvr.snapshot("cam2") is None
+            recs = await nvr.recordings(1).list(start="2026-09-05T00:00:00Z")
+            assert recs == [Recording(start="2026-09-05T10:00:00Z", duration=60.0)]
+            url = await nvr.recordings("cam-1").url("2026-09-05T10:00:00Z", 60)
+            assert url.startswith("http://mediamtx")
+
+    asyncio.run(go())
+    assert all(r["key"] == APP_KEY for r in _FakeCore.log)
+
+
+def test_timeline_alerts_state(stack):
+    core, _ = stack
+
+    async def go():
+        nvr = AsyncOpenNVR(core)
+        assert await nvr.timeline.search(camera="cam1", label="car", limit=5) == \
+            [{"id": 9, "camera_id": 1, "label": "car"}]
+        assert _FakeCore.log[-1]["query"] == {"camera_id": "1", "label": "car", "limit": "5"}
+        assert await nvr.timeline.evidence(9) == b"\xff\xd8ev"
+        assert await nvr.timeline.plate_stats(days=3) == {"total_reads": 3}
+        assert await nvr.alerts.inbox(unacked=True) == [{"id": 1, "acknowledged_at": None}]
+        assert await nvr.state.get("missing", default="d") == "d"
+        await nvr.state.set("cooldown", {"cam1": 12.5})
+        assert await nvr.state.get("cooldown") == {"cam1": 12.5}
+        assert await nvr.state.items() == {"cooldown": {"cam1": 12.5}}
+        assert await nvr.state.delete("cooldown") is True
+        assert await nvr.state.delete("cooldown") is False
+        with pytest.raises(PlatformError):
+            await nvr.state.set("toolarge", "x")
+        await nvr.aclose()
+
+    asyncio.run(go())
+
+
+def test_ai_capabilities_and_infer(stack):
+    core, kaic = stack
+
+    async def go():
+        async with AsyncOpenNVR(core, kaic_url=kaic, kaic_api_key="k") as nvr:
+            caps = await nvr.ai.capabilities()
+            assert "yolov8" in caps["adapters"]
+            assert _FakeKaiC.log[-1]["key"] == "k"
+            out = await nvr.ai.infer("yolov8", b"\xff\xd8", task="object_detection",
+                                     camera_id="cam1", params={"threshold": 0.4},
+                                     correlation_id="corr-1")
+            assert out["result"]["detections"][0]["label"] == "person"
+            sent = _FakeKaiC.log[-1]
+            assert sent["path"] == "/api/v1/infer/yolov8" and sent["corr"] == "corr-1"
+            assert sent["body"]["task"] == "object_detection"
+            assert sent["body"]["camera_id"] == "cam1" and sent["body"]["threshold"] == 0.4
+            assert sent["body"]["frame_b64"] == "/9g="
+            with pytest.raises(KaiCError):
+                await nvr.ai.infer("broken", b"\xff\xd8", task="object_detection")
+
+    asyncio.run(go())
+
+
+def test_unreachable_reads_degrade_writes_raise(monkeypatch):
+    monkeypatch.setenv("OPENNVR_APP_KEY", APP_KEY)
+
+    async def go():
+        nvr = AsyncOpenNVR("http://127.0.0.1:9", timeout=0.2)
+        assert await nvr.cameras() == [] and await nvr.snapshot(1) is None
+        assert await nvr.timeline.search() is None
+        assert await nvr.ai.capabilities() is None          # no KAIC_URL
+        with pytest.raises(PlatformError):
+            await nvr.ai.infer("x", b"", task="t")
+        with pytest.raises(PlatformError):
+            await nvr.state.set("k", 1)
+        await nvr.aclose()
+
+    asyncio.run(go())
+
+
+def test_shared_http_client_is_not_closed(monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("OPENNVR_APP_KEY", APP_KEY)
+
+    async def go():
+        shared = httpx.AsyncClient()
+        async with AsyncOpenNVR("http://127.0.0.1:9", http_client=shared):
+            pass
+        assert not shared.is_closed
+        await shared.aclose()
+
+    asyncio.run(go())
+
+
+def test_requires_a_url(monkeypatch):
+    monkeypatch.delenv("OPENNVR_URL", raising=False)
+    with pytest.raises(ValueError):
+        AsyncOpenNVR()
+
+
+# ── parity: every public sync method has an async twin with the same
+#    signature (so a feature added to one cannot be forgotten on the other)
+
+
+@pytest.mark.parametrize("sync_cls,async_cls", [
+    (OpenNVR, AsyncOpenNVR), (RecordingsAPI, AsyncRecordingsAPI),
+    (TimelineAPI, AsyncTimelineAPI), (AlertsAPI, AsyncAlertsAPI),
+    (StateAPI, AsyncStateAPI), (AIAPI, AsyncAIAPI),
+])
+def test_async_surface_mirrors_sync(sync_cls, async_cls):
+    renamed = {"close": "aclose", "__enter__": "__aenter__", "__exit__": "__aexit__"}
+    not_ported = {"stream"}       # blocking WebSocket session — documented
+    for name, member in inspect.getmembers(sync_cls, inspect.isfunction):
+        if name.startswith("_") and name not in renamed or name in not_ported:
+            continue
+        twin = renamed.get(name, name)
+        assert hasattr(async_cls, twin), f"{async_cls.__name__} lacks {twin}"
+        if name in renamed or name == "__init__":
+            continue
+        sp = list(inspect.signature(member).parameters)
+        ap = list(inspect.signature(getattr(async_cls, twin)).parameters)
+        assert sp == ap, f"{sync_cls.__name__}.{name}{sp} != {async_cls.__name__}.{twin}{ap}"

--- a/sdk/opennvr-app-sdk/uv.lock
+++ b/sdk/opennvr-app-sdk/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "opennvr-app-sdk"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The sync OpenNVR client is right for a detector loop; an app that serves a /ui, runs on FastAPI/Starlette, or drives an agent loop that must never block had to push every platform call through asyncio.to_thread — the OpenNVR Agent wrote its own async clients instead, which is exactly the duplication the SDK exists to remove.

opennvr_app_sdk.aio.AsyncOpenNVR is the same surface await-ed: the same method names, arguments, return types and degrade/raise rules (reads → None/[] and log; writes raise PlatformError; infer raises KaiCError). Shared with the sync client rather than copied: the route paths, the KAI-C request builder (frame_app.build_infer_request, now used by KaiCClient too) and the response parsers (client.parse_cameras / parse_recordings / parse_state_items). A parity test walks every public sync method and asserts the async twin exists with the same signature, so a feature added to one cannot be forgotten on the other. http_client= shares an existing httpx.AsyncClient (a FastAPI lifespan pool, a test transport) and is then left open. ai.stream() — a blocking WebSocket session — has no async form yet and is documented as the one gap.

First consumer: the camera-agent's KaicCapabilitiesClient keeps its TTL cache and parse but fetches through AsyncAIAPI.capabilities().

SDK 0.4.0 (additive; server api_version unchanged at 1.2).