### PR TITLE
feat(scaffold): out-of-tree apps pin the PyPI SDK; tests accept exter…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The out-of-tree developer path works end to end.** A paid,
+  `license_key` app was built in its own repository on nothing but the
+  PyPI wheel (`docs/EXTERNAL_APP_WALKTHROUGH.md`); the platform surface
+  held, the on-ramp did not: `scripts/create_opennvr_app.py` now takes
+  `--sdk auto|path|pypi` and, for a `--dest` outside this repository,
+  pins `opennvr-app-sdk>=<version>,<1.0` with a Dockerfile that builds
+  without a checkout (before, it wrote an editable path into a tree the
+  developer does not have). Server tests no longer assume every index
+  entry is installable, so the first real `kind: external` listing will
+  not break CI. Remaining findings are listed in the walkthrough.
 - **The App SDK is released to PyPI.** `pip install opennvr-app-sdk`
   is now the on-ramp: `.github/workflows/publish-sdk.yml` tests the
   package on 3.11–3.13, builds and `twine check`s the sdist + wheel,

--- a/docs/DEVELOPER_PROGRAM.md
+++ b/docs/DEVELOPER_PROGRAM.md
@@ -53,8 +53,10 @@ This page is the deal. The technical on-ramp starts at
 
 0. **Install the SDK** — `pip install opennvr-app-sdk` (Apache-2.0, on
    PyPI; the repository's examples use it as an editable path).
-1. **Scaffold** — `python3 scripts/create_opennvr_app.py my-app --task object_detection`
-   gives you a compiling app with a test; fill in one method.
+1. **Scaffold** — `python3 scripts/create_opennvr_app.py my-app --task object_detection --dest ~/your/repos`
+   gives you a compiling app with a test, pinned to the PyPI SDK; fill in
+   one method. ([EXTERNAL_APP_WALKTHROUGH.md](EXTERNAL_APP_WALKTHROUGH.md)
+   is the whole path, paid app included.)
 2. **Run it against a stack** — `OPENNVR_URL` + the site key to
    bootstrap; the app is issued its own key on first registration and
    uses it from then on.

--- a/docs/EXTERNAL_APP_WALKTHROUGH.md
+++ b/docs/EXTERNAL_APP_WALKTHROUGH.md
@@ -1,0 +1,75 @@
+# The outside-the-repo walk — building a paid app on the published SDK
+
+Everything in `examples/` is built inside this repository, where the
+SDK is an editable path and core is one directory away. A third-party
+developer has none of that: they `pip install opennvr-app-sdk`, work in
+their own repository, sell their app on their own site, and list it as
+`kind: external`. This page is that walk, done for real against SDK
+0.4.0 on PyPI, with what it found. Repeat it after any SDK release —
+whatever breaks here is the next roadmap.
+
+## The app: Plate VIP
+
+A deliberately small but complete **paid** app, in its own repository,
+depending on nothing but the wheel:
+
+* **Archetype:** `DomainEventSubscriber` on `plate.recognized.v1` — it
+  builds on the LPR app's events, so it needs no model and no frames.
+* **Rule:** a watch list from the catalog config form (`params`,
+  applied live through `on_config_update`), one alert per plate per
+  cooldown; the cooldown is kept in core (`nvr.state`) so a restart
+  never re-alerts.
+* **Alerts:** `build_dispatcher` → the operator inbox over NATS.
+* **Commerce:** manifest `pricing: subscription`, `price_note`,
+  `entitlement: license_key`; `verify_license` checks a signed key the
+  vendor issues (`issue_key`). Core's `PUT /apps/plate-vip/license` →
+  `POST /entitlement/verify` exchange is exercised in the app's own
+  tests against the SDK's contract server, with the site key.
+* **Listing:** a `kind: external` index entry pointing at the vendor's
+  page; the catalog shows the card, the pricing badge, *Learn more*,
+  and never offers Install.
+
+```
+plate-vip/
+├── plate_vip.py           # ~200 lines, of which the rule is 25
+├── tests/test_plate_vip.py
+├── pyproject.toml         # dependencies = ["opennvr-app-sdk>=0.4.0,<1.0"]
+├── Dockerfile             # FROM python:3.12-slim; pip install opennvr-app-sdk
+└── config.example.yml
+```
+
+Result: `uv sync` from PyPI, 7 tests green, the licence round-trip
+identical to what core does, `docker build` with no checkout. The
+platform surface an outsider needs **is all there**: the archetype, the
+contract server, per-app credentials, the platform client, durable
+state, the licence hook and the external listing all came from the
+wheel.
+
+## What it found
+
+| # | Finding | Status |
+|---|---|---|
+| 1 | `scripts/create_opennvr_app.py --dest <outside>` still wrote an **editable path** to this checkout's SDK and a Dockerfile that only builds from the repo root — an outsider's first `uv sync` fails. | **Fixed:** `--sdk auto\|path\|pypi`; out-of-tree defaults to PyPI (`opennvr-app-sdk>=<version>,<1.0`, no `[tool.uv.sources]`, a self-contained Dockerfile). `server/tests/test_create_app_scaffold.py`. |
+| 2 | Five server tests assumed **every index entry is installable** (`image`, `install`, a compose service) — the first real external listing would have broken CI. | **Fixed:** kind-aware (`test_apps_index.py`, `test_validate_apps_index.py`). |
+| 3 | `DomainEventSubscriber` and `AlertSubscriber` hand you no dispatcher: unlike `Detector`, an event-driven app must `set_default_source` + `build_dispatcher` itself and call `.fire()`. | Open — a `self.dispatcher` built from the standard config keys would make the archetypes symmetric. |
+| 4 | Every app re-declares the same ten config fields (`nats_*`, `contract_*`, `opennvr_url/token`, `webhook_url`, `nats_alerts_*`) and their YAML parsing. | Open — an SDK `BaseAppConfig` + `load_base_config()` that apps extend. |
+| 5 | The generator needs a clone of this repository to run at all. | Open — ship it as `opennvr-app-sdk`'s console script (`opennvr-app new <id>`), templates inside the wheel. |
+| 6 | Nothing shows an operator *why* an external app is greyed until they enter a key: the 402 text is right, the card could say "licence required" up front. | Open (frontend polish). |
+
+Nothing in the list is a contract problem: the registry, entitlement
+and platform routes behaved exactly as documented, and `min_sdk_version`
+was satisfied by the wheel. The gaps are on-ramp ergonomics — the
+generator and the boilerplate — which is what you would expect the
+first outsider to hit.
+
+## Repeating the walk
+
+```bash
+python3 scripts/create_opennvr_app.py my-app --task object_detection --dest ~/somewhere-else
+cd ~/somewhere-else/my-app && uv sync && uv run pytest -q     # from PyPI, no checkout
+```
+
+Then make it paid (`pricing`, `entitlement`, `verify_license`), point a
+`kind: external` index entry at it, run `make validate-apps-index`, and
+enable it in a stack: the catalog must refuse with 402 until the key
+you issued is entered.

--- a/docs/FIRST_DETECTOR.md
+++ b/docs/FIRST_DETECTOR.md
@@ -23,6 +23,13 @@ like [`examples/home-assistant-relay`](../examples/home-assistant-relay).)
 
 ## 1. Generate the app (1 min)
 
