### PR TITLE
perf(camera-agent): size Smart Turn v3 to the CPU it runs on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `punkt_tab` so a sovereign site never downloads at first reply.
   `RawPcmSerializer` follows the 1.x `FrameSerializer` (BaseObject,
   `setup(FrameProcessorSetup)`, no `type`).
+- **camera-agent turn-taking sized to the hardware.** Smart Turn v3's
+  cost was measured on a CPU-only 4-core box (one ~60–90 ms verdict per
+  pause, Silero ≈0.7 % of a core) and the agent now fits itself to what
+  it runs on: numpy's BLAS/OpenMP pools are capped to one thread before
+  the model loads (uncapped, the 8 s log-mel fanned out across every core
+  and was *slower*, 90–130 ms), onnxruntime's thread count follows the
+  cores the process may actually use (scheduler affinity and cgroup CPU
+  quotas, not `os.cpu_count()`), and a single-core box gets a plain
+  silence timer instead of the model. New `turn_detector` (auto | smart
+  | timer), `turn_cpu_threads` and `turn_timer_secs` knobs;
+  `turn_max_secs` defaults to the model's 8 s window. The resolved
+  profile is logged at startup and returned by `GET /hardware` under
+  `turn`. MODELS_AND_LATENCY.md gains "Turn detection on CPU".
 
 ### Added
 

--- a/examples/camera-agent/Dockerfile
+++ b/examples/camera-agent/Dockerfile
@@ -27,12 +27,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Pin Pipecat carefully — its API has shifted between minor versions.
-# The upper bound MUST stay <0.0.60: 0.0.10x removed FrameSerializerType
-# and reworked the InputAudioRawFrame constructor, both of which
-# serializer.py / the RawPcmSerializer depend on. Keep this in lock-step
-# with pyproject.toml. If you bump these, re-run the example's test suite
-# and the demo page locally before committing.
+# Pin Pipecat carefully — its API has shifted between minor versions
+# (the 1.x line moved turn-taking into the user aggregator and the
+# serializer/transport modules; camera_agent.py, services.py and
+# serializer.py are written against 1.8). Keep this in lock-step with
+# pyproject.toml. If you bump these, re-run the example's test suite
+# (tests/test_pipeline_e2e.py drives the real pipeline) and the demo page
+# locally before committing.
 # Resilient install for slow / flaky PyPI links (pipecat's silero extra pulls
 # torch — a large download). Three layers of resilience:
 #   * --mount=type=cache keeps the pip wheel cache across build attempts, so a
@@ -65,6 +66,17 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Silero VAD ship inside the pipecat wheel already (no download).
 ENV NLTK_DATA=/opt/nltk_data
 RUN python -m nltk.downloader -d /opt/nltk_data punkt_tab
+
+# CPU fit. The only heavy math in THIS container is Smart Turn v3's
+# end-of-turn verdict (once per pause: an 8 s log-mel in numpy + a small
+# ONNX model) and Silero VAD (~0.7% of a core). Left uncapped, numpy's
+# BLAS/OpenMP fans the log-mel across every core, which measured SLOWER
+# on a 4-core box (90–130 ms vs ~60 ms single-threaded) and competes with
+# Whisper/Piper/Ollama next door. camera_agent.py sets the same defaults
+# when these are absent; here so `docker run -e` overrides are explicit.
+# onnxruntime's own pool is sized by `turn_cpu_threads` in config.yml
+# (auto: 1 thread, 2 from 8 cores) — see MODELS_AND_LATENCY.md.
+ENV OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1
 
 # The OpenNVR App SDK — monitor_host.py (the create_monitor convergence)
 # imports opennvr_app_sdk, and the count/crossing rule libraries below are

--- a/examples/camera-agent/MODELS_AND_LATENCY.md
+++ b/examples/camera-agent/MODELS_AND_LATENCY.md
@@ -104,6 +104,58 @@ and (b) doesn't react to room noise. Two layers handle this:
   `looks_like_noise()` drops these so a noisy room can't trigger a phantom turn;
   the UI just keeps listening. Set `stt_noise_filter: false` to disable.
 
