### PR TITLE
fix(apps-bus): render the leaf-link password — nats-server never expa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Apps bus: the leaf link to the platform bus never authenticated —
+  app alerts stopped.** `nats/apps.conf` put `$INTERNAL_API_KEY` inside
+  the leaf remote URL; nats-server expands `$VAR` only as a whole
+  value, never inside a URL, so `nats-apps` presented the literal
+  string as its password and the platform server refused it forever.
+  Both servers were healthy and every app logged "connected", but
+  nothing crossed: no app alert reached the inbox, no detection reached
+  an app (reproduced against nats-server 2.10 — an LPR alert published
+  on the apps bus never arrived on the platform bus; with the fix it
+  does). `apps-entrypoint.sh` now renders the key (percent-encoded, so
+  a base64 key with `/`, `+`, `=` works) into the config before start
+  and refuses to start with the placeholder in place. And the failure
+  is loud from now on: core polls `nats-apps`' `/leafz` and, after two
+  minutes without a leaf connection, logs an error, raises a high
+  inbox alert (hourly while it lasts) and reports it at
+  `GET /api/v1/apps/bus`; `NATS_APPS_MONITOR_URL` overrides the
+  derived monitoring URL. docs/APP_CREDENTIALS.md → "When alerts stop".
+
 ### Changed
 
 - **camera-agent on Pipecat 1.8 with Smart Turn v3.** The agent moves

--- a/docs/APP_CREDENTIALS.md
+++ b/docs/APP_CREDENTIALS.md
@@ -118,6 +118,40 @@ bus, keeps using the configured `nats_url` + `nats_token` on the
 platform bus, exactly as before. Set `NATS_APPS_URL=` (empty) in `.env`
 to turn the apps bus off.
 
+### When alerts stop
+
+The apps bus reaches the platform bus over **one leaf link**, and
+everything crosses it: app alerts to the inbox, domain events to core,
+the platform's detections to the apps. When that link is down nothing
+looks broken — both NATS containers are healthy, every app logs
+`joining NATS at ['nats://nats-apps:4222'] as <app id>` and stays
+connected — and the operator's alerts simply stop. So:
+
+* **Core watches the link** (`services/apps_bus_watch.py`): it polls
+  `nats-apps`' monitoring endpoint (`/leafz` on port 8222, derived from
+  `NATS_APPS_URL`; override with `NATS_APPS_MONITOR_URL`) every 30 s. No
+  leaf connection for more than two minutes logs an error, raises a
+  **high** inbox alert ("Apps bus is not linked to the platform bus")
+  once an hour while it lasts, and shows under `GET /api/v1/apps/bus`
+  (`linked`, `remotes`, `unlinked_for_s`). Recovery is logged.
+* **The link authenticates with `INTERNAL_API_KEY`** — `nats-apps`
+  presents it as the `opennvr-apps-bus` user on the platform server's
+  port 7422. `nats/apps.conf` is a *template*: nats-server does not
+  expand `$VAR` inside a URL, so `apps-entrypoint.sh` renders the key
+  (percent-encoded — a base64 key carries `/`, `+`, `=`) into
+  `/tmp/apps.conf` before starting, and refuses to start if the
+  placeholder is still there. Both containers must see the same value.
+* To look yourself: `curl -s http://nats-apps:8222/leafz` from inside
+  the stack (`leafs` must not be empty); `docker logs opennvr_nats_apps`
+  for `Leafnode Error 'Authorization Violation'`; `docker logs
+  opennvr_nats` for `authentication error` on 7422.
+
+Do **not** "fix" this by letting apps fall back to the platform bus with
+the site token: that silently trades every app's manifest-scoped
+permissions for the unrestricted bus the apps bus exists to take away.
+An unlinked apps bus is an outage to surface, not a path to route
+around.
+
 ## Version negotiation
 
 The register response's `registry.min_sdk_version` is the oldest SDK the

--- a/nats/apps-entrypoint.sh
+++ b/nats/apps-entrypoint.sh
@@ -1,13 +1,57 @@
 #!/bin/sh
 # Start the apps bus and reload it whenever core rewrites the users file.
 #