+> Building in your **own repository**? Pass `--dest ~/where/you/work`:
+> the generator then pins the published `opennvr-app-sdk` from PyPI and
+> writes a Dockerfile that builds without this checkout (`--sdk pypi`
+> forces it; `--sdk path` keeps the in-tree editable dependency).
+> [EXTERNAL_APP_WALKTHROUGH.md](EXTERNAL_APP_WALKTHROUGH.md) is that path
+> walked end to end, licence gate included.
+
 From the repo root:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Start here. Pick the row that matches what you're doing.
 - **[DEVELOPER_PROGRAM.md](DEVELOPER_PROGRAM.md)** — **start here if you are building an app**: what the platform gives you, paid apps, the compatibility promise.
 - **[FIRST_DETECTOR.md](FIRST_DETECTOR.md)** — write your first detector app in ~15 minutes.
 - **[CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md)** — publish an app to the catalog.
+- **[EXTERNAL_APP_WALKTHROUGH.md](EXTERNAL_APP_WALKTHROUGH.md)** — a paid, out-of-tree app built on the PyPI SDK, and what the walk found.
 - **[APP_SURFACES.md](APP_SURFACES.md)** — the surfaces (config, state, actions) an app exposes.
 - **[APPS_INSTALL.md](APPS_INSTALL.md)** — one-click install design (desired-state + reconciler).
 - **[APP_CREDENTIALS.md](APP_CREDENTIALS.md)** — per-app keys: the register handshake, roster scoping, rotate/revoke.

--- a/scripts/create_opennvr_app.py
+++ b/scripts/create_opennvr_app.py
@@ -78,6 +78,72 @@ def sdk_path_for(app_dir: Path) -> str:
         return _SDK_DIR.as_posix()
 
 
