### PR TITLE
fix(frontend): typecheck in CI; DeviceFirewall used a Button variant …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,11 @@ jobs:
       - name: Install dependencies
         working-directory: app
         run: npm ci
+      # vite build does not typecheck (esbuild strips types), so a type
+      # error can ship unnoticed — tsc is the gate for that.
+      - name: Typecheck
+        working-directory: app
+        run: npm run typecheck
       - name: Build
         working-directory: app
         run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,11 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Frontend typecheck in CI.** `vite build` strips types without
+  checking them, so `DeviceFirewall` shipped a `variant="secondary"`
+  that no `Button` variant accepts (now `outline`). `npm run
+  typecheck` (`tsc --noEmit`) runs before the build in `ci.yml`.
+
 - **Test suites no longer leak swapped `core.*` modules into each
   other.** `server/tests/conftest.py` snapshots the `core` namespace of
   `sys.modules` per test module and restores it, so a suite that purges

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite --config vite.config.ts",
     "build": "vite build --config vite.config.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint .",
     "preview": "vite preview --config vite.config.ts"
   },

--- a/app/src/views/settings/DeviceFirewall.tsx
+++ b/app/src/views/settings/DeviceFirewall.tsx
@@ -152,7 +152,7 @@ export function DeviceFirewall() {
           </p>
         </div>
         <Button
-          variant={active ? 'secondary' : 'primary'}
+          variant={active ? 'outline' : 'primary'}
           disabled={busy === 'toggle'}
           onClick={() => toggle(!active)}
         >


### PR DESCRIPTION
…that does not exist

`vite build` (what CI runs) strips types without checking them, so `variant={active ? 'secondary' : 'primary'}` in DeviceFirewall has been shipping although 'secondary' is not a ButtonVariant — at runtime it falls through to the default style, which is why nobody noticed. Now 'outline', which is the intended "turn it off" look.

`npm run typecheck` (tsc --noEmit) is added and runs before the build in ci.yml so the next one is caught.

Note for anyone with a stale local node_modules: the "Cannot find module 'xlsx'" error is not in the tree — xlsx is in package.json and the lockfile; `npm ci` fixes it.