### PR TITLE
docs(enterprise): the offer, the reference appliance, and a complianc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Enterprise: the offer, the appliance, the evidence pack.**
+  `docs/ENTERPRISE.md` states what an enterprise engagement includes
+  (reference-appliance deployment, the evidence pack reviewed against
+  the customer's framework, §889 via Scout, support with response
+  times, custom AI) and what it never includes. `docs/REFERENCE_APPLIANCE.md`
+  is the known-good site: three sizes with hardware, the storage
+  arithmetic, the three network segments and exposed ports, host
+  hardening, and the checklist the evidence pack scores.
+  `scripts/evidence_pack.py` generates that pack from a running
+  deployment, read-only: posture, the camera security check, recording
+  coverage against retention, adapters with fingerprints and declared
+  egress, installed apps with signer and egress, firewall rules,
+  retention, the audit log for the period — plus `EVIDENCE.md`
+  (PASS / ATTENTION / UNKNOWN per check, framework → files) and a
+  `manifest.json` of SHA-256 hashes. Stream URLs and secrets are
+  redacted; missing routes are recorded, never fatal.
+
 - **SDK toward 1.0 (on main; no tag until QA signs off 0.5.0).**
   `opennvr_app_sdk.testing` — `RecorderChannel`, `app_config`,
   `detection` / `inference_event` / `tier0_event` / `domain_event`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The architecture is published — a peer-citable paper this year, 34 references,
 
 **It runs on the hardware you already have.** If the machine it's on has a camera — a laptop webcam, a USB or Pi camera, the onboard sensor on a drone or robot — the agent can discover and use it with zero provisioning. Any device that can see a camera or a stream can run its own on-board sovereign agent.
 
-**It's built for sovereignty.** For homelab users that means the doorbell that doesn't phone home. For defence, critical infrastructure, healthcare, and government deployments it means tactical AI that runs on your hardware under your control — models you've fine-tuned, models you can't share with a vendor, analytics whose detection logic itself is operationally sensitive. The procurement brief is in [`docs/GOVERNMENT_DEPLOYMENT.md`](docs/GOVERNMENT_DEPLOYMENT.md).
+**It's built for sovereignty.** For homelab users that means the doorbell that doesn't phone home. For defence, critical infrastructure, healthcare, and government deployments it means tactical AI that runs on your hardware under your control — models you've fine-tuned, models you can't share with a vendor, analytics whose detection logic itself is operationally sensitive. The procurement brief is in [`docs/GOVERNMENT_DEPLOYMENT.md`](docs/GOVERNMENT_DEPLOYMENT.md); the enterprise offer — reference appliance, compliance evidence pack, supported deployment — in [`docs/ENTERPRISE.md`](docs/ENTERPRISE.md).
 
 ## How it compares
 
@@ -329,7 +329,7 @@ Commercial deployments — deployment assistance, NDA adapter authoring, complia
 
 **Getting started** — [Docker quickstart](DOCKER_QUICKSTART.md) · [User manual](USER_MANUAL.md) · [Camera assignments — give each camera a job](docs/CAMERA_ASSIGNMENTS.md) · [Local dev setup](docs/LOCAL_SETUP.md) · [Use cases by industry](docs/USE_CASES.md) · [Comparisons](docs/COMPARISONS.md)
 
-**Architecture & security** — [Security architecture](docs/SECURITY_ARCHITECTURE.md) · [Compliance mapping](docs/COMPLIANCE.md) · [Government deployment brief](docs/GOVERNMENT_DEPLOYMENT.md) · [AI Adapter Contract](docs/AI_ADAPTER_CONTRACT.md) · [Edge autonomy & robotics](docs/EDGE_AUTONOMY.md)
+**Architecture & security** — [Security architecture](docs/SECURITY_ARCHITECTURE.md) · [Compliance mapping](docs/COMPLIANCE.md) · [Enterprise](docs/ENTERPRISE.md) · [Reference appliance](docs/REFERENCE_APPLIANCE.md) · [Government deployment brief](docs/GOVERNMENT_DEPLOYMENT.md) · [AI Adapter Contract](docs/AI_ADAPTER_CONTRACT.md) · [Edge autonomy & robotics](docs/EDGE_AUTONOMY.md)
 
 **Project** — [Roadmap](docs/ROADMAP.md) · [Support](docs/SUPPORT.md) · [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md)
 

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -54,6 +54,21 @@ defending the architectural choice in a regulated procurement, see
 printable one-pager for IT decision-makers; this page is the
 implementation evidence behind it.
 
