### PR TITLE
feat(sdk): toward 1.0 — testing helpers, typed domain events, `opennv…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,11 @@ jobs:
       matrix:
         example:
           - abandoned-object
+          - alert-notifier
           - alerts-subscriber
           - camera-agent
           - footage-search
+          - gate-controller
           - home-assistant-relay
           - inference-listener
           - intrusion-detection
@@ -161,6 +163,12 @@ jobs:
       - name: Run pytest
         working-directory: examples/${{ matrix.example }}
         run: uv run pytest -q
+      # What a listing reviewer checks, on every example, every PR
+      # (the camera-agent is an agent, not a catalog app — no manifest).
+      - name: opennvr-app validate
+        if: matrix.example != 'camera-agent'
+        working-directory: examples/${{ matrix.example }}
+        run: uv run opennvr-app validate .
 
   # ── React frontend build ─────────────────────────────────────────
   frontend:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **SDK toward 1.0 (on main; no tag until QA signs off 0.5.0).**
+  `opennvr_app_sdk.testing` — `RecorderChannel`, `app_config`,
+  `detection` / `inference_event` / `tier0_event` / `domain_event`
+  builders, `feed(app, *events)` through the real decode → rule →
+  dispatch path, `FakeCore` (a loopback core: cameras, snapshots,
+  state, alerts, register), and a pytest plugin with the same as
+  fixtures; the scaffold's smoke test now uses them. The v1 domain
+  events as typed classes (`PlateRecognized`, `AccessDecided`,
+  `OccupancyChanged`, `OccupancyHeatmap`, `OccupancyFootfall`,
+  `VisitRecorded`, `DetectionObserved`): `DomainEvent.typed()` parses
+  with required fields enforced and additive fields kept,
+  `DomainEventPublisher.publish_typed()` writes. `opennvr-app validate
+  [path]` checks the manifest, `config.example.yml` through the app's
+  own `AppConfig`, `apps-index-entry.yml` against the manifest and the
+  catalog policy, and the repository shape. `AsyncOpenNVR().ai.stream()`
+  (`AsyncInferStream`) closes the last sync/async gap; the parity test
+  now has no exceptions. Found by `validate`: occupancy-counting's
+  `config.example.yml` did not load (no `opennvr_url`) — fixed.
+
 - **Build from source for every app repository.** A reusable workflow,
   `.github/workflows/build-catalog-app.yml` (`workflow_call`): an
   `open-nvr/app-*` repository calls it with its `app_id`, and it checks

--- a/docs/APP_PLATFORM.md
+++ b/docs/APP_PLATFORM.md
@@ -76,10 +76,18 @@ async with AsyncOpenNVR() as nvr:                 # or AsyncOpenNVR(http_client=
 ```
 
 Pass `http_client=` to share one `httpx.AsyncClient` (a FastAPI
-lifespan pool, a test transport); the client then leaves it open. The
-one gap: `ai.stream()` (a blocking WebSocket session) has no async form
-yet — call `ai.infer()` per frame from async code. The OpenNVR Agent's
-capabilities probe is the first consumer.
+lifespan pool, a test transport); the client then leaves it open.
+Streaming inference has its async form too:
+
+```python
+async with nvr.ai.stream("yolov8", camera_id=cam.handle) as session:
+    while running:
+        result = await session.infer(jpeg)       # same §5.1 shape, same teardown rules
+```
+
+Every public method of the sync client has its awaited twin — a test
+pins that, so a feature added to one cannot be forgotten on the other.
+The OpenNVR Agent's capabilities probe is the first consumer.
 
 ## Durable state
 

--- a/docs/DEVELOPER_PROGRAM.md
+++ b/docs/DEVELOPER_PROGRAM.md
@@ -85,7 +85,8 @@ they are allowed to add.
 
 1. **Install the SDK and scaffold.**
    `pip install opennvr-app-sdk && opennvr-app new my-app --task object_detection`
-   gives you a running app with a test. Fill in one method.
+   gives you a running app with a test. Fill in one method;
+   `opennvr-app validate` tells you what a reviewer would before you ask one.
 2. **Run it against a stack.** Point it at any OpenNVR
    ([LOCAL_SETUP.md](LOCAL_SETUP.md) gets one up in minutes); it
    self-registers, is issued its own key and appears in the catalog.
@@ -154,7 +155,7 @@ closed code in the catalog. Ship that as an external listing.
 
 | Core | `api_version` | Minimum SDK | Notable |
 |---|---|---|---|
-| main (Sep 2026) | 1.4 | 0.2.0 | enforced egress: `egress` on the app record, `GET`/`PUT /apps/{id}/egress`, `opennvr_app_sdk.egress`; signed images, verified at install (`signed_by` on index entries) |
+| main (Sep 2026) | 1.4 | 0.2.0 | enforced egress: `egress` on the app record, `GET`/`PUT /apps/{id}/egress`, `opennvr_app_sdk.egress`; signed images, verified at install (`signed_by` on index entries); SDK 0.6 (unreleased): `opennvr_app_sdk.testing`, typed domain events, `opennvr-app validate`, async `ai.stream()` |
 | main (Sep 2026) | 1.3 | 0.2.0 | `X-OpenNVR-Call`: core proves itself per app; the site key no longer reaches apps on SDK ≥ 0.6 |
 | 0.2.x line | 1.2 | 0.2.0 | per-app keys, user context, platform client, entitlements, async client, `opennvr-app new` |
 | 0.1.4 | 1.0 | — | registry contract: register, config, state, actions |

--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -100,6 +100,15 @@ The map lives in KAI-C beside the publisher, is part of this contract
 What already flows, now with names. Payload field tables list required
 fields; producers may add optional ones under the additive-only rule.
 
+Every v1 payload below is also a class in the App SDK
+(`opennvr_app_sdk.event_types`: `DetectionObserved`, `VisitRecorded`,
+`PlateRecognized`, `AccessDecided`, `OccupancyChanged`,
+`OccupancyHeatmap`, `OccupancyFootfall`). `event.typed()` on a
+`DomainEvent` parses the payload — required fields enforced, additive
+fields kept in `.extra`, off-contract payloads returned as `None` and
+logged — and `DomainEventPublisher.publish_typed(...)` writes one. The
+tables here remain normative; the classes follow them.
+
 ### `detection.observed.v1`
 
 Subject: `opennvr.events.detection.observed.v1.<camera_id>`

--- a/docs/FIRST_DETECTOR.md
+++ b/docs/FIRST_DETECTOR.md
@@ -136,7 +136,14 @@ Green means your app is wired to the SDK correctly *before* you've
 written a line of your own logic. As you replace the starter rule, keep
 this file green — extend it to pin your predicate (a below-threshold
 case stays quiet, an in-zone case fires, etc.), exactly the way the
-shipped examples' tests do.
+shipped examples' tests do. The test uses `opennvr_app_sdk.testing`
+(`RecorderChannel`, `inference_event`, `detection`, `feed`,
+`FakeCore`) — [SDK_REFERENCE.md](SDK_REFERENCE.md#testing-your-app--opennvr_app_sdktesting)
+lists the rest.
+
+Then `uv run opennvr-app validate .` — it checks the manifest, the
+example config, the listing entry and the repository shape the way a
+reviewer would, in a second.
 
 ## 4. Run it against the stack (5 min)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -289,7 +289,11 @@ to a release window. Pull requests and design discussions are welcome.
   key reaches an app), and enforced egress (apps on an internal
   network; the egress proxy allows declared + operator-allowed hosts,
   refusals in the inbox — `docs/APP_NETWORK.md`). Still open: install
-  counts (opt-in, aggregate) and a showcase page.
+  counts (opt-in, aggregate) and a showcase page. SDK toward 1.0
+  (on main, unreleased until QA signs off 0.5.0): `opennvr_app_sdk.testing`
+  (recorder, event builders, `feed`, `FakeCore`, pytest fixtures), the
+  v1 domain events as typed classes, `opennvr-app validate`, async
+  `ai.stream()`.
 - **Commercial direction** (decided Sep 2026): sovereign / NDAA-restricted
   enterprise deployments with support and compliance packs first;
   OpenNVR Models (per-site fine-tuning, delivered as licensed adapters

--- a/docs/SDK_REFERENCE.md
+++ b/docs/SDK_REFERENCE.md
@@ -72,7 +72,7 @@ nvr = OpenNVR()                      # OPENNVR_URL + the app's own key
 | `Recording` | `start`, `duration` |
 | `PlatformError` | Raised by writes; reads degrade to `None` / `[]` and log |
 | `InferStream` | The WebSocket inference session behind `nvr.ai.stream()`; `open()`, `infer(jpeg)`, `close()`, context-manager |
-| `AsyncOpenNVR` (`opennvr_app_sdk.aio`) | The same client `await`-ed, for FastAPI/agent loops: `await nvr.cameras()`, `await nvr.state.set(...)`, `async with`; `http_client=` shares a pool; no `ai.stream()` yet |
+| `AsyncOpenNVR` (`opennvr_app_sdk.aio`) | The same client `await`-ed, for FastAPI/agent loops: `await nvr.cameras()`, `await nvr.state.set(...)`, `async with`; `http_client=` shares a pool; `async with nvr.ai.stream(...) as s: await s.infer(jpeg)` (`AsyncInferStream`) |
 
 Lower-level helpers that predate the client and remain public:
 `discover_cameras(url)`, `cameras_for_skill(...)`,
@@ -103,6 +103,10 @@ alarm actions without any further code.
 | `domain_envelope(...)`, `domain_subject(schema, camera_id)` | The wire helpers |
 | `DomainEvent` | Parsed envelope: `id`, `schema`, `camera_id`, `ts`, `payload`, `producer`, `correlation_id`, `subject` |
 | `DomainEventSubscriber`, `domain_event_app`, `parse_domain_event` | The consuming archetype (above) |
+| `DomainEvent.typed()` | The payload as its contract class, or `None` when the SDK does not type the schema / the payload is off-contract (logged) |
+| `DomainEventPublisher.publish_typed(payload, camera_id=…)` | Publish a typed payload; the schema is the class's |
+| `PlateRecognized`, `AccessDecided`, `OccupancyChanged`, `OccupancyHeatmap`, `OccupancyFootfall`, `VisitRecorded`, `DetectionObserved` | The v1 contracts as frozen dataclasses: required fields enforced, additive fields kept in `.extra`, `to_payload()` / `from_payload()` round-trip; `AccessDecided.allow` fails closed on unknown decisions |
+| `EVENT_TYPES`, `typed_payload(schema, payload)` | schema → class, and the tolerant parser behind `typed()` |
 
 Schemas and their payloads: [EVENT_CONTRACTS.md](EVENT_CONTRACTS.md).
 
@@ -139,6 +143,46 @@ container) unless you need full frame rate.
 | `BaseAppConfig` | The dataclass of everything the SDK reads from `cfg`: `nats_url` (required), `nats_token`, `subject_pattern`, `webhook_url`, `nats_alerts_*`, `contract_*`, `opennvr_url` / `opennvr_token`, `config_poll_seconds`. Subclass it and add your own fields |
 | `load_app_config(path, cls=BaseAppConfig)` | One YAML file → your subclass: base keys validated (operator-readable errors), extra fields taken by name or defaulted, a field with no default required; put app checks in `__post_init__` |
 | `load_yaml(path)`, `require(cfg, key)` | The lower-level helpers, for anything richer |
