### PR TITLE
fix(bus): alert publish permission spelled exactly as the SDK spells …

### DIFF
--- a/server/services/nats_users.py
+++ b/server/services/nats_users.py
@@ -58,8 +58,11 @@ def _subject_ok(subject: str) -> bool:
 
 
 def _alert_token(value: str) -> str:
-    """The SDK sanitises alert-subject tokens the same way (alerts.py)."""
-    return re.sub(r"[^A-Za-z0-9_-]", "_", value) or "_"
+    """Byte-for-byte the SDK's ``alerts._sanitize_subject_token``: the
+    app's alert subject is ``opennvr.alerts.app.<this>.<camera>``, so the
+    publish permission must be spelled exactly as the SDK spells it."""
+    cleaned = re.sub(r"[^A-Za-z0-9_-]", "_", value).strip("_")
+    return cleaned or "unknown"
 
 
 def app_permissions(app_id: str, manifest: dict[str, Any] | None) -> dict[str, list[str]]:

--- a/server/tests/test_app_credentials.py
+++ b/server/tests/test_app_credentials.py
@@ -801,3 +801,20 @@ def test_bus_users_file_is_valid_with_no_apps_and_off_when_unset(monkeypatch, tm
             raise AssertionError("must not touch the DB when the feature is off")
 
     assert nats_users.write_users_conf(_DB()) is False
+
+
+def test_bus_alert_publish_permission_matches_the_sdk_subject():
+    """The permission is only useful if it is the subject the SDK will
+    actually publish on — same sanitiser, same edge cases."""
+    import sys
+
+    from services import nats_users
+
+    sdk_path = str(REPO_ROOT / "sdk" / "opennvr-app-sdk")
+    if sdk_path not in sys.path:
+        sys.path.insert(0, sdk_path)
+    from opennvr_app_sdk.alerts import _sanitize_subject_token
+
+    for app_id in ("plate-vip", "my.app", "_odd_", "weird id!", "___"):
+        allowed = nats_users.app_permissions(app_id, {})["publish"]
+        assert f"opennvr.alerts.app.{_sanitize_subject_token(app_id)}.>" in allowed, app_id


### PR DESCRIPTION
…the subject

nats_users._alert_token now mirrors alerts._sanitize_subject_token (strip leading/trailing underscores, 'unknown' fallback) — an app id like '_odd_' would otherwise get a permission for a subject it never publishes on and have its alerts refused. Pinned by a test that runs both sanitisers over the same edge cases.