+## Turn detection on CPU (Smart Turn v3)
+
+Since Pipecat 1.8 the agent closes a turn with **Smart Turn v3** — a small
+semantic end-of-turn model bundled in the wheel and run on CPU with
+onnxruntime — instead of a silence timer. What it costs, measured on a
+4-core ARM VM with no GPU (`tests/test_turn_hardware.py` covers the sizing;
+the numbers come from `LocalSmartTurnAnalyzerV3._predict_endpoint` on 8 s
+of audio):
+
+| Stage | When it runs | Cost |
+|---|---|---|
+| Silero VAD | every 32 ms audio chunk | ~0.24 ms per chunk (≈0.7 % of one core) |
+| Smart Turn v3 verdict | **once per pause** (VAD stop), not per frame | ~60–90 ms single-threaded |
+| same, BLAS/OMP left uncapped | | 90–130 ms — *slower*, and it takes every core |
+| model load | once per WebSocket conversation | ~50–90 ms |
+
+Two things follow, and the agent does both by itself:
+
+- **Thread caps.** The verdict's feature step is an 8 s Whisper-style log-mel
+  computed in numpy; uncapped, OpenBLAS/OpenMP fans it across every core,
+  which is slower for a 1×8 s input *and* steals cores from Whisper, Piper
+  and Ollama next door. `camera_agent.py` sets
+  `OMP_NUM_THREADS=OPENBLAS_NUM_THREADS=MKL_NUM_THREADS=1` before numpy
+  loads (the Dockerfile sets the same); an explicit value in the environment
+  wins. onnxruntime has its own pool — `turn_cpu_threads` — and **1 thread is
+  the fastest setting up to 7 cores**; auto uses 2 from 8 cores.
+- **Hardware profile.** `turn_detector: auto` (the default) looks at the cores
+  *this process may use* — scheduler affinity **and** a cgroup CPU quota
+  (`docker run --cpus`, compose `cpus:`), which `os.cpu_count()` ignores —
+  and runs Smart Turn whenever there are ≥ 2. On a single core it falls back
+  to a plain silence timer (`turn_timer_secs`, default 0.8 s; no model at
+  all). The startup log prints the resolved choice
+  (`turn-taking: Smart Turn v3 … 1 onnxruntime thread(s) … 4 core(s)`), and
+  `GET /hardware` returns it under `turn`.
+
+Knobs (`config.yml`):
+
+```yaml
+turn_detector: auto      # auto | smart | timer
+# turn_cpu_threads: 1    # onnxruntime threads per verdict (auto: 1, 2 from 8 cores)
+# turn_timer_secs: 0.8   # timer mode: silence that ends a turn
+turn_max_secs: 8.0       # the model only ever sees the last 8 s; more is pure cost
+turn_stop_secs: 2.0      # after this much silence the turn ends regardless
+```
+
+Memory is negligible (the model is ~8 MB; a 16 kHz int16 buffer for
+`turn_max_secs` is 256 KB). The one thing worth knowing on a busy box: the
+verdict runs on the pipeline's event loop thread pool, so a 60–90 ms pause
+verdict is the floor of the "you stop → agent starts" latency; the Whisper
+transcript for the turn is usually still in flight at that point, so it
+rarely adds to the wall clock.
+
 ## Recommended model choices
 
 | Role | Default (snappy) | Upgrade (quality, slower) | Why |

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -28,6 +28,20 @@ and speak.
 """
 from __future__ import annotations
 
+import os
+
+# Math-library thread caps — set BEFORE anything imports numpy (Pipecat
+# pulls it in lazily). Smart Turn v3's feature step (an 8 s Whisper
+# log-mel computed in numpy) otherwise fans out across every core through
+# OpenBLAS/OpenMP; on a 4-core box that made one end-of-turn verdict
+# SLOWER (90–130 ms) than single-threaded (~60 ms) while stealing cores
+# from Whisper and Piper next door. onnxruntime keeps its own pool, sized
+# by ``turn_cpu_threads``. An operator's explicit value in the
+# environment always wins (setdefault).
+for _var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_var, "1")
+del _var
+
 import argparse
 import asyncio
 import base64
@@ -168,8 +182,19 @@ class AppConfig:
     vad_stop_secs: float = 0.2
     vad_min_volume: float = 0.08
     turn_stop_secs: float = 2.0
-    turn_max_secs: float = 12.0
+    # Smart Turn v3 only ever looks at the LAST 8 s of a turn (it pads or
+    # truncates to the model window), so buffering more is pure cost.
+    turn_max_secs: float = 8.0
     turn_stop_timeout_secs: float = 6.0
+    # Hardware fit. turn_detector: "smart" (Smart Turn v3), "timer" (a
+    # plain silence timer, no model — for single-core boxes), or "auto"
+    # (smart when ≥2 cores are available to this process, else timer).
+    # turn_cpu_threads: onnxruntime threads for one Smart Turn verdict;
+    # None = auto (1 thread up to 7 cores — measured fastest — 2 from 8).
+    # turn_timer_secs: the silence that ends a turn in timer mode.
+    turn_detector: str = "auto"
+    turn_cpu_threads: int | None = None
+    turn_timer_secs: float = 0.8
     # Reasoning toggle for "thinking" models (Qwen3 etc.). Leave None for
     # non-thinking models (no effect). Set False to force snappy, non-thinking
     # tool-calling (appends Qwen3's ``/no_think`` switch); True to allow it.
@@ -2872,8 +2897,11 @@ def load_config(path: str | Path) -> AppConfig:
         vad_stop_secs=_float("vad_stop_secs", 0.2),
         vad_min_volume=_float("vad_min_volume", 0.08),
         turn_stop_secs=_float("turn_stop_secs", 2.0),
-        turn_max_secs=_float("turn_max_secs", 12.0),
+        turn_max_secs=_float("turn_max_secs", 8.0),
         turn_stop_timeout_secs=_float("turn_stop_timeout_secs", 6.0),
+        turn_detector=_str("turn_detector", "auto"),
+        turn_cpu_threads=(int(raw["turn_cpu_threads"]) if raw.get("turn_cpu_threads") else None),
+        turn_timer_secs=_float("turn_timer_secs", 0.8),
         enabled_tools=(
             list(raw["enabled_tools"])
             if isinstance(raw.get("enabled_tools"), list)
@@ -3737,6 +3765,7 @@ class CameraAgentRuntime:
             "gpu_recommended": bool(gpu_labels),
             "summary": summary,
             "rows": rows,
+            "turn": turn_hardware_profile(self.cfg),
             "tips": [
                 "Chat mode instead of voice skips Piper TTS — the measured "
                 "CPU hog (~4 cores while speaking).",
@@ -5006,32 +5035,117 @@ class CameraAgentRuntime:
 # ── Pipecat pipeline factory ───────────────────────────────────────
 
 
+def available_cores() -> int:
+    """CPU cores THIS process may actually use: the scheduler affinity
+    mask, further capped by a cgroup CPU quota (``docker run --cpus``,
+    compose ``cpus:``), which ``os.cpu_count()`` never reflects. Never
+    below 1."""
+    cores = None
+    try:
+        cores = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        pass
+    cores = cores or os.cpu_count() or 1
+    quota: float | None = None
+    try:  # cgroup v2
+        raw = Path("/sys/fs/cgroup/cpu.max").read_text().split()
+        if raw and raw[0] != "max":
+            quota = float(raw[0]) / float(raw[1])
+    except (OSError, ValueError, IndexError):
+        try:  # cgroup v1
+            q = float(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text())
+            per = float(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text())
+            if q > 0 and per > 0:
+                quota = q / per
+        except (OSError, ValueError):
+            pass
+    if quota:
+        cores = min(cores, max(1, int(math.ceil(quota))))
+    return max(1, int(cores))
+
+
+def turn_hardware_profile(cfg: Any, cores: int | None = None) -> dict[str, Any]:
+    """Resolve the turn-taking knobs against the hardware the agent is
+    running on. ``auto`` picks the semantic detector wherever it has a
+    core to run on, and one onnxruntime thread per verdict (measured
+    fastest on ≤4 cores: ~60 ms; two threads only pay off from 8 cores).
+    Explicit config values are honoured verbatim."""
+    cores = int(cores if cores is not None else available_cores())
+    wanted = str(getattr(cfg, "turn_detector", "auto") or "auto").strip().lower()
+    if wanted not in ("auto", "smart", "timer"):
+        logger.warning("turn_detector=%r is not auto|smart|timer; using auto", wanted)
+        wanted = "auto"
+    if wanted == "auto":
+        detector = "smart" if cores >= 2 else "timer"
+        why = ("auto: Smart Turn v3 has a core to run on" if detector == "smart"
+               else "auto: single core — silence timer, no model")
+    else:
+        detector, why = wanted, "set in config"
+    threads = getattr(cfg, "turn_cpu_threads", None)
+    if threads is None:
+        threads = 2 if cores >= 8 else 1
+    threads = max(1, min(int(threads), cores))
+    return {
+        "cores": cores,
+        "detector": detector,
+        "cpu_threads": threads,
+        "math_threads": os.environ.get("OMP_NUM_THREADS", "unset"),
+        "reason": why,
+    }
+
+
+def describe_turn_profile(cfg: Any) -> str:
+    p = turn_hardware_profile(cfg)
+    if p["detector"] == "smart":
+        return (f"Smart Turn v3 (semantic end-of-turn) on CPU, "
+                f"{p['cpu_threads']} onnxruntime thread(s), BLAS/OMP threads="
+                f"{p['math_threads']}; {p['cores']} core(s) available ({p['reason']})")
+    return (f"silence timer ({float(getattr(cfg, 'turn_timer_secs', 0.8)):.2f}s), "
+            f"no turn model; {p['cores']} core(s) available ({p['reason']})")
+
+
 def build_user_turn_params(cfg: Any) -> Any:
     """The user aggregator's parameters — where turn-taking lives in
     Pipecat 1.8. Silero VAD opens a turn; **Smart Turn v3** (the
     bundled semantic end-of-turn model, CPU) closes it; the aggregator's
     ``user_turn_stop_timeout`` is the last resort so a turn never hangs.