+
+## Testing your app — `opennvr_app_sdk.testing`
+
+No broker, no core, no Docker. The helpers every example's test suite
+used to hand-roll, versioned with the SDK so they stay right when the
+contracts move:
+
+| Name | Purpose |
+|---|---|
+| `RecorderChannel` | An alert channel that keeps `.alerts` (`.titles`, `.clear()`); `.dispatcher()` for the app |
+| `app_config(**overrides)` | A config object with every key the archetypes read (test hosts, nothing contacted) |
+| `detection(label, *, confidence, x, y, w, h, track_id)` | One contract-shaped detection |
+| `inference_event(*detections, camera_id=…)` | An adapter `InferenceCompletedEvent` — what `Detector` consumes |
+| `tier0_event(*tracks)`, `tier0_track(label, box=…)` | A Tier-0 event (pixel boxes; `tier0_to_detections` bridges it) |
+| `domain_event(schema, payload, camera_id=…)` | A contracted envelope; `payload` may be typed (`PlateRecognized(...)`) or a dict |
+| `feed(app, *events)` | Run raw events through the app's decode → handle → dispatch path; returns the alerts fired |
+| `FakeCore(cameras=…, snapshots=…)` | A loopback core for apps that use `OpenNVR()`: cameras, snapshots, state, alerts, register; `.requests` records every call |
+| `opennvr_app_sdk.testing.pytest_plugin` | The same as fixtures: `recorder`, `app_config_factory`, `fake_core` |
+
+```python
+from opennvr_app_sdk.testing import RecorderChannel, app_config, detection, feed, inference_event
+
+def test_fires_on_a_person():
+    rec = RecorderChannel()
+    app = MyDetector(app_config(watch_labels=["person"]), rec.dispatcher())
+    fired = feed(app, inference_event(detection("person")))
+    assert rec.titles == ["Person seen"] and fired == rec.alerts
+```
+
+## Validating — `opennvr-app validate`
+
+`opennvr-app validate [path]` imports the app and checks what the
+catalog, the registry and a listing reviewer would trip over: the
+manifest (id, version, category, params and their defaults, alert
+types, scopes, actions, commerce fields, the `verify_license` hook
+when `entitlement` says so), that `config.example.yml` loads through
+the app's own `AppConfig`, that `apps-index-entry.yml` mirrors the
+manifest and carries author, contact, source and `network_egress`,
+and the repository shape (Dockerfile, tests, LICENSE). Errors exit 1;
+warnings do not. Run it in the app's own environment.
 
 ## Scaffolding
 

--- a/examples/occupancy-counting/config.example.yml
+++ b/examples/occupancy-counting/config.example.yml
@@ -106,3 +106,9 @@ nats_alerts_token: null
 #     max_occupancy: 3
 #     zone: [[100, 100], [900, 100], [900, 900], [100, 900]]
 cameras: []
+
+# ── OpenNVR core ──────────────────────────────────────────────────
+# Where the app discovers cameras (and registers itself) when the
+# ``cameras`` list above is empty. Set OPENNVR_INTERNAL_API_KEY in the
+# environment for the first registration; the app then holds its own key.
+opennvr_url: "http://localhost:8000"

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -71,6 +71,10 @@ from .domain_subscriber import (
     DomainEvent, DomainEventSubscriber, domain_event_app, parse_domain_event,
 )
 from .egress import connect_via_proxy, proxy_address
+from .event_types import (
+    EVENT_TYPES, AccessDecided, DetectionObserved, OccupancyChanged, OccupancyFootfall,
+    OccupancyHeatmap, PlateRecognized, TypedPayload, VisitRecorded, typed_payload,
+)
 from .tier0 import (
     BestFrameClient,
     Tier0Snapshot,
@@ -87,6 +91,17 @@ __all__ = [
     # The stack's egress proxy, for plain-TCP clients (docs/APP_NETWORK.md)
     "proxy_address",
     "connect_via_proxy",
+    # Typed domain-event payloads (docs/EVENT_CONTRACTS.md as Python)
+    "TypedPayload",
+    "EVENT_TYPES",
+    "typed_payload",
+    "DetectionObserved",
+    "VisitRecorded",
+    "PlateRecognized",
+    "AccessDecided",
+    "OccupancyChanged",
+    "OccupancyHeatmap",
+    "OccupancyFootfall",
     # Domain events (producing side of docs/EVENT_CONTRACTS.md)
     "DomainEventPublisher",
     "domain_envelope",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/aio.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/aio.py
@@ -207,10 +207,12 @@ class AsyncAIAPI:
     """KAI-C: adapters that exist, and running one on a frame."""
 
     def __init__(self, kaic_url: str | None, api_key: str | None,
-                 timeout: float, client: httpx.AsyncClient | None = None) -> None:
+                 timeout: float, client: httpx.AsyncClient | None = None,
+                 client_id: str = "opennvr-app") -> None:
         self._base = (kaic_url or "").rstrip("/")
         self._key = api_key
         self._timeout = timeout
+        self._client_id = client_id
         self._owns = client is None
         self._client = client or httpx.AsyncClient(timeout=timeout, trust_env=False)
 
@@ -245,6 +247,18 @@ class AsyncAIAPI:
             raise KaiCError(f"KAI-C returned HTTP {r.status_code}: {r.text[:200]}")
         return r.json()
 
+    def stream(self, adapter: str, *, camera_id: str, timeout: float | None = None):
+        """A persistent WebSocket session for a camera, awaited:
+        ``async with nvr.ai.stream("yolov8", camera_id="cam1") as s:
+        result = await s.infer(jpeg)``."""
+        from .infer_stream import AsyncInferStream
+
+        if not self._base:
+            raise PlatformError("KAI-C is not configured (KAIC_URL)")
+        return AsyncInferStream(self._base, self._key, adapter=adapter,
+                                camera_id=camera_id, client_id=self._client_id,
+                                timeout=timeout or self._timeout)
+
     async def aclose(self) -> None:
         if self._owns:
             await self._client.aclose()
@@ -262,7 +276,8 @@ class AsyncOpenNVR:
     def __init__(self, url: str | None = None, *, token: str | None = None,
                  kaic_url: str | None = None, kaic_api_key: str | None = None,
                  timeout: float = DEFAULT_TIMEOUT,
-                 http_client: httpx.AsyncClient | None = None) -> None:
+                 http_client: httpx.AsyncClient | None = None,
+                 client_id: str = "opennvr-app") -> None:
         base = url or os.environ.get("OPENNVR_URL") or ""
         if not base:
             raise ValueError("AsyncOpenNVR(url=...) or OPENNVR_URL is required")
@@ -271,7 +286,7 @@ class AsyncOpenNVR:
         kaic = kaic_url or os.environ.get("KAIC_URL") or os.environ.get("OPENNVR_KAIC_URL")
         self.ai = AsyncAIAPI(kaic, kaic_api_key or os.environ.get("KAIC_API_KEY")
                              or os.environ.get("OPENNVR_INTERNAL_API_KEY"),
-                             timeout, http_client)
+                             timeout, http_client, client_id)
         self.timeline = AsyncTimelineAPI(self._http)
         self.alerts = AsyncAlertsAPI(self._http)
         self.state = AsyncStateAPI(self._http)

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_events.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_events.py
@@ -105,5 +105,16 @@ class DomainEventPublisher:
         )
         return self._channel.publish_json(subject, envelope)
 
+    def publish_typed(self, payload: Any, *, camera_id: str,
+                      correlation_id: str | None = None) -> bool:
+        """Publish a typed payload (``event_types``): the schema is the
+        class's, the wire payload is ``to_payload()``."""
+        from .event_types import is_typed_payload
+
+        if not is_typed_payload(payload):
+            raise TypeError(f"publish_typed needs a typed event payload, got {type(payload).__name__}")
+        return self.publish(type(payload).SCHEMA, camera_id=camera_id,
+                            payload=payload.to_payload(), correlation_id=correlation_id)
+
     def close(self) -> None:
         self._channel.close()

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_subscriber.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_subscriber.py
@@ -60,6 +60,14 @@ class DomainEvent:
     subject: str = ""
     raw: dict[str, Any] = field(default_factory=dict, compare=False, repr=False)
 