-# The users file lives on a volume core writes to. On a fresh volume it
-# does not exist yet, so seed a valid file with no matchable user; core
-# replaces it on its first start (services/nats_users.write_users_conf)
-# and after every key issue / rotate / revoke. nats-server re-reads its
-# config on SIGHUP, which `nats-server --signal reload` sends.
+# 1. Render the config. apps.conf is a template: nats-server does NOT
+#    expand $VAR inside a URL, so the leaf link's password must be put in
+#    by us — percent-encoded, since INTERNAL_API_KEY may be base64 with
+#    '/', '+' or '=' (nats-server URL-decodes it on the way out).
+#    `sh apps-entrypoint.sh --render` prints the rendered config and
+#    exits (what the tests exercise).
+# 2. Seed the users file. It lives on a volume core writes to. On a fresh
+#    volume it does not exist yet, so seed a valid file with no matchable
+#    user; core replaces it on its first start
+#    (services/nats_users.write_users_conf) and after every key issue /
+#    rotate / revoke. nats-server re-reads its config on SIGHUP, which
+#    `nats-server --signal reload` sends.
 set -eu
-USERS=/var/lib/opennvr/nats/users.conf
+TEMPLATE="${APPS_CONF_TEMPLATE:-/etc/nats/apps.conf}"
+RENDERED="${APPS_CONF_RENDERED:-/tmp/apps.conf}"
+USERS="${APPS_USERS_CONF:-/var/lib/opennvr/nats/users.conf}"
+
+url_encode() {
+  # Every character that is not unreserved (RFC 3986) — the userinfo
+  # part of a URL cannot carry '/', '@', ':', '#', '?', '+' or '=' raw.
+  printf '%s' "$1" | sed \
+    -e 's/%/%25/g' -e 's|/|%2F|g' -e 's/+/%2B/g' -e 's/=/%3D/g' \
+    -e 's/@/%40/g' -e 's/:/%3A/g' -e 's/#/%23/g' -e 's/?/%3F/g' \
+    -e 's/ /%20/g' -e 's/&/%26/g' -e 's/\[/%5B/g' -e 's/\]/%5D/g' \
+    -e 's/;/%3B/g' -e 's/\$/%24/g' -e 's/,/%2C/g' -e "s/'/%27/g" \
+    -e 's/"/%22/g' -e 's/</%3C/g' -e 's/>/%3E/g' -e 's/\\/%5C/g' \
+    -e 's/\^/%5E/g' -e 's/`/%60/g' -e 's/{/%7B/g' -e 's/}/%7D/g' \
+    -e 's/|/%7C/g' -e 's/!/%21/g' -e 's/\*/%2A/g' -e 's/(/%28/g' -e 's/)/%29/g'
+}
+
+render() {
+  if [ -z "${INTERNAL_API_KEY:-}" ]; then
+    echo "apps bus: INTERNAL_API_KEY is not set — the leaf link to the platform bus cannot authenticate" >&2
+    exit 1
+  fi
+  enc="$(url_encode "$INTERNAL_API_KEY")"
+  # '&' and '|' are special on sed's right-hand side; both were encoded
+  # above, so the only remaining risk is '\' — also encoded.
+  sed "s|@@INTERNAL_API_KEY_URL@@|$enc|g" "$TEMPLATE"
+}
+
+if [ "${1:-}" = "--render" ]; then
+  render
+  exit 0
+fi
+
+render > "$RENDERED"
+if grep -v '^[[:space:]]*#' "$RENDERED" | grep -q -e '@@INTERNAL_API_KEY_URL@@' -e '$INTERNAL_API_KEY'; then
+  echo "apps bus: config render left the key placeholder in place — refusing to start" >&2
+  exit 1
+fi
 mkdir -p "$(dirname "$USERS")"
 if [ ! -s "$USERS" ]; then
   cat > "$USERS" <<'SEED'
