### PR TITLE
ci(sdk): release opennvr-app-sdk to PyPI, and run its own tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,24 @@ jobs:
         working-directory: server
         run: uv run pytest tests/ -q
 
+  # ── App SDK ──────────────────────────────────────────────────────
+  # The examples exercise the SDK indirectly; this runs its own suite
+  # (the platform client, credentials, user context, contract server,
+  # the sync/async parity check). publish-sdk.yml runs the same across
+  # 3.11–3.13 plus the build on sdk/** changes.
+  sdk:
+    name: sdk (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "sdk/opennvr-app-sdk/uv.lock"
+      - name: Run pytest
+        working-directory: sdk/opennvr-app-sdk
+        run: uv run --frozen --group dev pytest -q
+
   # ── KAI-C middleware ─────────────────────────────────────────────
   # kai-c/ uses [dependency-groups] for dev deps (pytest + pytest-
   # asyncio); pyproject sets testpaths = ["test"] (singular) so a

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Test, build and publish the App SDK (sdk/opennvr-app-sdk) to PyPI.
+#
+#   - PR / push touching sdk/**   → tests, build the sdist + wheel, check
+#                                   metadata, install the wheel in a clean
+#                                   venv and import it (the "works from
+#                                   the repo, broken from PyPI" class).
+#   - tag sdk-v<version>          → the same, then publish to PyPI via
+#                                   trusted publishing (no API token in
+#                                   secrets: PyPI trusts this workflow +
+#                                   the `pypi` environment through OIDC).
+#
+# The tag must equal the version in pyproject.toml / _version.py — the
+# `verify-version` step refuses otherwise, so a release is one command:
+#     git tag sdk-v0.4.0 && git push origin sdk-v0.4.0
+#
+# One-time setup on PyPI (project owner): Manage → Publishing → add a
+# GitHub publisher with owner `open-nvr`, repository `open-nvr`,
+# workflow `publish-sdk.yml`, environment `pypi`. Then create the
+# `pypi` environment in this repo's settings (optionally with required
+# reviewers — that makes every release a click by a maintainer).
+
+name: publish-sdk
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "sdk/opennvr-app-sdk/**"
+      - ".github/workflows/publish-sdk.yml"
+    tags:
+      - "sdk-v*"
+  pull_request:
+    paths:
+      - "sdk/opennvr-app-sdk/**"
+      - ".github/workflows/publish-sdk.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-sdk-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: sdk/opennvr-app-sdk
+
+jobs:
+  test:
+    name: sdk (pytest, py${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Run tests
+        run: uv run --python ${{ matrix.python }} --group dev pytest -q
+
+  build:
+    name: sdist + wheel
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Verify the tag matches the package version
+        if: startsWith(github.ref, 'refs/tags/sdk-v')
+        run: |
+          tag="${GITHUB_REF#refs/tags/sdk-v}"
+          py=$(uv run --python 3.12 --no-project python -c \
+               "import re,pathlib;print(re.search(r'__version__ = \"([^\"]+)\"', pathlib.Path('opennvr_app_sdk/_version.py').read_text()).group(1))")
+          toml=$(uv run --python 3.12 --no-project python -c \
+               "import tomllib,pathlib;print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          echo "tag=$tag _version.py=$py pyproject=$toml"
+          test "$tag" = "$py" && test "$tag" = "$toml"
+
+      - name: Build
+        run: uv build --out-dir dist
+
+      - name: Check metadata (README renders on PyPI, licence, classifiers)
+        run: uv run --python 3.12 --no-project --with twine twine check --strict dist/*
+
+      - name: Install the wheel in a clean venv and import it
+        run: |
+          uv venv --python 3.12 /tmp/sdk-venv
+          uv pip install --python /tmp/sdk-venv/bin/python dist/*.whl
+          /tmp/sdk-venv/bin/python - <<'EOF'
+          import opennvr_app_sdk as s
+          from opennvr_app_sdk import OpenNVR, Detector, AppManifest, Alert
+          from opennvr_app_sdk.aio import AsyncOpenNVR
+          print("opennvr-app-sdk", s.__version__, "→", len(s.__all__), "public names")
+          EOF
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opennvr-app-sdk-dist
+          path: sdk/opennvr-app-sdk/dist/
+          if-no-files-found: error
+
+  publish:
+    name: publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/sdk-v')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/opennvr-app-sdk/
+    permissions:
+      id-token: write      # OIDC → PyPI trusted publishing
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: opennvr-app-sdk-dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          print-hash: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The App SDK is released to PyPI.** `pip install opennvr-app-sdk`
+  is now the on-ramp: `.github/workflows/publish-sdk.yml` tests the
+  package on 3.11–3.13, builds and `twine check`s the sdist + wheel,
+  installs the wheel in a clean venv, and on a `sdk-v<version>` tag
+  publishes through PyPI trusted publishing (the tag must match
+  `_version.py` and `pyproject.toml`). The package gains a README (the
+  PyPI page), its own Apache-2.0 `LICENSE` file, classifiers and project
+  URLs. `ci.yml` now runs the SDK's own suite, which it never did.
 - **SDK 0.4.0: an async platform client.** `opennvr_app_sdk.aio.AsyncOpenNVR`
   is `OpenNVR` `await`-ed — same methods, arguments, return types and
   degrade/raise rules — for apps that serve a `/ui`, run on

--- a/docs/DEVELOPER_PROGRAM.md
+++ b/docs/DEVELOPER_PROGRAM.md
@@ -51,6 +51,8 @@ This page is the deal. The technical on-ramp starts at
 
 ## How to ship
 
+0. **Install the SDK** — `pip install opennvr-app-sdk` (Apache-2.0, on
+   PyPI; the repository's examples use it as an editable path).
 1. **Scaffold** — `python3 scripts/create_opennvr_app.py my-app --task object_detection`
    gives you a compiling app with a test; fill in one method.
 2. **Run it against a stack** — `OPENNVR_URL` + the site key to

--- a/docs/SDK_REFERENCE.md
+++ b/docs/SDK_REFERENCE.md
@@ -136,6 +136,23 @@ container) unless you need full frame rate.
 `load_yaml(path)`, `require(cfg, key)` — the two helpers the runners
 use; pass your own `load_config` to `app()` for anything richer.
 
+## Releasing
+
+The package is published to PyPI as
+[`opennvr-app-sdk`](https://pypi.org/project/opennvr-app-sdk/) by
+`.github/workflows/publish-sdk.yml` through PyPI trusted publishing —
+no token lives in the repository. A release is:
+
+1. Bump `opennvr_app_sdk/_version.py` **and** `pyproject.toml` to the
+   same version, add the CHANGELOG entry, merge.
+2. `git tag sdk-v<version> && git push origin sdk-v<version>`.
+
+The workflow refuses a tag that does not match both files, runs the
+suite on 3.11–3.13, builds the sdist and wheel, `twine check`s them,
+installs the wheel in a clean venv and imports it, then publishes
+(the `pypi` environment may require a maintainer's approval). Every
+PR touching `sdk/**` runs the same pipeline minus the publish.
+
 ## Stability
 
 Every name above is covered by the

--- a/sdk/opennvr-app-sdk/LICENSE
+++ b/sdk/opennvr-app-sdk/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/opennvr-app-sdk/README.md
+++ b/sdk/opennvr-app-sdk/README.md
@@ -1,0 +1,75 @@
+# opennvr-app-sdk
+
+The SDK for building vision apps on [OpenNVR](https://opennvr.org), the
+self-hosted AI video platform. Cameras, Tier-0 detections, pluggable
+inference, an event bus, recordings, an operator alert inbox, users and
+per-camera permissions, and a catalog every deployment opens — all
+already running. You write the rule, the model or the workflow; this
+package is the only import you need.
+
+Apache-2.0 — ship your app under any licence, closed included.
+
+```bash
+pip install opennvr-app-sdk
+```
+
+## A detector in one method
+
+```python
+from opennvr_app_sdk import Alert, AppManifest, Detector, Param, app
+
+class Loitering(Detector):
+    manifest = AppManifest(
+        id="loitering", name="Loitering", version="1.0.0", category="perimeter",
+        requires_tasks=["object_detection"],
+        params=[Param("dwell_s", float, default=30.0)],
+    )
+
+    def setup(self):
+        self.present = self.keyed_state(ttl=10.0)   # forgets a camera 10 s after the last person
+
+    def on_detections(self, camera_id, detections, event):
+        people = [d for d in detections if d.get("label") == "person"]
+        if not people:
+            return
+        rec = self.present.touch(camera_id)
+        if rec.age >= self.cfg.dwell_s and not rec.alerted:
+            rec.alerted = True
+            yield Alert(title="Loitering", description=f"{len(people)} person(s) for {rec.age:.0f}s",
+                        camera_id=camera_id, severity="medium")
+
+if __name__ == "__main__":
+    raise SystemExit(app(Loitering).run())
+```
+
+That app subscribes to the platform's detections, serves the registry
+contract (`/health`, `/state`, `/manifest`, config form, actions),
+registers itself in the App Catalog, is issued its own credential, and
+fires alerts that reach the operator inbox — none of which you wrote.
+
+## The platform, from an app
+
+```python
+from opennvr_app_sdk import OpenNVR            # or opennvr_app_sdk.aio.AsyncOpenNVR
+
+nvr = OpenNVR()                                 # OPENNVR_URL + the app's key
+for cam in nvr.cameras():                       # only cameras assigned to this app
+    jpeg = nvr.snapshot(cam)
+    det = nvr.ai.infer("yolov8", jpeg, task="object_detection", camera_id=cam.handle)
+nvr.state.set("last_seen", {"cam1": 12.5})      # durable, survives restarts
+clips = nvr.recordings("cam1").list(start="2026-09-05T00:00:00Z")
+mine = nvr.alerts.inbox(unacked=True)
+```
+
+## Where to go next
+
+* [Developer program](https://github.com/open-nvr/open-nvr/blob/main/docs/DEVELOPER_PROGRAM.md) — the deal: no fee, your licence, the compatibility promise.
+* [Your first detector](https://github.com/open-nvr/open-nvr/blob/main/docs/FIRST_DETECTOR.md) — scaffold, run against a stack, list in the catalog.
+* [SDK reference](https://github.com/open-nvr/open-nvr/blob/main/docs/SDK_REFERENCE.md) — every public name, by task.
+* [Platform client](https://github.com/open-nvr/open-nvr/blob/main/docs/APP_PLATFORM.md), [app surfaces](https://github.com/open-nvr/open-nvr/blob/main/docs/APP_SURFACES.md), [credentials](https://github.com/open-nvr/open-nvr/blob/main/docs/APP_CREDENTIALS.md), [event contracts](https://github.com/open-nvr/open-nvr/blob/main/docs/EVENT_CONTRACTS.md).
+* [Example apps](https://github.com/open-nvr/open-nvr/tree/main/examples) — thirteen first-party apps built on this SDK.
+
+Compatibility: the app-registry contract is versioned (`api_version`)
+and tested in the OpenNVR repository on every change; `min_sdk_version`
+only moves when an older SDK would misbehave. Issues tagged `sdk` at
+[open-nvr/open-nvr](https://github.com/open-nvr/open-nvr/issues).

--- a/sdk/opennvr-app-sdk/pyproject.toml
+++ b/sdk/opennvr-app-sdk/pyproject.toml
@@ -5,8 +5,23 @@
 name = "opennvr-app-sdk"
 version = "0.4.0"
 description = "Shared SDK for OpenNVR monitoring apps: §11.5 alert dispatch, zone geometry, keyed TTL state, app manifests, and the Detector / FrameApp base loops."
+readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
+authors = [{ name = "OpenNVR contributors" }]
+keywords = ["opennvr", "nvr", "video", "computer-vision", "surveillance", "sdk"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering :: Image Recognition",
+    "Topic :: Software Development :: Libraries",
+]
 
 # The SDK owns the dependencies every app used to re-declare:
 # nats-py for the inference-subscribe loop + alert fan-out, httpx for
@@ -18,6 +33,14 @@ dependencies = [
     # Streaming inference sessions (InferStream) — KAI-C contract §6.
     "websockets>=13.0",
 ]
+
+[project.urls]
+Homepage = "https://opennvr.org"
+Documentation = "https://github.com/open-nvr/open-nvr/blob/main/docs/SDK_REFERENCE.md"
+"Developer program" = "https://github.com/open-nvr/open-nvr/blob/main/docs/DEVELOPER_PROGRAM.md"
+Source = "https://github.com/open-nvr/open-nvr/tree/main/sdk/opennvr-app-sdk"
+Changelog = "https://github.com/open-nvr/open-nvr/blob/main/CHANGELOG.md"
+Issues = "https://github.com/open-nvr/open-nvr/issues?q=label%3Asdk"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
`pip install opennvr-app-sdk` is the on-ramp the developer program promises; until now the package only existed as an editable path inside this repository, and ci.yml never ran its test suite at all (the examples exercised it indirectly).

- .github/workflows/publish-sdk.yml: on any PR/push touching sdk/**, run the suite on 3.11/3.12/3.13, `uv build` the sdist + wheel, `twine check --strict` them, install the wheel in a clean venv and import the public surface. On a `sdk-v<version>` tag — refused unless it equals both _version.py and pyproject.toml — publish through PyPI trusted publishing (OIDC, `pypi` environment, no token in secrets).
- ci.yml gains an `sdk (pytest)` job.
- The package gets what PyPI shows: a README (what the SDK is, a detector in one method, the platform client, links), its own Apache-2.0 LICENSE (shipped in the sdist and the wheel's dist-info), classifiers, keywords and project URLs.
- docs: release procedure in SDK_REFERENCE.md, `pip install` as step 0 of DEVELOPER_PROGRAM.md, CHANGELOG.

Verified locally: build → twine check PASSED ×2 → clean-venv import of 76 public names incl. opennvr_app_sdk.aio.