+    def typed(self) -> Any:
+        """The payload as its contract class (``PlateRecognized``,
+        ``AccessDecided``, …, see ``event_types``) — ``None`` when this
+        SDK does not type the schema or the payload is off-contract."""
+        from .event_types import typed_payload
+
+        return typed_payload(self.schema, self.payload)
+
 
 def parse_domain_event(data: bytes | str | dict, *, subject: str = "") -> DomainEvent | None:
     """Decode + validate an envelope; ``None`` for anything off-contract."""

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/event_types.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/event_types.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""Typed payloads for the contracted domain events.
+
+``docs/EVENT_CONTRACTS.md`` names every event the platform and its apps
+put on the bus — ``plate.recognized.v1``, ``access.decided.v1``, the
+occupancy trio, … — and their required payload fields. Until now an
+app read them as ``event.payload["plate_text"]`` and wrote them as a
+hand-built dict. These classes are the same contracts as Python:
+
+    from opennvr_app_sdk import PlateRecognized, AccessDecided
+
+    class Gate(DomainEventSubscriber):
+        subscriptions = [PlateRecognized.SCHEMA]
+
+        def on_event(self, event):
+            plate = event.typed()             # PlateRecognized, or None if off-contract
+            if plate and plate.confidence and plate.confidence > 0.8:
+                self.publisher.publish_typed(
+                    AccessDecided(plate_text=plate.plate_text, decision="allow",
+                                  reason="registered"),
+                    camera_id=event.camera_id)
+
+Rules, all from the contract:
+
+* **Additive-only.** Fields a producer adds later ride in ``extra`` and
+  come back out of ``to_payload()`` untouched; a consumer on an older
+  SDK never loses them, a consumer on a newer SDK never breaks on
+  their absence.
+* **Required is required.** A payload missing a required field does
+  not parse (``ValueError``); ``DomainEvent.typed()`` turns that into
+  ``None`` and a log line, so a long-lived subscriber never dies to
+  one bad message.
+* **Unknown values are tolerated where the contract says so**
+  (``level``, ``reason``, ``decision`` are strings, not enums — a
+  gate must fail closed on a decision it does not recognise, and it
+  can only do that if parsing did not already reject it).
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import dataclass, field, fields
+from typing import Any, ClassVar, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound="TypedPayload")
+
+
+@dataclass(frozen=True)
+class TypedPayload:
+    """Base of every typed payload: ``SCHEMA``, ``from_payload``,
+    ``to_payload``. Subclasses list the contract's fields; ``extra``
+    keeps whatever else the producer sent."""
+
+    SCHEMA: ClassVar[str] = ""
+    #: Field names a payload MUST carry (the contract's non-optional rows).
+    REQUIRED: ClassVar[tuple[str, ...]] = ()
+
+    @classmethod
+    def from_payload(cls: type[T], payload: dict[str, Any]) -> T:
+        if not isinstance(payload, dict):
+            raise ValueError(f"{cls.SCHEMA}: payload must be an object")
+        names = {f.name for f in fields(cls)} - {"extra"}
+        missing = [name for name in cls.REQUIRED if payload.get(name) is None]
+        if missing:
+            raise ValueError(f"{cls.SCHEMA}: missing required field(s) {missing}")
+        known = {k: v for k, v in payload.items() if k in names}
+        extra = {k: v for k, v in payload.items() if k not in names}
+        try:
+            return cls(**known, extra=extra)  # type: ignore[arg-type]
+        except TypeError as exc:
+            raise ValueError(f"{cls.SCHEMA}: {exc}") from exc
+
+    def to_payload(self) -> dict[str, Any]:
+        """The wire payload: every contract field (nullable ones as
+        ``null``), then ``extra`` — never overriding a contract field."""
+        out: dict[str, Any] = {}
+        for f in fields(self):
+            if f.name == "extra":
+                continue
+            value = getattr(self, f.name)
+            out[f.name] = list(value) if isinstance(value, tuple) else value
+        for k, v in self.extra.items():
+            out.setdefault(k, v)
+        return out
+
+    # Keyword-only so ``PlateRecognized("R197GB")`` fills plate_text, not extra.
+    extra: dict[str, Any] = field(default_factory=dict, compare=False, kw_only=True)
+
+
+# ── the v1 contracts ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DetectionObserved(TypedPayload):
+    """``detection.observed.v1`` — one Tier-0 frame result with tracks."""
+
+    SCHEMA: ClassVar[str] = "detection.observed.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("frame", "tracks")
+    frame: dict[str, Any] = field(default_factory=dict)      # {"w", "h"}
+    tracks: list[dict[str, Any]] = field(default_factory=list)
+    calibrating: bool = False
+
+
+@dataclass(frozen=True)
+class VisitRecorded(TypedPayload):
+    """``visit.recorded.v1`` — a finished timeline visit persisted by core."""
+
+    SCHEMA: ClassVar[str] = "visit.recorded.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("event_id", "label", "started_at", "ended_at")
+    event_id: int = 0
+    label: str = ""
+    started_at: str = ""
+    ended_at: str = ""
+    evidence_path: str | None = None
+
+
+@dataclass(frozen=True)
+class PlateRecognized(TypedPayload):
+    """``plate.recognized.v1`` — one accepted OCR read."""
+
+    SCHEMA: ClassVar[str] = "plate.recognized.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("plate_text",)
+    plate_text: str = ""
+    confidence: float | None = None
+    vehicle_label: str | None = None
+    event_id: int | None = None
+    plate_box: list[float] | None = None
+    plate_box_confidence: float | None = None
+    plate_box_image: list[int] | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        out = super().to_payload()
+        # The optional geometry fields are "absent", not null, when unknown.
+        for name in ("plate_box", "plate_box_confidence", "plate_box_image"):
+            if out.get(name) is None:
+                out.pop(name, None)
+        return out
+
+
+@dataclass(frozen=True)
+class AccessDecided(TypedPayload):
+    """``access.decided.v1`` — an admission decision for a plate at a gate.
+    Consumers actuate only on ``decision == "allow"``; anything else,
+    including values this SDK does not know, is "do not actuate"."""
+
+    SCHEMA: ClassVar[str] = "access.decided.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("plate_text", "decision", "reason")
+    plate_text: str = ""
+    decision: str = "deny"
+    reason: str = "unknown"
+    owner: str | None = None
+    unit: str | None = None
+    confidence: float | None = None
+
+    @property
+    def allow(self) -> bool:
+        return self.decision == "allow"
+
+
+@dataclass(frozen=True)
+class OccupancyChanged(TypedPayload):
+    """``occupancy.changed.v1`` — a zone's head-count moved."""
+
+    SCHEMA: ClassVar[str] = "occupancy.changed.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("count", "level")
+    count: int = 0
+    level: str = "normal"
+    max_occupancy: int | None = None
+    min_occupancy: int | None = None
+
+
+@dataclass(frozen=True)
+class OccupancyHeatmap(TypedPayload):
+    """``occupancy.heatmap.v1`` — a sparse delta of a per-camera heat grid."""
+
+    SCHEMA: ClassVar[str] = "occupancy.heatmap.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("cols", "rows", "cells", "frames", "period_seconds")
+    cols: int = 0
+    rows: int = 0
+    cells: list[list[int]] = field(default_factory=list)     # [[index, hits], …]
+    frames: int = 0
+    period_seconds: int = 60
+    labels: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class OccupancyFootfall(TypedPayload):
+    """``occupancy.footfall.v1`` — entries, exits and finished stays since the last publish."""
+
+    SCHEMA: ClassVar[str] = "occupancy.footfall.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("entries", "exits", "dwell_count", "dwell_seconds",
+                                           "dwell_max_seconds", "period_seconds")
+    entries: int = 0
+    exits: int = 0
+    dwell_count: int = 0
+    dwell_seconds: float = 0.0
+    dwell_max_seconds: float = 0.0
+    period_seconds: int = 60
+    labels: list[str] = field(default_factory=list)
+
+
+#: schema → typed payload class, for every contract this SDK knows.
+EVENT_TYPES: dict[str, type[TypedPayload]] = {
+    cls.SCHEMA: cls for cls in (
+        DetectionObserved, VisitRecorded, PlateRecognized, AccessDecided,
+        OccupancyChanged, OccupancyHeatmap, OccupancyFootfall,
+    )
+}
+
+
+def typed_payload(schema: str, payload: dict[str, Any]) -> TypedPayload | None:
+    """The typed payload for ``schema``, ``None`` when the schema is not
+    one this SDK types (a newer contract, or an app's own) or the
+    payload is off-contract (logged)."""
+    cls = EVENT_TYPES.get(schema)
+    if cls is None:
+        return None
+    try:
+        return cls.from_payload(payload)
+    except ValueError as exc:
+        logger.warning("domain event %s: payload off-contract: %s", schema, exc)
+        return None
+
+
+def is_typed_payload(obj: Any) -> bool:
+    return dataclasses.is_dataclass(obj) and isinstance(obj, TypedPayload) and bool(type(obj).SCHEMA)

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/infer_stream.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/infer_stream.py
@@ -146,3 +146,128 @@ def _close(conn: Any) -> None:
         conn.close()
     except Exception:  # noqa: BLE001
         pass
+
+
+# ── the async twin ──────────────────────────────────────────────────
+
+
+class AsyncInferStream:
+    """:class:`InferStream` for an asyncio app (``AsyncOpenNVR().ai.stream``):
+    same handshake, framing, sequence and teardown rules, awaited::
+
+        async with nvr.ai.stream("yolov8", camera_id="cam1") as session:
+            result = await session.infer(jpeg)
+
+    ``websocket_factory`` (tests) is an ``async (url, headers) -> conn``
+    whose ``conn`` has awaitable ``send``/``recv``/``close``; the
+    default is ``websockets.asyncio.client.connect``.
+    """
+
+    def __init__(self, kaic_url: str, api_key: str | None, *, adapter: str,
+                 camera_id: str, client_id: str = "opennvr-app",
+                 timeout: float = 10.0,
+                 websocket_factory: Callable[[str, list[tuple[str, str]]], Any] | None = None,
+                 ) -> None:
+        self._sync = InferStream(kaic_url, api_key, adapter=adapter, camera_id=camera_id,
+                                 client_id=client_id, timeout=timeout)
+        self.url = self._sync.url
+        self._api_key = api_key
+        self._camera_id = str(camera_id)
+        self._client_id = client_id
+        self._timeout = timeout
+        self._factory = websocket_factory
+        self._conn: Any = None
+        self._seq = 0
+        self.correlation_id: str | None = None
+
+    async def _connect(self, headers: list[tuple[str, str]]) -> Any:
+        if self._factory is not None:
+            return await self._factory(self.url, headers)
+        try:
+            from websockets.asyncio.client import connect
+        except ImportError as exc:  # pragma: no cover
+            raise KaiCError("streaming inference needs the 'websockets' package (>= 13)") from exc
+        try:
+            return await connect(self.url, additional_headers=headers,
+                                 open_timeout=self._timeout, close_timeout=2.0,
+                                 max_size=MAX_MESSAGE_BYTES)
+        except Exception as exc:  # noqa: BLE001
+            raise KaiCError(f"WS connect to {self.url} failed: {exc}") from exc
+
+    async def _recv(self, conn: Any) -> Any:
+        import asyncio
+
+        return await asyncio.wait_for(conn.recv(), timeout=self._timeout)
+
+    async def open(self, correlation_id: str | None = None) -> "AsyncInferStream":
+        """Connect + §6.1 handshake (idempotent)."""
+        if self._conn is not None:
+            return self
+        cid = correlation_id or f"app-{uuid.uuid4().hex[:12]}"
+        headers = [("X-Correlation-Id", cid)]
+        if self._api_key:
+            headers.append(("X-Internal-Api-Key", self._api_key))
+        conn = await self._connect(headers)
+        try:
+            await conn.send(json.dumps({"type": "handshake", "client_id": self._client_id,
+                                        "camera_id": self._camera_id,
+                                        "frame_transport": "websocket"}))
+            ack = _loads(await self._recv(conn))
+            if not isinstance(ack, dict) or ack.get("type") != "handshake_ack":
+                raise KaiCError(f"unexpected handshake response: {ack!r}")
+        except KaiCError:
+            await _aclose(conn)
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await _aclose(conn)
+            raise KaiCError(f"WS handshake failed: {exc}") from exc
+        self._conn = conn
+        self.correlation_id = cid
+        self._seq = 0
+        return self
+
+    async def infer(self, jpeg: bytes) -> dict[str, Any]:
+        """Send one frame, return a §5.1-shaped result. Raises
+        ``KaiCError`` and closes the session on any failure."""
+        await self.open()
+        self._seq += 1
+        try:
+            await self._conn.send(json.dumps({"type": "frame", "seq": self._seq,
+                                              "ts_ms": int(time.monotonic() * 1000),
+                                              "content_type": "image/jpeg"}))
+            await self._conn.send(jpeg)
+            raw = await self._recv(self._conn)
+        except Exception as exc:  # noqa: BLE001
+            await self.close()
+            raise KaiCError(f"WS infer failed: {exc}") from exc
+        try:
+            payload = _loads(raw)
+        except Exception as exc:  # noqa: BLE001
+            raise KaiCError(f"WS recv: non-JSON payload: {exc}") from exc
+        if not isinstance(payload, dict) or payload.get("type") != "result":
+            raise KaiCError(f"WS recv: unexpected message {payload!r}")
+        return {
+            "status": "ok",
+            "model_name": "", "model_version": "",
+            "inference_ms": int(payload.get("inference_ms", 0) or 0),
+            "result": payload.get("result") or {},
+            "correlation_id": self.correlation_id,
+        }
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            await _aclose(self._conn)
+            self._conn = None
+
+    async def __aenter__(self) -> "AsyncInferStream":
+        return await self.open()
+
+    async def __aexit__(self, *exc) -> None:
+        await self.close()
+
+
+async def _aclose(conn: Any) -> None:
+    try:
+        await conn.close()
+    except Exception:  # noqa: BLE001
+        pass

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/scaffold.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/scaffold.py
@@ -236,6 +236,7 @@ def print_next_steps(app_id: str, app_dir: Path, *, mode: str) -> None:
     print("  uv sync                 # " + ("opennvr-app-sdk from PyPI + pytest"
                                             if mode == "pypi" else "the SDK (editable) + pytest"))
     print("  uv run pytest -q        # the smoke test — should be GREEN")
+    print("  uv run opennvr-app validate .   # what a reviewer would check")
     print(f"  # open {module}.py and fill in on_detections — that's the rule")
     print("  cp config.example.yml config.yml   # then edit it")
     print(f"  uv run python {module}.py --config config.yml --once")
@@ -248,7 +249,7 @@ def main(argv: list[str] | None = None, *, repo_root: Path | None = None,
          default_dest: Path | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="opennvr-app",
-        description=f"OpenNVR App SDK {__version__} — scaffold vision apps.")
+        description=f"OpenNVR App SDK {__version__} — scaffold and validate vision apps.")
     sub = parser.add_subparsers(dest="command", required=True)
     new = sub.add_parser("new", help="scaffold a runnable Detector app")
     new.add_argument("app_id", help="kebab-case app id, e.g. 'gate-watch' (= AppManifest.id)")