@@ -20,7 +64,10 @@ authorization {
 SEED
 fi
 
-nats-server -c /etc/nats/apps.conf &
+# Fail fast with nats-server's own parse error rather than a restart loop.
+nats-server -c "$RENDERED" -t
+
+nats-server -c "$RENDERED" &
 PID=$!
 last="$(md5sum "$USERS" | cut -d' ' -f1)"
 while kill -0 "$PID" 2>/dev/null; do

--- a/nats/apps.conf
+++ b/nats/apps.conf
@@ -12,6 +12,15 @@
 # Subjects flow both ways over the leaf link to the platform server, so
 # an app's alert reaches the inbox and the platform's detections reach
 # the app — but only the subjects each app's permissions allow.
+#
+# THIS FILE IS A TEMPLATE. nats-server expands ``$VAR`` only where a
+# whole value is the variable (``token: $INTERNAL_API_KEY`` in
+# nats.conf); inside a URL it is left as the literal text
+# "$INTERNAL_API_KEY", so the leaf link would present that string as its
+# password and the platform server would refuse it forever — with both
+# buses up, every app "connected", and no alert ever crossing to the
+# inbox. apps-entrypoint.sh renders @@INTERNAL_API_KEY_URL@@ (the key,
+# percent-encoded for a URL) into /tmp/apps.conf and starts from that.
 
 server_name: opennvr-nats-apps
 
@@ -19,7 +28,7 @@ include "/var/lib/opennvr/nats/users.conf"
 
 leafnodes {
   remotes: [
-    { url: "nats://opennvr-apps-bus:$INTERNAL_API_KEY@nats:7422" }
+    { url: "nats://opennvr-apps-bus:@@INTERNAL_API_KEY_URL@@@nats:7422" }
   ]
 }
 

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -358,6 +358,10 @@ class Settings(BaseSettings):
     # off), and the URL apps are told to join with their own key.
     nats_users_conf: str = ""
     nats_apps_url: str = ""
+    # Where nats-apps publishes /leafz (services/apps_bus_watch.py checks
+    # the leaf link to the platform bus is up). Empty = derived from
+    # nats_apps_url's host on the standard monitoring port 8222.
+    nats_apps_monitor_url: str = ""
 
     @field_validator("trusted_proxy_cidrs", "internal_service_cidrs")
     @classmethod

--- a/server/main.py
+++ b/server/main.py
@@ -538,6 +538,31 @@ async def lifespan(app: FastAPI):
     spawn_background(background_recording_watchdog(),
                      name="recording-watchdog")
 
+    # Apps-bus link watchdog: the apps bus is a leaf of the platform bus
+    # and every app alert crosses that one link. When it is down both
+    # servers look healthy and alerts just stop — so core checks
+    # nats-apps' /leafz itself and raises an inbox alert if the link is
+    # gone for more than a couple of minutes.
+    async def background_apps_bus_watch():
+        try:
+            from services import apps_bus_watch
+
+            url = apps_bus_watch.monitor_url(settings.nats_apps_url,
+                                             settings.nats_apps_monitor_url)
+            if not url:
+                return
+            await asyncio.sleep(30)  # let nats-apps come up and dial the leaf
+            while True:
+                try:
+                    await asyncio.to_thread(apps_bus_watch.check_once, url)
+                except Exception as e:
+                    main_logger.error(f"Apps-bus watch failed: {e}", exc_info=True)
+                await asyncio.sleep(apps_bus_watch.CHECK_INTERVAL_S)
+        except Exception as e:
+            main_logger.error(f"Apps-bus watch scheduler failed: {e}", exc_info=True)
+
+    spawn_background(background_apps_bus_watch(), name="apps-bus-watch")
+
     # Recordings-index reconciler: startup backfill of the recordings table
     # from the on-disk archive, then a periodic recent-window convergence
     # pass. Keeps the DB (the listing/timeline source of truth) honest even

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -685,6 +685,26 @@ async def list_apps(
     return [_serialize_app(row) for row in rows]
 
 
+@router.get("/bus")
+async def get_apps_bus(
+    current_user: User = Depends(get_current_active_user),
+):
+    """The apps bus and its leaf link to the platform bus, as core last
+    saw it (``services/apps_bus_watch.py``). ``linked: false`` for more
+    than the grace period is the "apps are up but alerts stopped"
+    condition; the inbox alert says the same thing."""
+    from core.config import settings
+    from services import apps_bus_watch
+
+    url = apps_bus_watch.monitor_url(settings.nats_apps_url, settings.nats_apps_monitor_url)
+    return {
+        "enabled": bool(settings.nats_apps_url),
+        "url": settings.nats_apps_url or None,
+        "monitor_url": url or None,
+        **apps_bus_watch.state(),
+    }
+
+
 @router.get("/index")
 async def get_apps_index(
     current_user: User = Depends(get_current_active_user),

--- a/server/services/apps_bus_watch.py
+++ b/server/services/apps_bus_watch.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Is the apps bus actually joined to the platform bus?
+
+The apps bus (``nats-apps``) is a leaf of the platform server: every
+app's alert crosses that one link to reach the inbox, and every
+platform detection crosses it the other way to reach the app. When the
+link is down the failure is SILENT — both servers are healthy, every
+app logs "connected", the operator's alerts simply stop. (The first
+time it happened the leaf link's password was never rendered into the
+URL and the platform server refused it for days.)
+
+So core watches the link itself: ``nats-apps`` publishes its leaf
+connections at ``/leafz`` on its monitoring port; if that list is
+empty for longer than a grace period, core logs an error, raises an
+inbox alert (once an hour while it lasts) and shows it under
+``/health``'s detail. Recovery clears the condition and is logged.
+Nothing here can raise — the watchdog is best-effort.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+CHECK_INTERVAL_S = 30          # how often the background loop asks
+GRACE_S = 120                  # unlinked this long before it counts
+ALERT_EVERY_S = 3600           # one inbox alert per hour while it lasts
+MONITOR_PORT = 8222
+
+
+def monitor_url(nats_apps_url: str, explicit: str = "") -> str:
+    """``nats://nats-apps:4222`` → ``http://nats-apps:8222/leafz``; an
+    explicit monitor URL (``NATS_APPS_MONITOR_URL``) wins; "" when the
+    apps bus is off."""
+    if explicit:
+        return explicit.rstrip("/") + ("" if explicit.endswith("/leafz") else "/leafz")
+    if not nats_apps_url:
+        return ""
+    host = urlsplit(nats_apps_url).hostname
+    return f"http://{host}:{MONITOR_PORT}/leafz" if host else ""
+
+
+def parse_leafz(payload: Any) -> dict[str, Any]:
+    """The bit of ``/leafz`` the watchdog cares about."""
+    leafs = payload.get("leafs") if isinstance(payload, dict) else None
+    leafs = leafs if isinstance(leafs, list) else []
+    names = [str(leaf.get("name") or "?") for leaf in leafs if isinstance(leaf, dict)]
+    return {"linked": bool(leafs), "leafs": len(leafs), "remotes": names}
+
+
+@dataclass
+class LinkState:
+    """What the last checks said (module-level, read by ``/health``)."""
+    checked_at: float = 0.0
+    reachable: bool | None = None       # could /leafz be fetched at all
+    linked: bool | None = None          # a leaf connection exists
+    remotes: list[str] = field(default_factory=list)
+    unlinked_since: float | None = None
+    last_alert_at: float = 0.0
+    error: str = ""
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "checked_at": (datetime.fromtimestamp(self.checked_at, UTC).isoformat()
+                           if self.checked_at else None),
+            "reachable": self.reachable,
+            "linked": self.linked,
+            "remotes": list(self.remotes),
+            "unlinked_for_s": (int(time.time() - self.unlinked_since)
+                               if self.unlinked_since else 0),
+            "error": self.error,
+        }
+
+
+_state = LinkState()
+_lock = threading.Lock()
+
+
+def state() -> dict[str, Any]:
+    with _lock:
+        return _state.snapshot()
+
+
+def reset_for_tests() -> None:
+    global _state
+    with _lock:
+        _state = LinkState()
+
+
+def fetch_leafz(url: str, timeout: float = 3.0) -> dict[str, Any]:
+    """GET the monitoring endpoint; ``{"error": ...}`` instead of raising."""
+    import httpx
+
+    try:
+        r = httpx.get(url, timeout=timeout)
+        r.raise_for_status()
+        return parse_leafz(r.json())
+    except Exception as exc:  # anything means "unreachable"
+        return {"error": f"{type(exc).__name__}: {exc}"[:200]}
+
+
+def observe(result: dict[str, Any], *, now: float | None = None) -> dict[str, Any]:
+    """Fold one check into the state. Returns ``{"transition": ..., "alert": bool}``
+    — ``transition`` is ``"lost"`` / ``"restored"`` / ``None`` and ``alert``
+    says whether an inbox alert is due now (the caller writes it)."""
+    now = time.time() if now is None else now
+    out: dict[str, Any] = {"transition": None, "alert": False}
+    with _lock:
+        st = _state
+        st.checked_at = now
+        if "error" in result:
+            st.reachable = False
+            st.linked = None
+            st.remotes = []
+            st.error = str(result["error"])
+            # An unreachable monitor is its own problem (compose healthcheck
+            # covers a dead container); it does not count as "unlinked".
+            return out
+        st.reachable = True
+        st.error = ""
+        st.linked = bool(result.get("linked"))
+        st.remotes = list(result.get("remotes") or [])
+        if st.linked:
+            if st.unlinked_since is not None and now - st.unlinked_since >= GRACE_S:
+                out["transition"] = "restored"
+            st.unlinked_since = None
+            st.last_alert_at = 0.0
+            return out
+        if st.unlinked_since is None:
+            st.unlinked_since = now
+            return out
+        if now - st.unlinked_since < GRACE_S:
+            return out
+        if st.last_alert_at == 0.0:
+            out["transition"] = "lost"
+        if now - st.last_alert_at >= ALERT_EVERY_S:
+            st.last_alert_at = now
+            out["alert"] = True
+    return out
+
+
+def alert_envelope(now: float | None = None) -> dict[str, Any]:
+    now = time.time() if now is None else now
+    snap = state()
+    return {
+        "alert_id": f"apps-bus-unlinked-{int(now // ALERT_EVERY_S)}",
+        "severity": "high",
+        "title": "Apps bus is not linked to the platform bus — app alerts cannot reach the inbox",
+        "description": (
+            "The apps bus (nats-apps) has had no leaf connection to the platform "
+            f"bus for {snap['unlinked_for_s'] // 60} minute(s). Installed apps are "
+            "connected and running, but nothing they publish crosses to core: no "
+            "app alerts, no domain events, and the platform's detections do not "
+            "reach them. Check `docker logs opennvr_nats_apps` for "
+            "'Leafnode Error' / 'Authorization Violation' (the leaf link "
+            "authenticates with INTERNAL_API_KEY — nats-apps and nats must "
+            "see the same value) and `docker logs opennvr_nats` for "
+            "'authentication error' on port 7422. docs/APP_CREDENTIALS.md → "
+            "\"When alerts stop\"."
+        ),
+        "source": {"kind": "platform", "name": "nats-apps"},
+        "tags": ["apps-bus", "leaf-link", "infrastructure"],
+        "evidence": snap,
+        "fired_at": datetime.fromtimestamp(now, UTC).isoformat(),
+    }
+
+
+def check_once(url: str, db=None) -> dict[str, Any]:
+    """One full cycle: fetch, fold, log, alert. Never raises."""
+    result = fetch_leafz(url)
+    verdict = observe(result)
+    try:
+        if verdict["transition"] == "lost":
+            logger.error("apps bus: NO leaf connection to the platform bus for %ds — app alerts "
+                         "and platform detections are not crossing (%s)", GRACE_S, url)
+        elif verdict["transition"] == "restored":
+            logger.info("apps bus: leaf link to the platform bus restored (%s)",
+                        ", ".join(state()["remotes"]) or "?")
+        elif "error" in result:
+            logger.debug("apps bus: monitor %s unreachable: %s", url, result["error"])
+        if verdict["alert"]:
+            from services.alerts_inbox import apply_alert
+            apply_alert(alert_envelope(), db=db)
+    except Exception as exc:
+        logger.warning("apps bus watch: could not record the condition: %s", exc)
+    return verdict

--- a/server/tests/test_apps_bus_watch.py
+++ b/server/tests/test_apps_bus_watch.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""The apps-bus leaf link: rendered correctly by the nats-apps entrypoint,
+and watched by core so a dead link is loud instead of "alerts stopped"."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.test_app_credentials import (  # noqa: F401 — fixture re-export
+    _manifest, _site, env,
+)
+
+import core.auth as auth_mod  # noqa: E402
+from models import AppAlert as AppAlertRow  # noqa: E402
+from services import apps_bus_watch as w  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO / "nats" / "apps-entrypoint.sh"
+TEMPLATE = REPO / "nats" / "apps.conf"
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    w.reset_for_tests()
+    yield
+    w.reset_for_tests()
+
+
+# ── the entrypoint renders the leaf password into the URL ──────────────
+
+
+def _config_lines(text: str) -> str:
+    """The template's comments explain the bug and quote the literal; only
+    the lines nats-server acts on count."""
+    return "\n".join(line for line in text.splitlines() if not line.strip().startswith("#"))
+
+
+def _render(key: str) -> str:
+    env_ = {**os.environ, "INTERNAL_API_KEY": key, "APPS_CONF_TEMPLATE": str(TEMPLATE)}
+    return subprocess.run(["sh", str(ENTRYPOINT), "--render"], env=env_,
+                          capture_output=True, text=True, check=True).stdout
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
+def test_template_has_no_dollar_variable_in_the_leaf_url():
+    # nats-server does not expand $VAR inside a URL — that is the bug
+    # this file guards against. The template carries a placeholder only.
+    live = _config_lines(TEMPLATE.read_text())
+    assert "$INTERNAL_API_KEY" not in live
+    assert "@@INTERNAL_API_KEY_URL@@" in live
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
+def test_render_puts_the_hex_key_in_the_leaf_url():
+    out = _render("c0ffee1234deadbeef")
+    assert 'url: "nats://opennvr-apps-bus:c0ffee1234deadbeef@nats:7422"' in out
+    live = _config_lines(out)
+    assert "@@INTERNAL_API_KEY_URL@@" not in live and "$INTERNAL_API_KEY" not in live
+    assert 'include "/var/lib/opennvr/nats/users.conf"' in out
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
+def test_render_percent_encodes_a_base64_key():
+    # `openssl rand -base64 32` (the .env.example advice) yields '/', '+', '='
+    out = _render("l/3WTLMGLPazDFuLBjajSFHehrj0I3e25wcQt4amHGA=")
+    assert "opennvr-apps-bus:l%2F3WTLMGLPazDFuLBjajSFHehrj0I3e25wcQt4amHGA%3D@nats:7422" in out
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
+def test_render_encodes_every_url_special_character():
+    out = _render("a@b:c#d?e&f|g h%i")
+    assert "opennvr-apps-bus:a%40b%3Ac%23d%3Fe%26f%7Cg%20h%25i@nats:7422" in out
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
+def test_render_refuses_without_a_key():
+    env_ = {k: v for k, v in os.environ.items() if k != "INTERNAL_API_KEY"}
+    env_["APPS_CONF_TEMPLATE"] = str(TEMPLATE)
+    r = subprocess.run(["sh", str(ENTRYPOINT), "--render"], env=env_, capture_output=True, text=True)
+    assert r.returncode == 1 and "INTERNAL_API_KEY is not set" in r.stderr
+
+
+# ── the watchdog ───────────────────────────────────────────────────────
+
+
+def test_monitor_url_is_derived_from_the_apps_bus_url():
+    assert w.monitor_url("nats://nats-apps:4222") == "http://nats-apps:8222/leafz"
+    assert w.monitor_url("nats://10.0.0.5:4222", "http://mon:9999") == "http://mon:9999/leafz"
+    assert w.monitor_url("") == ""
+
+
+def test_parse_leafz():
+    assert w.parse_leafz({"leafs": []}) == {"linked": False, "leafs": 0, "remotes": []}
+    got = w.parse_leafz({"leafs": [{"name": "opennvr-nats", "is_spoke": True}]})
+    assert got == {"linked": True, "leafs": 1, "remotes": ["opennvr-nats"]}
+    assert w.parse_leafz("junk")["linked"] is False
+
+
+def test_unlinked_counts_only_after_the_grace_period_and_alerts_hourly():
+    t0 = 1_000_000.0
+    assert w.observe({"linked": False, "remotes": []}, now=t0) == {"transition": None, "alert": False}
+    assert w.observe({"linked": False, "remotes": []}, now=t0 + 60) == {"transition": None, "alert": False}
+    lost = w.observe({"linked": False, "remotes": []}, now=t0 + w.GRACE_S)
+    assert lost == {"transition": "lost", "alert": True}
+    # while it lasts: no re-alert inside the hour, one after
+    assert w.observe({"linked": False, "remotes": []}, now=t0 + w.GRACE_S + 600) == {"transition": None, "alert": False}
+    assert w.observe({"linked": False, "remotes": []}, now=t0 + w.GRACE_S + w.ALERT_EVERY_S) == {"transition": None, "alert": True}
+    snap = w.state()
+    assert snap["linked"] is False and snap["unlinked_for_s"] > 0
+    # recovery
+    back = w.observe({"linked": True, "remotes": ["opennvr-nats"]}, now=t0 + w.GRACE_S + 4000)
+    assert back == {"transition": "restored", "alert": False}
+    assert w.state()["linked"] is True and w.state()["remotes"] == ["opennvr-nats"]
+
+
+def test_unreachable_monitor_is_not_treated_as_unlinked():
+    t0 = 2_000_000.0
+    for i in range(10):
+        assert w.observe({"error": "ConnectError: boom"}, now=t0 + i * 60) == {"transition": None, "alert": False}
+    snap = w.state()
+    assert snap["reachable"] is False and snap["linked"] is None and "boom" in snap["error"]
+
+
+def test_check_once_writes_the_inbox_alert(monkeypatch, env):
+    tc, _ids, SessionLocal = env
+    t0 = 3_000_000.0
+    monkeypatch.setattr(w, "fetch_leafz", lambda url, timeout=3.0: {"linked": False, "leafs": 0, "remotes": []})
+    clock = {"now": t0}
+    monkeypatch.setattr(w.time, "time", lambda: clock["now"])
+    s = SessionLocal()
+    try:
+        assert w.check_once("http://nats-apps:8222/leafz", db=s)["alert"] is False
+        clock["now"] = t0 + w.GRACE_S
+        assert w.check_once("http://nats-apps:8222/leafz", db=s)["alert"] is True
+        s.commit()
+        rows = s.query(AppAlertRow).filter(AppAlertRow.alert_id.like("apps-bus-unlinked-%")).all()
+        assert len(rows) == 1
+        assert "not linked to the platform bus" in rows[0].title
+        assert rows[0].severity == "high"
+    finally:
+        s.close()
+
+
+def test_bus_endpoint_reports_the_link(monkeypatch, env):
+    tc, _ids, _ = env
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "nats_apps_url", "nats://nats-apps:4222", raising=False)
+    tc.app.dependency_overrides[auth_mod.get_current_active_user] = \
+        tc.app.dependency_overrides[auth_mod.get_current_superuser]
+    w.observe({"linked": True, "remotes": ["opennvr-nats"]})
+    r = tc.get("/apps/bus")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["enabled"] is True and body["monitor_url"] == "http://nats-apps:8222/leafz"
+    assert body["linked"] is True and body["remotes"] == ["opennvr-nats"]


