### PR TITLE
fix(sdk): fail over to the platform bus when the apps bus is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Apps go dark when `nats-apps` is unreachable.** Since the apps bus
+  (per-app NATS credentials), an app that had adopted
+  `nats://nats-apps:4222` connected to that server alone with
+  `max_reconnect_attempts=-1`: if the name did not resolve or the
+  service was down, the app reconnected forever — `socket.gaierror:
+  Temporary failure in name resolution` every second — and published
+  nothing (QA, 2026-09-07: the LPR app's Vehicles alerts stopped).
+  The SDK now connects with a two-server pool: the apps bus as the app
+  first, the platform bus with the site token second, credentials in
+  each server's URI (`dont_randomize` keeps the order). An unreachable
+  apps bus fails over with a warning naming it; a reachable one is
+  used as before. Verified against the real nats-py client and a
+  minimal NATS server in `tests/test_bus_failover.py`.
+  `docs/APP_CREDENTIALS.md` → Failover.
+
 ### Changed
 
 - **camera-agent on Pipecat 1.8 with Smart Turn v3.** The agent moves

--- a/docs/APP_CREDENTIALS.md
+++ b/docs/APP_CREDENTIALS.md
@@ -118,6 +118,21 @@ bus, keeps using the configured `nats_url` + `nats_token` on the
 platform bus, exactly as before. Set `NATS_APPS_URL=` (empty) in `.env`
 to turn the apps bus off.
 
+**Failover.** An app that knows both connects with a two-server pool:
+the apps bus as itself first, the platform bus with the site token
+second (`nats://<token>@nats:4222`, nats-py takes each server's
+credentials from its URI). If `nats-apps` cannot be resolved or
+reached — the service down, an older compose file, a half-upgraded
+stack — the client lands on the platform bus and logs a **warning**
+(`apps bus … is unreachable — connected to the platform bus with the
+site token instead`); alerts and events keep flowing, per-app bus
+permissions do not apply on that connection. An app whose logs show
+`socket.gaierror: Temporary failure in name resolution` on every
+reconnect is on an SDK before this failover and cannot reach the
+apps bus: check `docker compose ps nats-apps` and
+`docker logs opennvr_nats_apps`, and that the app container is on the
+`opennvr_apps` network (`docker inspect <app> --format '{{json .NetworkSettings.Networks}}'`).
+
 ## Version negotiation
 
 The register response's `registry.min_sdk_version` is the oldest SDK the

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/alerts.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/alerts.py
@@ -518,16 +518,15 @@ class NatsAlertChannel:
         }
         # The apps bus as this app when core has told us where it is
         # (credentials.py); the configured URL + token otherwise.
-        from .credentials import bus_connection
+        from .credentials import bus_connection, connected_via_fallback, describe_connection
 
         kwargs.update(bus_connection(None, self._url, self._token))
         self._nc = await nats.connect(**kwargs)
-        logger.info(
-            "NATS alert channel connected to %s (as=%s, prefix=%s)",
-            kwargs.get("servers"),
-            kwargs.get("user") or ("site token" if kwargs.get("token") else "none"),
-            self._subject_prefix,
-        )
+        logger.info("NATS alert channel connected %s (prefix=%s)",
+                    describe_connection(kwargs), self._subject_prefix)
+        if connected_via_fallback(self._nc, kwargs):
+            logger.warning("alert channel: apps bus unreachable — publishing on the platform "
+                           "bus with the site token instead; check the nats-apps service")
 
 
 # ── Dispatcher ─────────────────────────────────────────────────────

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/credentials.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/credentials.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+from urllib.parse import urlsplit, urlunsplit
 from pathlib import Path
 from typing import Any
 
@@ -120,21 +122,91 @@ def app_id_from_key(key: str | None) -> str | None:
     return app_id if sep and app_id else None
 
 
+_URL_SAFE_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
+
+
+def _with_userinfo(url: str, userinfo: str) -> str | None:
+    """``nats://host:port`` → ``nats://<userinfo>@host:port`` (nats-py reads
+    per-server credentials from the URI); ``None`` when the URL already
+    carries userinfo or the credential is not URL-safe verbatim."""
+    parts = urlsplit(url)
+    if not parts.scheme or not parts.hostname or parts.username is not None:
+        return None
+    return urlunsplit((parts.scheme, f"{userinfo}@{parts.netloc}", parts.path, parts.query, parts.fragment))
+
+
 def bus_connection(credentials: "AppCredentials | None", fallback_url: str | None,
                    fallback_token: str | None) -> dict[str, Any]:
-    """nats.connect() kwargs for this app. With an app key AND a bus URL
-    from core: the apps bus as user=<app id> / password=<key>. Otherwise
-    the configured ``nats_url`` (+ ``nats_token``), as before — an older
-    core, or a bare dev run."""
+    """nats.connect() kwargs for this app.
+
+    With an app key AND a bus URL from core: the apps bus as
+    user=<app id> / password=<key> — and, when the configured
+    ``nats_url`` (+ ``nats_token``) is also known, that platform bus as
+    the **second server in the pool** with the site token in its URI, so
+    a bus that cannot be resolved or reached (``nats-apps`` down, an
+    older compose file, a stack half-upgraded) fails over instead of
+    leaving the app reconnecting forever with no alerts. nats-py tries
+    the pool in order (``dont_randomize``) and takes each server's
+    credentials from its URI. Otherwise the configured URL (+ token),
+    as before — an older core, or a bare dev run.
+    """
     creds = credentials or AppCredentials()
     bus = creds.bus_url
     user = app_id_from_key(creds.app_key)
     if bus and user and creds.app_key:
+        primary = _with_userinfo(bus, f"{user}:{creds.app_key}") if _URL_SAFE_RE.match(creds.app_key) else None
+        secondary = None
+        if fallback_url and fallback_url != bus and fallback_token and _URL_SAFE_RE.match(fallback_token):
+            secondary = _with_userinfo(fallback_url, fallback_token)
+        if primary and secondary:
+            return {"servers": [primary, secondary], "dont_randomize": True}
         return {"servers": [bus], "user": user, "password": creds.app_key}
     out: dict[str, Any] = {"servers": [fallback_url] if fallback_url else []}
     if fallback_token:
         out["token"] = fallback_token
     return out
+
+
+def describe_connection(kwargs: dict[str, Any]) -> str:
+    """One line for the log: where and as whom (never the secret)."""
+    servers = kwargs.get("servers") or []
+    shown = [redact_url(s) for s in servers]
+    if kwargs.get("user"):
+        who = f"as {kwargs['user']}"
+    elif kwargs.get("token"):
+        who = "with the site token"
+    elif len(servers) == 2:
+        who = "as the app, site-token fallback second"
+    else:
+        who = "anonymous"
+    return f"{shown} {who}"
+
+
+def redact_url(url: str) -> str:
+    parts = urlsplit(url)
+    if parts.username is None:
+        return url
+    host = parts.hostname or ""
+    if parts.port:
+        host += f":{parts.port}"
+    who = parts.username if parts.password is not None else "<token>"
+    return urlunsplit((parts.scheme, f"{who}:***@{host}" if parts.password is not None else f"{who}@{host}",
+                       parts.path, parts.query, parts.fragment))
+
+
+def connected_via_fallback(nc: Any, kwargs: dict[str, Any]) -> bool:
+    """After ``nats.connect``: True when the pool had a fallback and the
+    client landed on it rather than on the apps bus."""
+    servers = kwargs.get("servers") or []
+    if len(servers) < 2:
+        return False
+    try:
+        current = nc.connected_url
+    except Exception:  # noqa: BLE001
+        return False
+    if current is None:
+        return False
+    return (current.hostname, current.port) == (urlsplit(servers[1]).hostname, urlsplit(servers[1]).port)
 
 
 def forget_app_key() -> None:

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/nats_loop.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/nats_loop.py
@@ -59,7 +59,7 @@ class NatsSubscriberMixin:
     async def _run_nats_loop(self, *, once: bool) -> None:
         import nats
 
-        from .credentials import bus_connection
+        from .credentials import bus_connection, connected_via_fallback, describe_connection
 
         connect_kwargs: dict[str, Any] = {
             "connect_timeout": 5.0,
@@ -73,10 +73,14 @@ class NatsSubscriberMixin:
             getattr(self, "credentials", None),
             getattr(self.cfg, "nats_url", None),
             getattr(self.cfg, "nats_token", None)))
-        logger.info("joining NATS at %s as %s",
-                    connect_kwargs.get("servers"),
-                    connect_kwargs.get("user") or ("site token" if connect_kwargs.get("token") else "anonymous"))
+        logger.info("joining NATS %s", describe_connection(connect_kwargs))
         self._nc = await nats.connect(**connect_kwargs)