@@ -263,7 +264,16 @@ def main(argv: list[str] | None = None, *, repo_root: Path | None = None,
                      help="also lay down the repository files for open-nvr/app-<id>: CI, the "
                           "publish workflow (build + sign through the org's build-catalog-app), "
                           "the App Catalog listing entry. Implies --sdk pypi.")
+    val = sub.add_parser("validate", help="check an app's manifest, example config, listing and repository shape")
+    val.add_argument("path", nargs="?", default=".", help="the app directory (default: current directory)")
     args = parser.parse_args(argv)
+
+    if args.command == "validate":
+        from .validate import print_report, validate_app
+
+        report = validate_app(Path(args.path).expanduser())
+        print_report(report, Path(args.path))
+        return 0 if report.ok else 1
 
     dest_dir = Path(args.dest).expanduser().resolve()
     try:

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/app/tests/test_smoke.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/templates/app/tests/test_smoke.py
@@ -4,71 +4,29 @@
 """
 Smoke tests for __APP_NAME__ — the parity bar for a generated app.
 
-These drive the detector THROUGH ``handle_event`` (the SDK base's
-decode → on_detections → dispatch path) without spinning up a NATS
-broker: an in-memory recorder channel captures whatever the rule fires.
-Keep this green as you replace the starter rule with your own.
+These drive the detector through the SDK's decode → on_detections →
+dispatch path without a NATS broker, using ``opennvr_app_sdk.testing``:
+a recorder channel captures whatever the rule fires, and the event
+builders produce contract-shaped inference events. Keep this green as
+you replace the starter rule with your own.
 """
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any
-
-from opennvr_app_sdk import Alert, AlertDispatcher
+from opennvr_app_sdk import Alert
+from opennvr_app_sdk.testing import RecorderChannel, detection, feed, inference_event
 
 from __APP_MODULE__ import __APP_CLASS__, AppConfig, load_config
 
 
-class _RecorderChannel:
-    """Captures dispatched alerts in memory so a test can assert on them
-    without a webhook or NATS broker."""
-
-    name = "recorder"
-
-    def __init__(self) -> None:
-        self.alerts: list[Alert] = []
-
-    def send(self, alert: Alert) -> bool:
-        self.alerts.append(alert)
-        return True
-
-
-def _build(
-    *, watch_labels: list[str] | None = None,
-) -> tuple[__APP_CLASS__, _RecorderChannel]:
+def _build(*, watch_labels: list[str] | None = None) -> tuple[__APP_CLASS__, RecorderChannel]:
     """Construct the detector with an in-memory dispatcher."""
     config = AppConfig(
         nats_url="nats://test:4222",
         subject_pattern="opennvr.inference.>",
         watch_labels=watch_labels or ["person"],
     )
-    recorder = _RecorderChannel()
-    dispatcher = AlertDispatcher([recorder])
-    detector = __APP_CLASS__(config, dispatcher)
-    return detector, recorder
-
-
-def _event(*, label: str = "person", camera_id: str = "cam-1") -> dict[str, Any]:
-    """A minimal §12 InferenceCompletedEvent body with one detection."""
-    return {
-        "correlation_id": "corr-1",
-        "adapter": "yolov8",
-        "adapter_version": "1.0.0",
-        "camera_id": camera_id,
-        "model_fingerprint": "sha256:test",
-        "completed_at": "2026-01-02T03:04:05Z",
-        "result": {
-            "detections": [
-                {
-                    "label": label,
-                    "confidence": 0.9,
-                    "bbox": {"x": 0.4, "y": 0.4, "w": 0.1, "h": 0.1},
-                    "track_id": None,
-                    "attributes": {},
-                },
-            ],
-        },
-    }
+    recorder = RecorderChannel()
+    return __APP_CLASS__(config, recorder.dispatcher()), recorder
 
 
 # ── The parity bar ─────────────────────────────────────────────────
@@ -78,7 +36,8 @@ def test_matching_detection_fires_one_alert():
     """A watched-label detection fires exactly one alert, carrying the
     camera + correlation id through to the §11.5 envelope."""
     detector, recorder = _build(watch_labels=["person"])
-    fired = detector.handle_event(_event(label="person", camera_id="cam-1"))
+    fired = feed(detector, inference_event(detection("person"), camera_id="cam-1",
+                                           correlation_id="corr-1"))
 
     assert len(fired) == 1
     alert = fired[0]
@@ -92,18 +51,14 @@ def test_matching_detection_fires_one_alert():
 def test_non_watched_label_is_quiet():
     """A detection whose label isn't watched fires nothing."""
     detector, recorder = _build(watch_labels=["person"])
-    fired = detector.handle_event(_event(label="bicycle"))
-
-    assert fired == []
+    assert feed(detector, inference_event(detection("bicycle"))) == []
     assert recorder.alerts == []
 
 
 def test_no_detections_is_quiet():
     """An event with an empty detections list fires nothing."""