+def sdk_version() -> str:
+    """The SDK version in this checkout — the floor a PyPI-mode app pins."""
+    try:
+        text = (_SDK_DIR / "opennvr_app_sdk" / "_version.py").read_text(encoding="utf-8")
+    except OSError:
+        return "0.4.0"          # the first PyPI release — a safe floor
+    match = re.search(r'__version__ = "([^"]+)"', text)
+    return match.group(1) if match else "0.4.0"
+
+
+def is_in_tree(app_dir: Path) -> bool:
+    try:
+        app_dir.resolve().relative_to(_REPO_ROOT.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def apply_pypi_mode(app_dir: Path, app_id: str, version: str) -> None:
+    """Rewrite the rendered pyproject + Dockerfile for an app that lives
+    OUTSIDE this repository and gets the SDK from PyPI — no editable
+    path, no ``COPY sdk/...`` from a checkout the developer does not
+    have. This is what a third-party developer needs; the in-tree form
+    stays for the examples, which must track the SDK on main."""
+    pyproject = app_dir / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    text = text.replace(
+        '    "opennvr-app-sdk",\n',
+        f'    "opennvr-app-sdk>={version},<1.0",\n')
+    start = text.find("# Editable path dep on the in-repo SDK.")
+    end = text.find("[project.optional-dependencies]")
+    if start != -1 and end != -1:
+        text = text[:start] + text[end:]
+    pyproject.write_text(text, encoding="utf-8")
+
+    module = kebab_to_snake(app_id)
+    (app_dir / "Dockerfile").write_text(f"""# syntax=docker/dockerfile:1.7
+# {kebab_to_title(app_id)} — OpenNVR Detector app, built on the published SDK.
+#
+# Build (from this directory — no OpenNVR checkout needed):
+#   docker build -t {app_id}:0.1.0 .
+#
+# Run (on the stack's compose network):
+#   docker run --rm --network opennvr_internal \\
+#     -v $(pwd)/config.yml:/app/config.yml:ro {app_id}:0.1.0
+
+FROM python:3.12-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \\
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# The SDK owns the runtime stack (NATS loop, alert fan-out, the platform
+# client). Pin the same floor as pyproject.toml.
+RUN pip install --no-cache-dir "opennvr-app-sdk>={version},<1.0"
+
+COPY {module}.py config.example.yml ./
+
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "{module}.py"]
+CMD ["--config", "config.yml"]
+""", encoding="utf-8")
+
+
 def build_tokens(app_id: str, task: str, app_dir: Path) -> dict[str, str]:
     """The token → replacement map applied to file contents and names."""
     return {
@@ -102,9 +168,16 @@ def rename_path_part(part: str, tokens: dict[str, str]) -> str:
     return substitute(part, tokens)
 
 
-def generate(app_id: str, task: str, dest_dir: Path) -> Path:
+def generate(app_id: str, task: str, dest_dir: Path, *, sdk: str = "auto") -> Path:
     """Render the template into ``dest_dir/<app-id>/``. Returns the path
-    to the created app directory. Raises on validation failures."""
+    to the created app directory. Raises on validation failures.
+
+    ``sdk``: ``"path"`` keeps the editable dependency on this checkout's
+    SDK (the examples); ``"pypi"`` pins the published package instead
+    (a third-party app in its own repository); ``"auto"`` picks by where
+    the app lands — in-tree → path, anywhere else → pypi."""
+    if sdk not in ("auto", "path", "pypi"):
+        raise ValueError(f"sdk must be auto, path or pypi (got {sdk!r})")
     if not _KEBAB_RE.match(app_id):
         raise ValueError(
             f"app-id {app_id!r} is not kebab-case — use lowercase letters, "
@@ -137,10 +210,13 @@ def generate(app_id: str, task: str, dest_dir: Path) -> Path:
         content = src.read_text(encoding="utf-8")
         dst.write_text(substitute(content, tokens), encoding="utf-8")
 
+    mode = sdk if sdk != "auto" else ("path" if is_in_tree(app_dir) else "pypi")
+    if mode == "pypi":
+        apply_pypi_mode(app_dir, app_id, sdk_version())
     return app_dir
 
 
-def _print_next_steps(app_id: str, app_dir: Path) -> None:
+def _print_next_steps(app_id: str, app_dir: Path, *, pypi: bool = False) -> None:
     module = kebab_to_snake(app_id)
     try:
         rel = app_dir.relative_to(Path.cwd())
@@ -149,14 +225,18 @@ def _print_next_steps(app_id: str, app_dir: Path) -> None:
     print(f"\nScaffolded {app_id!r} at {app_dir}\n")
     print("Next steps:")
     print(f"  cd {rel}")
-    print("  uv sync                 # install the SDK (editable) + pytest")
+    if pypi:
+        print("  uv sync                 # install opennvr-app-sdk from PyPI + pytest")
+    else:
+        print("  uv sync                 # install the SDK (editable) + pytest")
     print("  uv run pytest -q        # the smoke test — should be GREEN")
     print(f"  # open {module}.py and fill in on_detections — that's the rule")
     print(f"  cp config.example.yml config.yml   # then edit it")
     print(f"  uv run python {module}.py --config config.yml --once")
+    docs = ("https://github.com/open-nvr/open-nvr/blob/main/docs/" if pypi else "docs/")
     print("\nRun it against the stack + publish to the App Store:")
-    print("  docs/FIRST_DETECTOR.md      # the 15-minute walkthrough")
-    print("  docs/CONTRIBUTING_APPS.md   # add it to the curated app index")
+    print(f"  {docs}FIRST_DETECTOR.md      # the 15-minute walkthrough")
+    print(f"  {docs}CONTRIBUTING_APPS.md   # list it in the catalog (installable or external)")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -179,16 +259,26 @@ def main(argv: list[str] | None = None) -> int:
         default=str(_REPO_ROOT / "examples"),
         help="parent directory to create <app-id>/ under. Default: examples/.",
     )
+    parser.add_argument(
+        "--sdk",
+        choices=("auto", "path", "pypi"),
+        default="auto",
+        help="where the app gets opennvr-app-sdk: 'path' = editable dep on "
+             "this checkout (for examples/), 'pypi' = the published package "
+             "(for an app in its own repository). Default: auto — pypi when "
+             "--dest is outside this repository.",
+    )
     args = parser.parse_args(argv)
 
     dest_dir = Path(args.dest).expanduser().resolve()
     try:
-        app_dir = generate(args.app_id, args.task, dest_dir)
+        app_dir = generate(args.app_id, args.task, dest_dir, sdk=args.sdk)
     except (ValueError, FileExistsError, FileNotFoundError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
-    _print_next_steps(args.app_id, app_dir)
+    pypi = args.sdk == "pypi" or (args.sdk == "auto" and not is_in_tree(app_dir))
+    _print_next_steps(args.app_id, app_dir, pypi=pypi)
     return 0
 
 

--- a/server/tests/test_apps_index.py
+++ b/server/tests/test_apps_index.py
@@ -214,9 +214,17 @@ def test_index_yaml_entries_are_well_formed():
     non-empty)."""
     for e in _load_apps_index():
         assert e.name and e.summary and e.category and e.version
+        # https only — repo-relative paths 404ed in the SPA and were an
+        # unconstrained href sink (review M5).
+        assert e.docs_url.startswith("https://")
+        if e.kind == "external":
+            # A link-out listing: distributed by its author, nothing to
+            # install, so no image and no compose block by design.
+            assert e.external_url.startswith("https://")
+            assert e.image is None and e.install is None
+            continue
+        # First-party installables come from our registry and our docs.
         assert e.image.startswith("ghcr.io/open-nvr/")
-        # https GitHub URLs — repo-relative paths 404ed in the SPA and
-        # were an unconstrained href sink (review M5).
         assert e.docs_url.startswith("https://github.com/open-nvr/")
         assert e.install.compose.strip()
         assert e.install.command.strip().startswith("docker compose")
@@ -227,6 +235,8 @@ def test_index_yaml_has_no_secrets():
     reference ${INTERNAL_API_KEY} from the operator's .env, never a
     baked value."""
     for e in _load_apps_index():
+        if e.install is None:          # external listing — nothing to install
+            continue
         assert "${INTERNAL_API_KEY}" in e.install.compose
         # The effective test-env secret must not have leaked into the file.
         assert os.environ["INTERNAL_API_KEY"] not in e.install.compose

--- a/server/tests/test_create_app_scaffold.py
+++ b/server/tests/test_create_app_scaffold.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""scripts/create_opennvr_app.py — the two shapes it must produce.
+
+In-tree (``examples/<id>``) the app tracks this checkout's SDK through
+an editable path, so the examples never drift from main. Out of tree —
+a third-party developer's own repository — there is no checkout to
+point at: the app must pin the published ``opennvr-app-sdk`` and its
+Dockerfile must build from PyPI alone. The outside-the-repo walk
+(docs/EXTERNAL_APP_WALKTHROUGH.md) found the second shape missing.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "create_opennvr_app", REPO_ROOT / "scripts" / "create_opennvr_app.py")
+gen = importlib.util.module_from_spec(_spec)
+sys.modules["create_opennvr_app"] = gen
+_spec.loader.exec_module(gen)
+
+
+def _files(app_dir: Path) -> dict[str, str]:
+    return {p.name: p.read_text() for p in app_dir.iterdir() if p.is_file()}
+
+
+def test_out_of_tree_pins_pypi_and_builds_without_a_checkout(tmp_path):
+    app_dir = gen.generate("gate-watch", "object_detection", tmp_path)   # auto → pypi
+    f = _files(app_dir)
+    version = gen.sdk_version()
+    assert f'"opennvr-app-sdk>={version},<1.0"' in f["pyproject.toml"]
+    assert "tool.uv.sources" not in f["pyproject.toml"]
+    assert "editable" not in f["pyproject.toml"]
+    assert f'pip install --no-cache-dir "opennvr-app-sdk>={version},<1.0"' in f["Dockerfile"]
+    assert "COPY sdk/" not in f["Dockerfile"] and "examples/" not in f["Dockerfile"]
+    assert "COPY gate_watch.py config.example.yml ./" in f["Dockerfile"]
+    # The app itself is the same either way.
+    assert "class GateWatch(Detector)" in f["gate_watch.py"]
+
+
+def test_in_tree_keeps_the_editable_path(tmp_path, monkeypatch):
+    # Simulate examples/<id> by pointing the generator's notion of the
+    # repo root at tmp_path and scaffolding under it.
+    monkeypatch.setattr(gen, "_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(gen, "_SDK_DIR", tmp_path / "sdk" / "opennvr-app-sdk")
+    app_dir = gen.generate("gate-watch", "object_detection", tmp_path / "examples")
+    f = _files(app_dir)
+    assert 'opennvr-app-sdk = { path = "../../sdk/opennvr-app-sdk", editable = true }' \
+        in f["pyproject.toml"]
+    assert "COPY sdk/opennvr-app-sdk /opt/opennvr-app-sdk" in f["Dockerfile"]
+
+
+def test_explicit_mode_overrides_auto(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    monkeypatch.setattr(gen, "_REPO_ROOT", repo)
+    monkeypatch.setattr(gen, "_SDK_DIR", repo / "sdk" / "opennvr-app-sdk")
+    in_tree_but_pypi = gen.generate("a-one", "object_detection",
+                                    repo / "examples", sdk="pypi")
+    assert "tool.uv.sources" not in _files(in_tree_but_pypi)["pyproject.toml"]
+    out_but_path = gen.generate("a-two", "object_detection",
+                                tmp_path / "outside", sdk="path")
+    assert "editable = true" in _files(out_but_path)["pyproject.toml"]
+    with pytest.raises(ValueError):
+        gen.generate("a-three", "object_detection", tmp_path, sdk="conda")

--- a/server/tests/test_validate_apps_index.py
+++ b/server/tests/test_validate_apps_index.py
@@ -242,6 +242,8 @@ def test_real_overlay_has_every_shipped_service():
     assert _REAL_OVERLAY_SERVICES, "could not read docker-compose.apps.yml"
     shipped = yaml.safe_load(_SHIPPED_INDEX.read_text())
     for entry in shipped:
+        if entry.get("kind") == "external":
+            continue                   # link-out listing: no service by design
         assert entry["id"] in _REAL_OVERLAY_SERVICES, (
             f"shipped entry '{entry['id']}' has no compose service"
         )


### PR DESCRIPTION
…nal listings

The outside-the-repo walk (docs/EXTERNAL_APP_WALKTHROUGH.md): a paid, license_key app built in its own repository on nothing but the opennvr-app-sdk 0.4.0 wheel — DomainEventSubscriber on plate.recognized.v1, live watch-list config, cooldown in nvr.state, verify_license exercised through the contract server exactly as core does it, a kind: external listing through the validator. The platform surface held. The on-ramp did not, in two places, both fixed here:

- scripts/create_opennvr_app.py wrote an editable path to THIS checkout's SDK and a Dockerfile that only builds from the repo root, so an outsider's first `uv sync` failed. New `--sdk auto|path|pypi`: a --dest outside the repository pins opennvr-app-sdk>=<version>,<1.0, drops [tool.uv.sources], and gets a self-contained Dockerfile; the examples keep the editable path. server/tests/test_create_app_scaffold.py.
- Five server tests assumed every shipped index entry is installable (image, install block, compose service). Now kind-aware, so the first real external listing does not break CI; verified with a temporary external entry, none shipped (a fictional vendor does not belong in every deployment's catalog).

Remaining findings — no dispatcher on the event archetypes, ten re-declared config keys per app, the generator needing a clone, a "licence required" hint on the card — are recorded in the walkthrough.