### PR TITLE
feat(catalog): licence-required hint, verified badge, Featured row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **App Catalog: licence hint, verified badge, Featured row.** A
+  listing with `entitlement: license_key` now says so *before* install
+  ("licence key required" badge + one line on what happens next), so
+  the 402 on enable is never a surprise. Two reviewer-set index flags,
+  `verified` (identity confirmed, image reproducible from source —
+  must name an `author`) and `featured` (a row at the top of the
+  catalog), with validator rules and the review policy in
+  CONTRIBUTING_APPS.md. `GET /apps/index` returns both.
 - **SDK 0.5.0 (unreleased): less boilerplate for every app.** The three
   on-ramp gaps the outside-the-repo walk left open, closed:
   `BaseAppConfig` + `load_app_config(path, cls)` replace the config

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -25,7 +25,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Activity, ArrowRight, Boxes, Check, Copy, Download, ExternalLink, RefreshCw, Settings2, Trash2 } from 'lucide-react'
+import { Activity, ArrowRight, BadgeCheck, Boxes, Check, Copy, Download, ExternalLink, KeyRound, RefreshCw, Settings2, Trash2 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
 import { useAuth } from '../auth/AuthContext'
 import { extractApiError } from '../lib/apiError'
@@ -126,6 +126,35 @@ function PricingBadge({ pricing, note }: { pricing?: string; note?: string }) {
   )
 }
 
+/** "Licence key required" — shown BEFORE install so an operator knows a
+ * licensed app will not enable until an administrator enters a key the
+ * app accepts (the installed card then carries the LicensePanel). */
+function LicenceRequiredBadge({ entitlement }: { entitlement?: string }) {
+  if (entitlement !== 'license_key') return null
+  return (
+    <Badge
+      variant="warning"
+      title="Installs normally, but cannot be enabled until an administrator enters a licence key the app verifies"
+    >
+      <KeyRound size={12} /> licence key required
+    </Badge>
+  )
+}
+
+/** The maintainers vouch for this author — identity confirmed, image
+ * reproducible from the linked source. Set by reviewers in the index. */
+function VerifiedBadge({ verified, author }: { verified?: boolean; author?: string }) {
+  if (!verified) return null
+  return (
+    <Badge
+      variant="success"
+      title={`Verified developer${author ? `: ${author}` : ''} — identity confirmed and image reproducible from source, per OpenNVR's app review`}
+    >
+      <BadgeCheck size={12} /> verified
+    </Badge>
+  )
+}
+
 /** Resolve an external ui_url for THIS browser: apps rarely know their
  * deployment hostname at build time, so "{host}" is substituted with
  * wherever the operator is browsing from. */