-    detector, recorder = _build()
-    event = _event()
-    event["result"]["detections"] = []
-    assert detector.handle_event(event) == []
+    detector, _ = _build()
+    assert feed(detector, inference_event()) == []
 
 
 def test_config_loader_roundtrips(tmp_path):

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/testing/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/testing/__init__.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""Test helpers for OpenNVR apps — no broker, no core, no Docker.
+
+Every example app's test suite used to carry the same forty lines: a
+recorder channel, a ``SimpleNamespace`` config, an inference event
+literal. This package is those lines, once, versioned with the SDK so
+the shapes stay right when the contracts move.
+
+    from opennvr_app_sdk.testing import (
+        RecorderChannel, app_config, detection, inference_event, feed,
+    )
+
+    def test_fires_on_a_person():
+        recorder = RecorderChannel()
+        app = MyDetector(app_config(watch_labels=["person"]), recorder.dispatcher())
+        fired = feed(app, inference_event(detection("person", x=0.5, y=0.5)))
+        assert [a.title for a in fired] == ["Person seen"]
+        assert recorder.alerts == fired
+
+There is also a pytest plugin with the same things as fixtures
+(``recorder``, ``app_config_factory``, ``fake_core``): add
+``pytest_plugins = ["opennvr_app_sdk.testing.pytest_plugin"]`` to your
+``conftest.py``. ``FakeCore`` is a tiny in-process platform (cameras,
+snapshot, state, alerts, register) for apps that use ``OpenNVR()``.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+from ..alerts import Alert, AlertDispatcher
+from ..domain_events import domain_envelope
+from .fake_core import FakeCore
+
+__all__ = [
+    "RecorderChannel", "app_config", "detection", "inference_event", "tier0_event",
+    "domain_event", "feed", "FakeCore",
+]
+
+
+class RecorderChannel:
+    """An alert channel that keeps every alert in ``alerts``."""
+
+    name = "recorder"
+
+    def __init__(self) -> None:
+        self.alerts: list[Alert] = []
+
+    def send(self, alert: Alert) -> bool:
+        self.alerts.append(alert)
+        return True
+
+    def dispatcher(self) -> AlertDispatcher:
+        """An ``AlertDispatcher`` that fires only into this recorder."""
+        return AlertDispatcher([self])
+
+    def clear(self) -> None:
+        self.alerts.clear()
+
+    @property
+    def titles(self) -> list[str]:
+        return [a.title for a in self.alerts]
+
+
+def app_config(**overrides: Any) -> SimpleNamespace:
+    """A config object with every key the SDK archetypes read, plus
+    yours. Bus and core point at test hosts; nothing is contacted."""
+    base: dict[str, Any] = dict(
+        nats_url="nats://test:4222", nats_token=None, subject_pattern=None,
+        webhook_url=None, nats_alerts_url=None, nats_alerts_token=None,
+        nats_alerts_subject_prefix="opennvr.alerts",
+        contract_port=None, contract_bind_host="127.0.0.1", contract_host=None,
+        opennvr_url="http://core.test:8000", opennvr_token=None,
+        poll_interval_seconds=0.01,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def detection(label: str = "person", *, confidence: float = 0.9,
+              x: float = 0.4, y: float = 0.4, w: float = 0.1, h: float = 0.1,
+              track_id: str | int | None = None, **extra: Any) -> dict[str, Any]:
+    """One contract-shaped detection (normalised ``bbox`` in 0–1)."""
+    det: dict[str, Any] = {"label": label, "confidence": confidence,
+                           "bbox": {"x": x, "y": y, "w": w, "h": h}}
+    if track_id is not None:
+        det["track_id"] = track_id
+    det.update(extra)
+    return det
+
+
+def inference_event(*detections: dict[str, Any], camera_id: str = "cam-1",
+                    adapter: str = "yolov8", completed_at: str | None = None,
+                    correlation_id: str | None = None, **overrides: Any) -> dict[str, Any]:
+    """An adapter ``InferenceCompletedEvent`` (what ``Detector`` consumes
+    from ``opennvr.inference.>``) carrying ``detections``."""
+    event: dict[str, Any] = {
+        "correlation_id": correlation_id or f"corr-{uuid.uuid4().hex[:8]}",
+        "adapter": adapter, "adapter_version": "1.0.0",
+        "camera_id": camera_id, "model_fingerprint": "sha256:test",
+        "completed_at": completed_at or _now(),
+        "result": {"detections": list(detections)},
+    }
+    event.update(overrides)
+    return event
+
+
+def tier0_event(*tracks: dict[str, Any], camera_id: str = "cam-1",
+                frame: tuple[int, int] = (1280, 720), calibrating: bool = False,
+                **overrides: Any) -> dict[str, Any]:
+    """A Tier-0 (``opennvr.tier0.v1``) event. Tracks carry pixel boxes:
+    ``{"id", "label", "score", "box": [x1, y1, x2, y2]}``; use
+    ``tier0_track`` or pass dicts. ``tier0_to_detections`` bridges it."""
+    event: dict[str, Any] = {
+        "schema": "opennvr.tier0.v1", "camera_id": camera_id, "ts": _now(),
+        "frame": {"w": frame[0], "h": frame[1]}, "calibrating": calibrating,
+        "tracks": list(tracks),
+    }
+    event.update(overrides)
+    return event
+
+
+def tier0_track(label: str = "person", *, track_id: str = "t1", score: float = 0.9,
+                bbox: tuple[float, float, float, float] = (500, 300, 600, 500),
+                stationary: bool = False, **extra: Any) -> dict[str, Any]:
+    t: dict[str, Any] = {"id": track_id, "label": label, "score": score, "box": list(bbox),
+                         "stationary": stationary}
+    t.update(extra)
+    return t
+
+
+def domain_event(schema: str, payload: Any, *, camera_id: str = "cam-1",
+                 producer: str = "test", correlation_id: str | None = None) -> dict[str, Any]:
+    """A contracted domain-event envelope. ``payload`` may be a typed
+    payload (``PlateRecognized(...)``) or a dict."""
+    from ..event_types import is_typed_payload
+
+    if is_typed_payload(payload):
+        schema = schema or type(payload).SCHEMA
+        payload = payload.to_payload()
+    return domain_envelope(schema, camera_id=camera_id, payload=payload,
+                           producer=producer, correlation_id=correlation_id)
+
+
+def feed(app: Any, *events: dict[str, Any] | bytes | str, subject: str = "") -> list[Alert]:
+    """Run raw events through an app's decode → handle → dispatch path
+    (``_handle_raw``) exactly as the bus would, without a broker. Returns
+    the alerts fired across all of them (a ``DomainEventSubscriber``
+    reports fired alerts through its dispatcher; here its return value
+    is the count of accepted events, so check the recorder)."""
+    fired: list[Alert] = []
+    for ev in events:
+        raw = ev if isinstance(ev, (bytes, str)) else json.dumps(ev)
+        raw = raw.encode() if isinstance(raw, str) else raw
+        try:
+            out = app._handle_raw(raw, subject=subject)
+        except TypeError:
+            out = app._handle_raw(raw)
+        if isinstance(out, list):
+            fired.extend(out)
+    return fired
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+__all__.append("tier0_track")

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/testing/fake_core.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/testing/fake_core.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""A tiny in-process OpenNVR core for app tests.
+
+Serves the internal routes the platform client (``OpenNVR`` /
+``AsyncOpenNVR``) and the SDK's registration use, on a loopback port,
+from plain dicts you set up: cameras with assignments, snapshots,
+per-app state (a dict), an alerts inbox, and ``POST /apps/register``
+(issues a key on first registration like core does). Every request is
+recorded in ``requests`` so a test can assert what the app asked for.
+
+    with FakeCore(cameras=[{"camera_id": "cam1", "name": "Gate"}]) as core:
+        nvr = OpenNVR(core.url, token="oak_test")
+        assert [c.name for c in nvr.cameras()] == ["Gate"]
+        nvr.state.set("seen", 3)
+        assert core.state["seen"] == 3
+"""
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+class FakeCore:
+    def __init__(self, *, cameras: list[dict[str, Any]] | None = None,
+                 snapshots: dict[str, bytes] | None = None,
+                 alerts: list[dict[str, Any]] | None = None,
+                 events: list[dict[str, Any]] | None = None,
+                 app_key: str = "oak_test-app_" + "0" * 32) -> None:
+        self.cameras = [self._camera(c, i) for i, c in enumerate(cameras or [], start=1)]
+        self.snapshots = dict(snapshots or {})
+        self.alerts = list(alerts or [])
+        self.events = list(events or [])
+        self.state: dict[str, Any] = {}
+        self.registrations: list[dict[str, Any]] = []
+        self.requests: list[dict[str, Any]] = []
+        self.app_key = app_key
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self.url = ""
+
+    @staticmethod
+    def _camera(c: dict[str, Any], i: int) -> dict[str, Any]:
+        out = {"camera_id": f"cam{i}", "open_nvr_camera_id": str(i), "name": f"Camera {i}",
+               "role": "", "frame_url": f"rtsp://tap/cam-{i}", "assignments": []}
+        out.update(c)
+        return out
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    def start(self) -> "FakeCore":
+        core = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *a: Any) -> None:  # quiet
+                pass
+
+            def _reply(self, status: int, body: Any, ctype: str = "application/json") -> None:
+                raw = body if isinstance(body, bytes) else json.dumps(body).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def _body(self) -> Any:
+                n = int(self.headers.get("Content-Length") or 0)
+                return json.loads(self.rfile.read(n) or b"null") if n else None
+
+            def _route(self, method: str) -> None:
+                u = urlparse(self.path)
+                body = self._body() if method in ("POST", "PUT") else None
+                core.requests.append({"method": method, "path": u.path,
+                                      "query": {k: v[0] for k, v in parse_qs(u.query).items()},
+                                      "key": self.headers.get("X-Internal-Api-Key"), "body": body})
+                status, out, ctype = core.handle(method, u.path, dict(parse_qs(u.query)), body)
+                self._reply(status, out, ctype)
+
+            def do_GET(self):  # noqa: N802
+                self._route("GET")
+
+            def do_POST(self):  # noqa: N802
+                self._route("POST")
+
+            def do_PUT(self):  # noqa: N802
+                self._route("PUT")
+
+            def do_DELETE(self):  # noqa: N802
+                self._route("DELETE")
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+
+    def __enter__(self) -> "FakeCore":
+        return self.start()
+
+    def __exit__(self, *exc: Any) -> None:
+        self.stop()
+
+    # ── routes ─────────────────────────────────────────────────────
+
+    def handle(self, method: str, path: str, query: dict[str, list[str]], body: Any):
+        """(status, body, content-type) for one request. Override or
+        extend in a subclass for routes your app needs beyond these."""
+        p = path
+        if method == "POST" and p == "/api/v1/apps/register":
+            self.registrations.append(body or {})
+            app_id = ((body or {}).get("manifest") or {}).get("id", "app")
+            out = {"id": app_id, "enabled": True, "status": "registered",
+                   "config": (body or {}).get("config") or {},
+                   "has_api_key": True, "entitlement": {"mode": "none", "status": "none"},
+                   "registry": {"server_version": "test", "api_version": "1.4",
+                                "min_sdk_version": "0.2.0"}}
+            if len(self.registrations) == 1 or (body or {}).get("wants_key"):
+                out["api_key"] = self.app_key
+            return 200, out, "application/json"
+        if method == "GET" and p == "/api/v1/internal/camera-agent/cameras":
+            return 200, {"cameras": self.cameras}, "application/json"
+        if method == "GET" and p.startswith("/api/v1/internal/app/cameras/") and p.endswith("/snapshot"):
+            cam = p.split("/")[-2]
+            jpeg = self.snapshots.get(cam) or self.snapshots.get(self._cam_id(cam))
+            if jpeg is None:
+                return 503, {"detail": "no snapshot"}, "application/json"
+            return 200, jpeg, "image/jpeg"
+        if method == "GET" and p == "/api/v1/internal/camera-agent/events":
+            return 200, {"events": self.events}, "application/json"
+        if method == "GET" and p == "/api/v1/internal/app/alerts":
+            return 200, {"alerts": self.alerts}, "application/json"
+        if p == "/api/v1/internal/app/state" and method == "GET":
+            prefix = (query.get("prefix") or [""])[0]
+            return 200, {"items": [{"key": k, "value": v} for k, v in self.state.items()
+                                   if k.startswith(prefix)]}, "application/json"
+        if p.startswith("/api/v1/internal/app/state/"):
+            key = p.rsplit("/", 1)[1]
+            if method == "GET":
+                if key in self.state:
+                    return 200, {"key": key, "value": self.state[key]}, "application/json"
+                return 404, {"detail": "No such key"}, "application/json"
+            if method == "PUT":
+                self.state[key] = body                      # the value IS the body (core's shape)
+                return 200, {"key": key, "value": body}, "application/json"
+            if method == "DELETE":
+                existed = key in self.state
+                self.state.pop(key, None)
+                return 200, {"deleted": existed}, "application/json"
+        return 404, {"detail": f"FakeCore has no route {method} {p}"}, "application/json"
+
+    def _cam_id(self, numeric: str) -> str:
+        for c in self.cameras:
+            if c.get("open_nvr_camera_id") == numeric:
+                return c["camera_id"]
+        return numeric

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/testing/pytest_plugin.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/testing/pytest_plugin.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""pytest fixtures over ``opennvr_app_sdk.testing``. Enable with
+``pytest_plugins = ["opennvr_app_sdk.testing.pytest_plugin"]`` in
+``conftest.py``."""
+from __future__ import annotations
+
+import pytest
+
+from . import FakeCore, RecorderChannel, app_config
+
+
+@pytest.fixture
+def recorder() -> RecorderChannel:
+    """A fresh alert recorder; ``recorder.dispatcher()`` for the app."""
+    return RecorderChannel()
+
+
+@pytest.fixture
+def app_config_factory():
+    """``app_config_factory(watch_labels=[...])`` → a config object."""
+    return app_config
+
+
+@pytest.fixture
+def fake_core():
+    """A running ``FakeCore`` (``fake_core.url``), stopped after the test."""
+    core = FakeCore().start()
+    try:
+        yield core
+    finally:
+        core.stop()

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/validate.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/validate.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""``opennvr-app validate [path]`` — check an app before it meets a stack.
+
+Everything the catalog, the registry and a listing reviewer would
+trip over, found on the developer's machine in a second:
+
+* the **manifest** — id, version, category, params (names, types,
+  defaults), alert types, scopes, actions, state views, commerce
+  fields, the licence hook when ``entitlement`` says so;
+* the **example config** (``config.example.yml``) loads through the
+  app's own ``AppConfig`` — the operator-facing error text is what a
+  developer sees first;
+* the **listing** (``apps-index-entry.yml``, if present) mirrors the
+  manifest — id, name, version, ``requires_tasks``, ``emits`` — and
+  carries what the catalog policy requires (author, contact, source
+  under the org, ``network_egress``, the org's image ref);
+* the **repository shape** — Dockerfile, tests, a licence.
+
+Errors fail the command (exit 1); warnings do not. The manifest is
+found by importing the app module named in ``pyproject.toml``'s
+``[project.scripts]`` (or the one ``*.py`` that builds an
+``AppManifest``), so run it in the app's own environment.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import re
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .manifest import ENTITLEMENT_MODES, PRICING_MODELS, AppManifest, Param
+
+_KEBAB_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+_SCOPE_RE = re.compile(r"^events:[a-z0-9_]+(?:\.[a-z0-9_]+)*$")
+_SCHEMA_RE = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+\.v\d+$")
+
+#: Categories the catalog groups by (the manifest's own comment + what
+#: the shipped apps use). Anything else is a warning, not an error.
+KNOWN_CATEGORIES = frozenset({
+    "perimeter", "analytics", "vehicle", "doorstep", "forensics", "integration",
+    "automation", "notifications", "assistant", "observability", "people", "retail", "safety",
+})
+#: The canonical task registry (server/config/tasks.yml) — an unknown
+#: task greys the app out in every catalog, so it is worth a warning.
+KNOWN_TASKS = frozenset({
+    "object_detection", "face_recognition", "image_captioning", "vqa", "face_detection",
+    "person_detection", "license_plate_recognition", "multi_object_tracking",
+    "speech_to_text", "text_to_speech",
+})
+KNOWN_PARAM_TYPES = frozenset({"str", "int", "float", "bool", "list", "dict", "json",
+                               "geometry.polygon", "geometry.tripwire", "image", "time_range"})
+SEVERITIES = frozenset({"low", "medium", "high", "critical"})
+_PY_TYPES = {"str": str, "int": int, "float": (int, float), "bool": bool, "list": list, "dict": dict}
+
+
+@dataclass
+class Report:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    manifest: AppManifest | None = None
+    module_name: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def error(self, text: str) -> None:
+        self.errors.append(text)
+
+    def warn(self, text: str) -> None:
+        self.warnings.append(text)
+
+    def note(self, text: str) -> None:
+        self.notes.append(text)
+
+
+# ── finding the app ─────────────────────────────────────────────────
+
+
+def find_app_module(app_dir: Path) -> str | None:
+    """The module that builds the manifest: the ``[project.scripts]``
+    target in pyproject.toml, else the one top-level ``*.py`` that
+    mentions ``AppManifest(``."""
+    pyproject = app_dir / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            data = {}
+        for target in (data.get("project", {}).get("scripts") or {}).values():
+            module = str(target).split(":", 1)[0].strip()
+            if module and (app_dir / f"{module}.py").exists():
+                return module
+    candidates = [p.stem for p in sorted(app_dir.glob("*.py"))
+                  if "AppManifest(" in p.read_text(encoding="utf-8", errors="ignore")]
+    return candidates[0] if len(candidates) == 1 else (None if not candidates else candidates[0])
+
+
+def load_manifest(app_dir: Path, module_name: str) -> tuple[AppManifest | None, Any]:
+    """Import the module from ``app_dir`` and return ``(manifest, module)``:
+    a module-level ``AppManifest`` or the ``manifest`` of an archetype
+    subclass defined there."""
+    sys.path.insert(0, str(app_dir))
+    try:
+        sys.modules.pop(module_name, None)
+        module = importlib.import_module(module_name)
+    finally:
+        try:
+            sys.path.remove(str(app_dir))
+        except ValueError:
+            pass
+    for name in ("manifest", "MANIFEST"):
+        m = getattr(module, name, None)
+        if isinstance(m, AppManifest):
+            return m, module
+    for _name, obj in inspect.getmembers(module, inspect.isclass):
+        if obj.__module__ == module.__name__ and isinstance(getattr(obj, "manifest", None), AppManifest):
+            return obj.manifest, module
+    for _name, obj in inspect.getmembers(module):
+        if isinstance(obj, AppManifest):
+            return obj, module
+    return None, module
+
+
+def app_class(module: Any, manifest: AppManifest) -> type | None:
+    for _name, obj in inspect.getmembers(module, inspect.isclass):
+        if getattr(obj, "manifest", None) is manifest and obj.__module__ == module.__name__:
+            return obj
+    return None
+
+
+# ── checks ──────────────────────────────────────────────────────────
+
+
+def check_manifest(m: AppManifest, report: Report, cls: type | None = None) -> None:
+    if not _KEBAB_RE.match(m.id or ""):
+        report.error(f"manifest.id {m.id!r} is not kebab-case (lowercase letters, digits, single hyphens)")
+    if not (m.name or "").strip():
+        report.error("manifest.name is empty")
+    if not _SEMVER_RE.match(m.version or ""):
+        report.error(f"manifest.version {m.version!r} is not semantic (MAJOR.MINOR.PATCH)")
+    if m.category not in KNOWN_CATEGORIES:
+        report.warn(f"manifest.category {m.category!r} is not one the catalog groups by "
+                    f"({', '.join(sorted(KNOWN_CATEGORIES))}) — it will show under its own heading")
+    if not (m.summary or "").strip():
+        report.warn("manifest.summary is empty — the catalog card shows 'No summary provided.'")
+    for task in m.requires_tasks:
+        if task not in KNOWN_TASKS:
+            report.warn(f"requires_tasks {task!r} is not a canonical task — no adapter advertises it, "
+                        "so the catalog will grey the app out (server/config/tasks.yml)")
+    for scope in m.requires_scopes:
+        if not _SCOPE_RE.match(scope):
+            report.error(f"requires_scopes {scope!r} must look like 'events:<domain>.<event>'")
+    if m.subscribes is not None and not re.match(r"^[A-Za-z0-9_.*>-]+$", m.subscribes):
+        report.error(f"subscribes {m.subscribes!r} is not a NATS subject pattern")
+
+    seen: set[str] = set()
+    for p in m.params:
+        _check_param(p, seen, report)
+    names = [a.name for a in m.emits]
+    for name in names:
+        if names.count(name) > 1:
+            report.error(f"emits: alert type {name!r} declared twice")
+        if not re.match(r"^[a-z0-9_-]+$", name or ""):
+            report.error(f"emits: alert type name {name!r} — use lowercase letters, digits, _ or -")
+    for a in m.emits:
+        if a.severity not in SEVERITIES:
+            report.error(f"emits[{a.name}].severity {a.severity!r} must be one of {sorted(SEVERITIES)}")
+    action_names = [a.name for a in m.actions]
+    for name in action_names:
+        if action_names.count(name) > 1:
+            report.error(f"actions: {name!r} declared twice")
+    view_names = [getattr(v, "name", None) or getattr(v, "title", "") for v in m.state_schema]
+    for name in view_names:
+        if name and view_names.count(name) > 1:
+            report.warn(f"state_schema: two views named {name!r}")
+
+    if m.pricing not in PRICING_MODELS:
+        report.error(f"pricing {m.pricing!r} must be one of {sorted(PRICING_MODELS)}")
+    if m.entitlement not in ENTITLEMENT_MODES:
+        report.error(f"entitlement {m.entitlement!r} must be one of {sorted(ENTITLEMENT_MODES)}")
+    if m.pricing != "free" and not (m.price_note or "").strip():
+        report.warn("pricing is not 'free' but price_note is empty — say what it costs")
+    if m.pricing != "free" and m.entitlement == "none":
+        report.warn("a paid app with entitlement='none' can be enabled without a licence — "
+                    "declare entitlement='license_key' and implement verify_license if you gate it")
+    if m.entitlement == "license_key" and cls is not None:
+        impl = getattr(cls, "verify_license", None)
+        base = None
+        for parent in cls.__mro__[1:]:
+            if hasattr(parent, "verify_license"):
+                base = getattr(parent, "verify_license")
+                break
+        if impl is None or impl is base:
+            report.error("entitlement='license_key' but the app does not override verify_license() — "
+                         "core will never accept a key")
+    if m.ui_mode == "external" and not (m.ui_url or "").startswith(("http://", "https://")):
+        report.error("ui_mode='external' needs an http(s) ui_url ('{host}' is substituted)")
+    if m.has_ui and cls is not None and m.ui_mode == "internal":
+        if not any(hasattr(parent, "render_ui") or hasattr(parent, "ui_html") for parent in cls.__mro__):
+            report.note("has_ui=True: make sure the contract server serves GET /ui")
+
+
+def _check_param(p: Param, seen: set[str], report: Report) -> None:
+    if not re.match(r"^[a-z][a-z0-9_]*$", p.name or ""):
+        report.error(f"params: name {p.name!r} — use snake_case")
+    if p.name in seen:
+        report.error(f"params: {p.name!r} declared twice")
+    seen.add(p.name)
+    type_name = p.type.__name__ if isinstance(p.type, type) else str(p.type)
+    if type_name not in KNOWN_PARAM_TYPES:
+        report.warn(f"params[{p.name}].type {type_name!r} is not one the catalog form renders "
+                    f"({', '.join(sorted(KNOWN_PARAM_TYPES))}) — it falls back to a JSON box")
+    if p.default is not None and type_name in _PY_TYPES:
+        expected = _PY_TYPES[type_name]
+        bad = (type_name in ("int", "float") and isinstance(p.default, bool)) \
+            or not isinstance(p.default, expected)
+        if bad:
+            report.error(f"params[{p.name}].default {p.default!r} is not a {type_name}")
+    if type_name == "geometry.polygon" and p.default not in (None, []) and not isinstance(p.default, list):
+        report.error(f"params[{p.name}] geometry.polygon default must be a list of points or []")
+    if p.required and p.default is not None:
+        report.warn(f"params[{p.name}] is required but has a default — one of the two is redundant")
+    if p.suggestions and not all(isinstance(s, str) for s in p.suggestions):
+        report.error(f"params[{p.name}].suggestions must be strings")
+    if p.per_camera and type_name not in ("geometry.polygon", "geometry.tripwire", "list", "dict",
+                                          "time_range", "json", "str", "int", "float", "bool"):
+        report.warn(f"params[{p.name}] per_camera with type {type_name!r} — the per-camera editor may not render it")
+
+
+def check_config(app_dir: Path, module: Any, report: Report) -> None:
+    example = app_dir / "config.example.yml"
+    if not example.exists():
+        report.warn("no config.example.yml — operators and the Docker template need one")
+        return
+    from .config import BaseAppConfig, load_app_config
+
+    cfg_cls = getattr(module, "AppConfig", None)
+    if not (isinstance(cfg_cls, type) and issubclass(cfg_cls, BaseAppConfig)):
+        loader = getattr(module, "load_config", None)
+        if callable(loader):
+            try:
+                loader(example)
+                report.note("config.example.yml loads through load_config()")
+            except Exception as exc:  # noqa: BLE001
+                report.error(f"config.example.yml does not load through load_config(): {exc}")
+            return
+        report.note("no AppConfig(BaseAppConfig) in the module — config.example.yml checked for base keys only")
+        cfg_cls = BaseAppConfig
+    try:
+        load_app_config(example, cfg_cls)
+        report.note(f"config.example.yml loads as {cfg_cls.__name__}")
+    except Exception as exc:  # noqa: BLE001
+        report.error(f"config.example.yml does not load as {cfg_cls.__name__}: {exc}")
+
+
+def check_listing(app_dir: Path, m: AppManifest, report: Report) -> None:
+    path = app_dir / "apps-index-entry.yml"
+    if not path.exists():
+        report.note("no apps-index-entry.yml — the listing is checked only when it lives with the app")
+        return
+    import yaml
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        report.error(f"apps-index-entry.yml is not valid YAML: {exc}")
+        return
+    entry = raw[0] if isinstance(raw, list) and raw else raw
+    if not isinstance(entry, dict):
+        report.error("apps-index-entry.yml must hold one mapping (or a one-item list)")
+        return
+    for key, want in (("id", m.id), ("name", m.name), ("version", str(m.version))):
+        if str(entry.get(key, "")) != str(want):
+            report.error(f"listing.{key} {entry.get(key)!r} != manifest.{key} {want!r}")
+    if sorted(entry.get("requires_tasks") or []) != sorted(m.requires_tasks):
+        report.error(f"listing.requires_tasks {entry.get('requires_tasks')!r} != manifest {m.requires_tasks!r}")
+    emits = sorted(a.name for a in m.emits)
+    if sorted(entry.get("emits") or []) != emits:
+        report.error(f"listing.emits {entry.get('emits')!r} != manifest alert types {emits!r}")
+    if entry.get("kind", "installable") == "installable":
+        for key in ("author", "contact"):
+            if not str(entry.get(key) or "").strip() or "example.com" in str(entry.get(key)) \
+                    or str(entry.get(key)).startswith("Your "):
+                report.error(f"listing.{key} is missing or still the placeholder")
+        source = str(entry.get("source") or "")
+        if not source.startswith("https://github.com/open-nvr/"):
+            report.warn(f"listing.source {source!r} is not a repository under the open-nvr organisation — "
+                        "catalog apps live there (docs/CONTRIBUTING_APPS.md)")
+        if entry.get("network_egress") is None:
+            report.error("listing.network_egress is required ([] if the app never leaves the site)")
+        image = str(entry.get("image") or "")
+        if image and not image.startswith(f"ghcr.io/open-nvr/{m.id}"):
+            report.warn(f"listing.image {image!r} is not ghcr.io/open-nvr/{m.id} — the org's CI publishes there")
+        if not entry.get("image_digest"):
+            report.note("listing.image_digest not set yet — take it from the publish workflow's summary")
+        if str(entry.get("summary") or "").startswith("What "):
+            report.warn("listing.summary is still the scaffold placeholder")
+    report.note("apps-index-entry.yml mirrors the manifest")
+
+
+def check_repository(app_dir: Path, report: Report) -> None:
+    if not (app_dir / "Dockerfile").exists():
+        report.warn("no Dockerfile — the catalog builds one from source")
+    if not any((app_dir / "tests").glob("test_*.py")) if (app_dir / "tests").is_dir() else True:
+        report.warn("no tests/test_*.py — a listing review expects a green test suite")
+    if (app_dir / ".github" / "workflows").is_dir() and not any(
+            p.name in ("LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING") for p in app_dir.iterdir()):
+        report.warn("no LICENSE file — add AGPL-3.0 or Apache-2.0 (your copyright) before the first tag")
+
+
+# ── entry point ─────────────────────────────────────────────────────
+
+
+def validate_app(app_dir: Path) -> Report:
+    report = Report()
+    app_dir = app_dir.resolve()
+    if not app_dir.is_dir():
+        report.error(f"{app_dir} is not a directory")
+        return report
+    module_name = find_app_module(app_dir)
+    if module_name is None:
+        report.error("no app module found — expected a [project.scripts] entry in pyproject.toml "
+                     "or a top-level *.py that builds an AppManifest")
+        return report
+    report.module_name = module_name
+    try:
+        manifest, module = load_manifest(app_dir, module_name)
+    except Exception as exc:  # noqa: BLE001
+        report.error(f"importing {module_name!r} failed: {exc.__class__.__name__}: {exc}")
+        return report
+    if manifest is None:
+        report.error(f"module {module_name!r} defines no AppManifest (module-level or on the app class)")
+        return report
+    report.manifest = manifest
+    cls = app_class(module, manifest)
+    check_manifest(manifest, report, cls)
+    check_config(app_dir, module, report)
+    check_listing(app_dir, manifest, report)
+    check_repository(app_dir, report)
+    return report
+
+
+def print_report(report: Report, app_dir: Path) -> None:
+    m = report.manifest
+    head = f"{m.id} {m.version} ({m.category})" if m else str(app_dir)
+    print(f"opennvr-app validate — {head}")
+    for line in report.notes:
+        print(f"  · {line}")
+    for line in report.warnings:
+        print(f"  ! {line}")
+    for line in report.errors:
+        print(f"  ✗ {line}")
+    if report.ok:
+        print(f"OK — {len(report.warnings)} warning(s)")
+    else:
+        print(f"FAILED — {len(report.errors)} error(s), {len(report.warnings)} warning(s)")

--- a/sdk/opennvr-app-sdk/tests/test_aio.py
+++ b/sdk/opennvr-app-sdk/tests/test_aio.py
@@ -188,7 +188,7 @@ def test_requires_a_url(monkeypatch):
 ])
 def test_async_surface_mirrors_sync(sync_cls, async_cls):
     renamed = {"close": "aclose", "__enter__": "__aenter__", "__exit__": "__aexit__"}