### PR DESCRIPTION
…nded it, so no app alert ever crossed to the platform bus

Root cause of "alerts have stopped" on every install since the apps bus landed: nats/apps.conf put $INTERNAL_API_KEY inside the leaf remote URL. nats-server expands $VAR only as a whole config value, never inside a URL, so nats-apps presented the literal string as its password and the platform server refused the leaf link forever. Both servers healthy, every app 'connected' — and nothing crossing: no app alert reached the inbox, no detection reached an app. Reproduced against nats-server 2.10.22: an LPR alert published on the apps bus never arrives on the platform bus; with this change it does (also on a fresh volume, and through a users-file reload).

- nats/apps.conf is now a template with @@INTERNAL_API_KEY_URL@@; apps-entrypoint.sh renders the key percent-encoded (a base64 key carries '/', '+', '='), refuses to start with the placeholder still in place, and runs nats-server -t so a bad config fails with its own parse error instead of a restart loop. --render prints the result.
- core watches the link (services/apps_bus_watch.py): polls nats-apps' /leafz every 30 s; no leaf connection for 2 min logs an error, raises a high inbox alert hourly while it lasts, and is reported at GET /api/v1/apps/bus. NATS_APPS_MONITOR_URL overrides the derived URL.
- docs/APP_CREDENTIALS.md 'When alerts stop'; CHANGELOG.
- server/tests/test_apps_bus_watch.py (11): the rendered URL for hex, base64 and every URL-special character; refusal without a key; the grace period / hourly alert / recovery state machine; the inbox row; the endpoint.