-    Interruptions stay off (the demo client sends no cancel frames)."""
-    from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
-    from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
+    Interruptions stay off (the demo client sends no cancel frames).
+
+    Sized to the hardware by ``turn_hardware_profile``: the model's
+    onnxruntime thread count follows the cores available, and a
+    single-core box gets a plain silence timer instead of the model."""
     from pipecat.audio.vad.silero import SileroVADAnalyzer
     from pipecat.processors.aggregators.llm_response_universal import LLMUserAggregatorParams
     from pipecat.turns.user_start import VADUserTurnStartStrategy
-    from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
     from pipecat.turns.user_turn_strategies import UserTurnStrategies
+
+    profile = turn_hardware_profile(cfg)
+    if profile["detector"] == "smart":
+        from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
+        from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
+        from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
+
+        stop = TurnAnalyzerUserTurnStopStrategy(
+            turn_analyzer=LocalSmartTurnAnalyzerV3(
+                cpu_count=int(profile["cpu_threads"]),
+                params=SmartTurnParams(
+                    stop_secs=float(getattr(cfg, "turn_stop_secs", 2.0)),
+                    max_duration_secs=float(getattr(cfg, "turn_max_secs", 8.0)),
+                ),
+            ),
+        )
+    else:
+        from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
+
+        stop = SpeechTimeoutUserTurnStopStrategy(
+            user_speech_timeout=float(getattr(cfg, "turn_timer_secs", 0.8)),
+        )
 
     return LLMUserAggregatorParams(
         vad_analyzer=SileroVADAnalyzer(params=turn_vad_params(cfg)),
         user_turn_strategies=UserTurnStrategies(
             start=[VADUserTurnStartStrategy(enable_interruptions=False)],
-            stop=[TurnAnalyzerUserTurnStopStrategy(
-                turn_analyzer=LocalSmartTurnAnalyzerV3(
-                    params=SmartTurnParams(
-                        stop_secs=float(getattr(cfg, "turn_stop_secs", 2.0)),
-                        max_duration_secs=float(getattr(cfg, "turn_max_secs", 12.0)),
-                    ),
-                ),
-            )],
+            stop=[stop],
         ),
         user_turn_stop_timeout=float(getattr(cfg, "turn_stop_timeout_secs", 6.0)),
     )