-    not_ported = {"stream"}       # blocking WebSocket session — documented
+    not_ported: set[str] = set()  # everything has its twin, stream() included
     for name, member in inspect.getmembers(sync_cls, inspect.isfunction):
         if name.startswith("_") and name not in renamed or name in not_ported:
             continue
@@ -199,3 +199,73 @@ def test_async_surface_mirrors_sync(sync_cls, async_cls):
         sp = list(inspect.signature(member).parameters)
         ap = list(inspect.signature(getattr(async_cls, twin)).parameters)
         assert sp == ap, f"{sync_cls.__name__}.{name}{sp} != {async_cls.__name__}.{twin}{ap}"
+
+
+# ── ai.stream(): the async WebSocket session ───────────────────────────
+
+
+class _AsyncConn:
+    def __init__(self, replies):
+        self.sent, self.replies, self.closed = [], list(replies), False
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def recv(self):
+        r = self.replies.pop(0)
+        if isinstance(r, Exception):
+            raise r
+        return r
+
+    async def close(self):
+        self.closed = True
+
+
+def test_async_infer_stream_handshake_frames_and_teardown():
+    from opennvr_app_sdk.infer_stream import AsyncInferStream
+    from opennvr_app_sdk import KaiCError
+    conns = []
+
+    async def factory(url, headers):
+        assert url == "ws://kaic:8100/api/v1/infer/yolov8/stream"
+        assert ("X-Internal-Api-Key", "k") in headers
+        c = _AsyncConn([json.dumps({"type": "handshake_ack"}),
+                        json.dumps({"type": "result", "inference_ms": 7,
+                                    "result": {"detections": [{"label": "person"}]}}),
+                        ConnectionError("gone")])
+        conns.append(c)
+        return c
+
+    async def run():
+        s = AsyncInferStream("http://kaic:8100", "k", adapter="yolov8", camera_id="cam1",
+                             websocket_factory=factory)
+        async with s:
+            out = await s.infer(b"\xff\xd8")
+            assert out["result"]["detections"][0]["label"] == "person"
+            assert out["inference_ms"] == 7 and out["correlation_id"] == s.correlation_id
+            hdr = json.loads(conns[0].sent[1])
+            assert hdr["type"] == "frame" and hdr["seq"] == 1 and conns[0].sent[2] == b"\xff\xd8"
+            assert json.loads(conns[0].sent[0])["camera_id"] == "cam1"
+            with pytest.raises(KaiCError):
+                await s.infer(b"\xff\xd8")
+            assert conns[0].closed
+        assert len(conns) == 1
+
+        bad = AsyncInferStream("https://kaic", None, adapter="x", camera_id="c",
+                               websocket_factory=lambda u, h: _ret(_AsyncConn([json.dumps({"type": "error"})])))
+        assert bad.url == "wss://kaic/api/v1/infer/x/stream"
+        with pytest.raises(KaiCError):
+            await bad.open()
+        # Through the client: the session carries the client's identity.
+        nvr = AsyncOpenNVR("http://core", token="oak_x_" + "0" * 32, kaic_url="http://kaic:8100",
+                           kaic_api_key="k", client_id="gate-cam")
+        sess = nvr.ai.stream("yolov8", camera_id="cam9")
+        assert isinstance(sess, AsyncInferStream) and sess._client_id == "gate-cam"
+        await nvr.aclose()
+
+    asyncio.run(run())
+
+
+async def _ret(value):
+    return value
+

