### PR TITLE
feat(installer): signed catalog images, verified before every pinned …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -666,3 +666,11 @@ OLLAMA_KEEP_ALIVE=-1
 # Set APPS_EGRESS_PROXY_URL empty to stop handing apps the proxy at all
 # (only meaningful together with APPS_EGRESS_ENFORCED=false).
 # APPS_EGRESS_PROXY_URL=http://egress-proxy:3128
+
+# ── One-click installer: image signatures ─────────────────────────
+# The app-installer (docker-compose.installer.yml) verifies a Sigstore
+# signature on every pinned catalog image before it installs it: an
+# ghcr.io/open-nvr image must have been signed by OpenNVR's own CI.
+# "off" skips the check — only for an air-gapped deployment that cannot
+# reach the Sigstore transparency log. docs/APPS_INSTALL.md → Image signing.
+# INSTALLER_SIGNATURES=require

--- a/.github/workflows/app-images-smoke.yml
+++ b/.github/workflows/app-images-smoke.yml
@@ -194,7 +194,9 @@ jobs:
       matrix:
         include:
           - { app: abandoned-object,           module: abandoned_object }
+          - { app: alert-notifier,             module: alert_notifier }
           - { app: footage-search,             module: footage_search }
+          - { app: gate-controller,            module: gate_controller }
           - { app: home-assistant-relay,       module: home_assistant_relay }
           - { app: intrusion-detection,        module: intrusion_detection }
           - { app: license-plate-recognition,  module: license_plate_recognition }

--- a/.github/workflows/publish-app-images.yml
+++ b/.github/workflows/publish-app-images.yml
@@ -30,7 +30,7 @@
 # Architecture: linux/amd64 + linux/arm64, same rationale as the core
 # image (Apple Silicon and Raspberry Pi are first-class Tier 0 targets;
 # an amd64-only manifest makes ``docker pull`` fail there with a bare
-# daemon error). All ten images are python:3.11-slim + the in-repo SDK
+# daemon error). All twelve images are python:3.11-slim + the in-repo SDK
 # with no heavy native deps, so the QEMU arm64 leg is cheap.
 #
 # To add a new catalog app: add it to apps_index.yml, to the smoke
@@ -64,12 +64,19 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Sigstore keyless signing: the job proves its identity to Fulcio
+      # with a GitHub OIDC token; the resulting certificate names THIS
+      # workflow, ref and repository, and the installer verifies against
+      # exactly that (scripts/app-installer/signing.py). No key to keep.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - { app: abandoned-object,           title: Abandoned Object }
+          - { app: alert-notifier,             title: Alert Notifier }
           - { app: footage-search,             title: Footage Search }
+          - { app: gate-controller,            title: Gate Controller }
           - { app: home-assistant-relay,       title: Home Assistant Relay }
           - { app: intrusion-detection,        title: Intrusion Detection }
           - { app: license-plate-recognition,  title: License Plate Recognition }
@@ -89,6 +96,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v2.4.1"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -119,6 +131,7 @@ jobs:
             org.opencontainers.image.documentation=https://github.com/open-nvr/open-nvr/blob/main/examples/${{ matrix.app }}/README.md
 
       - name: Build + push ${{ matrix.app }}
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -131,3 +144,20 @@ jobs:
           # usually finds every layer already built.
           cache-from: type=gha,scope=${{ matrix.app }}
           cache-to: type=gha,scope=${{ matrix.app }},mode=max
