### PR TITLE
feat(catalog): build-from-source workflow for app repositories, `open…

### DIFF
--- a/.github/workflows/build-catalog-app.yml
+++ b/.github/workflows/build-catalog-app.yml
@@ -1,0 +1,176 @@
+# ==========================================================================
+# build-catalog-app — the org's build-from-source workflow for catalog apps
+# ==========================================================================
+#
+# A REUSABLE workflow (``workflow_call``). An app repository under the
+# open-nvr organisation calls it from its own publish workflow:
+#
+#     jobs:
+#       publish:
+#         uses: open-nvr/open-nvr/.github/workflows/build-catalog-app.yml@main
+#         with:
+#           app_id: my-app
+#         permissions:
+#           contents: read
+#           packages: write
+#           id-token: write
+#
+# and this workflow checks out THAT repository at the ref that triggered
+# it, builds its Dockerfile for amd64 + arm64, pushes the image to
+# ghcr.io/open-nvr/<app_id>, and signs the manifest digest with Sigstore
+# keyless signing. The signing certificate names *this* workflow file on
+# *this* repository's main branch as the job workflow — which is exactly
+# the identity the one-click installer verifies before a pinned install
+# (scripts/app-installer/signing.py). That is what "built from source by
+# OpenNVR's CI" means mechanically: the image can only have come through
+# here, from a repository under the org, at a tag anyone can read.
+#
+# The job summary prints the digest as an ``image_digest:`` line, ready
+# to paste into the listing entry (or run scripts/pin_apps_index.py).
+#
+# Guard rails: the caller must be a repository under the open-nvr org
+# (a fork calling this from elsewhere fails before anything is built),
+# and app_id must be kebab-case (it becomes the package name).
+#
+# ``opennvr-app new <id> --repo`` scaffolds an app repository with the
+# publish workflow already in place (docs/CONTRIBUTING_APPS.md §2).
+# ==========================================================================
+
+name: build-catalog-app
+
+on:
+  workflow_call:
+    inputs:
+      app_id:
+        description: "Catalog app id (kebab-case) — becomes ghcr.io/open-nvr/<app_id>"
+        required: true
+        type: string
+      context:
+        description: "Docker build context, relative to the calling repository"
+        required: false
+        type: string
+        default: "."
+      dockerfile:
+        description: "Dockerfile path, relative to the calling repository"
+        required: false
+        type: string
+        default: "Dockerfile"
+      platforms:
+        description: "Platforms to build"
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+      title:
+        description: "Human title for the image labels (defaults to app_id)"
+        required: false
+        type: string
+        default: ""
+    outputs:
+      digest:
+        description: "The signed multi-arch manifest digest (sha256:…)"
+        value: ${{ jobs.build.outputs.digest }}
+      image:
+        description: "The image ref the digest belongs to"
+        value: ${{ jobs.build.outputs.image }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build + sign ${{ inputs.app_id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      image: ghcr.io/open-nvr/${{ inputs.app_id }}
+    steps:
+      - name: Guard — org repository, kebab-case id
+        env:
+          OWNER: ${{ github.repository_owner }}
+          APP_ID: ${{ inputs.app_id }}
+        run: |
+          set -euo pipefail
+          if [ "$OWNER" != "open-nvr" ]; then
+            echo "::error::build-catalog-app builds only repositories under the open-nvr organisation (caller owner: $OWNER)"
+            exit 1
+          fi
+          if ! printf '%s' "$APP_ID" | grep -Eq '^[a-z0-9]+(-[a-z0-9]+)*$'; then
+            echo "::error::app_id '$APP_ID' is not kebab-case"
+            exit 1
+          fi
+
+      - name: Checkout the calling repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v2.4.1"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/open-nvr/${{ inputs.app_id }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=OpenNVR ${{ inputs.title || inputs.app_id }}
+            org.opencontainers.image.description=OpenNVR catalog app — ${{ inputs.title || inputs.app_id }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.vendor=OpenNVR
+
+      - name: Build + push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ inputs.app_id }}
+          cache-to: type=gha,scope=${{ inputs.app_id }},mode=max
+
+      - name: Sign (Sigstore keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/open-nvr/${{ inputs.app_id }}
+        run: |
+          set -euo pipefail
+          test -n "$DIGEST"
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+          {
+            echo "### ${IMAGE}"
+            echo
+            echo "Built from \`${{ github.repository }}@${{ github.ref_name }}\` (${{ github.sha }}), signed."
+            echo
+            echo '```yaml'
+            echo "  image: ${IMAGE}:latest"
+            echo "  image_digest: ${DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Build from source for every app repository.** A reusable workflow,
+  `.github/workflows/build-catalog-app.yml` (`workflow_call`): an
+  `open-nvr/app-*` repository calls it with its `app_id`, and it checks
+  that repository out at the pushed ref, builds the Dockerfile for
+  amd64 + arm64, pushes `ghcr.io/open-nvr/<id>`, signs the digest
+  (Sigstore keyless — the certificate names this workflow, so the
+  installer's existing identity check covers third-party apps) and
+  prints the `image_digest:` line in the job summary. It refuses any
+  caller outside the org. `opennvr-app new <id> --repo` scaffolds the
+  repository files — `ci.yml`, a four-line `publish.yml` that calls the
+  workflow, `apps-index-entry.yml` (the listing, reviewed with the
+  code), `.gitignore`/`.dockerignore` — and pins the published SDK.
+  `scripts/pin_apps_index.py` / `make pin-apps-index` is the release
+  step that writes every catalog entry's current digest into the index
+  (from GHCR, cosign-verified, textually so comments survive; `--check`
+  reports drift). `CONTRIBUTING_APPS.md` §2 now describes this path
+  instead of author-pushed images.
+
 - **Signed catalog images, verified at install.**
   `publish-app-images.yml` now signs every image it pushes with
   Sigstore keyless signing (cosign + the workflow's GitHub OIDC

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 PY ?= python3
 
-.PHONY: help secrets secrets-env check-secrets sync-agent-tasks validate-apps-index sdk-docs
+.PHONY: help secrets secrets-env check-secrets sync-agent-tasks validate-apps-index pin-apps-index sdk-docs
 
 help:
 	@echo "OpenNVR Makefile targets:"
@@ -21,6 +21,8 @@ help:
 	@echo "                           camera-agent bundle (keeps the parity test green)."
 	@echo "  make validate-apps-index Validate server/config/apps_index.yml (App"
 	@echo "                           Store submission gate — run before opening a PR)."
+	@echo "  make pin-apps-index      Release step: write every catalog app's current"
+	@echo "                           image digest into apps_index.yml (cosign-verified)."
 	@echo "  make sdk-docs            Render the App SDK's public API (docstrings) to"
 	@echo "                           sdk/opennvr-app-sdk/docs/api/ with pdoc."
 
@@ -104,6 +106,17 @@ sys.exit('server/.env still contains placeholder values:') if errs else print('s
 # malformed community submission is caught before merge.
 # See docs/CONTRIBUTING_APPS.md.
 validate-apps-index:
+	@$(PY) scripts/validate_apps_index.py
+
+# --------------------------------------------------------------------------
+# make pin-apps-index
+# --------------------------------------------------------------------------
+# The release step that makes one-click installs deploy exact, signed
+# bytes: asks GHCR what each catalog image's tag resolves to, verifies the
+# signature with cosign, and writes image_digest into apps_index.yml
+# (textually — the comments survive). Then validate, commit, tag.
+pin-apps-index:
+	@$(PY) scripts/pin_apps_index.py --verify
 	@$(PY) scripts/validate_apps_index.py
 
 # --------------------------------------------------------------------------

--- a/docs/APPS_INSTALL.md
+++ b/docs/APPS_INSTALL.md
@@ -198,10 +198,13 @@ registry the host can pull from. **The app images ARE now published**:
 `ghcr.io/open-nvr/<id>` on each main push and release tag (multi-arch,
 same tag policy as core), so the index's `image` refs resolve. What the
 index still ships WITHOUT is a per-entry `image_digest` — so an install
-today logs the UNPINNED warning and pulls the tag. Recording digests in
-the index at release time is the remaining step to make pinning bite;
-the mechanism itself is complete and tested, and the local `build:`
-overlay with `:local-build` tags remains the dev / air-gapped path.
+today logs the UNPINNED warning and pulls the tag. Recording digests is
+the release step `make pin-apps-index` (`scripts/pin_apps_index.py`):
+it asks GHCR what each entry's tag resolves to, cosign-verifies the
+digest against the org's CI identity, and writes `image_digest` into
+the index textually (comments survive); `--check` reports drift. The
+mechanism itself is complete and tested, and the local `build:` overlay
+with `:local-build` tags remains the dev / air-gapped path.
 
 ## Image signing
 

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -129,35 +129,63 @@ live status dot and an auto-generated config form.
   spellings (`ocr`, `object_tracking`) won't match adapters advertising
   the canonical ones.
 
-## 2. Publish your image and get its digest
+## 2. Get a repository under the org — CI builds, signs and publishes
 
-Publish to GHCR (recommended) or any registry the operator's host can pull
-from. Then capture the **immutable digest** your tag resolved to — that is
-what pins the install.
+Catalog images are not pushed by their authors. They are **built from
+source by the org's CI**, signed, and pushed to `ghcr.io/open-nvr/<id>`
+— that is the property the whole catalog rests on (an operator can read
+the source that produced the bytes they run). The pieces:
 
-```bash
-# Build + push (GitHub Container Registry example)
-docker build -t ghcr.io/<you>/my-app:1.0.0 -t ghcr.io/<you>/my-app:latest examples/my-app
-docker push ghcr.io/<you>/my-app:1.0.0
-docker push ghcr.io/<you>/my-app:latest
+1. **Scaffold the repository files.** `opennvr-app new my-app --repo`
+   (or add them to an existing app) lays down
+   `.github/workflows/ci.yml` (pytest on every push and PR),
+   `.github/workflows/publish.yml`, and `apps-index-entry.yml` — your
+   listing, reviewed with your code. `publish.yml` is four lines: it
+   calls the org's reusable workflow,
 
-# Read back the sha256 digest the tag now points at
-docker buildx imagetools inspect ghcr.io/<you>/my-app:latest --format '{{.Manifest.Digest}}'
-# -> sha256:3f8c...e91   (this is your image_digest)
-```
+   ```yaml
+   jobs:
+     publish:
+       uses: open-nvr/open-nvr/.github/workflows/build-catalog-app.yml@main
+       with: { app_id: my-app }
+       permissions: { contents: read, packages: write, id-token: write }
+   ```
 
-Make the package **public** so an operator can pull it without a login.
+   which checks out *your* repository at the pushed ref, builds your
+   `Dockerfile` for amd64 + arm64, pushes `ghcr.io/open-nvr/my-app`
+   (`:latest`, `:<version>`, `:sha-…`) and signs the digest with
+   Sigstore keyless signing. It refuses to run for a repository outside
+   the org — which is the point.
+2. **Ask for the repository.** Open an issue titled *App: my-app* in
+   `open-nvr/open-nvr` with a link to your code. A maintainer creates
+   `open-nvr/app-my-app` and transfers or seeds it from yours (history
+   preserved); you are its maintainer, with write access. Add a
+   `LICENSE` (AGPL-3.0 or Apache-2.0, your copyright) before the first
+   tag.
+3. **Tag a release.** `git tag v1.0.0 && git push --tags`. The publish
+   job's summary prints the two lines the listing needs:
+
+   ```yaml
+     image: ghcr.io/open-nvr/my-app:latest
+     image_digest: sha256:3f8c…e91
+   ```
+
+   Put the digest into `apps-index-entry.yml`. (Maintainers re-pin the
+   whole index at each platform release with `make pin-apps-index`,
+   which reads the current digests from GHCR and cosign-verifies each
+   one before writing it.)
 
 > Don't have a published image yet? An app that ships only as a local
-> `build:` overlay (like the first-party detectors today) may omit
-> `image_digest` and set `build_context` instead — but it will install
-> **unpinned (dev only)**. Publish + pin before you expect production
-> operators to install it.
+> `build:` overlay (like the first-party detectors in `examples/`) may
+> omit `image_digest` and set `build_context` instead — but it installs
+> **unpinned (dev only)** and is never signature-checked. Publish + pin
+> before you expect production operators to install it.
 
 ## 3. Add one entry to `apps_index.yml`
 
 Append **one** entry to
-[`server/config/apps_index.yml`](../server/config/apps_index.yml). Copy the
+[`server/config/apps_index.yml`](../server/config/apps_index.yml) — the
+`apps-index-entry.yml` from your repository, or copy the
 annotated template —
 [`docs/apps-index-entry.template.yml`](apps-index-entry.template.yml) — and
 fill every field. Here it is inline for reference:

--- a/docs/DEVELOPER_PROGRAM.md
+++ b/docs/DEVELOPER_PROGRAM.md
@@ -18,10 +18,11 @@ in fifteen minutes.
    under **AGPL-3.0 or Apache-2.0 — your choice**. You keep the copyright.
    Your name and contact are on the listing, in the README and in the
    source headers. We never rewrite history: the first commit is yours.
-2. **We build it, host it and ship it.** CI builds your image from your
-   tagged source, pins the digest into the index, and every OpenNVR install
-   can install it with one click. You don't run a registry, a CDN or a
-   download page.
+2. **We build it, host it and ship it.** The org's `build-catalog-app`
+   workflow builds your image from your tagged source, signs it, pushes
+   it to `ghcr.io/open-nvr/<id>`, and the digest pins it in the index;
+   every OpenNVR install can install it with one click. You don't run a
+   registry, a CDN or a download page.
 3. **You can charge for it.** OpenNVR takes **no fee**. Sell a fine-tuned
    model, a data service, a hosted notifier, support — the platform gives
    you the licence hook (`entitlement: license_key`, verified by *your*
@@ -91,12 +92,18 @@ they are allowed to add.
 3. **Make it a product.** Manifest `params` (config form), `state_schema`
    (live views), `actions` (operator verbs), `has_ui` (a page), and
    `pricing` / `entitlement` if you sell something.
-4. **Ask for a repository.** Open an issue titled *App: my-app* with a
-   link to your code. We create `open-nvr/app-my-app`, transfer or seed it
-   from your repository, and you are its maintainer.
-5. **List it.** One PR adding an entry to `server/config/apps_index.yml`
-   — [CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md). CI builds and pins the
-   image; a reviewer merges; every install sees it.
+4. **Ask for a repository.** `opennvr-app new my-app --repo` lays down
+   the repository files (CI, the publish workflow, the listing entry).
+   Open an issue titled *App: my-app* with a link to your code. We
+   create `open-nvr/app-my-app`, transfer or seed it from your
+   repository, and you are its maintainer. From then on every push to
+   `main` and every `v*` tag builds your image **from that source**,
+   signs it, and pushes `ghcr.io/open-nvr/my-app` — through the org's
+   `build-catalog-app` workflow, the same one that builds ours.
+5. **List it.** One PR adding your `apps-index-entry.yml` to
+   `server/config/apps_index.yml` — [CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md).
+   The digest from your tag's build pins it; a reviewer merges; every
+   install sees it.
 
 Reviews get a first response within **five working days**; issues tagged
 `sdk` within **two**. Security reports go through a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -278,9 +278,11 @@ to a release window. Pull requests and design discussions are welcome.
   and declared network egress on the card; closed software lists as
   external; paid = open code that gates a licensed model or service.
   Shipped: maintainer-verified badge, Featured row, provenance line,
-  validator rules. Next: build-from-source CI for third-party
-  repositories, an app-repository template. Shipped: signed catalog
-  images (Sigstore keyless in the publish workflow) verified by the
+  validator rules, the org's `build-catalog-app` reusable workflow
+  (any `open-nvr/app-*` repository builds, signs and publishes its image
+  from source by calling it), `opennvr-app new --repo` (CI, publish
+  workflow and listing entry scaffolded), `make pin-apps-index`. Shipped:
+  signed catalog images (Sigstore keyless in the publish workflow) verified by the
   installer before any pinned install; per-app NATS credentials (the `nats-apps`
   leaf bus; user = app id, permissions from the manifest;
   `requires_scopes` enforced on the bus), per-app call tokens (no site

--- a/docs/SDK_REFERENCE.md
+++ b/docs/SDK_REFERENCE.md
@@ -142,11 +142,15 @@ container) unless you need full frame rate.
 
 ## Scaffolding
 
-`opennvr-app new <app-id> [--task T] [--dest DIR] [--sdk auto|pypi|path]`
+`opennvr-app new <app-id> [--task T] [--dest DIR] [--sdk auto|pypi|path] [--repo]`
 — the generator ships in the wheel (`opennvr_app_sdk.scaffold`). Out of
 a checkout it pins the published SDK and writes a self-contained
 Dockerfile; inside the OpenNVR repository (`scripts/create_opennvr_app.py`)
-it keeps the editable path so examples track the SDK on main.
+it keeps the editable path so examples track the SDK on main. `--repo`
+adds what a repository under the `open-nvr` organisation needs: CI, a
+`publish.yml` that builds and signs the image through the org's
+`build-catalog-app` workflow, and the App Catalog listing entry
+(`apps-index-entry.yml`) — [CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md) §2.
 
 ## Releasing
 

--- a/scripts/pin_apps_index.py
+++ b/scripts/pin_apps_index.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Pin the App Catalog: write each installable entry's ``image_digest``.
+
+The one-click installer deploys ``image@sha256:…`` — the exact bytes a
+reviewer vouched for — only when the index carries a digest. This
+script asks the registry what each entry's tag resolves to right now
+and writes it into ``server/config/apps_index.yml`` **textually** (the
+file is mostly comments; a YAML round-trip would lose them). Run it as
+the release step after the publish workflows have finished:
+
+    python3 scripts/pin_apps_index.py                 # pin every installable entry
+    python3 scripts/pin_apps_index.py --app footage-search --app alert-notifier
+    python3 scripts/pin_apps_index.py --check         # exit 1 if any pin differs from the tag now
+    python3 scripts/pin_apps_index.py --verify        # also cosign-verify each digest (needs cosign)
+    python3 scripts/pin_apps_index.py --dry-run
+
+Digests come from the registry's manifest endpoint (an anonymous pull
+token for ghcr.io; ``Docker-Content-Digest`` of the multi-arch index),
+so no Docker daemon is needed. ``--verify`` runs ``cosign verify`` with
+the org's CI identity (scripts/app-installer/signing.py) so a release
+never pins an unsigned image.
+
+Standard library only. The resolver is injectable for tests.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX_PATH = REPO_ROOT / "server" / "config" / "apps_index.yml"
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "app-installer"))
+
+_ACCEPT = ", ".join([
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+])
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_REF_RE = re.compile(r"^(?P<registry>[^/]+)/(?P<repo>[^:@]+)(?::(?P<tag>[^@]+))?$")
+
+Resolver = Callable[[str], str]
+
+
+def split_ref(image: str) -> tuple[str, str, str]:
+    """``ghcr.io/open-nvr/x:latest`` → (registry, repository, tag)."""
+    m = _REF_RE.match(image.split("@", 1)[0])
+    if not m:
+        raise ValueError(f"not a registry image ref: {image!r}")
+    registry, repo, tag = m.group("registry"), m.group("repo"), m.group("tag") or "latest"
+    if "." not in registry and ":" not in registry and registry != "localhost":
+        raise ValueError(f"{image!r} has no registry host (a local build tag cannot be pinned)")
+    return registry, repo, tag
+
+
+def _anonymous_token(registry: str, repo: str) -> str | None:
+    """A pull token for a public repository (ghcr.io and Docker-Hub-style
+    ``/token`` endpoints); ``None`` when the registry does not need one."""
+    if registry == "ghcr.io":
+        url = f"https://ghcr.io/token?scope=repository:{urllib.parse.quote(repo)}:pull"
+    elif registry in ("docker.io", "registry-1.docker.io", "index.docker.io"):
+        url = f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{urllib.parse.quote(repo)}:pull"
+    else:
+        return None
+    with urllib.request.urlopen(url, timeout=20) as resp:  # noqa: S310 — fixed registry URLs
+        return json.loads(resp.read().decode()).get("token")
+
+
+def resolve_digest(image: str) -> str:
+    """The digest ``image``'s tag points at right now (HEAD manifest)."""
+    registry, repo, tag = split_ref(image)
+    host = "registry-1.docker.io" if registry in ("docker.io", "index.docker.io") else registry
+    req = urllib.request.Request(f"https://{host}/v2/{repo}/manifests/{tag}", method="HEAD",
+                                 headers={"Accept": _ACCEPT})
+    token = _anonymous_token(registry, repo)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            digest = resp.headers.get("Docker-Content-Digest", "")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{image}: registry answered {exc.code} — is the package public and published?") from exc
+    if not _DIGEST_RE.match(digest or ""):
+        raise RuntimeError(f"{image}: registry returned no usable digest ({digest!r})")
+    return digest
+
+
+def cosign_verify(image: str, digest: str) -> tuple[bool, str]:
+    """``cosign verify`` against the signer the installer would expect."""
+    from signing import expected_signer, verify_argv  # scripts/app-installer
+
+    signer = expected_signer(image.split("@", 1)[0] + "@" + digest)
+    if signer is None:
+        return False, "no known signer (not a ghcr.io/open-nvr image and no 'signing' declared)"
+    ref = image.split("@", 1)[0].rsplit(":", 1)[0] if ":" in image.split("/")[-1] else image
+    proc = subprocess.run(verify_argv(f"{ref}@{digest}", signer),  # noqa: S603 — fixed argv
+                          capture_output=True, text=True, check=False)
+    if proc.returncode == 0:
+        return True, "signature verified"
+    return False, (proc.stderr or proc.stdout or "cosign failed").strip().splitlines()[-1]
+
+
+# ── textual edit of the index ───────────────────────────────────────
+
+_ENTRY_START = re.compile(r"^- id:\s*(?P<id>[a-z0-9-]+)\s*$")
+_IMAGE_LINE = re.compile(r"^(?P<indent>\s+)image:\s*(?P<image>\S+)\s*(?P<comment>#.*)?$")
+_DIGEST_LINE = re.compile(r"^(?P<indent>\s+)(?P<commented>#\s*)?image_digest:.*$")
+
+
+def set_digests(text: str, digests: dict[str, str]) -> tuple[str, dict[str, str | None]]:
+    """Return the index text with ``image_digest`` set for every id in
+    ``digests`` — the existing (or commented-out) ``image_digest:`` line
+    of that entry replaced, or a new one inserted right after its
+    ``image:`` line — plus ``{id: previous digest or None}``. Every other
+    byte of the file, comments included, is left alone."""
+    lines = text.split("\n")
+    # Entry line ranges: [start, next start).
+    starts = [i for i, line in enumerate(lines) if _ENTRY_START.match(line)]
+    ranges = {}
+    for n, i in enumerate(starts):
+        end = starts[n + 1] if n + 1 < len(starts) else len(lines)
+        ranges[_ENTRY_START.match(lines[i]).group("id")] = (i, end)
+    missing = [i for i in digests if i not in ranges]
+    if missing:
+        raise KeyError(f"entries not found in the index: {missing}")
+
+    previous: dict[str, str | None] = {}
+    edits: list[tuple[int, str | None, str]] = []      # (line index, replace|None=insert-after, text)
+    for app_id, digest in digests.items():
+        lo, hi = ranges[app_id]
+        image_at = digest_at = None
+        for i in range(lo, hi):
+            if image_at is None and _IMAGE_LINE.match(lines[i]):
+                image_at = i
+            md = _DIGEST_LINE.match(lines[i])
+            if md and digest_at is None:
+                digest_at = i
+                value = lines[i].split("image_digest:", 1)[1].split("#", 1)[0].strip()
+                previous[app_id] = None if md.group("commented") else (value or None)
+        if image_at is None:
+            raise KeyError(f"no 'image:' line in entry {app_id!r}")
+        indent = _IMAGE_LINE.match(lines[image_at]).group("indent")
+        new_line = f"{indent}image_digest: {digest}"
+        if digest_at is not None:
+            edits.append((digest_at, "replace", new_line))
+        else:
+            previous.setdefault(app_id, None)
+            edits.append((image_at, "after", new_line))
+
+    out: list[str] = []
+    by_line = {i: (kind, t) for i, kind, t in edits}
+    for i, line in enumerate(lines):
+        kind, t = by_line.get(i, (None, None))
+        if kind == "replace":
+            out.append(t)
+        else:
+            out.append(line)
+            if kind == "after":
+                out.append(t)
+    return "\n".join(out), previous
+
+
+def load_entries(path: Path) -> list[dict]:
+    raw = yaml.safe_load(path.read_text()) or []
+    return [e for e in raw if isinstance(e, dict) and e.get("id")]
+
+
+def main(argv: list[str] | None = None, *, resolver: Resolver = resolve_digest,
+         verifier=cosign_verify, index_path: Path = INDEX_PATH) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--app", action="append", default=[], help="only this id (repeatable)")
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if any entry's pin differs from what its tag resolves to now; write nothing")
+    ap.add_argument("--verify", action="store_true", help="cosign-verify every digest before writing")
+    ap.add_argument("--dry-run", action="store_true", help="print what would change; write nothing")
+    ap.add_argument("--index", default=str(index_path), help=argparse.SUPPRESS)
+    args = ap.parse_args(argv)
+    path = Path(args.index)
+
+    entries = [e for e in load_entries(path) if e.get("kind", "installable") != "external"]
+    if args.app:
+        unknown = sorted(set(args.app) - {e["id"] for e in entries})
+        if unknown:
+            print(f"error: not installable entries: {unknown}", file=sys.stderr)
+            return 2
+        entries = [e for e in entries if e["id"] in args.app]
+
+    digests: dict[str, str] = {}
+    rc = 0
+    for e in entries:
+        image = str(e.get("image") or "")
+        try:
+            digest = resolver(image)
+        except Exception as exc:  # noqa: BLE001 — report per entry, keep going
+            print(f"  {e['id']}: FAILED — {exc}", file=sys.stderr)
+            rc = 1
+            continue
+        if args.verify:
+            ok, why = verifier(image, digest)
+            if not ok:
+                print(f"  {e['id']}: UNSIGNED — {why} (not pinned)", file=sys.stderr)
+                rc = 1
+                continue
+        current = e.get("image_digest")
+        if args.check:
+            if current != digest:
+                print(f"  {e['id']}: pin {current or '(none)'} != tag now {digest}")
+                rc = 1
+            else:
+                print(f"  {e['id']}: pinned and current")
+            continue
+        digests[e["id"]] = digest
+        mark = "unchanged" if current == digest else ("was " + current if current else "NEW")
+        print(f"  {e['id']}: {digest}  ({mark})")
+
+    if args.check or args.dry_run or not digests:
+        return rc
+    text, _previous = set_digests(path.read_text(), digests)
+    path.write_text(text)
+    print(f"wrote {len(digests)} pin(s) to {path}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_apps_index.py
+++ b/scripts/validate_apps_index.py
@@ -304,7 +304,11 @@ def _check_compose_snippet(
         # what the copy-paste actually runs diverge.
         svc_image = svc.get("image")
         if isinstance(svc_image, str) and app_id and image:
-            allowed = {image, _pin_slot_for(app_id)}
+            # Two pin-slot shapes: the in-tree examples default to their
+            # local build; an app from its own repository (opennvr-app new
+            # --repo) defaults to its published image — no local build.
+            env_key = app_id.upper().replace("-", "_") + "_IMAGE"
+            allowed = {image, _pin_slot_for(app_id), "${" + env_key + ":-" + image + "}"}
             if svc_image not in allowed:
                 errors.append(
                     f"{label}: install.compose service '{svc_name}' image "

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/scaffold.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/scaffold.py
@@ -37,6 +37,12 @@ except ImportError:                      # loaded by file path, no package
         Path(__file__).with_name("_version.py").read_text(encoding="utf-8")).group(1)
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates" / "app"
+#: ``--repo``: the files that turn the app folder into a repository under
+#: the org — CI, the publish workflow that builds + signs through
+#: open-nvr/open-nvr's build-catalog-app.yml, the listing entry.
+REPO_TEMPLATE_DIR = Path(__file__).resolve().parent / "templates" / "repo"
+#: Dotfiles ship in the wheel under safe names and are renamed on output.
+_RENAME = {"_github": ".github", "_gitignore": ".gitignore", "_dockerignore": ".dockerignore"}
 DOCS_URL = "https://github.com/open-nvr/open-nvr/blob/main/docs/"
 _KEBAB_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 _SKIP = {"__pycache__", ".venv", ".pytest_cache", "uv.lock"}
@@ -133,6 +139,7 @@ def build_tokens(app_id: str, task: str, app_dir: Path, *, mode: str,
     tokens = {
         "__APP_ID__": app_id,
         "__APP_MODULE__": kebab_to_snake(app_id),
+        "__APP_ENV__": kebab_to_snake(app_id).upper(),
         "__APP_CLASS__": kebab_to_pascal(app_id),
         "__APP_NAME__": kebab_to_title(app_id),
         "__TASK__": task,
@@ -149,12 +156,19 @@ def substitute(text: str, tokens: dict[str, str]) -> str:
 
 
 def generate(app_id: str, task: str, dest_dir: Path, *, sdk: str = "auto",
-             repo_root: Path | None = None, template_dir: Path = TEMPLATE_DIR) -> Path:
+             repo_root: Path | None = None, template_dir: Path = TEMPLATE_DIR,
+             repo: bool = False) -> Path:
     """Render the template into ``dest_dir/<app-id>/``; return that path.
     ``sdk``: ``auto`` (pypi unless the app lands inside ``repo_root``),
-    ``pypi`` or ``path`` (requires ``repo_root``)."""
+    ``pypi`` or ``path`` (requires ``repo_root``). ``repo``: also lay
+    down the repository files (CI, the publish workflow, the listing
+    entry) — an app destined for ``open-nvr/app-<id>``; implies pypi."""
     if sdk not in ("auto", "path", "pypi"):
         raise ValueError(f"sdk must be auto, path or pypi (got {sdk!r})")
+    if repo and sdk == "path":
+        raise ValueError("--repo scaffolds a standalone repository; it pins the published SDK (--sdk pypi)")
+    if repo:
+        sdk = "pypi"
     if not _KEBAB_RE.match(app_id):
         raise ValueError(
             f"app-id {app_id!r} is not kebab-case — lowercase letters, digits "
@@ -169,18 +183,44 @@ def generate(app_id: str, task: str, dest_dir: Path, *, sdk: str = "auto",
         raise ValueError("sdk='path' needs repo_root (an OpenNVR checkout)")
 
     tokens = build_tokens(app_id, task, app_dir, mode=mode, repo_root=repo_root)
-    for src in sorted(template_dir.rglob("*")):
-        rel_parts = src.relative_to(template_dir).parts
-        if any(p in _SKIP for p in rel_parts):
-            continue
-        dst = app_dir.joinpath(*(substitute(p, tokens) for p in rel_parts))
-        if src.is_dir():
-            dst.mkdir(parents=True, exist_ok=True)
-            continue
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        dst.write_text(substitute(src.read_text(encoding="utf-8"), tokens),
-                       encoding="utf-8")
+    tokens["__REPO_SECTION__"] = _REPO_README_SECTION if repo else ""
+    sources = [template_dir] + ([REPO_TEMPLATE_DIR] if repo else [])
+    for source_dir in sources:
+        for src in sorted(source_dir.rglob("*")):
+            rel_parts = src.relative_to(source_dir).parts
+            if any(p in _SKIP for p in rel_parts):
+                continue
+            dst = app_dir.joinpath(*(substitute(_RENAME.get(p, p), tokens) for p in rel_parts))
+            if src.is_dir():
+                dst.mkdir(parents=True, exist_ok=True)
+                continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(substitute(src.read_text(encoding="utf-8"), tokens),
+                           encoding="utf-8")
     return app_dir
+
+
+_REPO_README_SECTION = """
+## This repository
+
+Scaffolded with `opennvr-app new --repo` for a home under the `open-nvr`
+organisation (`open-nvr/app-__APP_ID__`):
+
+* `.github/workflows/ci.yml` runs the tests on every push and PR.
+* `.github/workflows/publish.yml` builds the image **from this source**,
+  for amd64 + arm64, pushes `ghcr.io/open-nvr/__APP_ID__` and signs it
+  (Sigstore keyless) through OpenNVR's `build-catalog-app` workflow on
+  every push to `main` and every `v*` tag. The job summary prints the
+  `image_digest:` for the listing.
+* `apps-index-entry.yml` is the App Catalog listing, reviewed with the
+  code; the listing PR copies it into `server/config/apps_index.yml`.
+
+Pick a licence (AGPL-3.0 or Apache-2.0, your copyright) and add the
+`LICENSE` file before the first tag. Then: open an issue titled
+*App: __APP_ID__* in `open-nvr/open-nvr` with a link here, and a
+maintainer creates the repository under the org and transfers or seeds
+it from yours — you stay its maintainer.
+"""
 
 
 def print_next_steps(app_id: str, app_dir: Path, *, mode: str) -> None:
@@ -219,16 +259,26 @@ def main(argv: list[str] | None = None, *, repo_root: Path | None = None,
     new.add_argument("--sdk", choices=("auto", "path", "pypi"), default="auto",
                      help="pypi = pin the published opennvr-app-sdk (default outside an "
                           "OpenNVR checkout); path = editable dep on a checkout's SDK.")
+    new.add_argument("--repo", action="store_true",
+                     help="also lay down the repository files for open-nvr/app-<id>: CI, the "
+                          "publish workflow (build + sign through the org's build-catalog-app), "
+                          "the App Catalog listing entry. Implies --sdk pypi.")
     args = parser.parse_args(argv)
 
     dest_dir = Path(args.dest).expanduser().resolve()
     try:
-        app_dir = generate(args.app_id, args.task, dest_dir, sdk=args.sdk, repo_root=repo_root)
+        app_dir = generate(args.app_id, args.task, dest_dir, sdk=args.sdk, repo_root=repo_root,
+                           repo=args.repo)
     except (ValueError, FileExistsError, FileNotFoundError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    mode = args.sdk if args.sdk != "auto" else ("path" if _in_tree(app_dir, repo_root) else "pypi")
+    mode = "pypi" if args.repo else (
+        args.sdk if args.sdk != "auto" else ("path" if _in_tree(app_dir, repo_root) else "pypi"))
     print_next_steps(args.app_id, app_dir, mode=mode)
+    if args.repo:
+        print("\nRepository files: .github/workflows/{ci,publish}.yml, apps-index-entry.yml")
+        print("  git init && git add -A && git commit -m 'scaffold' — then ask for open-nvr/app-"
+              f"{args.app_id} (issue 'App: {args.app_id}')")
     return 0
 
 

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/app/README.md
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/app/README.md
@@ -61,3 +61,4 @@ Every OpenNVR install browses the curated index. Add one entry —
 installable from your image, or `kind: external` linking to where you
 distribute it — per [CONTRIBUTING_APPS.md](__DOCS__CONTRIBUTING_APPS.md);
 the deal for developers is [DEVELOPER_PROGRAM.md](__DOCS__DEVELOPER_PROGRAM.md).
+__REPO_SECTION__

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_dockerignore
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_dockerignore
@@ -1,0 +1,9 @@
+.git
+.venv
+.github
+tests
+__pycache__
+*.pyc
+config.yml
+app.key
+app.key.bus

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_github/workflows/ci.yml
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# Tests on every push and PR. The publish workflow (publish.yml) builds
+# and signs the image through OpenNVR's build-catalog-app workflow.
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Sync dependencies
+        run: uv sync
+      - name: Run pytest
+        run: uv run pytest -q
+      - name: Validate the listing entry
+        run: |
+          uv run python - <<'PY'
+          import yaml, sys
+          e = yaml.safe_load(open("apps-index-entry.yml"))
+          e = e[0] if isinstance(e, list) else e
+          missing = [k for k in ("id", "name", "author", "contact", "source", "network_egress", "image") if k not in e]
+          sys.exit(f"apps-index-entry.yml missing {missing}" if missing else 0)
+          PY

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_github/workflows/publish.yml
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_github/workflows/publish.yml
@@ -1,0 +1,26 @@
+# Build + sign the catalog image through OpenNVR's build-from-source
+# workflow. It checks out THIS repository at the pushed ref, builds the
+# Dockerfile for amd64 + arm64, pushes ghcr.io/open-nvr/__APP_ID__ and
+# signs the digest (Sigstore keyless). The job summary prints the
+# ``image_digest:`` line for the listing entry.
+#
+# Runs on every push to main and every v* tag. Requires this repository
+# to live under the open-nvr organisation (the workflow refuses others).
+name: publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    uses: open-nvr/open-nvr/.github/workflows/build-catalog-app.yml@main
+    with:
+      app_id: __APP_ID__
+      title: __APP_NAME__
+    permissions:
+      contents: read
+      packages: write
+      id-token: write

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_gitignore
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/_gitignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+config.yml
+app.key
+app.key.bus

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/apps-index-entry.yml
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/repo/apps-index-entry.yml
@@ -1,0 +1,43 @@
+# The App Catalog listing for __APP_NAME__ — ONE entry, appended to
+# server/config/apps_index.yml in the open-nvr/open-nvr repository by a
+# PR (docs/CONTRIBUTING_APPS.md). Kept here so it is reviewed with the
+# code and ci.yml checks the required fields.
+#
+# Fill in author, contact and network_egress before the listing PR.
+# image_digest comes from the publish workflow's job summary after a
+# v* tag (or: scripts/pin_apps_index.py in the platform repository).
+- id: __APP_ID__
+  name: __APP_NAME__
+  summary: "What __APP_NAME__ does, in one operator-facing sentence."
+  category: analytics                # perimeter | analytics | vehicle | doorstep | forensics | integration
+  version: "0.1.0"                   # = AppManifest.version — quoted
+  kind: installable
+  pricing: free
+  author: "Your Name"                # shown on the card
+  contact: "you@example.com"         # email or https:// URL that reaches you
+  source: https://github.com/open-nvr/app-__APP_ID__
+  network_egress: []                 # every host the app reaches outside the stack; [] = never
+  image: ghcr.io/open-nvr/__APP_ID__:latest
+  # image_digest: sha256:<64-hex>    # from the publish workflow summary — pins the install
+  requires_tasks: [__TASK__]
+  emits: [__APP_ID__]
+  docs_url: https://github.com/open-nvr/app-__APP_ID__/blob/main/README.md
+  install:
+    compose: |
+      services:
+        __APP_ID__:
+          image: ${__APP_ENV___IMAGE:-ghcr.io/open-nvr/__APP_ID__:latest}
+          container_name: opennvr___APP_MODULE__
+          restart: unless-stopped
+          environment:
+            - OPENNVR_INTERNAL_API_KEY=${INTERNAL_API_KEY}
+            - NATS_URL=nats://nats:4222
+            - OPENNVR_URL=http://opennvr-core:8000
+            - HTTP_PROXY=${APPS_EGRESS_PROXY_URL-http://egress-proxy:3128}
+            - HTTPS_PROXY=${APPS_EGRESS_PROXY_URL-http://egress-proxy:3128}
+            - NO_PROXY=opennvr-core,nats,nats-apps,egress-proxy,localhost,127.0.0.1
+          volumes:
+            - ./config.yml:/app/config.yml:ro
+          networks:
+            - opennvr_apps
+    command: docker compose -f docker-compose.yml -f docker-compose.apps.yml --profile apps up -d __APP_ID__

--- a/sdk/opennvr-app-sdk/tests/test_scaffold_and_config.py
+++ b/sdk/opennvr-app-sdk/tests/test_scaffold_and_config.py
@@ -203,3 +203,44 @@ def test_param_suggestions_ride_the_manifest():
     assert ps["watch_labels"]["suggestions"] == ["person", "car"]
     assert "suggestions" not in ps["dwell_s"]          # absent when empty (wire unchanged)
     assert "person" in DETECTION_LABELS and "car" in DETECTION_LABELS
+
+
+def test_repo_mode_lays_down_the_repository_files(tmp_path):
+    """``--repo``: the app folder becomes a repository for open-nvr/app-<id>
+    — CI, the publish workflow that builds + signs through the org's
+    build-catalog-app, the listing entry — and pins the published SDK."""
+    import yaml
+
+    app_dir = scaffold.generate("gate-watch", "object_detection", tmp_path, repo=True)
+    f = _files(app_dir)
+    assert {".github/workflows/ci.yml", ".github/workflows/publish.yml", "apps-index-entry.yml",
+            ".gitignore", ".dockerignore"} <= set(f)
+    pub = yaml.safe_load(f[".github/workflows/publish.yml"])
+    job = pub["jobs"]["publish"]
+    assert job["uses"] == "open-nvr/open-nvr/.github/workflows/build-catalog-app.yml@main"
+    assert job["with"] == {"app_id": "gate-watch", "title": "Gate Watch"}
+    assert job["permissions"] == {"contents": "read", "packages": "write", "id-token": "write"}
+    assert pub[True]["push"]["tags"] == ["v*"]
+    entry = yaml.safe_load(f["apps-index-entry.yml"])[0]
+    assert entry["id"] == "gate-watch" and entry["image"] == "ghcr.io/open-nvr/gate-watch:latest"
+    assert entry["source"] == "https://github.com/open-nvr/app-gate-watch"
+    assert entry["network_egress"] == [] and entry["requires_tasks"] == ["object_detection"]
+    assert "${GATE_WATCH_IMAGE:-ghcr.io/open-nvr/gate-watch:latest}" in entry["install"]["compose"]
+    assert "opennvr_apps" in entry["install"]["compose"]
+    assert "image_digest" not in entry                      # comes from the publish summary
+    assert "## This repository" in f["README.md"] and "open-nvr/app-gate-watch" in f["README.md"]
+    assert f'"opennvr-app-sdk>={__version__},<1.0"' in f["pyproject.toml"]   # pypi pin
+    assert "tool.uv.sources" not in f["pyproject.toml"]
+    assert "app.key" in f[".gitignore"] and "config.yml" in f[".gitignore"]
+    # Without --repo none of that appears, and the README has no repo section.
+    plain = _files(scaffold.generate("gate-two", "object_detection", tmp_path))
+    assert not any(k.startswith(".github") or k == "apps-index-entry.yml" for k in plain)
+    assert "## This repository" not in plain["README.md"] and not plain["README.md"].endswith("\n\n")
+    with pytest.raises(ValueError, match="standalone"):
+        scaffold.generate("gate-three", "object_detection", tmp_path, sdk="path", repo=True, repo_root=tmp_path)
+
+
+def test_cli_new_repo(tmp_path, capsys):
+    assert scaffold.main(["new", "gate-watch", "--dest", str(tmp_path), "--repo"]) == 0
+    assert (tmp_path / "gate-watch" / ".github" / "workflows" / "publish.yml").exists()
+    assert "open-nvr/app-gate-watch" in capsys.readouterr().out

--- a/server/tests/test_pin_apps_index.py
+++ b/server/tests/test_pin_apps_index.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""scripts/pin_apps_index.py — writes image digests into the catalog
+index textually (comments survive), with an injected resolver."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location("pin_apps_index", REPO_ROOT / "scripts" / "pin_apps_index.py")
+pin = importlib.util.module_from_spec(_spec)
+sys.modules["pin_apps_index"] = pin
+_spec.loader.exec_module(pin)
+
+SAMPLE = """\
+# The curated index — comments everywhere.
+- id: alpha
+  name: Alpha
+  kind: installable
+  image: ghcr.io/open-nvr/alpha:latest   # published by CI
+  # image_digest: sha256:<64-hex>        # fill at release
+  install:
+    compose: |
+      services:
+        alpha:
+          image: ghcr.io/open-nvr/alpha:latest
+- id: beta
+  name: Beta
+  image: ghcr.io/open-nvr/beta:latest
+  image_digest: sha256:%s
+  requires_tasks: []
+- id: gamma
+  name: Gamma
+  kind: external
+  external_url: https://vendor.example
+- id: delta
+  name: Delta
+  image: opennvr/delta:local-build
+"""
+OLD = "b" * 64
+NEW_A = "sha256:" + "a" * 64
+NEW_B = "sha256:" + "c" * 64
+
+
+def test_split_ref():
+    assert pin.split_ref("ghcr.io/open-nvr/alpha:latest") == ("ghcr.io", "open-nvr/alpha", "latest")
+    assert pin.split_ref("ghcr.io/open-nvr/alpha") == ("ghcr.io", "open-nvr/alpha", "latest")
+    assert pin.split_ref("ghcr.io/open-nvr/alpha:1.2@sha256:" + "0" * 64)[2] == "1.2"
+    with pytest.raises(ValueError, match="no registry"):
+        pin.split_ref("opennvr/delta:local-build")
+
+
+def test_set_digests_replaces_commented_and_real_lines_and_keeps_everything_else():
+    text = SAMPLE % OLD
+    out, previous = pin.set_digests(text, {"alpha": NEW_A, "beta": NEW_B})
+    assert previous == {"alpha": None, "beta": "sha256:" + OLD}
+    assert f"  image: ghcr.io/open-nvr/alpha:latest   # published by CI\n  image_digest: {NEW_A}\n  install:" in out
+    assert "# image_digest: sha256:<64-hex>" not in out          # the placeholder was replaced in place
+    assert f"  image_digest: {NEW_B}\n  requires_tasks: []" in out
+    assert out.startswith("# The curated index — comments everywhere.\n")
+    assert "          image: ghcr.io/open-nvr/alpha:latest\n" in out   # the compose snippet untouched
+    parsed = {e["id"]: e for e in yaml.safe_load(out)}
+    assert parsed["alpha"]["image_digest"] == NEW_A and parsed["beta"]["image_digest"] == NEW_B
+    # Inserting where no digest line exists at all.
+    out2, prev2 = pin.set_digests("- id: x\n  image: ghcr.io/open-nvr/x:latest\n  emits: []\n", {"x": NEW_A})
+    assert out2 == f"- id: x\n  image: ghcr.io/open-nvr/x:latest\n  image_digest: {NEW_A}\n  emits: []\n"
+    assert prev2 == {"x": None}
+    with pytest.raises(KeyError):
+        pin.set_digests(text, {"nope": NEW_A})
+
+
+def _run(tmp_path, argv, resolver, verifier=None, capsys=None):
+    idx = tmp_path / "apps_index.yml"
+    if not idx.exists():
+        idx.write_text(SAMPLE % OLD)
+    rc = pin.main(argv + ["--index", str(idx)], resolver=resolver,
+                  verifier=verifier or (lambda image, digest: (True, "ok")))
+    return rc, idx
+
+
+def test_main_pins_installable_entries_only(tmp_path, capsys):
+    seen = []
+
+    def resolver(image):
+        seen.append(image)
+        if "delta" in image:
+            raise ValueError("no registry host")
+        return NEW_A if "alpha" in image else NEW_B
+    rc, idx = _run(tmp_path, [], resolver)
+    assert rc == 1                                                   # delta cannot be pinned → reported
+    out = capsys.readouterr()
+    assert "delta: FAILED" in out.err and "alpha: sha256:aaaa" in out.out and "(NEW)" in out.out
+    assert "gamma" not in "".join(seen)                              # external: never resolved
+    parsed = {e["id"]: e for e in yaml.safe_load(idx.read_text())}
+    assert parsed["alpha"]["image_digest"] == NEW_A and parsed["beta"]["image_digest"] == NEW_B
+    assert "image_digest" not in parsed["delta"]
+
+
+def test_main_check_dry_run_app_filter_and_verify(tmp_path, capsys):
+    resolver = lambda image: NEW_B if "beta" in image else NEW_A  # noqa: E731
+    rc, idx = _run(tmp_path, ["--check", "--app", "beta"], resolver)
+    assert rc == 1 and "beta: pin sha256:bbbb" in capsys.readouterr().out
+    assert yaml.safe_load(idx.read_text())[1]["image_digest"] == "sha256:" + OLD   # nothing written
+    rc, _ = _run(tmp_path, ["--dry-run", "--app", "alpha"], resolver)
+    assert rc == 0 and "image_digest" not in yaml.safe_load(idx.read_text())[0]
+    rc, _ = _run(tmp_path, ["--app", "nope"], resolver)
+    assert rc == 2
+    # --verify refuses to pin what does not verify.
+    rc, _ = _run(tmp_path, ["--verify", "--app", "alpha"], resolver,
+                 verifier=lambda image, digest: (False, "no matching signatures"))
+    assert rc == 1 and "alpha: UNSIGNED" in capsys.readouterr().err
+    assert "image_digest" not in yaml.safe_load(idx.read_text())[0]
+    rc, _ = _run(tmp_path, ["--verify", "--app", "alpha"], resolver)
+    assert rc == 0 and yaml.safe_load(idx.read_text())[0]["image_digest"] == NEW_A
+    rc, _ = _run(tmp_path, ["--check", "--app", "alpha"], resolver)
+    assert rc == 0 and "pinned and current" in capsys.readouterr().out

--- a/server/tests/test_validate_apps_index.py
+++ b/server/tests/test_validate_apps_index.py
@@ -477,3 +477,16 @@ def test_images_outside_the_org_must_declare_their_signer(tmp_path, monkeypatch)
     assert any("not a valid regexp" in x for x in errs(signing={"identity": "("}))
     assert any("signing.issuer" in x for x in errs(signing={"identity": "^x$", "issuer": "http://x"}))
     assert any("unknown keys" in x for x in errs(signing={"identity": "^x$", "key": "abc"}))
+
+
+def test_compose_snippet_may_default_the_pin_slot_to_the_published_image(tmp_path, monkeypatch):
+    """An app from its own repository (opennvr-app new --repo) has no
+    local build: its snippet's pin slot defaults to the published image."""
+    monkeypatch.setattr(validator, "_load_overlay_services", lambda overlay=None: {"sample-app"})
+    def with_image(img):
+        e = dict(_GOOD_ENTRY, install=dict(_GOOD_ENTRY["install"],
+                 compose=_GOOD_ENTRY["install"]["compose"].replace("ghcr.io/open-nvr/sample-app:latest", img)))
+        return validator.validate_index(_write(tmp_path, [e]))[0]
+    assert with_image("${SAMPLE_APP_IMAGE:-ghcr.io/open-nvr/sample-app:latest}") == []
+    assert with_image("${SAMPLE_APP_IMAGE:-opennvr/sample-app:local-build}") == []
+    assert any("does not match" in x for x in with_image("${SAMPLE_APP_IMAGE:-ghcr.io/evil/sample-app:latest}"))


### PR DESCRIPTION
…nvr-app new --repo`, index pinning

* .github/workflows/build-catalog-app.yml — a reusable workflow (workflow_call). An open-nvr/app-* repository calls it with its app_id; it checks that repository out at the pushed ref, builds the Dockerfile for amd64 + arm64, pushes ghcr.io/open-nvr/<id>, signs the digest (Sigstore keyless — the certificate names this workflow on this repository's main, which the installer's identity check already covers) and prints the image_digest: line in the job summary. Refuses callers outside the org and non-kebab ids.
* SDK scaffold: `opennvr-app new <id> --repo` also renders templates/repo — ci.yml, a four-line publish.yml calling the workflow, apps-index-entry.yml (the listing, reviewed with the code), .gitignore/.dockerignore (shipped under safe names, renamed on output) — appends a "This repository" README section and pins the published SDK. Tests cover the files, the workflow call, the entry, and the path/repo conflict.
* scripts/pin_apps_index.py + `make pin-apps-index`: the release step — resolve each installable entry's tag on GHCR (anonymous token, HEAD manifest), optionally cosign-verify, and write image_digest into the index textually (comments survive; --check reports drift; --dry-run; --app). Tested with an injected resolver.
* validate_apps_index accepts a pin slot defaulting to the entry's own published image (an app from its own repository has no local build).
* CONTRIBUTING_APPS §2 rewritten around the org-built path; DEVELOPER_PROGRAM, SDK_REFERENCE, APPS_INSTALL, ROADMAP, CHANGELOG.