--- a/sdk/opennvr-app-sdk/tests/test_event_types.py
+++ b/sdk/opennvr-app-sdk/tests/test_event_types.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""Typed domain-event payloads (event_types) and their seats on
+DomainEvent.typed() and DomainEventPublisher.publish_typed()."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from opennvr_app_sdk import (
+    EVENT_TYPES, AccessDecided, DetectionObserved, OccupancyChanged, OccupancyFootfall,
+    OccupancyHeatmap, PlateRecognized, VisitRecorded, typed_payload,
+)
+from opennvr_app_sdk.domain_events import DomainEventPublisher
+from opennvr_app_sdk.domain_subscriber import parse_domain_event
+
+
+def test_every_v1_contract_is_typed_and_round_trips():
+    samples = {
+        DetectionObserved: {"frame": {"w": 1280, "h": 720}, "calibrating": False,
+                            "tracks": [{"id": "t1", "label": "person", "conf": 0.9, "bbox": [1, 2, 3, 4]}]},
+        VisitRecorded: {"event_id": 9, "label": "car", "started_at": "2026-09-06T10:00:00Z",
+                        "ended_at": "2026-09-06T10:01:00Z", "evidence_path": None},
+        PlateRecognized: {"plate_text": "R197GB", "confidence": 0.93, "vehicle_label": "car",
+                          "event_id": 9, "plate_box": [10, 10, 80, 30], "plate_box_confidence": 0.88,
+                          "plate_box_image": [320, 120]},
+        AccessDecided: {"plate_text": "R197GB", "decision": "allow", "reason": "registered",
+                        "owner": "Flat 3", "unit": "3", "confidence": 0.93},
+        OccupancyChanged: {"count": 4, "level": "over", "max_occupancy": 3, "min_occupancy": None},
+        OccupancyHeatmap: {"cols": 16, "rows": 9, "cells": [[17, 3], [18, 1]], "frames": 40,
+                           "period_seconds": 60, "labels": ["person"]},
+        OccupancyFootfall: {"entries": 3, "exits": 1, "dwell_count": 2, "dwell_seconds": 41.5,
+                            "dwell_max_seconds": 30.0, "period_seconds": 60, "labels": ["person"]},
+    }
+    assert set(EVENT_TYPES) == {c.SCHEMA for c in samples}
+    for cls, payload in samples.items():
+        obj = cls.from_payload(payload)
+        assert isinstance(obj, cls) and obj.extra == {}
+        assert obj.to_payload() == payload                       # exact round trip
+        assert typed_payload(cls.SCHEMA, payload) == obj
+
+
+def test_additive_fields_survive_and_required_fields_are_enforced(caplog):
+    p = PlateRecognized.from_payload({"plate_text": "X", "lane": 2})
+    assert p.extra == {"lane": 2} and p.to_payload() == {
+        "plate_text": "X", "confidence": None, "vehicle_label": None, "event_id": None, "lane": 2}
+    with pytest.raises(ValueError, match="missing required"):
+        PlateRecognized.from_payload({"confidence": 0.9})
+    with pytest.raises(ValueError, match="payload must be an object"):
+        AccessDecided.from_payload(["allow"])                     # type: ignore[arg-type]
+    assert typed_payload("plate.recognized.v1", {}) is None       # logged, not raised
+    assert "off-contract" in caplog.text
+    assert typed_payload("something.new.v1", {"x": 1}) is None    # not typed by this SDK
+    # extra never overrides a contract field on the way out
+    q = PlateRecognized("Y", extra={"plate_text": "Z"})
+    assert q.to_payload()["plate_text"] == "Y"
+
+
+def test_access_decisions_fail_closed_on_unknown_values():
+    assert AccessDecided("X", "allow", "registered").allow
+    assert not AccessDecided("X", "deny", "unknown").allow
+    weird = AccessDecided.from_payload({"plate_text": "X", "decision": "escalate", "reason": "new-policy"})
+    assert not weird.allow and weird.decision == "escalate"       # parsed, not actuated
+    assert OccupancyChanged.from_payload({"count": 1, "level": "critical"}).level == "critical"
+
+
+def test_domain_event_typed_and_publish_typed():
+    raw = json.dumps({"id": "e1", "schema": "access.decided.v1", "camera_id": "gate",
+                      "ts": "2026-09-06T10:00:00Z", "producer": "lpr",
+                      "payload": {"plate_text": "X", "decision": "allow", "reason": "registered"}})
+    ev = parse_domain_event(raw, subject="s")
+    assert ev.typed() == AccessDecided("X", "allow", "registered")
+    off = parse_domain_event(json.dumps({"schema": "access.decided.v1", "camera_id": "g", "payload": {}}))
+    assert off.typed() is None
+    unknown = parse_domain_event(json.dumps({"schema": "x.y.v1", "camera_id": "g", "payload": {"a": 1}}))
+    assert unknown.typed() is None and unknown.payload == {"a": 1}
+
+    sent = []
+
+    class _Chan:
+        def publish_json(self, subject, envelope):
+            sent.append((subject, envelope))
+            return True
+
+        def close(self):
+            pass
+
+    pub = DomainEventPublisher("nats://x", producer="app:test")
+    pub._channel = _Chan()
+    assert pub.publish_typed(OccupancyChanged(count=2, level="normal"), camera_id="lobby")
+    subject, env = sent[0]
+    assert subject == "opennvr.events.occupancy.changed.v1.lobby"
+    assert env["schema"] == "occupancy.changed.v1" and env["producer"] == "app:test"
+    assert env["payload"] == {"count": 2, "level": "normal", "max_occupancy": None, "min_occupancy": None}
+    with pytest.raises(TypeError):
+        pub.publish_typed({"count": 2}, camera_id="lobby")      # a dict is not typed