+## The evidence pack
+
+Everything on this page, as it stands on one deployment, in one zip:
+
+```
+python3 scripts/evidence_pack.py --url https://nvr.example.org --user admin --days 90
+```
+
+Posture, the camera security check, recording coverage, adapters and
+fingerprints, installed apps with their signer and egress, firewall
+rules and the audit log for the period, plus `EVIDENCE.md` (PASS /
+ATTENTION / UNKNOWN per check, framework → files) and `manifest.json`
+with the SHA-256 of every artefact. Read-only; credentials redacted.
+[ENTERPRISE.md](ENTERPRISE.md#the-evidence-pack).
+
 ## Audit-chain quick reference
 
 For an auditor asking "show me the evidence trail for an alert":

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -1,0 +1,122 @@
+# OpenNVR for the enterprise
+
+OpenNVR is free software; every capability on this page ships in
+`main` under AGPL-3.0 and runs on hardware you own. What an enterprise
+buys is not access — it is *assurance*: a deployment that is evidenced,
+supported, and defensible in front of a procurement officer, an
+auditor or a regulator. This page is the whole offer.
+
+## Who this is for
+
+Sites that cannot use the incumbents. Government, defence and critical
+infrastructure bound by FCC §889 / NDAA covered-vendor rules. Hospitals,
+utilities, ports, campuses and manufacturers whose video may not leave
+the premises, whose AI may not run on someone else's cloud, and whose
+compliance function needs evidence rather than a vendor's word. Sites
+under GDPR or India's DPDP Act that need local processing, operator-held
+keys and a record of who saw what.
+
+The platform's answer to each of those is architectural, not
+contractual: an offline-first posture that refuses cloud routes by
+default, AI sovereignty enforced at adapter registration, an
+append-only audit trail with a boot-time posture record, cameras on an
+isolated network, apps confined to an internal network with enforced
+egress, catalog images built from source and signed. The
+[security architecture](SECURITY_ARCHITECTURE.md) and the
+[compliance mapping](COMPLIANCE.md) document the controls; the
+[reference appliance](REFERENCE_APPLIANCE.md) is the shape a site
+follows to get them all; the evidence pack below proves them.
+
+## What an engagement includes
+
+**Deployment on the reference appliance.** We size the site
+(cameras, retention, AI), specify the hardware or validate yours
+against [REFERENCE_APPLIANCE.md](REFERENCE_APPLIANCE.md), install on
+your network, and hand over with the hardening checklist complete and
+the first evidence pack all-pass. Air-gapped installs are the normal
+case, not the exception — images arrive on media, signatures are
+verified offline with `INSTALLER_SIGNATURES` set knowingly, and the
+[apps-index pinning](APPS_INSTALL.md#image-signing) is done before
+the media is cut.
+
+**The compliance evidence pack.** Generated from your deployment by
+`scripts/evidence_pack.py` (below), reviewed and annotated by us
+against *your* control framework — ISO 27001, SOC 2, NIST CSF, HIPAA,
+IEC 62443, the DPDP Act — with the control-mapping spreadsheet, the
+audit-log queries and the operator runbooks an auditor asks for.
+Delivered at hand-over and on the cadence your audit cycle needs.
+
+**§889 attestation.** For procurement that must show no covered-vendor
+equipment: the platform's built-in security check flags Covered List
+cameras from the inventory; OpenNVR Scout is the formal assessment
+(OEM-rebrand resolution, CVE cross-reference, signed report) —
+[GOVERNMENT_DEPLOYMENT.md](GOVERNMENT_DEPLOYMENT.md).
+
+**Support with response times.** Named severities, defined response
+and resolution windows, a private vulnerability-disclosure path, and
+an upgrade cadence agreed with your change board: tested images on a
+schedule, release notes read for you, nothing surprising on a Friday.
+
+**Custom AI under your control.** Adapters for models you cannot
+share (built under NDA, delivered as contract-compliant containers you
+own), fine-tuning on your footage that never leaves the site, and
+apps built on the App SDK for your workflow — open source in the
+catalog if you choose, private to you if you must.
+
+**Architecture review and training.** A named reviewer signs off the
+integration with your network, identity and SIEM; a half-day operator
+track and a two-day developer track for your teams.
+
+What it never includes: a private fork, a feature only paying
+customers get, or a cloud service holding your video. Every capability
+above lands in `main`; the [support page](SUPPORT.md) says so in more
+words, and why.
+
+## The evidence pack
+
+```
+python3 scripts/evidence_pack.py --url https://nvr.example.org --user admin --days 90
+```
+
+A read-only tool that asks the deployment's own API the questions an
+auditor asks and writes the answers into one zip: posture
+(`deployment_mode`, `ai_sovereignty`, plaintext outputs), the camera
+security check (covered vendors, public IPs, plaintext streams,
+default credentials), recording coverage against the retention period,
+AI adapters with their model fingerprints and declared egress,
+installed apps with their signer and what they may reach, the firewall
+rules, and the audit log for the period — plus `EVIDENCE.md`, a
+readable report that marks each check **PASS / ATTENTION / UNKNOWN**
+and maps every framework to the files that evidence it, and
+`manifest.json` with the SHA-256 of every artefact so the pack is
+tamper-evident. Camera stream URLs are redacted of credentials before
+they are written; nothing leaves the site but the zip you carry.
+
+An all-pass pack is the hand-over criterion of an engagement and the
+monthly artefact a compliance function files. A pack with ATTENTION
+rows is a work list. Run it yourself, on any deployment, today.
+
+## How it is priced
+
+Per site, per year, sized by the appliance tier (S / M / L) and the
+support level; custom AI and Scout assessments are scoped work. There
+is no per-camera licence, no per-user seat and no charge for the
+software. Ask for a quote with the site's shape (cameras, retention,
+AI, network) and the framework you report under; a scoping call and
+an honest answer follow — including "you do not need us" when a
+community deployment will do.
+
+Contact: **[contact@opennvr.org](mailto:contact@opennvr.org)** — vendor
+onboarding paperwork, security questionnaires, MSAs and insurance
+certificates are handled through the same door
+([SUPPORT.md](SUPPORT.md#compliance-and-contracting)).
+
+## Why an open platform is the safer buy
+
+Because the alternative is trust without evidence. A closed NVR asks
+you to believe its cloud is sovereign and its firmware is clean;
+OpenNVR shows you — every line of the middleware is auditable, every
+model is fingerprinted, every app's network reach is declared,
+enforced and logged, every image is built from public source by the
+project's CI and signed. When the auditor asks "how do you know", the
+answer is a file in the evidence pack, not a slide from a vendor.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ Start here. Pick the row that matches what you're doing.
 ## Security, compliance & deployment
 - **[SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md)** — threat model + the `V-###` control matrix (code refs `See V-###` point here).
 - **[COMPLIANCE.md](COMPLIANCE.md)** — control-to-framework mapping (procurement evidence).
+- **[ENTERPRISE.md](ENTERPRISE.md)** — the enterprise offer: reference appliance deployment, the compliance evidence pack, §889, support with response times, custom AI.
+- **[REFERENCE_APPLIANCE.md](REFERENCE_APPLIANCE.md)** — the known-good site: three sizes, storage arithmetic, three network segments, host hardening, the checklist the evidence pack scores.
 - **[GOVERNMENT_DEPLOYMENT.md](GOVERNMENT_DEPLOYMENT.md)** — air-gapped / regulated deployment brief.
 - **[EDGE_AUTONOMY.md](EDGE_AUTONOMY.md)** — edge / robotics on-board agent notes.
 - **[../SECURITY.md](../SECURITY.md)** — how to report a vulnerability.

--- a/docs/REFERENCE_APPLIANCE.md
+++ b/docs/REFERENCE_APPLIANCE.md
@@ -1,0 +1,173 @@
+# Reference appliance
+
+A known-good shape for an OpenNVR site: the hardware, the network, the
+storage arithmetic and the hardening checklist an operator follows to
+get a deployment whose posture the
+[evidence pack](ENTERPRISE.md#the-evidence-pack) reports as all-pass.
+Nothing here is required — OpenNVR runs on a laptop — but a regulated
+site that follows this page can say *why* it looks the way it does, and
+a support engagement starts from it.
+
+## Three sizes
+
+| | **S — edge** | **M — site** | **L — campus** |
+|---|---|---|---|
+| Cameras (Tier-0 detection on all) | up to 8 | up to 32 | up to 96 per node |
+| CPU | 4-core ARM64 or x86-64 (Raspberry Pi 5 8 GB, Intel N100) | 8-core x86-64 with an iGPU (Intel Core i5/i7 12th gen+, AMD Ryzen 5/7) | 16-core x86-64, ECC RAM |
+| Decode | Hardware: `DETECT_HWACCEL=rpi` / `vaapi` / `qsv` | Hardware: `vaapi` / `qsv` | Hardware: `vaapi` / `qsv` / `nvidia` |
+| Inference | Tier-0 on CPU (substream, `DETECT_FPS=2`) | Tier-0 on CPU or iGPU (OpenVINO); one adapter GPU optional | NVIDIA GPU, 8 GB+ VRAM, for adapters (plates, faces, VLM) |
+| RAM | 8 GB | 32 GB | 64 GB+ |
+| System disk | 64 GB NVMe / eMMC | 256 GB NVMe | 512 GB NVMe (mirrored) |
+| Recording storage | 1–2 TB (USB/SATA SSD) | 8–16 TB (2× SATA/NVMe, mirrored) | 32 TB+ (RAID-6 / ZFS raidz2, or NAS over the storage VLAN) |
+| Network | 2× 1 GbE (camera + management) | 2× 2.5 GbE or 1× 10 GbE + 1 GbE | 2× 10 GbE (camera + management), 10 GbE storage |
+| Power | 15–25 W | 45–90 W | 200–400 W (GPU) |
+
+The numbers are for Tier-0 detection on every camera at 2 fps on the
+substream — the default, CPU-honest configuration
+([DETECT_CPU.md](DETECT_CPU.md)). Raising `DETECT_FPS`, analysing main
+streams, or adding face/plate/VLM adapters moves a site up a size.
+Decode dominates: an iGPU or a hardware decoder is worth more than
+extra cores.
+
+## Storage arithmetic
+
+Recording is continuous by default (one segment per hour,
+`RECORDING_SEGMENT_SECONDS=3600`). Per camera:
+
+```
+GB per day  ≈  bitrate (Mbit/s) × 10.8
+```
+
+| Stream | Typical bitrate | GB / day | 30 days | 90 days |
+|---|---|---|---|---|
+| 1080p H.264 | 4 Mbit/s | 43 | 1.3 TB | 3.9 TB |
+| 1080p H.265 | 2 Mbit/s | 22 | 0.65 TB | 1.9 TB |
+| 4K H.265 | 8 Mbit/s | 86 | 2.6 TB | 7.8 TB |
+
+Multiply by cameras, add 15 % for filesystem overhead and evidence
+stills, and size to the **retention the policy requires**, not to the
+disk you have — the retention setting (Settings → Storage,
+`retention_days`) is the control an auditor reads.
+Prefer H.265 on the camera; it halves everything above. Keep
+recordings on their own filesystem (`RECORDINGS_PATH`) so a full disk
+never stops the database or the audit log.
+
+## Network: three segments
+
+The [security architecture](SECURITY_ARCHITECTURE.md#3-the-three-tier-architecture-in-code)
+is a three-tier model; the appliance realises it with three VLANs on a
+dual-homed host.
+
+```
+   cameras ──── VLAN 10 (camera LAN, RFC1918, NO gateway, no DNS) ──── NIC 1
+                                                                        │
+                                                          ┌─────────────┴─────────────┐
+                                                          │  appliance                │
+                                                          │  MediaMTX ingress (RTSP)  │
+                                                          │  core · Tier-0 · KAI-C    │
+                                                          │  nats · nats-apps · apps  │
+                                                          │  nginx :443 · WebRTC UDP  │
+                                                          └─────────────┬─────────────┘
+                                                                        │
+   operators / SIEM / NAS ── VLAN 20 (management), VLAN 30 (storage) ── NIC 2
+```
+
+* **Camera VLAN**: cameras and NIC 1 only. No default gateway, no route
+  to the internet, no public DNS. Cameras authenticate to the appliance
+  and to nothing else. `CAMERA_NETWORK_INTERFACE` names this NIC.
+* **Management VLAN**: where operators browse to `https://<appliance>`
+  (nginx, self-signed or your CA), where the SIEM subscribes to
+  `opennvr.audit.*`, where a VPN concentrator terminates for remote
+  operators. `NGINX_BIND_HOST` pins the UI to this NIC; WebRTC media
+  (`WEBRTC_ICE_PORT`, UDP 8189) is published on the same NIC.
+* **Storage VLAN** (M/L): NAS traffic, backups. Optional; on S it is
+  the management VLAN.
+* **Internet**: none by default. `DEPLOYMENT_MODE=offline` refuses
+  every cloud route; `AI_SOVEREIGNTY=local_only` refuses adapters that
+  declare egress; apps live on an internal Docker network and reach
+  only the hosts their listing declared or the operator allowed
+  ([APP_NETWORK.md](APP_NETWORK.md)). Updates arrive as pulled images
+  through the management VLAN's egress proxy, or by sneakernet.
+
+Ports the appliance exposes, and to whom:
+
+| Port | Service | Segment |
+|---|---|---|
+| 443/tcp | nginx — UI, API, HLS, WebRTC signalling, playback | management |
+| 8189/udp+tcp | WebRTC media (DTLS-SRTP) | management |
+| 8322/tcp | RTSPS re-stream (VLC / downstream recorders) | loopback by default; management if published |
+| 554/tcp (inbound to cameras) | RTSP from cameras | camera VLAN only |
+| 8000, 8100, 4222, 3128, … | core, KAI-C, NATS, egress proxy | Docker bridge only — never published |
+
+## Host
+
+* Linux LTS — Ubuntu 24.04 LTS or Debian 12; Raspberry Pi OS (64-bit)
+  on S. Unattended security updates on; kernel from the distribution.
+* Docker Engine from Docker's repository (not a snap), Compose v2.
+  The compose project runs as the distribution's `docker` group; no
+  container is privileged except the opt-in one-click installer,
+  which is off unless `APPS_INSTALL_ENABLED=true`.
+* Time: `chrony` against an internal NTP source (the audit log's
+  timestamps are evidence).
+* Disk encryption (LUKS) on the system and recording volumes where
+  the site policy asks for encryption at rest; the key held by the
+  operator, entered at boot or via TPM.
+* Firewall on the host (`nftables`/`ufw`): default deny inbound; allow
+  443 and 8189 from the management VLAN, 8322 if published; nothing
+  from the camera VLAN except established RTSP replies.
+* Secrets in `.env` only, generated by `make secrets`; the boot
+  validator refuses placeholders. Back `.env` up to the site's secrets
+  store — losing `CREDENTIAL_ENCRYPTION_KEY` loses the camera
+  credentials.
+
+## Hardening checklist
+
+What `scripts/evidence_pack.py` reports as PASS when all of it holds.
+
+- [ ] `DEPLOYMENT_MODE=offline`, `AI_SOVEREIGNTY=local_only`,
+      `MEDIAMTX_ALLOW_PLAINTEXT_OUTPUTS` unset (the defaults).
+- [ ] Camera VLAN has no default gateway; `CAMERA_NETWORK_INTERFACE` set.
+- [ ] Every camera on RTSPS where the camera supports it
+      (`transport_security: rtsps_required`), and on a non-default
+      username — the Compliance page's security check shows no flags.
+- [ ] No camera from an FCC Covered List vendor (the same check flags
+      them; [GOVERNMENT_DEPLOYMENT.md](GOVERNMENT_DEPLOYMENT.md) is the
+      substitution guide).
+- [ ] `NGINX_BIND_HOST` pinned to the management NIC; UI reached over
+      TLS only (your CA, or the bundled self-signed cert imported into
+      operator browsers).
+- [ ] Recording enabled on every camera that the policy says to record;
+      the retention setting equal to the policy's retention.
+- [ ] Apps: only catalog apps, digest-pinned and signed
+      (`INSTALLER_SIGNATURES=require`, the default); egress enforcement
+      on (`APPS_EGRESS_ENFORCED=true`, the default); the Network line on
+      every app card shows no refused attempts you cannot explain.
+- [ ] AI adapters: none declaring `network_egress`; every one reporting
+      a model fingerprint; adapter permissions approved by name.
+- [ ] Audit log forwarded to the SIEM (`examples/alerts-subscriber` or
+      the NATS `opennvr.audit.*` subjects); `policy.boot_posture`
+      appears at every boot.
+- [ ] Backups: the database (`opennvr_db_data`) nightly, `.env` in the
+      secrets store, recordings per the retention policy (or explicitly
+      not backed up — write it down).
+- [ ] Physical: locked rack, port security on the camera switch,
+      console access logged — the residual risks
+      [COMPLIANCE.md](COMPLIANCE.md#whats-explicitly-out-of-scope) leaves
+      with you.
+
+## Multi-site
+
+Each site is an appliance; there is no central server to own. What a
+head office gets is what the sites publish: audit events and alerts
+to a central SIEM over the management network, and evidence packs on
+a schedule. Federated live view across sites is
+`DEPLOYMENT_MODE=hybrid` territory and an explicit, audited decision
+per site.
+
+## Related
+
+[ENTERPRISE.md](ENTERPRISE.md) — what an enterprise engagement includes ·
+[SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md) — the controls
+behind every line above · [DETECT_CPU.md](DETECT_CPU.md) — sizing the
+detector · [COMPLIANCE.md](COMPLIANCE.md) — framework mapping ·
+[APP_NETWORK.md](APP_NETWORK.md) — app egress.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -295,7 +295,9 @@ to a release window. Pull requests and design discussions are welcome.
   v1 domain events as typed classes, `opennvr-app validate`, async
   `ai.stream()`.
 - **Commercial direction** (decided Sep 2026): sovereign / NDAA-restricted
-  enterprise deployments with support and compliance packs first;
+  enterprise deployments with support and compliance packs first
+  (shipped: `docs/ENTERPRISE.md`, `docs/REFERENCE_APPLIANCE.md`,
+  `scripts/evidence_pack.py`);
   OpenNVR Models (per-site fine-tuning, delivered as licensed adapters
   through the catalog) second; a paid partner tier (certification,
   hosted licence service, lead routing — paid by the vendor, never a

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -53,7 +53,9 @@ synchronous-feeling channel; maintainers watch it actively.
 
 ## Commercial support (paid)
 
-Contact: **[contact@opennvr.org](mailto:contact@opennvr.org)**
+Contact: **[contact@opennvr.org](mailto:contact@opennvr.org)** — the
+enterprise offer as a whole (appliance, evidence pack, §889, support,
+custom AI) is on one page: [ENTERPRISE.md](ENTERPRISE.md).
 
 Commercial support exists because some deployments need things community
 volunteers can't offer at scale: response-time guarantees, deployment
@@ -92,6 +94,8 @@ ISO 27001 / SOC 2 / HIPAA / FedRAMP / similar — we deliver the audit
 artefacts mapped to your specific framework, including the audit-log
 queries, control-mapping spreadsheets, and operator-runbook templates
 the auditor will want. Builds on the public [COMPLIANCE.md](COMPLIANCE.md)
+and on the pack any deployment can generate itself
+(`scripts/evidence_pack.py`, see [ENTERPRISE.md](ENTERPRISE.md#the-evidence-pack)),
 but tailored to your control framework.
 
 #### SLA-backed incident response

--- a/scripts/evidence_pack.py
+++ b/scripts/evidence_pack.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Generate a compliance evidence pack from a running OpenNVR.
+
+An auditor, a procurement officer or a CISO asks the same questions of
+every deployment: what posture is it running in, does anything leave
+the site, which cameras are covered-list or exposed, which models are
+loaded and were they tampered with, what apps are installed and what
+may they reach, is recording actually happening, and who did what.
+This script asks the deployment's own API those questions and writes
+the answers — raw JSON, a CSV, and a readable ``EVIDENCE.md`` that
+maps each answer to the control frameworks in ``docs/COMPLIANCE.md`` —
+into one zip with a manifest of SHA-256 hashes, so the pack itself is
+tamper-evident.
+
+    python3 scripts/evidence_pack.py --url https://nvr.example.org --user admin
+    #   password from $OPENNVR_PASSWORD (or prompted); or --token <jwt>
+    python3 scripts/evidence_pack.py --url http://localhost:8000 --user admin --days 90 --out site-a.zip
+
+Read-only: every call is a GET (plus the login). Camera stream URLs
+are redacted of embedded credentials before they are written. Nothing
+is sent anywhere but the deployment you name. A route that fails or is
+unavailable is recorded in the manifest as missing; the pack is still
+produced — an incomplete pack that says so beats no pack.
+
+Standard library only. The fetcher is injectable for tests.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import getpass
+import hashlib
+import io
+import json
+import os
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+TOOL_VERSION = "1.0"
+API = "/api/v1"
+
+#: (method, path) → (status, body bytes, content-type)
+Fetcher = Callable[[str, str], tuple[int, bytes, str]]
+
+_CRED_IN_URL = re.compile(r"(?i)(rtsps?|https?|onvif)://([^/@\s:]+)(:[^/@\s]*)?@")
+
+
+def redact(obj: Any) -> Any:
+    """Strip ``user:pass@`` from any URL-shaped string, recursively, and
+    drop fields that are plainly secrets."""
+    if isinstance(obj, dict):
+        return {k: ("<redacted>" if _secret_key(k) else redact(v)) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [redact(v) for v in obj]
+    if isinstance(obj, str):
+        return _CRED_IN_URL.sub(r"\1://<redacted>@", obj)
+    return obj
+
+
+def _secret_key(key: str) -> bool:
+    k = key.lower()
+    return any(s in k for s in ("password", "secret", "token", "api_key", "apikey", "license_key"))
+
+
+# ── fetching ────────────────────────────────────────────────────────
+
+
+def http_fetcher(base_url: str, token: str | None, *, insecure: bool = False) -> Fetcher:
+    base = base_url.rstrip("/")
+    ctx = ssl._create_unverified_context() if insecure else None  # noqa: S323 — operator opt-in
+
+    def fetch(method: str, path: str) -> tuple[int, bytes, str]:
+        req = urllib.request.Request(base + path, method=method,
+                                     headers={"Accept": "application/json, text/csv, */*"})
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        try:
+            with urllib.request.urlopen(req, timeout=60, context=ctx) as resp:  # noqa: S310
+                return resp.status, resp.read(), resp.headers.get("Content-Type", "")
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read() or b"", exc.headers.get("Content-Type", "") if exc.headers else ""
+        except Exception as exc:  # noqa: BLE001
+            return 0, str(exc).encode(), "text/plain"
+    return fetch
+
+
+def login(base_url: str, username: str, password: str, *, insecure: bool = False) -> str:
+    ctx = ssl._create_unverified_context() if insecure else None  # noqa: S323
+    body = json.dumps({"username": username, "password": password}).encode()
+    req = urllib.request.Request(base_url.rstrip("/") + f"{API}/auth/login-json", data=body, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30, context=ctx) as resp:  # noqa: S310
+        data = json.loads(resp.read().decode())
+    token = data.get("access_token")
+    if not token:
+        raise SystemExit("login succeeded but no access_token in the response")
+    return token
+
+
+# ── the pack ────────────────────────────────────────────────────────
+
+#: What is collected: (name in the zip, path, kind). ``json`` files are
+#: parsed, redacted and pretty-printed; ``raw`` are stored as received.
+COLLECT: list[tuple[str, str, str]] = [
+    ("core/health.json", "/health", "json"),
+    ("core/posture.json", f"{API}/system/posture", "json"),
+    ("core/resources.json", f"{API}/system/resources", "json"),
+    ("compliance/summary.json", f"{API}/compliance/summary", "json"),
+    ("compliance/security-check.json", f"{API}/compliance/security-check", "json"),
+    ("compliance/recording-coverage.json", f"{API}/compliance/recording-coverage?days={{days}}", "json"),
+    ("compliance/access-audit.json", f"{API}/compliance/access-audit?days={{days}}&limit=500", "json"),
+    ("compliance/coverage.csv", f"{API}/compliance/export?days={{days}}", "raw"),
+    ("ai/capabilities.json", f"{API}/ai-models/capabilities", "json"),
+    ("ai/health.json", f"{API}/ai-models/health", "json"),
+    ("ai/tier0-gate.json", f"{API}/ai-models/tier0-gate", "json"),
+    ("apps/installed.json", f"{API}/apps", "json"),
+    ("apps/index.json", f"{API}/apps/index", "json"),
+    ("cameras/cameras.json", f"{API}/cameras/", "json"),
+    ("network/camera-lan.json", f"{API}/network/camera-lan", "json"),
+    ("network/uplink.json", f"{API}/network/uplink", "json"),
+    ("security/firewall-rules.json", f"{API}/security/firewall/rules", "json"),
+    ("security/retention.json", f"{API}/security/settings/recordings_retention", "json"),
+]
+AUDIT_PAGE = 500
+AUDIT_MAX = 20000
+
+
+def collect(fetch: Fetcher, *, days: int) -> tuple[dict[str, bytes], dict[str, Any]]:
+    """Every artefact as bytes, plus the parsed JSON ones for the report."""
+    files: dict[str, bytes] = {}
+    parsed: dict[str, Any] = {}
+    missing: dict[str, str] = {}
+    for name, path, kind in COLLECT:
+        status, body, _ctype = fetch("GET", path.replace("{days}", str(days)))
+        if status != 200:
+            missing[name] = f"HTTP {status}" if status else f"unreachable: {body[:120].decode(errors='replace')}"
+            continue
+        if kind == "json":
+            try:
+                data = redact(json.loads(body.decode() or "null"))
+            except ValueError:
+                missing[name] = "not JSON"
+                continue
+            parsed[name] = data
+            files[name] = (json.dumps(data, indent=2, sort_keys=True) + "\n").encode()
+        else:
+            files[name] = body
+    # Audit log: paged, bounded, newest first as the API returns it.
+    since = datetime.now(timezone.utc).replace(microsecond=0)
+    start = since.timestamp() - days * 86400
+    start_iso = datetime.fromtimestamp(start, timezone.utc).isoformat().replace("+00:00", "Z")
+    entries: list[Any] = []
+    skip = 0
+    while skip < AUDIT_MAX:
+        status, body, _ = fetch("GET", f"{API}/audit-logs/?skip={skip}&limit={AUDIT_PAGE}&start={urllib.parse.quote(start_iso)}")
+        if status != 200:
+            missing["audit/audit-logs.json"] = f"HTTP {status}" if status else "unreachable"
+            break
+        try:
+            page = json.loads(body.decode() or "{}")
+        except ValueError:
+            missing["audit/audit-logs.json"] = "not JSON"
+            break
+        items = page.get("items") if isinstance(page, dict) else page
+        if not isinstance(items, list):
+            items = page.get("logs") if isinstance(page, dict) else None
+        if not items:
+            break
+        entries.extend(items)
+        if len(items) < AUDIT_PAGE:
+            break
+        skip += AUDIT_PAGE
+    if "audit/audit-logs.json" not in missing:
+        entries = redact(entries)
+        parsed["audit/audit-logs.json"] = entries
+        files["audit/audit-logs.json"] = (json.dumps(entries, indent=2, sort_keys=True) + "\n").encode()
+        by_action: dict[str, int] = {}
+        for e in entries:
+            if isinstance(e, dict):
+                by_action[str(e.get("action"))] = by_action.get(str(e.get("action")), 0) + 1
+        parsed["audit/by-action.json"] = by_action
+        files["audit/by-action.json"] = (json.dumps(by_action, indent=2, sort_keys=True) + "\n").encode()
+    parsed["_missing"] = missing
+    return files, parsed
+
+
+# ── the readable report ─────────────────────────────────────────────
+
+
+def _g(parsed: dict[str, Any], name: str, *keys: str, default: Any = None) -> Any:
+    cur = parsed.get(name)
+    for k in keys:
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(k)
+    return default if cur is None else cur
+
+
+def findings(parsed: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """(status, check, detail) rows: status is PASS / ATTENTION / UNKNOWN."""
+    rows: list[tuple[str, str, str]] = []
+
+    def row(ok: bool | None, check: str, detail: str) -> None:
+        rows.append(("PASS" if ok else "ATTENTION" if ok is False else "UNKNOWN", check, detail))
+
+    mode = _g(parsed, "core/posture.json", "deployment_mode")
+    row(None if mode is None else mode == "offline", "Deployment mode is offline (cloud routes return 403)",
+        f"deployment_mode={mode!r}")
+    ai = _g(parsed, "core/posture.json", "ai_sovereignty")
+    row(None if ai is None else ai == "local_only", "AI sovereignty is local_only (adapters with network egress refused)",
+        f"ai_sovereignty={ai!r}")
+    pt = _g(parsed, "core/posture.json", "mediamtx_allow_plaintext_outputs")
+    row(None if pt is None else not pt, "Plaintext media outputs disabled", f"mediamtx_allow_plaintext_outputs={pt!r}")
+
+    sc = parsed.get("compliance/security-check.json")
+    if isinstance(sc, dict):
+        summary = sc.get("summary") if isinstance(sc.get("summary"), dict) else {}
+        n = summary.get("cameras", len(sc.get("cameras") or []))
+        covered = int(summary.get("covered_vendor") or 0)
+        row(not covered, "No FCC Covered List (§889) camera vendors in the inventory",
+            f"{covered} flagged of {n} active camera(s)")
+        exposed = int(summary.get("internet_exposed") or 0)
+        row(not exposed, "No camera on a public, internet-routable IP", f"{exposed} flagged")
+        plain = int(summary.get("plaintext_stream") or 0)
+        row(not plain, "No plaintext (RTSP without TLS) camera streams", f"{plain} flagged")
+        weak = int(summary.get("weak_credentials") or 0)
+        row(not weak, "No default or blank camera usernames", f"{weak} flagged")
+    else:
+        row(None, "Camera security check", "compliance/security-check.json missing")
+
+    caps = parsed.get("ai/capabilities.json")
+    if isinstance(caps, dict):
+        adapters = caps.get("adapters") if isinstance(caps.get("adapters"), dict) else {}
+        egress, fingerprinted = [], []
+        for name, a in adapters.items():
+            if not isinstance(a, dict):
+                continue
+            contract = a.get("capabilities") if isinstance(a.get("capabilities"), dict) else a
+            if contract.get("network_egress"):
+                egress.append(name)
+            model = contract.get("model") if isinstance(contract.get("model"), dict) else {}
+            if contract.get("model_fingerprint") or model.get("fingerprint"):
+                fingerprinted.append(name)
+        row(not egress, "No AI adapter declares network egress",
+            ", ".join(egress) or f"{len(adapters)} adapter(s), none")
+        row(None if not adapters else len(fingerprinted) == len(adapters),
+            "Every AI adapter reports a model fingerprint (drift is detectable)",
+            f"{len(fingerprinted)} of {len(adapters)}")
+    else:
+        row(None, "AI adapter posture", "ai/capabilities.json missing")
+
+    apps = parsed.get("apps/installed.json")
+    index = parsed.get("apps/index.json")
+    if isinstance(apps, list):
+        signed = {}
+        if isinstance(index, dict) and isinstance(index.get("apps"), list):
+            signed = {a.get("id"): a.get("signed_by") for a in index["apps"] if isinstance(a, dict)}
+        unsigned = [a.get("id") for a in apps if isinstance(a, dict) and not signed.get(a.get("id"))]
+        row(not unsigned, "Every installed app has a known image signer",
+            ", ".join(map(str, unsigned)) or f"{len(apps)} app(s)")
+        denied = [a.get("id") for a in apps if isinstance(a, dict) and (a.get("egress") or {}).get("denied")]
+        row(not denied, "No app has refused egress attempts on record", ", ".join(map(str, denied)) or "none")
+        reaching = [f"{a.get('id')} → {', '.join((a.get('egress') or {}).get('enforced') or [])}"
+                    for a in apps if isinstance(a, dict) and (a.get("egress") or {}).get("enforced")]
+        row(True, "Apps that may reach outside the stack (declared or operator-allowed)",
+            "; ".join(reaching) or "none — every app is confined to the stack")
+    else:
+        row(None, "Installed apps", "apps/installed.json missing")
+
+    cov = parsed.get("compliance/recording-coverage.json")
+    if isinstance(cov, dict) and isinstance(cov.get("coverage"), list):
+        days_n = int(cov.get("days") or 1)
+        by_cam: dict[Any, float] = {}
+        for r in cov["coverage"]:
+            if isinstance(r, dict):
+                by_cam[r.get("camera_id")] = by_cam.get(r.get("camera_id"), 0.0) + float(r.get("total_duration_hours") or 0)
+        enabled = int(_g(parsed, "compliance/summary.json", "recording_enabled", default=0) or 0)
+        if by_cam or enabled:
+            expected = max(enabled, len(by_cam)) * days_n * 24.0
+            pct = round(100.0 * sum(by_cam.values()) / expected, 1) if expected else 0.0
+            row(pct >= 95.0, "Recording coverage ≥ 95 % of expected hours over the period",
+                f"{pct}% — {round(sum(by_cam.values()), 1)} h recorded across {len(by_cam)} camera(s), "
+                f"{enabled} with recording enabled, {days_n} day(s)")
+        else:
+            row(None, "Recording coverage", "no cameras with recording enabled and no recordings in the period")
+    else:
+        row(None, "Recording coverage", "compliance/recording-coverage.json missing")
+
+    ret = parsed.get("security/retention.json")
+    ret_days = None
+    if isinstance(ret, dict):
+        value = ret.get("value") if isinstance(ret.get("value"), dict) else ret
+        ret_days = value.get("retention_days") if isinstance(value, dict) else None
+    row(True if ret_days else None, "Recording retention is an explicit setting",
+        f"retention_days={ret_days}" if ret_days else "default (30 days) or not readable")
+
+    audit = parsed.get("audit/audit-logs.json")
+    row(None if audit is None else len(audit) > 0, "Audit log carries events for the period",
+        f"{len(audit)} event(s)" if isinstance(audit, list) else "audit/audit-logs.json missing")
+    by = parsed.get("audit/by-action.json") or {}
+    boot = by.get("policy.boot_posture", 0)
+    row(True if boot else None, "Boot posture recorded in the audit log", f"{boot} boot(s) in the period")
+    return rows
+
+
+CONTROL_MAP = [
+    ("CISA Secure-by-Design", "default-deny posture, no shipped password, TLS-by-default",
+     "core/posture.json, compliance/security-check.json"),
+    ("NIST CSF 2.0 — Identify / Protect / Detect", "inventory, RBAC + TLS, fingerprint drift + correlation ids",
+     "cameras/cameras.json, ai/capabilities.json, audit/audit-logs.json"),
+    ("ISO/IEC 27001:2022 A.8 / A.5", "access control, logging, secure configuration",
+     "audit/audit-logs.json, compliance/access-audit.json, security/firewall-rules.json"),
+    ("NIST AI RMF 1.0", "model provenance, AI sovereignty, declared adapter permissions",
+     "ai/capabilities.json, core/posture.json"),
+    ("FCC §889 / NDAA covered vendors", "no Covered List cameras; local, auditable alternative",
+     "compliance/security-check.json"),
+    ("GDPR Art. 5/25/30 · India DPDP", "local processing, operator-managed keys, retention, records of processing",
+     "core/posture.json, compliance/recording-coverage.json, apps/installed.json (egress)"),
+    ("Supply chain (SLSA-style)", "digest-pinned, signed catalog images; built from source under the org",
+     "apps/index.json (signed_by, image_digest)"),
+]
+
+
+def render_report(parsed: dict[str, Any], *, url: str, days: int, generated_at: str,
+                  operator: str | None) -> str:
+    version = _g(parsed, "core/health.json", "version", default="unknown")
+    rows = findings(parsed)
+    counts = {s: sum(1 for r in rows if r[0] == s) for s in ("PASS", "ATTENTION", "UNKNOWN")}
+    out = [
+        "# OpenNVR compliance evidence pack",
+        "",
+        f"Deployment: `{url}` · core {version} · generated {generated_at}"
+        + (f" · by `{operator}`" if operator else "") + f" · period: last {days} days",
+        "",
+        "Every file in this pack was read from the deployment's own API at the time above; "
+        "`manifest.json` lists each with its SHA-256. Stream URLs are redacted of embedded "
+        "credentials. Nothing here was edited by hand.",
+        "",
+        "## Posture at a glance",
+        "",
+        f"**{counts['PASS']} pass · {counts['ATTENTION']} need attention · {counts['UNKNOWN']} could not be determined**",
+        "",
+        "| Status | Check | Evidence |",
+        "|---|---|---|",
+    ]
+    for status, check, detail in rows:
+        mark = {"PASS": "✅ PASS", "ATTENTION": "⚠️ ATTENTION", "UNKNOWN": "❔ UNKNOWN"}[status]
+        out.append(f"| {mark} | {check} | {detail} |")
+    out += ["", "## Control mapping", "",
+            "Where each framework's evidence lives in this pack (the implementation behind each row is "
+            "documented in `docs/COMPLIANCE.md` and `docs/SECURITY_ARCHITECTURE.md`).", "",
+            "| Framework | Controls evidenced | Files |", "|---|---|---|"]
+    for fw, controls, files in CONTROL_MAP:
+        out.append(f"| {fw} | {controls} | `{files}` |")
+    missing = parsed.get("_missing") or {}
+    out += ["", "## Contents", ""]
+    for name in sorted(n for n in parsed if not n.startswith("_")):
+        out.append(f"* `{name}`")
+    if missing:
+        out += ["", "## Not collected", "",
+                "These routes did not answer; the pack is incomplete to that extent and says so.", ""]
+        for name, why in sorted(missing.items()):
+            out.append(f"* `{name}` — {why}")
+    out += ["", "## What this pack is not", "",
+            "It is the deployment's own account of itself, produced by a read-only tool. It is not a "
+            "penetration test, not a §889 attestation of the camera hardware (OpenNVR Scout is that), "
+            "and not a statement about the physical perimeter, the operator's network outside the "
+            "stack, or the cameras' firmware — the residual risks `docs/COMPLIANCE.md` lists remain "
+            "the operator's. A framework audit uses this pack as evidence, not as the audit.", ""]
+    return "\n".join(out)
+
+
+def build_pack(fetch: Fetcher, *, url: str, days: int, out_path: str,
+               operator: str | None = None, now: datetime | None = None) -> dict[str, Any]:
+    """Collect, render, zip. Returns the manifest."""
+    now = now or datetime.now(timezone.utc)
+    generated_at = now.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    files, parsed = collect(fetch, days=days)
+    files["EVIDENCE.md"] = render_report(parsed, url=url, days=days, generated_at=generated_at,
+                                         operator=operator).encode()
+    manifest = {
+        "tool": "opennvr-evidence-pack", "tool_version": TOOL_VERSION,
+        "generated_at": generated_at, "deployment": url, "operator": operator, "period_days": days,
+        "core_version": _g(parsed, "core/health.json", "version"),
+        # Every artefact but the manifest itself (it cannot hash itself).
+        "files": {name: {"sha256": hashlib.sha256(data).hexdigest(), "bytes": len(data)}
+                  for name, data in sorted(files.items())},
+        "missing": parsed.get("_missing") or {},
+        "findings": [{"status": s, "check": c, "detail": d} for s, c, d in findings(parsed)],
+    }
+    files["manifest.json"] = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name in sorted(files):
+            zf.writestr(name, files[name])
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--url", required=True, help="the deployment, e.g. https://nvr.example.org")
+    ap.add_argument("--user", help="superuser to log in as (password from $OPENNVR_PASSWORD or a prompt)")
+    ap.add_argument("--token", help="a superuser JWT instead of logging in")
+    ap.add_argument("--days", type=int, default=30, help="period for coverage / access audit / audit log (1–90)")
+    ap.add_argument("--out", help="zip path (default: opennvr-evidence-<host>-<date>.zip)")
+    ap.add_argument("--insecure", action="store_true", help="skip TLS verification (self-signed lab deployments)")
+    args = ap.parse_args(argv)
+    if not 1 <= args.days <= 90:
+        print("error: --days must be 1..90", file=sys.stderr)
+        return 2
+    token = args.token
+    if not token:
+        if not args.user:
+            print("error: --user (with $OPENNVR_PASSWORD) or --token is required", file=sys.stderr)
+            return 2
+        password = os.environ.get("OPENNVR_PASSWORD") or getpass.getpass(f"password for {args.user}: ")
+        try:
+            token = login(args.url, args.user, password, insecure=args.insecure)
+        except Exception as exc:  # noqa: BLE001
+            print(f"error: login failed: {exc}", file=sys.stderr)
+            return 2
+    host = urllib.parse.urlsplit(args.url).hostname or "deployment"
+    out = args.out or f"opennvr-evidence-{host}-{datetime.now(timezone.utc):%Y%m%d}.zip"
+    manifest = build_pack(http_fetcher(args.url, token, insecure=args.insecure), url=args.url,
+                          days=args.days, out_path=out, operator=args.user)
+    counts = {s: sum(1 for f in manifest["findings"] if f["status"] == s) for s in ("PASS", "ATTENTION", "UNKNOWN")}
+    print(f"wrote {out}: {len(manifest['files'])} file(s); {counts['PASS']} pass, "
+          f"{counts['ATTENTION']} attention, {counts['UNKNOWN']} unknown"
+          + (f"; {len(manifest['missing'])} route(s) not collected" if manifest["missing"] else ""))
+    for f in manifest["findings"]:
+        if f["status"] == "ATTENTION":
+            print(f"  ! {f['check']} — {f['detail']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/tests/test_evidence_pack.py
+++ b/server/tests/test_evidence_pack.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""scripts/evidence_pack.py — the compliance evidence pack, built from
+canned API answers through the injected fetcher."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location("evidence_pack", REPO_ROOT / "scripts" / "evidence_pack.py")
+ep = importlib.util.module_from_spec(_spec)
+sys.modules["evidence_pack"] = ep
+_spec.loader.exec_module(ep)
+
+ANSWERS = {
+    "/health": {"status": "ok", "version": "0.2.0"},
+    "/api/v1/system/posture": {"deployment_mode": "offline", "ai_sovereignty": "local_only",
+                               "mediamtx_allow_plaintext_outputs": False},
+    "/api/v1/compliance/summary": {"total_cameras": 2, "recording_enabled": 2},
+    "/api/v1/compliance/security-check": {
+        "posture": "attention",
+        "summary": {"cameras": 2, "covered_vendor": 0, "internet_exposed": 0, "plaintext_stream": 1,
+                    "weak_credentials": 0},
+        "cameras": [{"id": 1, "name": "Gate", "flags": [{"code": "plaintext_stream"}]},
+                    {"id": 2, "name": "Yard", "flags": []}]},
+    "/api/v1/compliance/recording-coverage?days=30": {
+        "days": 30, "coverage": [{"camera_id": 1, "total_duration_hours": 700.0},
+                                 {"camera_id": 2, "total_duration_hours": 720.0}]},
+    "/api/v1/compliance/access-audit?days=30&limit=500": {"entries": []},
+    "/api/v1/ai-models/capabilities": {"adapters": {
+        "yolov8": {"url": "http://y", "capabilities": {"model": {"fingerprint": "sha256:aa"}, "network_egress": []}},
+        "cloudy": {"url": "http://c", "capabilities": {"model": {"fingerprint": "sha256:bb"},
+                                                       "network_egress": ["api.vendor.example"]}}}},
+    "/api/v1/apps": [
+        {"id": "alert-notifier", "egress": {"enforced": ["api.telegram.org"], "denied": [],
+                                            "declared": ["api.telegram.org"], "allow": []},
+         "config": {"webhook_token": "s3cret", "webhook_url": "https://bob:pw@hook.example/x"}},
+        {"id": "loitering-detection", "egress": {"enforced": [], "denied": [{"host": "evil.example", "port": 443}]}},
+    ],
+    "/api/v1/apps/index": {"apps": [{"id": "alert-notifier", "signed_by": "OpenNVR CI"},
+                                    {"id": "loitering-detection", "signed_by": None}]},
+    "/api/v1/cameras/": {"cameras": [{"id": 1, "name": "Gate", "rtsp_url": "rtsp://admin:hunter2@10.0.0.1/s",
+                                      "password": "x"}]},
+}
+AUDIT = [{"id": i, "action": "policy.boot_posture" if i == 1 else "camera.created", "timestamp": "t"}
+         for i in range(1, 8)]
+
+
+def fake_fetch(method, path):
+    assert method == "GET"
+    if path.startswith("/api/v1/audit-logs/"):
+        skip = int(path.split("skip=")[1].split("&")[0])
+        page = AUDIT[skip:skip + 500]
+        return 200, json.dumps({"logs": page, "total": len(AUDIT)}).encode(), "application/json"
+    if path.startswith("/api/v1/compliance/export"):
+        return 200, b"camera,date,hours\nGate,2026-09-01,24\n", "text/csv"
+    if path in ANSWERS:
+        return 200, json.dumps(ANSWERS[path]).encode(), "application/json"
+    if path.startswith("/api/v1/network/"):
+        return 0, b"connection refused", "text/plain"
+    return 404, b'{"detail":"nope"}', "application/json"
+
+
+def test_redaction():
+    assert ep.redact("rtsp://admin:hunter2@10.0.0.1/s") == "rtsp://<redacted>@10.0.0.1/s"
+    assert ep.redact({"password": "x", "api_key": "y", "url": "https://u:p@h/", "n": 1}) == \
+        {"password": "<redacted>", "api_key": "<redacted>", "url": "https://<redacted>@h/", "n": 1}
+    assert ep.redact([{"nested": {"license_key": "k"}}]) == [{"nested": {"license_key": "<redacted>"}}]
+
+
+def test_pack_contents_findings_and_manifest(tmp_path):
+    out = tmp_path / "pack.zip"
+    manifest = ep.build_pack(fake_fetch, url="https://nvr.test", days=30, out_path=str(out),
+                             operator="admin", now=datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc))
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+        assert {"EVIDENCE.md", "manifest.json", "core/posture.json", "compliance/security-check.json",
+                "compliance/coverage.csv", "apps/installed.json", "audit/audit-logs.json",
+                "audit/by-action.json", "cameras/cameras.json"} <= names
+        assert "network/uplink.json" not in names                      # unreachable → missing, not fatal
+        report = zf.read("EVIDENCE.md").decode()
+        installed = zf.read("apps/installed.json").decode()
+        cameras = zf.read("cameras/cameras.json").decode()
+        audit = json.loads(zf.read("audit/audit-logs.json"))
+        stored_manifest = json.loads(zf.read("manifest.json"))
+    # Redaction reached every artefact.
+    assert "hunter2" not in cameras and "s3cret" not in installed and "bob:pw" not in installed
+    assert '"password": "<redacted>"' in cameras
+    # Paged audit log, counted by action.
+    assert len(audit) == 7 and stored_manifest["files"]["audit/by-action.json"]
+    # Findings: pass / attention / unknown as the canned data dictates.
+    by_check = {f["check"]: f for f in manifest["findings"]}
+    assert by_check["Deployment mode is offline (cloud routes return 403)"]["status"] == "PASS"
+    assert by_check["No plaintext (RTSP without TLS) camera streams"]["status"] == "ATTENTION"
+    assert by_check["No AI adapter declares network egress"]["status"] == "ATTENTION"
+    assert "cloudy" in by_check["No AI adapter declares network egress"]["detail"]
+    assert by_check["Every installed app has a known image signer"]["detail"] == "loitering-detection"
+    assert by_check["No app has refused egress attempts on record"]["status"] == "ATTENTION"
+    cov = by_check["Recording coverage ≥ 95 % of expected hours over the period"]
+    assert cov["status"] == "PASS" and cov["detail"].startswith("98.6%")
+    assert by_check["Boot posture recorded in the audit log"]["status"] == "PASS"
+    # The report reads the same story and names what was not collected.
+    assert "⚠️ ATTENTION | No plaintext" in report and "network/uplink.json" in report
+    assert "## Control mapping" in report and "FCC §889" in report
+    assert manifest["missing"]["network/uplink.json"].startswith("unreachable")
+    assert manifest["core_version"] == "0.2.0" and manifest["generated_at"] == "2026-09-06T12:00:00Z"
+    # Hashes match the bytes in the zip.
+    import hashlib
+    with zipfile.ZipFile(out) as zf:
+        for name, meta in stored_manifest["files"].items():
+            assert hashlib.sha256(zf.read(name)).hexdigest() == meta["sha256"]
+
+
+def test_everything_missing_still_produces_a_pack(tmp_path):
+    out = tmp_path / "empty.zip"
+    manifest = ep.build_pack(lambda m, p: (0, b"down", "text/plain"), url="http://x", days=7, out_path=str(out))
+    assert set(manifest["files"]) == {"EVIDENCE.md"}
+    with zipfile.ZipFile(out) as zf:
+        assert set(zf.namelist()) == {"EVIDENCE.md", "manifest.json"}
+    assert all(f["status"] == "UNKNOWN" for f in manifest["findings"])
+    assert len(manifest["missing"]) == len(ep.COLLECT) + 1
+
+
+def test_cli_arguments(capsys):
+    assert ep.main(["--url", "http://x", "--days", "500", "--token", "t"]) == 2
+    assert ep.main(["--url", "http://x"]) == 2
+    assert "--user" in capsys.readouterr().err


### PR DESCRIPTION
…e evidence pack generator

* docs/ENTERPRISE.md — who it is for, what an engagement includes (reference-appliance deployment, the evidence pack reviewed against the customer's framework, §889 via Scout, support with response times, custom AI under NDA, review and training), what it never includes, how it is priced (per site, per year, by tier; no per-camera or per-seat licence), and why an open platform is the safer buy.
* docs/REFERENCE_APPLIANCE.md — three sizes (S edge / M site / L campus) with CPU, decode, inference, RAM, storage, network and power; the storage arithmetic (GB/day ≈ Mbit/s × 10.8); the three network segments and every exposed port; host hardening; the checklist the evidence pack scores; multi-site.
* scripts/evidence_pack.py — read-only, stdlib: logs in (or takes a token), collects posture, the camera security check, recording coverage, access audit, coverage CSV, AI capabilities/health/Tier-0 gate, installed apps + index (signer, egress), cameras, network, firewall rules, retention, and the paged audit log for the period; redacts credentials in URLs and secret-named fields; writes EVIDENCE.md (PASS / ATTENTION / UNKNOWN per check, framework → files, what was not collected, what the pack is not) and manifest.json with SHA-256 per artefact into one zip. Missing routes are recorded, not fatal. Tested with an injected fetcher.
* SUPPORT.md and COMPLIANCE.md point at the pack; docs/README and the README index the two pages; ROADMAP, CHANGELOG.