@@ -176,6 +205,9 @@ type IndexApp = {
   price_note?: string
   entitlement?: 'none' | 'license_key'
   author?: string
+  // Reviewer-set curation flags (never from the submitter's manifest).
+  verified?: boolean
+  featured?: boolean
   image?: string | null
   requires_tasks?: string[]
   emits?: string[]
@@ -1512,11 +1544,23 @@ function AvailableAppCard({ app, tasks, onInstall }: { app: IndexApp; tasks: Set
         <Badge variant="info">{app.category}</Badge>
         <span className="text-xs text-[var(--text-dim)]">v{app.version}</span>
         <PricingBadge pricing={app.pricing} note={app.price_note} />
+        <LicenceRequiredBadge entitlement={app.entitlement} />
         {app.kind === 'external' && <Badge variant="neutral">third-party</Badge>}
       </CardHeader>
       <CardContent className="space-y-3 text-sm">
         <div className="text-[var(--text-dim)]">{app.summary || 'No summary provided.'}</div>
-        {app.author && <div className="text-xs text-[var(--text-dim)]">by {app.author}</div>}
+        {(app.author || app.verified) && (
+          <div className="flex items-center gap-2 text-xs text-[var(--text-dim)]">
+            {app.author && <span>by {app.author}</span>}
+            <VerifiedBadge verified={app.verified} author={app.author} />
+          </div>
+        )}
+        {app.entitlement === 'license_key' && (
+          <div className="text-xs text-[var(--text-dim)]">
+            Licensed app: after install, an administrator enters the vendor's key in the
+            catalog; the app cannot be enabled until it accepts one.
+          </div>
+        )}
 
         {requires.length > 0 && (
           <div>
@@ -1608,6 +1652,10 @@ export function AppCatalog() {
     () => (indexQuery.data ?? []).filter((a) => !a.installed),
     [indexQuery.data]
   )
+  // Featured = reviewer-flagged listings not yet installed; they render in
+  // their own row above the full list (and stay in the list too, so a
+  // category scan still finds them).
+  const featured = useMemo(() => available.filter((a) => a.featured), [available])
 
   const refresh = () => {
     appsQuery.refetch()
@@ -1655,6 +1703,17 @@ export function AppCatalog() {
       {/* ---------------------- Available to install --------------------- */}
       {/* Best-effort: if the index endpoint errors, we simply omit this group
           rather than blanking the page above. */}
+      {!indexQuery.isError && featured.length > 0 && (
+        <div className="space-y-3">
+          <GroupHeader title="Featured" count={featured.length} />
+          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+            {featured.map((app) => (
+              <AvailableAppCard key={`featured-${app.id}`} app={app} tasks={tasks} onInstall={() => setInstallApp(app)} />
+            ))}
+          </div>
+        </div>
+      )}
+
       {!indexQuery.isError && (
         <div className="space-y-3">
           <GroupHeader title="Available to install" count={available.length} />

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -244,6 +244,13 @@ index entry plus your app under `examples/<id>/` — one topic per PR.
   `subscription` app that gates features declares `entitlement:
   license_key` and implements `verify_license` — a reviewer will try
   enabling it without a key and expect a 402.
+- **Curation flags are the reviewer's, not the submitter's.** Leave
+  `verified` and `featured` out of your entry. A reviewer sets
+  `verified: true` once the author's identity is confirmed (a
+  maintained public repository or organisation behind the `author`
+  name) and the image is reproducible from the linked source;
+  `featured: true` is editorial and rotates. Submissions that carry
+  either flag are asked to remove it.
 - **External listings link somewhere real.** `kind: external` needs an
   https `external_url` under your control and an `author`; the
   validator rejects an install block on an external entry.

--- a/docs/DEVELOPER_PROGRAM.md
+++ b/docs/DEVELOPER_PROGRAM.md
@@ -115,9 +115,11 @@ Apps are an investment; the platform must not spend it.
   shows the pricing badge and author.
 * Community apps are showcased in the project README and release
   notes — open your listing PR and say a line about it.
-* Verified-developer badges, featured rows and install counts are on
-  the roadmap ([ROADMAP.md](ROADMAP.md)); the index fields they need
-  (`author`, `kind`) already exist.
+* A **verified** badge (identity confirmed, image reproducible from
+  source — set by reviewers, see
+  [CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md)) and a **Featured** row at
+  the top of every catalog. Install counts are on the roadmap
+  ([ROADMAP.md](ROADMAP.md)).
 
 ## Getting help
 

--- a/docs/EXTERNAL_APP_WALKTHROUGH.md
+++ b/docs/EXTERNAL_APP_WALKTHROUGH.md
@@ -54,7 +54,7 @@ wheel.
 | 3 | `DomainEventSubscriber` handed you no dispatcher: unlike `Detector`, an event-driven app had to `set_default_source` + `build_dispatcher` itself. | **Fixed (SDK 0.5.0):** `self.dispatcher` from the standard config keys, `self.fire(alert)` scoped to the app's identity, counted on `/health`. |
 | 4 | Every app re-declared the same ten config fields (`nats_*`, `contract_*`, `opennvr_url/token`, `webhook_url`, `nats_alerts_*`) and their YAML parsing. | **Fixed (SDK 0.5.0):** `BaseAppConfig` + `load_app_config(path, cls)`; the template's config block went from ~70 lines to 12, Plate VIP from 241 to 210. |
 | 5 | The generator needed a clone of this repository to run at all. | **Fixed (SDK 0.5.0):** `opennvr-app new <id>` ships in the wheel with the template; `scripts/create_opennvr_app.py` is a wrapper for in-tree use. |
-| 6 | Nothing shows an operator *why* an external app is greyed until they enter a key: the 402 text is right, the card could say "licence required" up front. | Open (frontend polish). |
+| 6 | Nothing told an operator *before* install that a licensed app will not enable until a key is entered: the 402 text was right, the card said nothing. | **Fixed:** available cards carry a "licence key required" badge and a one-line explanation; the catalog also gained reviewer-set `verified` / `featured` flags. |
 
 Nothing in the list is a contract problem: the registry, entitlement
 and platform routes behaved exactly as documented, and `min_sdk_version`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -273,10 +273,10 @@ to a release window. Pull requests and design discussions are welcome.
   variants beyond the ONNX-only adapters that ship in v0.1.
 - **Native Kubernetes operator** for Helm-chart deployments at scale.
 - **App Catalog for developers** (see `docs/DEVELOPER_PROGRAM.md`):
-  a verified-developer badge on listings, a featured row, install
-  counts (opt-in, aggregate) and a community showcase. The index
-  fields these need — `author`, `kind`, `pricing` — already ship;
-  the catalog UI and the review policy behind the badge do not yet.
+  the verified-developer badge and the Featured row ship (reviewer-set
+  `verified` / `featured` index flags; policy in CONTRIBUTING_APPS.md).
+  Still open: install counts (opt-in, aggregate — needs a telemetry
+  design first) and a community showcase page.
 
 ## How to influence the roadmap
 

--- a/docs/apps-index-entry.template.yml
+++ b/docs/apps-index-entry.template.yml
@@ -35,6 +35,10 @@
                                    #   (ContractMixin.verify_license) and refuses to enable the
                                    #   app until it says yes. Mirror these three in AppManifest.
   author: ""                       # Shown as "by <author>" on the listing.
+  # verified: true                 # REVIEWERS ONLY — the maintainers vouch for the author
+                                   #   (identity confirmed, image reproducible from the linked
+                                   #   source). Leave out of a submission; a reviewer adds it.
+  # featured: true                 # REVIEWERS ONLY — shown in the Featured row.
 
   image: ghcr.io/<you>/my-app:latest   # REQUIRED. Well-formed ref — ghcr.io/... or
                                        #   opennvr/... . This is the canonical pull ref

--- a/scripts/validate_apps_index.py
+++ b/scripts/validate_apps_index.py
@@ -358,6 +358,13 @@ def validate_entry(
         errors.append(f"{label}: entitlement must be none | license_key")
     if pricing != "free" and not entry.get("price_note"):
         warnings.append(f"{label}: pricing is '{pricing}' but price_note is empty")
+    # Curation flags are booleans a REVIEWER sets; a verified listing
+    # names its author (the badge reads "verified · <author>").
+    for flag in ("verified", "featured"):
+        if flag in entry and not isinstance(entry[flag], bool):
+            errors.append(f"{label}: {flag} must be true or false")
+    if entry.get("verified") is True and not str(entry.get("author") or "").strip():
+        errors.append(f"{label}: a verified listing must name its author")
 
     # Required fields present + non-empty.
     required = tuple(f for f in REQUIRED_FIELDS

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -129,6 +129,12 @@ class IndexEntry(BaseModel):
     price_note: str = ""
     entitlement: str = "none"
     author: str = ""
+    # Catalog curation (reviewer-set, never by the submitter's manifest):
+    # ``verified`` = the maintainers vouch for the author (identity
+    # confirmed, image reproducible from the linked source); ``featured``
+    # = shown in the Featured row at the top of the catalog.
+    verified: bool = False
+    featured: bool = False
     requires_tasks: list[str] = []
     # RFC-0002 Phase 3 (decision 7): KAI-C adapters that must be
     # provisioned with the app; the reconciler ups + refcounts them.
@@ -676,6 +682,8 @@ async def get_apps_index(
                 "price_note": entry.price_note,
                 "entitlement": entry.entitlement,
                 "author": entry.author,
+                "verified": entry.verified,
+                "featured": entry.featured,
                 "requires_tasks": entry.requires_tasks,
                 "emits": entry.emits,
                 "docs_url": entry.docs_url,

--- a/server/tests/test_app_credentials.py
+++ b/server/tests/test_app_credentials.py
@@ -604,6 +604,7 @@ def test_index_external_listing_is_not_installable(monkeypatch, env):
     tc.app.dependency_overrides[auth_mod.get_current_active_user] = lambda: admin
     listing = tc.get("/apps/index", headers=_site()).json()["apps"][0]
     assert listing["kind"] == "external" and listing["install"] is None
+    assert listing["verified"] is False and listing["featured"] is False   # defaults
     assert listing["pricing"] == "paid" and listing["external_url"].startswith("https://acme")
     r = tc.post("/apps/index/acme-lpr/install")
     assert r.status_code == 400 and "external listing" in r.json()["detail"]

--- a/server/tests/test_apps_index.py
+++ b/server/tests/test_apps_index.py
@@ -275,6 +275,8 @@ def test_index_response_shape_matches_contract(client):
         "price_note",
         "entitlement",
         "author",
+        "verified",
+        "featured",
         "version",
         "image",
         "requires_tasks",

--- a/server/tests/test_validate_apps_index.py
+++ b/server/tests/test_validate_apps_index.py
@@ -401,3 +401,19 @@ def test_unparseable_snippet_fails(tmp_path):
     entry["install"] = dict(_GOOD_ENTRY["install"], compose="{ not: [valid")
     errors, _ = validator.validate_index(_write(tmp_path, [entry]))
     assert any("not valid YAML" in e for e in errors), errors
+
+
+# ─── Curation flags (verified / featured) ────────────────────────────────
+
+
+def test_curation_flags_are_booleans_and_verified_needs_an_author(tmp_path, monkeypatch):
+    monkeypatch.setattr(validator, "_load_overlay_services", lambda overlay=None: {"sample-app"})
+    ok = dict(_GOOD_ENTRY, author="Sample Co.", verified=True, featured=True)
+    errors, _ = validator.validate_index(_write(tmp_path, [ok]))
+    assert errors == []
+    bad_type = dict(_GOOD_ENTRY, verified="yes")
+    errors, _ = validator.validate_index(_write(tmp_path, [bad_type]))
+    assert any("verified must be true or false" in e for e in errors), errors
+    no_author = dict(_GOOD_ENTRY, verified=True, author="")
+    errors, _ = validator.validate_index(_write(tmp_path, [no_author]))
+    assert any("verified listing must name its author" in e for e in errors), errors


### PR DESCRIPTION
The last open line from the outside-the-repo walk, plus the two catalog items ROADMAP.md promised developers.

- Available-app cards with entitlement: license_key now carry a "licence key required" badge and a one-line note on what happens after install, so the 402 on enable is never the first an operator hears of it (the installed card already had the LicensePanel).
- Two reviewer-set index flags: `verified` (the maintainers vouch for the author — identity confirmed, image reproducible from source; the validator requires an author) and `featured` (a Featured row above "Available to install"; entries stay in the main list too). IndexEntry + GET /apps/index return both; the index template marks them REVIEWERS ONLY and CONTRIBUTING_APPS.md states the policy.
- Tests: validator rules for the flags; response-shape contract and the external-listing test cover the defaults.

Frontend: tsc clean apart from the two pre-existing errors (xlsx, DeviceFirewall); `vite build` fails identically on unmodified main because of the missing xlsx module — not this change.