+
+      # Sign the multi-arch manifest digest (not a tag — tags move). The
+      # signature lands next to the image in GHCR; the one-click
+      # installer refuses a pinned image whose signature does not
+      # verify against this workflow's identity, and anyone can check:
+      #   cosign verify \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      #     --certificate-identity-regexp '^https://github.com/open-nvr/' \
+      #     ghcr.io/open-nvr/<app>@<digest>
+      - name: Sign ${{ matrix.app }} (Sigstore keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          test -n "$DIGEST"
+          cosign sign --yes "ghcr.io/open-nvr/${{ matrix.app }}@${DIGEST}"
+          echo "signed ghcr.io/open-nvr/${{ matrix.app }}@${DIGEST}" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Signed catalog images, verified at install.**
+  `publish-app-images.yml` now signs every image it pushes with
+  Sigstore keyless signing (cosign + the workflow's GitHub OIDC
+  identity — no key to keep), and the one-click installer runs
+  `cosign verify` on every pinned image before `docker compose up`:
+  a `ghcr.io/open-nvr` image must have been signed by a workflow in an
+  `open-nvr` repository on `main` or a `v*` tag; any other image must
+  name its signer in the index entry (`signing: {identity, issuer}`,
+  validated) or is refused as *no known signer*. A failed signature is
+  a failed intent with the reason in the catalog; compose never runs.
+  `INSTALLER_SIGNATURES=off` for air-gapped deployments (logged loudly).
+  The installer image ships cosign; the catalog card shows **signed**
+  and the index API carries `signed_by`. Also: alert-notifier and
+  gate-controller were listed with `ghcr.io/open-nvr` images that no
+  workflow published — both are now in the publish and smoke matrices.
+  `docs/APPS_INSTALL.md` → Image signing.
+
 - **Enforced app egress.** Apps now run on `opennvr_apps`, an internal
   compose network with no route to the LAN or the internet, and leave
   it only through the new `egress-proxy` service (`scripts/egress-proxy`,

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -174,6 +174,11 @@ function ProvenanceLine({ app }: { app: IndexApp }) {
           open source · built from source
         </a>
       ) : null}
+      {!external && app.signed_by && (
+        <span title={`Image signed (Sigstore) by ${app.signed_by}; the installer verifies the signature before installing`}>
+          signed
+        </span>
+      )}
       {app.contact && (
         <a href={app.contact.includes('@') && !app.contact.startsWith('http') ? `mailto:${app.contact}` : app.contact}
            target="_blank" rel="noreferrer" className="hover:text-[var(--text)]">
@@ -258,6 +263,9 @@ type IndexApp = {
   source?: string | null
   contact?: string | null
   network_egress?: string[]
+  // Who the one-click installer expects to have signed the image
+  // ("OpenNVR CI", or a declared identity); null = unsigned.
+  signed_by?: string | null
   image?: string | null
   requires_tasks?: string[]
   emits?: string[]

--- a/docker-compose.installer.yml
+++ b/docker-compose.installer.yml
@@ -63,6 +63,11 @@ services:
       # up/down. Must match the app service blocks (docker-compose.apps.yml).
       - INSTALLER_COMPOSE_FILES=docker-compose.yml,docker-compose.apps.yml
       - INSTALLER_PROFILE=apps
+      # Image signatures: "require" (default) verifies every pinned image
+      # with cosign against its expected signer — the org's CI for
+      # ghcr.io/open-nvr images — before compose runs; "off" for an
+      # air-gapped deployment that cannot reach the Sigstore log.
+      - INSTALLER_SIGNATURES=${INSTALLER_SIGNATURES:-require}
     volumes:
       # ── THE privilege ──────────────────────────────────────────────
       # The Docker socket is mounted into THIS tiny service and NOWHERE

--- a/docs/APPS_INSTALL.md
+++ b/docs/APPS_INSTALL.md
@@ -203,6 +203,54 @@ the index at release time is the remaining step to make pinning bite;
 the mechanism itself is complete and tested, and the local `build:`
 overlay with `:local-build` tags remains the dev / air-gapped path.
 
+## Image signing
+
+A digest pin says *these exact bytes*. It does not say *who built
+them*: a digest in a listing PR could point at anything its author
+pushed to a registry. Signing closes that gap.
+
+**Publishing signs.** `.github/workflows/publish-app-images.yml` signs
+every catalog image it pushes with **Sigstore keyless signing** — cosign
+plus the workflow's GitHub OIDC identity. There is no signing key to
+keep, leak or rotate: the signature's certificate names the repository,
+the workflow file and the ref (`main` or a `v*` tag) that produced the
+image, and Sigstore's transparency log records it. Anyone can check:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/open-nvr/' \
+  ghcr.io/open-nvr/loitering-detection@sha256:…
+```
+
+**Installing verifies.** Before `docker compose up`, the reconciler runs
+`cosign verify` on the pinned ref against its *expected signer*
+(`scripts/app-installer/signing.py`):
+
+* a `ghcr.io/open-nvr/…` image must have been signed by a workflow in
+  a repository under `github.com/open-nvr`, running on `main` or a
+  release tag — the org's own CI, nothing else;
+* an image from anywhere else must name its signer in the index entry
+  (`signing: {identity: <regexp>, issuer: <url>}`), reviewed with the
+  entry; without one it has *no known signer* and is refused.
+
+A failed or missing signature is a `failed` intent with the reason in
+`message` — visible in the catalog — and compose never runs. Unpinned
+(dev-only) installs are not verified: there is no digest to bind a
+signature to, and they already log the loud UNPINNED warning.
+
+`INSTALLER_SIGNATURES=off` (in `.env`, read by
+`docker-compose.installer.yml`) disables the check for an air-gapped
+deployment that cannot reach the Sigstore log; the installer logs
+`IMAGE SIGNATURES NOT CHECKED` at start-up so nobody forgets. In
+`require` mode the installer refuses to start if `cosign` is missing
+from its image. The catalog card shows **signed** on every listing the
+installer would verify.
+
+Between them, digest + signature give the sentence the catalog is built
+on: *what a reviewer read is what runs, and it was built by the org's
+CI from that source.*
+
 ---
 
 ## The reconciler

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -28,6 +28,13 @@ trusts:
   `image_digest` **from the curated index entry, never from the caller** —
   an operator can only install an app that a reviewer already vetted into
   this file (see [`docs/APPS_INSTALL.md`](APPS_INSTALL.md)).
+- **Catalog images are signed, and the installer checks.** The org's
+  publish workflow signs every image it pushes (Sigstore keyless); the
+  one-click installer verifies a pinned image against that identity
+  before it runs and refuses one that does not match. An image built
+  outside the org's CI must declare who signs it (`signing:` in the
+  entry) or it is refused as *no known signer* —
+  [`docs/APPS_INSTALL.md` → Image signing](APPS_INSTALL.md#image-signing).
 - **A pinned `image_digest` is what makes one-click install trustworthy.**
   With a digest, the reconciler deploys `image@sha256:…` — the exact bytes
   the review vouched for (supply-chain integrity). Without one, it logs a

--- a/docs/DEVELOPER_PROGRAM.md
+++ b/docs/DEVELOPER_PROGRAM.md
@@ -147,7 +147,7 @@ closed code in the catalog. Ship that as an external listing.
 
 | Core | `api_version` | Minimum SDK | Notable |
 |---|---|---|---|
-| main (Sep 2026) | 1.4 | 0.2.0 | enforced egress: `egress` on the app record, `GET`/`PUT /apps/{id}/egress`, `opennvr_app_sdk.egress` |
+| main (Sep 2026) | 1.4 | 0.2.0 | enforced egress: `egress` on the app record, `GET`/`PUT /apps/{id}/egress`, `opennvr_app_sdk.egress`; signed images, verified at install (`signed_by` on index entries) |
 | main (Sep 2026) | 1.3 | 0.2.0 | `X-OpenNVR-Call`: core proves itself per app; the site key no longer reaches apps on SDK ≥ 0.6 |
 | 0.2.x line | 1.2 | 0.2.0 | per-app keys, user context, platform client, entitlements, async client, `opennvr-app new` |
 | 0.1.4 | 1.0 | — | registry contract: register, config, state, actions |
@@ -170,8 +170,11 @@ worth knowing.
   is refused and shows up in the operator's inbox with the host named
   ([APP_NETWORK.md](APP_NETWORK.md)). A catalog app with an empty list
   is one that *cannot* talk to the internet, not one that promises not to.
-* Catalog images are **built from your tagged source by CI** and
-  digest-pinned; what a reviewer read is what runs.
+* Catalog images are **built from your tagged source by CI**,
+  digest-pinned and **signed** (Sigstore keyless, the CI workflow's own
+  identity); the one-click installer verifies the signature before it
+  installs. What a reviewer read is what runs, and it was built by the
+  org's CI from that source.
 * Video, plates and faces **do not leave the site** unless the operator
   enables a feature that says so, in words, on the card.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -279,8 +279,9 @@ to a release window. Pull requests and design discussions are welcome.
   external; paid = open code that gates a licensed model or service.
   Shipped: maintainer-verified badge, Featured row, provenance line,
   validator rules. Next: build-from-source CI for third-party
-  repositories, an app-repository template, image signing on top of
-  digest pinning. Shipped: per-app NATS credentials (the `nats-apps`
+  repositories, an app-repository template. Shipped: signed catalog
+  images (Sigstore keyless in the publish workflow) verified by the
+  installer before any pinned install; per-app NATS credentials (the `nats-apps`
   leaf bus; user = app id, permissions from the manifest;
   `requires_scopes` enforced on the bus), per-app call tokens (no site
   key reaches an app), and enforced egress (apps on an internal

--- a/docs/apps-index-entry.template.yml
+++ b/docs/apps-index-entry.template.yml
@@ -61,6 +61,14 @@
                                    #   A pinned digest is what makes one-click install
                                    #   trustworthy (supply-chain integrity). Omit only for
                                    #   a local `build:`-overlay app; unpinned = dev only.
+  # signing:                       # ONLY for an image NOT built by the org's CI (not
+  #   identity: '^https://github.com/<you>/<repo>/\.github/workflows/.*$'
+  #   issuer: https://token.actions.githubusercontent.com
+                                   #   Who signed the image (Sigstore keyless): the OIDC
+                                   #   certificate identity the installer verifies with
+                                   #   cosign before a pinned install. ghcr.io/open-nvr
+                                   #   images are signed by OpenNVR CI and need nothing
+                                   #   here. docs/APPS_INSTALL.md → Image signing.
 
   requires_tasks: [object_detection]   # REQUIRED (may be []). Adapter task types your app
                                        #   depends on. Prefer canonical names from

--- a/scripts/app-installer/Dockerfile
+++ b/scripts/app-installer/Dockerfile
@@ -42,7 +42,13 @@ WORKDIR /app
 RUN pip install --no-cache-dir \
         "sqlalchemy>=2,<3" "psycopg2-binary>=2.9" "PyYAML>=6.0,<7.0"
 
+# cosign, for verifying catalog image signatures before an install
+# (scripts/app-installer/signing.py). Taken from the Sigstore project's
+# own multi-arch image, pinned; no network fetch at build time.
+COPY --from=ghcr.io/sigstore/cosign/cosign:v2.4.1 /ko-app/cosign /usr/local/bin/cosign
+
 COPY scripts/app-installer/reconciler.py ./reconciler.py
+COPY scripts/app-installer/signing.py    ./signing.py
 COPY scripts/app-installer/store.py      ./store.py
 COPY scripts/app-installer/main.py       ./main.py
 

--- a/scripts/app-installer/main.py
+++ b/scripts/app-installer/main.py
@@ -40,6 +40,10 @@ Config (env):
   INSTALLER_COMPOSE_FILES — comma-separated compose files, default
                           "docker-compose.yml,docker-compose.apps.yml".
   INSTALLER_PROFILE     — compose profile, default "apps".
+  INSTALLER_SIGNATURES  — "require" (default: a pinned image must carry a
+                          valid Sigstore signature from its expected
+                          signer, checked with cosign before compose
+                          runs) or "off" (air-gapped / lab). signing.py.
 
 Failure backoff: an intent that keeps failing (bad image, unpullable
 digest, poison row) is retried with exponential backoff (10s doubling
@@ -62,6 +66,13 @@ from reconciler import (
     docker_runner,
     load_curated_index,
     reconcile_once,
+)
+from signing import (
+    DEFAULT_MODE as DEFAULT_SIGNING_MODE,
+    SIGNING_MODES,
+    SigningPolicy,
+    cosign_available,
+    cosign_verifier,
 )
 from store import SqlIntentStore
 
@@ -112,12 +123,32 @@ def main() -> int:
         len(index), sorted(index),
     )
 
+    signing_mode = os.environ.get("INSTALLER_SIGNATURES", DEFAULT_SIGNING_MODE).strip().lower()
+    if signing_mode not in SIGNING_MODES:
+        logger.error("INSTALLER_SIGNATURES must be one of %s, got %r", SIGNING_MODES, signing_mode)
+        return 2
+    if signing_mode == "require" and not cosign_available():
+        logger.error(
+            "INSTALLER_SIGNATURES=require but 'cosign' is not on PATH — refusing "
+            "to start (rebuild the installer image, or set INSTALLER_SIGNATURES=off "
+            "for an air-gapped deployment that accepts unsigned images)"
+        )
+        return 2
+    signing = SigningPolicy(
+        mode=signing_mode,
+        verify=cosign_verifier(docker_runner) if signing_mode == "require" else None,
+    )
+    if signing_mode == "off":
+        logger.warning("IMAGE SIGNATURES NOT CHECKED (INSTALLER_SIGNATURES=off): pinned "
+                       "images deploy without proof of who built them")
+
     store = SqlIntentStore(database_url)
     logger.info(
-        "app-installer starting: poll=%ss compose_files=%s profile=%s",
+        "app-installer starting: poll=%ss compose_files=%s profile=%s signatures=%s",
         poll_seconds,
         list(compose_files),
         profile,
+        signing_mode,
     )
 
     # Per-id failure backoff state: consecutive failures + next allowed
@@ -138,6 +169,7 @@ def main() -> int:
                 skip_ids=skip_ids,
                 compose_files=compose_files,
                 profile=profile,
+                signing=signing,
             )
             for app_id, status_, message in outcomes:
                 logger.info(

--- a/scripts/app-installer/reconciler.py
+++ b/scripts/app-installer/reconciler.py
@@ -48,6 +48,11 @@ Design (desired-state + reconciler):
 * An index entry without a digest means UNPINNED — a loud warning is
   logged and the run is documented as dev-only (do not run unpinned in
   production).
+* A pinned image must carry a valid **Sigstore signature** from its
+  expected signer (the org's CI for ``ghcr.io/open-nvr`` images, or the
+  ``signing:`` identity the entry declares) — checked with ``cosign``
+  before compose runs, see ``signing.py``. ``INSTALLER_SIGNATURES=off``
+  disables it for air-gapped deployments.
 
 Testability: the docker/subprocess call is injected as a ``runner``
 callable so unit tests pass a fake runner and never touch real Docker.
@@ -64,6 +69,8 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Protocol
+
+from signing import Signer, SigningPolicy, parse_signer
 
 logger = logging.getLogger("opennvr.app-installer")
 
@@ -153,6 +160,10 @@ class CuratedApp:
     # app. Upped alongside it; refcounted across installed apps on
     # uninstall (released only when no other installed app requires it).
     requires_adapters: tuple[str, ...] = ()
+    # Who must have signed the image (``signing:`` in the entry). None →
+    # the org's CI for ghcr.io/open-nvr images, no known signer otherwise
+    # (see signing.expected_signer).
+    signer: Signer | None = None
 
 
 def load_curated_index(path: str | Path) -> dict[str, CuratedApp]:
@@ -195,6 +206,7 @@ def load_curated_index(path: str | Path) -> dict[str, CuratedApp]:
             image=image,
             image_digest=digest if isinstance(digest, str) else None,
             requires_adapters=adapters,
+            signer=parse_signer(entry.get("signing")),
         )
     return index
 
@@ -356,8 +368,14 @@ def reconcile_intent(
     held_adapters: frozenset[str] = frozenset(),
     compose_files: tuple[str, ...] = DEFAULT_COMPOSE_FILES,
     profile: str = DEFAULT_PROFILE,
+    signing: SigningPolicy | None = None,
 ) -> tuple[str, str]:
     """Reconcile ONE intent. Returns ``(status, message)``.
+
+    ``signing``: the image-signature policy (signing.py). With one, a
+    pinned image must verify against its expected signer BEFORE compose
+    runs; a refusal is a ``failed`` intent with the reason. ``None``
+    (library default; main.py always passes one) skips the check.
 
     Pure except for the injected ``runner`` — no Docker, no DB. This is
     the function the unit tests drive with a fake runner.
@@ -419,6 +437,11 @@ def reconcile_intent(
             )
         else:
             logger.info("Pinning app %r to %s", intent.id, pin)
+            if signing is not None:
+                ok, why = signing.check(intent.id, pin, curated.signer)
+                if not ok:
+                    logger.error("app %r: %s", intent.id, why)
+                    return "failed", why
         argv = build_up_argv(
             intent, adapters=curated.requires_adapters,
             compose_files=compose_files, profile=profile,
@@ -463,6 +486,7 @@ def reconcile_once(
     skip_ids: frozenset[str] = frozenset(),
     compose_files: tuple[str, ...] = DEFAULT_COMPOSE_FILES,
     profile: str = DEFAULT_PROFILE,
+    signing: SigningPolicy | None = None,
 ) -> list[tuple[str, str, str]]:
     """One reconcile sweep over every pending intent.
 
@@ -502,7 +526,7 @@ def reconcile_once(
         status_, message = reconcile_intent(
             intent, runner,
             index=index, held_adapters=held,
-            compose_files=compose_files, profile=profile,
+            compose_files=compose_files, profile=profile, signing=signing,
         )
         store.set_status(intent.id, status_, message, desired=intent.desired)
         outcomes.append((intent.id, status_, message))

--- a/scripts/app-installer/signing.py
+++ b/scripts/app-installer/signing.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Image signatures — what the digest pin does not prove.
+
+A digest pin says "these exact bytes". It does not say *who built
+them*: a digest in the index could be anything a PR author pushed to
+their own registry. Signing closes that gap. ``publish-app-images.yml``
+signs every catalog image it pushes with **Sigstore keyless signing**
+(cosign + the workflow's GitHub OIDC identity — no long-lived key to
+leak or rotate), and this module makes the installer refuse a pinned
+image whose signature does not verify against the expected identity
+before ``docker compose up`` ever sees it.
+
+The expected identity for an ``ghcr.io/open-nvr/…`` image is the
+org's own CI: a workflow in a repository under ``github.com/open-nvr``
+running on ``main`` or a ``v*`` tag, issued by GitHub's token service.
+An index entry may name a different signer explicitly
+(``signing: {identity: <regexp>, issuer: <url>}``) — that is how a
+catalog app built by another org's CI is trusted, and it is reviewed
+with the entry.
+
+Modes (``INSTALLER_SIGNATURES``):
+
+* ``require`` (default) — a pinned image must verify; otherwise the
+  intent fails with a message the operator can read in the catalog.
+  Unpinned (dev-only) installs are not verified: there is no digest to
+  bind a signature to, and they already log the loud UNPINNED warning.
+* ``off`` — no verification. For an air-gapped deployment that cannot
+  reach the Sigstore transparency log, or a lab. Logged at start-up so
+  nobody forgets.
+
+Verification is ``cosign verify`` run through the same injected
+``runner`` the compose calls use, so unit tests never need cosign.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger("opennvr.app-installer")
+
+SIGNING_MODES = ("require", "off")
+DEFAULT_MODE = "require"
+
+GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+#: Images the org's CI builds: any workflow in any open-nvr repository,
+#: running on main or a release tag. Anchored on both ends.
+ORG_IDENTITY_RE = (
+    r"^https://github\.com/open-nvr/[A-Za-z0-9_.-]+/\.github/workflows/"
+    r"[A-Za-z0-9_.-]+\.ya?ml@refs/(heads/main|tags/v[0-9][A-Za-z0-9_.-]*)$"
+)
+ORG_IMAGE_RE = re.compile(r"^ghcr\.io/open-nvr/[a-z0-9][a-z0-9._-]*(?::[^@/]+)?(?:@sha256:[0-9a-f]{64})?$")
+
+COSIGN_BIN = "cosign"
+
+
+@dataclass(frozen=True)
+class Signer:
+    """Who must have signed an image: a certificate-identity regexp and
+    the OIDC issuer that vouched for it."""
+
+    identity: str
+    issuer: str = GITHUB_OIDC_ISSUER
+
+
+def expected_signer(image: str, declared: Signer | None = None) -> Signer | None:
+    """The signer a pinned image must verify against: the entry's own
+    declaration when it has one, the org's CI for ``ghcr.io/open-nvr``
+    images, and ``None`` (no known signer → refused in ``require``
+    mode) for anything else."""
+    if declared is not None:
+        return declared
+    if ORG_IMAGE_RE.match(image.split("@", 1)[0]):
+        return Signer(identity=ORG_IDENTITY_RE)
+    return None
+
+
+def parse_signer(raw: object) -> Signer | None:
+    """``signing: {identity, issuer}`` from an index entry, validated.
+    Malformed → ``None`` with an error log (never a half-trusted signer)."""
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        logger.error("curated index: 'signing' must be a mapping, got %r", type(raw).__name__)
+        return None
+    identity = raw.get("identity")
+    issuer = raw.get("issuer", GITHUB_OIDC_ISSUER)
+    if not isinstance(identity, str) or not identity.strip() or len(identity) > 500:
+        logger.error("curated index: 'signing.identity' must be a non-empty regexp")
+        return None
+    try:
+        re.compile(identity)
+    except re.error as exc:
+        logger.error("curated index: 'signing.identity' is not a valid regexp: %s", exc)
+        return None
+    if not isinstance(issuer, str) or not issuer.startswith("https://"):
+        logger.error("curated index: 'signing.issuer' must be an https URL")
+        return None
+    return Signer(identity=identity.strip(), issuer=issuer.strip())
+
+
+def verify_argv(ref: str, signer: Signer) -> list[str]:
+    """``cosign verify`` for one digest-pinned ref. Output is JSON on
+    stdout on success; non-zero exit with the reason on stderr otherwise."""
+    return [
+        COSIGN_BIN, "verify",
+        "--certificate-oidc-issuer", signer.issuer,
+        "--certificate-identity-regexp", signer.identity,
+        ref,
+    ]
+
+
+#: ``(ref, signer) -> (ok, message)``
+Verifier = Callable[[str, Signer], tuple[bool, str]]
+
+
+def cosign_verifier(runner) -> Verifier:
+    """A verifier that shells ``cosign verify`` out through ``runner``
+    (the reconciler's injected command seam)."""
+    def verify(ref: str, signer: Signer) -> tuple[bool, str]:
+        result = runner(verify_argv(ref, signer), None)
+        if result.returncode == 0:
+            return True, "signature verified"
+        detail = (result.stderr or result.stdout or f"cosign exited {result.returncode}").strip()
+        return False, detail.splitlines()[-1] if detail else "cosign failed"
+    return verify
+
+
+@dataclass(frozen=True)
+class SigningPolicy:
+    mode: str = DEFAULT_MODE
+    verify: Verifier | None = None
+
+    def __post_init__(self):
+        if self.mode not in SIGNING_MODES:
+            raise ValueError(f"INSTALLER_SIGNATURES must be one of {SIGNING_MODES}, got {self.mode!r}")
+        if self.mode == "require" and self.verify is None:
+            raise ValueError("signing mode 'require' needs a verifier")
+
+    def check(self, app_id: str, pinned_ref: str, declared: Signer | None) -> tuple[bool, str]:
+        """Whether a pinned image may deploy. Never raises."""
+        if self.mode == "off":
+            return True, "signature check off (INSTALLER_SIGNATURES=off)"
+        signer = expected_signer(pinned_ref, declared)
+        if signer is None:
+            return False, (
+                f"refused: {pinned_ref} has no known signer — it is not an "
+                "ghcr.io/open-nvr image and its index entry declares no "
+                "'signing' identity (set INSTALLER_SIGNATURES=off to install unsigned images)"
+            )
+        try:
+            ok, message = self.verify(pinned_ref, signer)  # type: ignore[misc]
+        except Exception as exc:  # noqa: BLE001 — a crashing verifier is a refusal
+            ok, message = False, f"verifier error: {exc.__class__.__name__}: {exc}"
+        if ok:
+            logger.info("app %r: %s (identity %s, issuer %s)", app_id, message, signer.identity, signer.issuer)
+            return True, message
+        return False, (
+            f"refused: signature of {pinned_ref} did not verify against "
+            f"{signer.identity} (issuer {signer.issuer}): {message}"
+        )
+
+
+def cosign_available() -> bool:
+    return shutil.which(COSIGN_BIN) is not None

--- a/scripts/app-installer/tests/test_signing.py
+++ b/scripts/app-installer/tests/test_signing.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Image-signature policy (scripts/app-installer/signing.py) and its
+seat in the reconciler: a pinned image must verify against its expected
+signer before compose runs; unsigned or mis-signed → a failed intent
+that never touches Docker.
+
+Run with:
+    python -m pytest scripts/app-installer/tests -q
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import signing  # noqa: E402
+from reconciler import CuratedApp, Intent, RunResult, load_curated_index, reconcile_intent  # noqa: E402
+from signing import Signer, SigningPolicy, cosign_verifier, expected_signer, verify_argv  # noqa: E402
+
+PIN = "ghcr.io/open-nvr/loitering-detection@sha256:" + "a" * 64
+
+
+class _Runner:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def __call__(self, argv, env=None):
+        self.calls.append((argv, env))
+        return self.result
+
+
+# ── who must have signed ────────────────────────────────────────────
+
+
+def test_org_images_expect_the_orgs_ci():
+    s = expected_signer(PIN)
+    assert s is not None and s.issuer == signing.GITHUB_OIDC_ISSUER
+    rx = re.compile(s.identity)
+    ok = [
+        "https://github.com/open-nvr/open-nvr/.github/workflows/publish-app-images.yml@refs/heads/main",
+        "https://github.com/open-nvr/open-nvr/.github/workflows/publish-app-images.yml@refs/tags/v0.2.0",
+        "https://github.com/open-nvr/app-plate-vip/.github/workflows/build.yml@refs/tags/v1.0.0-rc1",
+    ]
+    bad = [
+        "https://github.com/evil-org/open-nvr/.github/workflows/publish-app-images.yml@refs/heads/main",
+        "https://github.com/open-nvr/open-nvr/.github/workflows/publish-app-images.yml@refs/heads/feature",
+        "https://github.com/open-nvr/open-nvr/.github/workflows/publish-app-images.yml@refs/pull/12/merge",
+        "https://github.com/open-nvr-fake/x/.github/workflows/a.yml@refs/heads/main",
+        "https://github.com/open-nvr/open-nvr/.github/workflows/publish-app-images.yml@refs/heads/main/extra",
+    ]
+    assert all(rx.match(i) for i in ok)
+    assert not any(rx.match(i) for i in bad)
+
+
+def test_other_registries_need_a_declared_signer():
+    assert expected_signer("docker.io/vendor/app@sha256:" + "b" * 64) is None
+    assert expected_signer("ghcr.io/open-nvr-fake/app@sha256:" + "b" * 64) is None
+    declared = Signer(identity="^https://github.com/vendor/app/.*$", issuer="https://token.actions.githubusercontent.com")
+    assert expected_signer("docker.io/vendor/app@sha256:" + "b" * 64, declared) is declared
+    assert expected_signer(PIN, declared) is declared           # an entry's declaration wins
+
+
+def test_parse_signer_rejects_malformed_declarations(caplog):
+    assert signing.parse_signer(None) is None
+    good = signing.parse_signer({"identity": "^https://github.com/vendor/.*$"})
+    assert good == Signer(identity="^https://github.com/vendor/.*$", issuer=signing.GITHUB_OIDC_ISSUER)
+    assert signing.parse_signer({"identity": "^x$", "issuer": "https://issuer.example"}).issuer == "https://issuer.example"
+    for raw in ["str", {"identity": ""}, {"identity": "("}, {"identity": "^x$", "issuer": "http://plain"}, {}]:
+        assert signing.parse_signer(raw) is None, raw
+    assert "signing" in caplog.text
+
+
+def test_curated_index_carries_the_declared_signer(tmp_path):
+    p = tmp_path / "apps_index.yml"
+    p.write_text(
+        "- id: vendor-app\n  image: docker.io/vendor/app:1\n  image_digest: sha256:" + "c" * 64 + "\n"
+        "  signing:\n    identity: '^https://github.com/vendor/app/.*$'\n"
+        "- id: plain-app\n  image: ghcr.io/open-nvr/plain-app:latest\n"
+    )
+    idx = load_curated_index(p)
+    assert idx["vendor-app"].signer == Signer(identity="^https://github.com/vendor/app/.*$")
+    assert idx["plain-app"].signer is None
+
+
+# ── the verifier + policy ───────────────────────────────────────────
+
+
+def test_cosign_verifier_argv_and_outcomes():
+    signer = Signer(identity="^id$", issuer="https://iss")
+    assert verify_argv(PIN, signer) == [
+        "cosign", "verify", "--certificate-oidc-issuer", "https://iss",
+        "--certificate-identity-regexp", "^id$", PIN,
+    ]
+    ok_runner = _Runner(RunResult(0, "[{...}]", "Verification for ... : OK"))
+    assert cosign_verifier(ok_runner)(PIN, signer) == (True, "signature verified")
+    assert ok_runner.calls[0][1] is None                          # no image-override env
+    bad = _Runner(RunResult(1, "", "Error: no matching signatures\nmain.go: error"))
+    assert cosign_verifier(bad)(PIN, signer) == (False, "main.go: error")
+
+
+def test_policy_modes():
+    with pytest.raises(ValueError):
+        SigningPolicy(mode="maybe")
+    with pytest.raises(ValueError):
+        SigningPolicy(mode="require")                             # needs a verifier
+    off = SigningPolicy(mode="off")
+    assert off.check("x", "docker.io/unknown/app@sha256:" + "0" * 64, None)[0] is True
+
+    seen = []
+
+    def verify(ref, signer):
+        seen.append((ref, signer.identity))
+        return ref == PIN, "sig"
+
+    req = SigningPolicy(mode="require", verify=verify)
+    ok, msg = req.check("loitering-detection", PIN, None)
+    assert ok and seen == [(PIN, signing.ORG_IDENTITY_RE)]
+    ok, msg = req.check("x", "ghcr.io/open-nvr/x@sha256:" + "1" * 64, None)
+    assert not ok and "did not verify" in msg
+    ok, msg = req.check("x", "docker.io/vendor/x@sha256:" + "1" * 64, None)
+    assert not ok and "no known signer" in msg and len(seen) == 2        # never asked
+
+    def boom(ref, signer):
+        raise RuntimeError("cosign missing")
+    ok, msg = SigningPolicy(mode="require", verify=boom).check("x", PIN, None)
+    assert not ok and "verifier error" in msg
+
+
+# ── in the reconciler ───────────────────────────────────────────────
+
+INDEX = {
+    "loitering-detection": CuratedApp(
+        id="loitering-detection", image="ghcr.io/open-nvr/loitering-detection:latest",
+        image_digest="sha256:" + "a" * 64),
+    "occupancy-counting": CuratedApp(
+        id="occupancy-counting", image="ghcr.io/open-nvr/occupancy-counting:latest",
+        image_digest=None),
+}
+
+
+def _intent(app_id="loitering-detection", digest="sha256:" + "a" * 64):
+    return Intent(id=app_id, image=INDEX[app_id].image, image_digest=digest,
+                  desired="installed", status="pending")
+
+
+def test_pinned_install_verifies_before_compose_and_refuses_on_failure():
+    calls = []
+    policy = SigningPolicy(mode="require", verify=lambda ref, s: (calls.append(ref) or False, "no matching signatures"))
+    runner = _Runner(RunResult(0, "up", ""))
+    status, message = reconcile_intent(_intent(), runner, index=INDEX, signing=policy)
+    assert status == "failed" and "did not verify" in message and "no matching signatures" in message
+    assert calls == [PIN]
+    assert runner.calls == []                                     # compose never ran
+
+
+def test_pinned_install_proceeds_when_the_signature_verifies():
+    policy = SigningPolicy(mode="require", verify=lambda ref, s: (True, "signature verified"))
+    runner = _Runner(RunResult(0, "up", ""))
+    status, _ = reconcile_intent(_intent(), runner, index=INDEX, signing=policy)
+    assert status == "applied"
+    argv, env = runner.calls[0]
+    assert argv[-2:] == ["egress-proxy", "loitering-detection"]
+    assert env == {"LOITERING_DETECTION_IMAGE": PIN}
+
+
+def test_unpinned_install_is_not_verified_and_stays_dev_only(caplog):
+    policy = SigningPolicy(mode="require", verify=lambda ref, s: (False, "should not be asked"))
+    runner = _Runner(RunResult(0, "up", ""))
+    status, _ = reconcile_intent(_intent("occupancy-counting", None), runner, index=INDEX, signing=policy)
+    assert status == "applied" and "UNPINNED" in caplog.text
+
+
+def test_signing_off_skips_the_check():
+    runner = _Runner(RunResult(0, "up", ""))
+    status, _ = reconcile_intent(_intent(), runner, index=INDEX, signing=SigningPolicy(mode="off"))
+    assert status == "applied" and len(runner.calls) == 1

--- a/scripts/validate_apps_index.py
+++ b/scripts/validate_apps_index.py
@@ -387,6 +387,36 @@ def validate_entry(
     elif not isinstance(egress, list) or not all(isinstance(h, str) and h.strip() for h in egress):
         errors.append(f"{label}: 'network_egress' must be a list of host names")
 
+    # Image signing (scripts/app-installer/signing.py): a ghcr.io/open-nvr
+    # image is signed by the org's CI and needs nothing here. Any other
+    # registry must declare who signs it — an OIDC certificate identity
+    # regexp (and issuer) the installer verifies with cosign — or the
+    # one-click installer refuses the pinned image as "no known signer".
+    signing = entry.get("signing")
+    image = str(entry.get("image") or "")
+    if signing is not None:
+        if not isinstance(signing, dict):
+            errors.append(f"{label}: 'signing' must be a mapping with 'identity' (and optional 'issuer')")
+        else:
+            identity = signing.get("identity")
+            if not isinstance(identity, str) or not identity.strip():
+                errors.append(f"{label}: 'signing.identity' must be a non-empty regexp")
+            else:
+                try:
+                    re.compile(identity)
+                except re.error as exc:
+                    errors.append(f"{label}: 'signing.identity' is not a valid regexp ({exc})")
+            issuer = signing.get("issuer", "https://token.actions.githubusercontent.com")
+            if not isinstance(issuer, str) or not issuer.startswith("https://"):
+                errors.append(f"{label}: 'signing.issuer' must be an https:// URL")
+            unknown = set(signing) - {"identity", "issuer"}
+            if unknown:
+                errors.append(f"{label}: 'signing' has unknown keys {sorted(unknown)}")
+    elif not external and image and not image.startswith("ghcr.io/open-nvr/") and entry.get("image_digest"):
+        errors.append(
+            f"{label}: a pinned image outside ghcr.io/open-nvr needs 'signing: "
+            "{identity: <regexp>}' — the installer verifies signatures before install")
+
     # Required fields present + non-empty.
     required = tuple(f for f in REQUIRED_FIELDS
                      if not (external and f in ("image", "install")))

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -145,6 +145,10 @@ class IndexEntry(BaseModel):
     source: str | None = None
     contact: str | None = None
     network_egress: list[str] = []
+    # Who signs the image (scripts/app-installer/signing.py). Absent for
+    # ghcr.io/open-nvr images — the org's CI signs those; declared
+    # ({identity: <regexp>, issuer}) for an image built elsewhere.
+    signing: dict[str, str] | None = None
     requires_tasks: list[str] = []
     # RFC-0002 Phase 3 (decision 7): KAI-C adapters that must be
     # provisioned with the app; the reconciler ups + refcounts them.
@@ -172,6 +176,19 @@ class IndexEntry(BaseModel):
         if self.entitlement not in ("none", "license_key"):
             raise ValueError("entitlement must be none | license_key")
         return self
+
+
+def _signed_by(entry: IndexEntry) -> str | None:
+    """Who the installer expects to have signed the image: ``"OpenNVR CI"``
+    for the org's own images, the declared identity for others, ``None``
+    when unsigned (only ever deploys with INSTALLER_SIGNATURES=off)."""
+    if entry.kind == "external":
+        return None
+    if entry.signing and entry.signing.get("identity"):
+        return str(entry.signing["identity"])
+    if (entry.image or "").startswith("ghcr.io/open-nvr/"):
+        return "OpenNVR CI"
+    return None
 
 
 @lru_cache(maxsize=1)
@@ -722,6 +739,9 @@ async def get_apps_index(
                 "source": entry.source,
                 "contact": entry.contact,
                 "network_egress": entry.network_egress,
+                # Signed: the one-click installer verifies a Sigstore
+                # signature from this identity before any pinned install.
+                "signed_by": _signed_by(entry),
                 "requires_tasks": entry.requires_tasks,
                 "emits": entry.emits,
                 "docs_url": entry.docs_url,

--- a/server/tests/test_apps_index.py
+++ b/server/tests/test_apps_index.py
@@ -280,6 +280,7 @@ def test_index_response_shape_matches_contract(client):
         "source",
         "contact",
         "network_egress",
+        "signed_by",
         "version",
         "image",
         "requires_tasks",
@@ -294,6 +295,7 @@ def test_index_response_shape_matches_contract(client):
     assert isinstance(app["emits"], list)
     assert app["requires_tasks"] == ["object_detection"]
     assert app["emits"] == ["loitering"]
+    assert app["signed_by"] == "OpenNVR CI"          # ghcr.io/open-nvr image: org CI signs it
 
 
 def test_index_uninstalled_apps_are_available(client):

--- a/server/tests/test_validate_apps_index.py
+++ b/server/tests/test_validate_apps_index.py
@@ -449,3 +449,31 @@ def test_catalog_apps_must_be_open_source_under_the_org(tmp_path, monkeypatch):
     assert validator.validate_index(_write(tmp_path, [ext]))[0] == []
     ext.pop("network_egress")
     assert any("network_egress" in x for x in validator.validate_index(_write(tmp_path, [ext]))[0])
+
+
+def test_images_outside_the_org_must_declare_their_signer(tmp_path, monkeypatch):
+    """The installer verifies a Sigstore signature before a pinned
+    install: org images are signed by the org's CI, anything else has
+    to say who signs it (scripts/app-installer/signing.py)."""
+    monkeypatch.setattr(validator, "_load_overlay_services", lambda overlay=None: {"sample-app"})
+    def errs(**over):
+        e = dict(_GOOD_ENTRY, **over)
+        for k, v in list(over.items()):
+            if v is None:
+                e.pop(k, None)
+        return validator.validate_index(_write(tmp_path, [e]))[0]
+    digest = "sha256:" + "a" * 64
+    vendor = dict(image="ghcr.io/vendor/app:1",
+                  install=dict(_GOOD_ENTRY["install"],
+                               compose=_GOOD_ENTRY["install"]["compose"].replace(
+                                   "ghcr.io/open-nvr/sample-app:latest", "ghcr.io/vendor/app:1")))
+    assert errs(image_digest=digest) == []                                     # org image: nothing to declare
+    assert any("needs 'signing" in x for x in errs(image_digest=digest, **vendor))
+    assert errs(**vendor) == []                                                # unpinned: dev-only anyway
+    good = {"identity": "^https://github.com/vendor/app/.*$"}
+    assert errs(image_digest=digest, signing=good, **vendor) == []
+    assert any("'signing'" in x for x in errs(signing="me"))
+    assert any("signing.identity" in x for x in errs(signing={"identity": ""}))
+    assert any("not a valid regexp" in x for x in errs(signing={"identity": "("}))
+    assert any("signing.issuer" in x for x in errs(signing={"identity": "^x$", "issuer": "http://x"}))
+    assert any("unknown keys" in x for x in errs(signing={"identity": "^x$", "key": "abc"}))


### PR DESCRIPTION
…install

A digest pin says "these exact bytes"; it does not say who built them. publish-app-images.yml now signs every image it pushes with Sigstore keyless signing (cosign + the workflow's GitHub OIDC identity — no key to keep), and the one-click installer runs `cosign verify` on the pinned ref before `docker compose up`.

* scripts/app-installer/signing.py: the expected signer — a workflow in an open-nvr repository on main or a v* tag for ghcr.io/open-nvr images; the entry's declared `signing: {identity, issuer}` otherwise; no known signer → refused. SigningPolicy(require|off), cosign run through the reconciler's injected runner; unpinned installs are not verified (dev-only, already loud). main.py reads INSTALLER_SIGNATURES (default require) and refuses to start without cosign in that mode; the Dockerfile ships cosign from the Sigstore image, pinned.
* CuratedApp carries the declared signer; the validator checks `signing` and requires it for a pinned image outside the org; IndexEntry.signing; the index API carries `signed_by`; the card shows "signed".
* publish-app-images.yml: id-token: write, cosign-installer, sign the built digest. alert-notifier and gate-controller were listed with ghcr.io/open-nvr images no workflow published — added to the publish and smoke matrices.
* docker-compose.installer.yml passes INSTALLER_SIGNATURES; .env.example documents it; docs/APPS_INSTALL.md gains "Image signing"; CONTRIBUTING_APPS, DEVELOPER_PROGRAM, template, ROADMAP, CHANGELOG.