@@ -7177,6 +7291,7 @@ def main(argv: list[str] | None = None) -> int:
     cfg = load_config(args.config)
     runtime = CameraAgentRuntime(cfg)
     app = build_app(runtime)
+    logger.info("turn-taking: %s", describe_turn_profile(cfg))
 
     import uvicorn
     config = uvicorn.Config(

--- a/examples/camera-agent/config.docker.yml
+++ b/examples/camera-agent/config.docker.yml
@@ -128,7 +128,18 @@ vad_confidence: 0.55
 vad_start_secs: 0.15
 vad_stop_secs: 0.2
 turn_stop_secs: 2.0
-turn_max_secs: 12.0
+# Smart Turn only ever looks at the last 8 s of a turn; buffering more is
+# pure cost.
+turn_max_secs: 8.0
+# Hardware fit (see MODELS_AND_LATENCY.md → "Turn detection on CPU").
+#   turn_detector: auto | smart | timer — auto runs Smart Turn v3 whenever
+#     this process has ≥2 cores and falls back to a plain silence timer
+#     (turn_timer_secs, no model) on a single core.
+#   turn_cpu_threads: onnxruntime threads for one verdict; leave unset for
+#     auto (1 thread — measured fastest up to 7 cores — 2 from 8 cores).
+turn_detector: auto
+# turn_cpu_threads: 1
+# turn_timer_secs: 0.8
 # Context window. The default (4096) no longer fits this config's toolset:
 # 13 advertised tool schemas + the system prompt (rules, clock, roster, task
 # guidance) measure ~3.5-4.5k tokens BEFORE any conversation history — and

--- a/examples/camera-agent/config.example.yml
+++ b/examples/camera-agent/config.example.yml
@@ -89,7 +89,18 @@ vad_confidence: 0.55
 vad_start_secs: 0.15
 vad_stop_secs: 0.2
 turn_stop_secs: 2.0
-turn_max_secs: 12.0
+# Smart Turn only ever looks at the last 8 s of a turn; buffering more is
+# pure cost.
+turn_max_secs: 8.0
+# Hardware fit (see MODELS_AND_LATENCY.md → "Turn detection on CPU").
+#   turn_detector: auto | smart | timer — auto runs Smart Turn v3 whenever
+#     this process has ≥2 cores and falls back to a plain silence timer
+#     (turn_timer_secs, no model) on a single core.
+#   turn_cpu_threads: onnxruntime threads for one verdict; leave unset for
+#     auto (1 thread — measured fastest up to 7 cores — 2 from 8 cores).
+turn_detector: auto
+# turn_cpu_threads: 1
+# turn_timer_secs: 0.8
 
 # How long Ollama keeps the model resident. Sent on every request, so a
 # host-run `ollama serve` stays warm even without OLLAMA_KEEP_ALIVE in its

--- a/examples/camera-agent/tests/test_turn_hardware.py
+++ b/examples/camera-agent/tests/test_turn_hardware.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Turn-taking sized to the hardware: Smart Turn v3's thread count follows
+the cores this process may use, a single-core box gets a silence timer
+instead of the model, and numpy's BLAS/OpenMP pools are capped so the
+end-of-turn log-mel doesn't fan out across the machine."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import camera_agent
+from camera_agent import (
+    AppConfig,
+    available_cores,
+    describe_turn_profile,
+    turn_hardware_profile,
+)
+from context import CameraSpec
+
+
+def _cfg(**over) -> AppConfig:
+    return AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+        cameras=[CameraSpec(camera_id="cam1", frame_url="http://x/1.jpg", role="front")],
+        **over,
+    )
+
+
+# ── the auto profile ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("cores,detector,threads", [
+    (1, "timer", 1),
+    (2, "smart", 1),
+    (4, "smart", 1),
+    (7, "smart", 1),
+    (8, "smart", 2),
+    (32, "smart", 2),
+])
+def test_auto_profile_follows_core_count(cores, detector, threads):
+    p = turn_hardware_profile(_cfg(), cores=cores)
+    assert (p["detector"], p["cpu_threads"], p["cores"]) == (detector, threads, cores)
+    assert p["reason"]
+
+
+def test_explicit_config_wins_over_auto():
+    p = turn_hardware_profile(_cfg(turn_detector="timer", turn_cpu_threads=3), cores=16)
+    assert p["detector"] == "timer" and p["cpu_threads"] == 3
+    # the model can't be asked for more threads than there are cores
+    p = turn_hardware_profile(_cfg(turn_cpu_threads=8), cores=2)
+    assert p["cpu_threads"] == 2
+    # smart on a single core is honoured when the operator insists
+    p = turn_hardware_profile(_cfg(turn_detector="smart"), cores=1)
+    assert p["detector"] == "smart" and p["cpu_threads"] == 1
+
+
+def test_bad_detector_value_falls_back_to_auto():
+    p = turn_hardware_profile(_cfg(turn_detector="magic"), cores=4)
+    assert p["detector"] == "smart"
+
+
+def test_describe_mentions_the_choice():
+    assert "Smart Turn v3" in describe_turn_profile(_cfg(turn_detector="smart"))
+    assert "silence timer" in describe_turn_profile(_cfg(turn_detector="timer"))
+
+
+# ── the hardware probe ─────────────────────────────────────────────────
+
+
+def test_available_cores_is_at_least_one_and_bounded_by_the_machine():
+    n = available_cores()
+    assert 1 <= n <= (os.cpu_count() or n)
+
+
+def test_available_cores_honours_a_cgroup_quota(monkeypatch, tmp_path):
+    (tmp_path / "cpu.max").write_text("150000 100000\n")   # 1.5 CPUs
+    real_read = camera_agent.Path.read_text
+
+    def fake_read(self, *a, **k):
+        if str(self) == "/sys/fs/cgroup/cpu.max":
+            return (tmp_path / "cpu.max").read_text()
+        return real_read(self, *a, **k)
+
+    monkeypatch.setattr(camera_agent.Path, "read_text", fake_read)
+    monkeypatch.setattr(camera_agent.os, "sched_getaffinity", lambda _pid: set(range(16)), raising=False)
+    assert available_cores() == 2   # ceil(1.5), never the 16 the mask allows
+
+
+# ── config plumbing ────────────────────────────────────────────────────
+
+
+def test_config_loads_turn_hardware_knobs(tmp_path):
+    (tmp_path / "c.yml").write_text(
+        "kaic_url: http://k\nkaic_api_key: x\nsystem_prompt: t\n"
+        "turn_detector: timer\nturn_cpu_threads: 2\nturn_timer_secs: 1.1\n"
+    )
+    cfg = camera_agent.load_config(str(tmp_path / "c.yml"))
+    assert cfg.turn_detector == "timer"
+    assert cfg.turn_cpu_threads == 2
+    assert cfg.turn_timer_secs == pytest.approx(1.1)
+    assert cfg.turn_max_secs == pytest.approx(8.0)   # the model's window
+
+
+def test_math_thread_caps_are_defaulted_at_import():
+    # camera_agent sets these before numpy can be imported; an explicit
+    # operator value in the environment would have been left alone.
+    for var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS"):
+        assert os.environ.get(var)
+
+
+def test_hardware_endpoint_reports_the_turn_profile():
+    from fastapi.testclient import TestClient
+
+    from camera_agent import CameraAgentRuntime, build_app
+
+    hw = TestClient(build_app(CameraAgentRuntime(_cfg()))).get("/hardware").json()
+    assert hw["turn"]["detector"] in ("smart", "timer")
+    assert hw["turn"]["cpu_threads"] >= 1
+
+
+# ── the real Pipecat objects (skipped where Pipecat isn't installed) ───
+
+
+pipecat = pytest.importorskip("pipecat")
+
+
+def test_smart_profile_builds_smart_turn_with_the_thread_count():
+    from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
+
+    params = camera_agent.build_user_turn_params(_cfg(turn_detector="smart", turn_cpu_threads=1))
+    stop = params.user_turn_strategies.stop[0]
+    assert isinstance(stop, TurnAnalyzerUserTurnStopStrategy)
+    analyzer = stop._turn_analyzer
+    so = analyzer._session.get_session_options()
+    assert so.intra_op_num_threads == 1 and so.inter_op_num_threads == 1
+    assert analyzer.params.max_duration_secs == pytest.approx(8.0)
+
+
+def test_timer_profile_builds_no_model():
+    from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
+
+    params = camera_agent.build_user_turn_params(_cfg(turn_detector="timer", turn_timer_secs=0.7))
+    stop = params.user_turn_strategies.stop[0]
+    assert isinstance(stop, SpeechTimeoutUserTurnStopStrategy)
+    assert stop._user_speech_timeout == pytest.approx(0.7)


### PR DESCRIPTION
Measured on a CPU-only 4-core box: one Smart Turn verdict per pause costs ~60-90 ms single-threaded and 90-130 ms with numpy's BLAS/OpenMP left uncapped (the 8 s log-mel fans out across every core and gets slower while starving Whisper/Piper/Ollama). Silero VAD is ~0.7% of a core.

- cap OMP/OPENBLAS/MKL threads to 1 before numpy loads (module top and the Dockerfile); an explicit environment value wins
- turn_hardware_profile(): cores the process may actually use (sched affinity + cgroup cpu.max / cfs quota, not os.cpu_count()) -> onnxruntime threads (1 up to 7 cores, 2 from 8) and the detector: Smart Turn v3 with >= 2 cores, a plain silence timer (no model) on a single core
- new config knobs turn_detector (auto|smart|timer), turn_cpu_threads, turn_timer_secs; turn_max_secs defaults to the model's 8 s window
- the resolved profile is logged at startup and exposed by GET /hardware under "turn"; MODELS_AND_LATENCY.md documents the numbers and knobs
- fix the Dockerfile's stale '<0.0.60' pin comment
- tests/test_turn_hardware.py (16): auto table, explicit overrides, cgroup quota, config plumbing, real Pipecat objects