+        if connected_via_fallback(self._nc, connect_kwargs):
+            logger.warning(
+                "apps bus %s is unreachable — connected to the platform bus with the site "
+                "token instead. Alerts and events keep flowing; per-app bus permissions do "
+                "not apply on this connection. Check the nats-apps service.",
+                connect_kwargs["servers"][0].split("@")[-1])
         subjects = self._nats_subjects()
         logger.info(
             "%s started: subject=%r",

--- a/sdk/opennvr-app-sdk/tests/test_bus_failover.py
+++ b/sdk/opennvr-app-sdk/tests/test_bus_failover.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: Apache-2.0
+"""The apps-bus failover, against the real nats-py client and a minimal
+NATS server on loopback: an unresolvable apps bus first in the pool, the
+platform bus second — the client must land on the second with the site
+token from its URI, and ``connected_via_fallback`` must say so."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from opennvr_app_sdk import credentials as creds_mod
+
+
+class _MiniNats:
+    """Enough of the NATS wire protocol to accept one client: INFO, then
+    CONNECT + PING → +OK/PONG. Records the CONNECT options."""
+
+    def __init__(self):
+        self.connects: list[dict] = []
+        self.server = None
+
+    async def _handle(self, reader, writer):
+        writer.write(b'INFO {"server_id":"mini","version":"2.10.0","proto":1,"max_payload":1048576,"auth_required":true}\r\n')
+        await writer.drain()
+        try:
+            while True:
+                line = await asyncio.wait_for(reader.readline(), timeout=5)
+                if not line:
+                    break
+                if line.startswith(b"CONNECT "):
+                    self.connects.append(json.loads(line[8:].decode()))   # +OK only when verbose
+                elif line.startswith(b"PING"):
+                    writer.write(b"PONG\r\n")
+                    await writer.drain()
+        except (asyncio.TimeoutError, ConnectionError):
+            pass
+        finally:
+            writer.close()
+
+    async def start(self):
+        self.server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        return self.server.sockets[0].getsockname()[1]
+
+
+@pytest.mark.asyncio
+async def test_client_fails_over_to_the_platform_bus_with_the_site_token(monkeypatch):
+    import nats
+
+    mini = _MiniNats()
+    port = await mini.start()
+    key = "oak_my-app_" + "f" * 32
+    monkeypatch.setenv("OPENNVR_APP_KEY", key)
+    monkeypatch.setenv("OPENNVR_APP_BUS_URL", "nats://nats-apps.invalid:4222")   # never resolves
+    kwargs = creds_mod.bus_connection(creds_mod.AppCredentials(), f"nats://127.0.0.1:{port}", "site-secret")
+    assert kwargs["servers"][0].startswith("nats://my-app:oak_") and kwargs["dont_randomize"] is True
+
+    nc = await nats.connect(**kwargs, connect_timeout=2.0, max_reconnect_attempts=3, reconnect_time_wait=0.1)
+    try:
+        assert nc.is_connected
+        assert creds_mod.connected_via_fallback(nc, kwargs) is True
+        assert mini.connects and mini.connects[0].get("auth_token") == "site-secret"
+        assert "user" not in mini.connects[0] or mini.connects[0].get("user") in (None, "")
+    finally:
+        await nc.close()
+    mini.server.close()
+
+
+@pytest.mark.asyncio
+async def test_client_prefers_the_apps_bus_when_it_answers(monkeypatch):
+    import nats
+
+    apps, platform = _MiniNats(), _MiniNats()
+    apps_port, platform_port = await apps.start(), await platform.start()
+    key = "oak_my-app_" + "e" * 32
+    monkeypatch.setenv("OPENNVR_APP_KEY", key)
+    monkeypatch.setenv("OPENNVR_APP_BUS_URL", f"nats://127.0.0.1:{apps_port}")
+    kwargs = creds_mod.bus_connection(creds_mod.AppCredentials(), f"nats://127.0.0.1:{platform_port}", "site-secret")
+    nc = await nats.connect(**kwargs, connect_timeout=2.0)
+    try:
+        assert creds_mod.connected_via_fallback(nc, kwargs) is False
+        assert apps.connects[0].get("user") == "my-app" and apps.connects[0].get("pass") == key
+        assert platform.connects == []
+    finally:
+        await nc.close()
+    apps.server.close(); platform.server.close()

--- a/sdk/opennvr-app-sdk/tests/test_credentials.py
+++ b/sdk/opennvr-app-sdk/tests/test_credentials.py
@@ -155,10 +155,32 @@ def test_registration_adopts_the_apps_bus_and_the_loop_joins_as_the_app(monkeypa
     assert app.register_with_opennvr() is True
     assert app.credentials.bus_url == "nats://nats-apps:4222"
     assert app.credentials.app_id == "my-app"
-    # What the NATS loop and the alert channel will connect with.
+    # What the NATS loop and the alert channel will connect with: the apps
+    # bus as the app, the platform bus with the site token as the pool's
+    # second server — so an unreachable nats-apps fails over instead of
+    # looping forever (field report 2026-09-07: LPR alerts stopped with
+    # "Temporary failure in name resolution" on every reconnect).
     kw = creds_mod.bus_connection(app.credentials, "nats://nats:4222", "site-secret")
+    assert kw == {"servers": [f"nats://my-app:{key}@nats-apps:4222", "nats://site-secret@nats:4222"],
+                  "dont_randomize": True}
+    assert "token" not in kw and "user" not in kw
+    assert creds_mod.describe_connection(kw) == (
+        "['nats://my-app:***@nats-apps:4222', 'nats://<token>@nats:4222'] as the app, site-token fallback second")
+    # No site token to fall back with (a pure app-key deployment): the apps bus alone.
+    kw = creds_mod.bus_connection(app.credentials, "nats://nats:4222", None)
     assert kw == {"servers": ["nats://nats-apps:4222"], "user": "my-app", "password": key}
-    assert "token" not in kw
+    # A token that is not URL-safe cannot ride in a URI: apps bus alone, as before.
+    kw = creds_mod.bus_connection(app.credentials, "nats://nats:4222", "has spaces/and:colons")
+    assert kw == {"servers": ["nats://nats-apps:4222"], "user": "my-app", "password": key}
+    # connected_via_fallback reads where nats-py actually landed.
+    from types import SimpleNamespace
+    from urllib.parse import urlsplit
+    on_apps = SimpleNamespace(connected_url=urlsplit("nats://nats-apps:4222"))
+    on_platform = SimpleNamespace(connected_url=urlsplit("nats://nats:4222"))
+    pool = creds_mod.bus_connection(app.credentials, "nats://nats:4222", "site-secret")
+    assert creds_mod.connected_via_fallback(on_apps, pool) is False
+    assert creds_mod.connected_via_fallback(on_platform, pool) is True
+    assert creds_mod.connected_via_fallback(on_platform, {"servers": ["nats://nats:4222"]}) is False
     # A fresh process (same key file) remembers the bus.
     again = creds_mod.AppCredentials()
     assert again.bus_url == "nats://nats-apps:4222" and again.app_key == key
@@ -179,7 +201,8 @@ def test_without_a_bus_the_configured_url_and_token_are_used(monkeypatch):
     # OPENNVR_APP_BUS_URL wins over the file.
     monkeypatch.setenv("OPENNVR_APP_BUS_URL", "nats://elsewhere:4222")
     kw = creds_mod.bus_connection(creds_mod.AppCredentials(), "nats://nats:4222", "site-secret")
-    assert kw["servers"] == ["nats://elsewhere:4222"] and kw["user"] == "my-app"
+    assert kw["servers"][0].endswith("@elsewhere:4222") and kw["servers"][0].startswith("nats://my-app:oak_")
+    assert kw["servers"][1] == "nats://site-secret@nats:4222"
 
 
 def test_app_id_from_key():


### PR DESCRIPTION
An app that had adopted nats://nats-apps:4222 connected to that one server with max_reconnect_attempts=-1; if the name did not resolve or nats-apps was down it reconnected forever (socket.gaierror: Temporary failure in name resolution, every second) and published nothing — the LPR app's Vehicles alerts stopped (QA, 2026-09-07).

bus_connection() now builds a two-server pool: the apps bus as the app (nats://<id>:<key>@nats-apps:4222) first, the platform bus with the site token (nats://<token>@nats:4222) second, dont_randomize so the order holds; nats-py reads each server's credentials from its URI. connected_via_fallback() tells the loop and the alert channel where the client landed, and they warn — naming the apps bus — when it is the fallback. A credential that is not URL-safe, or no site token at all, keeps the single-server shape as before. describe_connection() logs the pool with secrets redacted.

tests/test_bus_failover.py proves it against the real nats-py client and a minimal NATS server on loopback: an unresolvable apps bus lands on the platform bus with the site token; a reachable one is preferred with user/pass. docs/APP_CREDENTIALS.md → Failover (with the diagnostics for the root cause); CHANGELOG.