--- a/sdk/opennvr-app-sdk/tests/test_testing_helpers.py
+++ b/sdk/opennvr-app-sdk/tests/test_testing_helpers.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""opennvr_app_sdk.testing — the helpers app test suites build on."""
+from __future__ import annotations
+
+import pytest
+
+from opennvr_app_sdk import (
+    Alert, AlertType, AppManifest, Detector, DomainEventSubscriber, OpenNVR, PlateRecognized,
+    tier0_to_detections,
+)
+from opennvr_app_sdk.testing import (
+    FakeCore, RecorderChannel, app_config, detection, domain_event, feed, inference_event,
+    tier0_event, tier0_track,
+)
+
+pytest_plugins = ["opennvr_app_sdk.testing.pytest_plugin"]
+
+
+class _PersonWatch(Detector):
+    manifest = AppManifest(id="person-watch", name="Person Watch", version="1.0.0",
+                           category="analytics", emits=[AlertType("person_seen")])
+
+    def on_detections(self, camera_id, detections, event):
+        return [Alert(title=f"{d['label']} seen", description="", camera_id=camera_id)
+                for d in detections if d["label"] in self.cfg.watch_labels]
+
+
+def test_detector_through_the_helpers():
+    rec = RecorderChannel()
+    app = _PersonWatch(app_config(watch_labels=["person"]), rec.dispatcher())
+    fired = feed(app,
+                 inference_event(detection("person"), detection("bike"), camera_id="yard"),
+                 inference_event(detection("car")),
+                 b"{not json")
+    assert [a.title for a in fired] == ["person seen"] and fired[0].camera_id == "yard"
+    assert rec.alerts == fired and rec.titles == ["person seen"]
+    rec.clear()
+    assert rec.alerts == []
+
+
+def test_builders_have_the_contract_shapes():
+    ev = inference_event(detection("person", x=0.5, y=0.6, track_id=7, confidence=0.7))
+    assert ev["result"]["detections"][0] == {"label": "person", "confidence": 0.7,
+                                             "bbox": {"x": 0.5, "y": 0.6, "w": 0.1, "h": 0.1},
+                                             "track_id": 7}
+    assert ev["camera_id"] == "cam-1" and ev["adapter"] == "yolov8" and ev["completed_at"].endswith("Z")
+    t0 = tier0_event(tier0_track("car", bbox=(0, 0, 640, 360)), camera_id="gate")
+    dets = tier0_to_detections(t0)
+    assert dets[0]["label"] == "car" and dets[0]["bbox"] == {"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}
+    env = domain_event("", PlateRecognized("R197GB", confidence=0.9), camera_id="gate", producer="lpr")
+    assert env["schema"] == "plate.recognized.v1" and env["payload"]["plate_text"] == "R197GB"
+    assert env["camera_id"] == "gate" and env["producer"] == "lpr" and env["id"].startswith("evt_")
+    env2 = domain_event("custom.thing.v1", {"a": 1})
+    assert env2["schema"] == "custom.thing.v1" and env2["payload"] == {"a": 1}
+
+
+class _Gate(DomainEventSubscriber):
+    manifest = AppManifest(id="gate", name="Gate", version="1.0.0", category="vehicle")
+    subscriptions = ["plate.recognized.v1"]
+
+    def on_event(self, event):
+        plate = event.typed()
+        if plate is not None:
+            self.fire(Alert(title=f"plate {plate.plate_text}", description="", camera_id=event.camera_id))
+
+
+def test_domain_subscriber_through_the_helpers(recorder, app_config_factory):
+    app = _Gate(app_config_factory(), dispatcher=recorder.dispatcher())
+    feed(app, domain_event("", PlateRecognized("AB12CD"), camera_id="gate"), subject="s")
+    assert recorder.titles == ["plate AB12CD"]
+
+
+def test_fake_core_serves_the_platform_client(fake_core):
+    fake_core.cameras = [FakeCore._camera({"name": "Gate", "assignments": [{"skill": "lpr"}]}, 1),
+                         FakeCore._camera({"name": "Yard"}, 2)]
+    fake_core.snapshots["cam1"] = b"\xff\xd8jpeg"
+    nvr = OpenNVR(fake_core.url, token="oak_test-app_" + "0" * 32)
+    cams = nvr.cameras()
+    assert [c.name for c in cams] == ["Gate", "Yard"]
+    assert nvr.snapshot(cams[0]) == b"\xff\xd8jpeg" and nvr.snapshot(cams[1]) is None
+    nvr.state.set("seen", {"n": 3})
+    assert fake_core.state == {"seen": {"n": 3}}
+    assert nvr.state.get("seen") == {"n": 3} and nvr.state.get("nope", 0) == 0
+    assert nvr.state.items() == {"seen": {"n": 3}}
+    assert nvr.state.delete("seen") is True and nvr.state.delete("seen") is False
+    assert fake_core.requests[0]["path"] == "/api/v1/internal/camera-agent/cameras"
+    assert fake_core.requests[0]["key"].startswith("oak_")
+
+
+def test_fake_core_context_manager_and_register():
+    import json
+    import urllib.request
+
+    with FakeCore() as core:
+        req = urllib.request.Request(core.url + "/api/v1/apps/register", method="POST",
+                                     data=json.dumps({"url": "http://a:9200", "manifest": {"id": "a"},
+                                                      "wants_key": True}).encode(),
+                                     headers={"Content-Type": "application/json"})
+        body = json.loads(urllib.request.urlopen(req, timeout=5).read())
+        assert body["api_key"] == core.app_key and body["registry"]["api_version"] == "1.4"
+        assert core.registrations[0]["manifest"] == {"id": "a"}

--- a/sdk/opennvr-app-sdk/tests/test_validate.py
+++ b/sdk/opennvr-app-sdk/tests/test_validate.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""``opennvr-app validate`` — the manifest, config, listing and repository checks."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from opennvr_app_sdk import Action, AlertType, AppManifest, Param, scaffold
+from opennvr_app_sdk.validate import Report, check_manifest, find_app_module, validate_app
+
+
+def _report(**kw) -> Report:
+    base = dict(id="gate-watch", name="Gate Watch", version="1.0.0", category="perimeter",
+                summary="Watches gates.", requires_tasks=["object_detection"],
+                emits=[AlertType("gate_watch")])
+    cls = kw.pop("_cls", None)
+    base.update(kw)
+    r = Report()
+    check_manifest(AppManifest(**base), r, cls)
+    return r
+
+
+def test_manifest_checks():
+    assert _report().ok and _report().warnings == []
+    assert any("kebab" in e for e in _report(id="Gate_Watch").errors)
+    assert any("semantic" in e for e in _report(version="1.0").errors)
+    assert any("category" in w for w in _report(category="misc").warnings)
+    assert any("canonical task" in w for w in _report(requires_tasks=["mind_reading"]).warnings)
+    assert any("requires_scopes" in e for e in _report(requires_scopes=["plates"]).errors)
+    assert any("declared twice" in e for e in _report(emits=[AlertType("a"), AlertType("a")]).errors)
+    assert any("severity" in e for e in _report(emits=[AlertType("a", severity="loud")]).errors)
+    assert any("price_note" in w for w in _report(pricing="paid").warnings)
+    assert any("entitlement='none'" in w for w in _report(pricing="paid", price_note="$1").warnings)
+    assert any("declared twice" in e for e in _report(actions=[Action("go", "Go"), Action("go", "Go")]).errors)
+    assert any("ui_url" in e for e in _report(has_ui=True, ui_mode="external", ui_url="http://{host}:1/").errors) is False
+
+
+def test_param_checks():
+    ok = _report(params=[Param("watch_labels", list, default=["person"], suggestions=["car"]),
+                         Param("zone", "geometry.polygon", default=[], per_camera=True),
+                         Param("dwell_s", float, default=30)])
+    assert ok.ok and ok.warnings == []
+    r = _report(params=[Param("Watch", str), Param("dwell_s", int, default=True),
+                        Param("dwell_s", int), Param("odd", "colour"),
+                        Param("must", str, required=True, default="x"),
+                        Param("labels", list, suggestions=[1])])
+    errs = "\n".join(r.errors)
+    assert "snake_case" in errs and "not a int" in errs and "declared twice" in errs
+    assert "suggestions must be strings" in errs
+    warns = "\n".join(r.warnings)
+    assert "'colour'" in warns and "redundant" in warns
+
+
+def test_license_hook_must_be_overridden():
+    from opennvr_app_sdk import Detector
+
+    class Paid(Detector):
+        pass
+
+    class PaidRight(Detector):
+        def verify_license(self, key):  # noqa: ARG002
+            return None
+
+    assert any("verify_license" in e
+               for e in _report(pricing="paid", price_note="$1", entitlement="license_key", _cls=Paid).errors)
+    assert _report(pricing="paid", price_note="$1", entitlement="license_key", _cls=PaidRight).ok
+
+
+def test_validate_a_scaffolded_app(tmp_path: Path, capsys):
+    app_dir = scaffold.generate("gate-watch", "object_detection", tmp_path, repo=True)
+    assert find_app_module(app_dir) == "gate_watch"
+    report = validate_app(app_dir)
+    assert report.manifest is not None and report.manifest.id == "gate-watch"
+    # The scaffold is valid except for the listing placeholders the author must fill.
+    assert [e for e in report.errors if "placeholder" not in e] == [], report.errors
+    assert any("listing.author" in e for e in report.errors)
+    assert any("no LICENSE" in w for w in report.warnings)
+    assert any("config.example.yml loads" in n for n in report.notes)
+    # Fill the placeholders → clean.
+    entry = (app_dir / "apps-index-entry.yml").read_text()
+    entry = entry.replace('"Your Name"', '"Ada"').replace('"you@example.com"', '"ada@arkade.ai"') \
+                 .replace('"What Gate Watch does, in one operator-facing sentence."', '"Watches gates."')
+    (app_dir / "apps-index-entry.yml").write_text(entry)
+    (app_dir / "LICENSE").write_text("Apache-2.0")
+    report = validate_app(app_dir)
+    assert report.ok and report.warnings == [], (report.errors, report.warnings)
+    # A drifted listing is caught.
+    (app_dir / "apps-index-entry.yml").write_text(entry.replace('version: "0.1.0"', 'version: "9.9.9"')
+                                                  .replace("emits: [gate-watch]", "emits: [other]"))
+    report = validate_app(app_dir)
+    assert any("listing.version" in e for e in report.errors) and any("listing.emits" in e for e in report.errors)
+    # The CLI.
+    assert scaffold.main(["validate", str(app_dir)]) == 1
+    out = capsys.readouterr().out
+    assert "FAILED" in out and "listing.version" in out
+    assert scaffold.main(["validate", str(tmp_path / "nowhere")]) == 1
+
+
+def test_validate_without_a_module(tmp_path: Path):
+    (tmp_path / "README.md").write_text("nothing here")
+    report = validate_app(tmp_path)
+    assert not report.ok and "no app module" in report.errors[0]


### PR DESCRIPTION
…r-app validate`, async ai.stream()

On main, unreleased: no SDK tag until QA signs off 0.5.0.

* opennvr_app_sdk.testing — RecorderChannel, app_config, the detection / inference_event / tier0_event / tier0_track / domain_event builders, feed(app, *events) through the real decode → rule → dispatch path, FakeCore (a loopback core: cameras, snapshots, state, alerts, register; every request recorded), and a pytest plugin (recorder, app_config_factory, fake_core). The scaffold's smoke test uses them; the forty lines every example hand-rolled now live once, versioned with the contracts.
* event_types — the v1 domain events as frozen dataclasses (PlateRecognized, AccessDecided, OccupancyChanged, OccupancyHeatmap, OccupancyFootfall, VisitRecorded, DetectionObserved): required fields enforced, additive fields kept in .extra and round-tripped, unknown decision/level values parsed so a gate can fail closed on them. DomainEvent.typed() and DomainEventPublisher.publish_typed().
* opennvr-app validate [path] — manifest (id, version, category, params + defaults, alert types, scopes, actions, commerce, the verify_license hook), config.example.yml through the app's own AppConfig, apps-index-entry.yml against the manifest and the catalog policy, repository shape. Errors exit 1. CI runs it on every example; it found occupancy-counting's example config did not load (no opennvr_url) — fixed.
* AsyncInferStream + AsyncOpenNVR().ai.stream(): the last sync/async gap; the parity test has no exceptions left.
* ci.yml: alert-notifier and gate-controller were missing from the examples matrix — added.
* Docs: SDK_REFERENCE (testing, validate, typed events, async stream), APP_PLATFORM, EVENT_CONTRACTS, FIRST_DETECTOR, DEVELOPER_PROGRAM, ROADMAP, CHANGELOG.