### PR TITLE
fix(apps-bus): nats-apps never started — nats-server resolves every i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Apps bus never started: `nats-apps` restart-looped on its `include`
+  path, and every app failed to resolve it.** nats-server joins *every*
+  `include` onto the config file's own directory — an absolute path
+  included — so `include "/var/lib/opennvr/nats/users.conf"` from
+  `/etc/nats/apps.conf` opened `/etc/nats/var/lib/…/users.conf`, the
+  server exited on parse, and `restart: unless-stopped` looped it
+  forever. A container that never comes up has no DNS entry, which is
+  the `socket.gaierror: Temporary failure in name resolution` for
+  `nats-apps` every SDK app logged while reconnecting without end, and
+  why no alert has reached the inbox since the apps bus landed. The
+  entrypoint now renders the config *next to* the users file
+  (`/var/lib/opennvr/nats/apps.conf`, mode 600) and the template
+  includes a bare `users.conf`; a test pins the include relative.
+  Verified against nats-server 2.10 in the container's exact layout
+  from an empty volume: server up, leaf link up, users-file reload, an
+  LPR alert crossing to the platform bus. The core watchdog now treats
+  `nats-apps` not answering its monitoring endpoint for two minutes as
+  the same outage as a dead leaf link (log error + high inbox alert
+  "Apps bus is down"), instead of a debug line.
+
 - **Apps bus: the leaf link to the platform bus never authenticated —
   app alerts stopped.** `nats/apps.conf` put `$INTERNAL_API_KEY` inside
   the leaf remote URL; nats-server expands `$VAR` only as a whole

--- a/docs/APP_CREDENTIALS.md
+++ b/docs/APP_CREDENTIALS.md
@@ -141,6 +141,14 @@ connected — and the operator's alerts simply stop. So:
   (percent-encoded — a base64 key carries `/`, `+`, `=`) into
   `/tmp/apps.conf` before starting, and refuses to start if the
   placeholder is still there. Both containers must see the same value.
+* **`nats-apps` must be *up* first.** `docker compose ps nats-apps`
+  showing `Restarting` means its config did not parse — read
+  `docker logs opennvr_nats_apps`. nats-server joins every `include`
+  onto the config file's directory (absolute paths too), which is why
+  the entrypoint renders the config next to the users file and the
+  template includes a bare `users.conf`. While it restarts, apps log
+  `Temporary failure in name resolution` for `nats-apps` and reconnect
+  forever; core raises "Apps bus is down" after two minutes.
 * To look yourself: `curl -s http://nats-apps:8222/leafz` from inside
   the stack (`leafs` must not be empty); `docker logs opennvr_nats_apps`
   for `Leafnode Error 'Authorization Violation'`; `docker logs

--- a/nats/apps-entrypoint.sh
+++ b/nats/apps-entrypoint.sh
@@ -6,7 +6,9 @@
 #    by us — percent-encoded, since INTERNAL_API_KEY may be base64 with
 #    '/', '+' or '=' (nats-server URL-decodes it on the way out).
 #    `sh apps-entrypoint.sh --render` prints the rendered config and
-#    exits (what the tests exercise).
+#    exits (what the tests exercise). The rendered file lives NEXT TO
+#    the users file because nats-server resolves every `include` — even
+#    an absolute path — relative to the config file's directory.
 # 2. Seed the users file. It lives on a volume core writes to. On a fresh
 #    volume it does not exist yet, so seed a valid file with no matchable
 #    user; core replaces it on its first start
@@ -15,8 +17,8 @@
 #    `nats-server --signal reload` sends.
 set -eu
 TEMPLATE="${APPS_CONF_TEMPLATE:-/etc/nats/apps.conf}"
-RENDERED="${APPS_CONF_RENDERED:-/tmp/apps.conf}"
 USERS="${APPS_USERS_CONF:-/var/lib/opennvr/nats/users.conf}"
+RENDERED="${APPS_CONF_RENDERED:-$(dirname "$USERS")/apps.conf}"
 
 url_encode() {
   # Every character that is not unreserved (RFC 3986) — the userinfo
@@ -47,12 +49,13 @@ if [ "${1:-}" = "--render" ]; then
   exit 0
 fi
 
+mkdir -p "$(dirname "$USERS")"
 render > "$RENDERED"
+chmod 600 "$RENDERED" 2>/dev/null || true
 if grep -v '^[[:space:]]*#' "$RENDERED" | grep -q -e '@@INTERNAL_API_KEY_URL@@' -e '$INTERNAL_API_KEY'; then
   echo "apps bus: config render left the key placeholder in place — refusing to start" >&2
   exit 1
 fi
-mkdir -p "$(dirname "$USERS")"
 if [ ! -s "$USERS" ]; then
   cat > "$USERS" <<'SEED'
 # seeded by apps-entrypoint.sh — core replaces this file

--- a/nats/apps.conf
+++ b/nats/apps.conf
@@ -20,11 +20,18 @@
 # password and the platform server would refuse it forever — with both
 # buses up, every app "connected", and no alert ever crossing to the
 # inbox. apps-entrypoint.sh renders @@INTERNAL_API_KEY_URL@@ (the key,
-# percent-encoded for a URL) into /tmp/apps.conf and starts from that.
+# percent-encoded for a URL) into /var/lib/opennvr/nats/apps.conf — the
+# users file's own directory — and starts from that.
+#
+# The include below MUST stay relative: nats-server joins EVERY include
+# path onto the config file's directory, an absolute one included
+# ("/var/lib/opennvr/nats/users.conf" from /etc/nats/apps.conf opened
+# /etc/nats/var/lib/opennvr/nats/users.conf, and the server never
+# started — a restart loop, and "nats-apps" resolving for no app).
 
 server_name: opennvr-nats-apps
 
-include "/var/lib/opennvr/nats/users.conf"
+include "users.conf"
 
 leafnodes {
   remotes: [

--- a/server/services/apps_bus_watch.py
+++ b/server/services/apps_bus_watch.py
@@ -116,17 +116,18 @@ def observe(result: dict[str, Any], *, now: float | None = None) -> dict[str, An
         st = _state
         st.checked_at = now
         if "error" in result:
+            # nats-apps itself is down or restarting (a config that will not
+            # parse loops forever under restart: unless-stopped) — the same
+            # outage for the apps as a dead link, so it counts the same way.
             st.reachable = False
             st.linked = None
             st.remotes = []
             st.error = str(result["error"])
-            # An unreachable monitor is its own problem (compose healthcheck
-            # covers a dead container); it does not count as "unlinked".
-            return out
-        st.reachable = True
-        st.error = ""
-        st.linked = bool(result.get("linked"))
-        st.remotes = list(result.get("remotes") or [])
+        else:
+            st.reachable = True
+            st.error = ""
+            st.linked = bool(result.get("linked"))
+            st.remotes = list(result.get("remotes") or [])
         if st.linked:
             if st.unlinked_since is not None and now - st.unlinked_since >= GRACE_S:
                 out["transition"] = "restored"
@@ -149,22 +150,30 @@ def observe(result: dict[str, Any], *, now: float | None = None) -> dict[str, An
 def alert_envelope(now: float | None = None) -> dict[str, Any]:
     now = time.time() if now is None else now
     snap = state()
+    down = snap["reachable"] is False
     return {
         "alert_id": f"apps-bus-unlinked-{int(now // ALERT_EVERY_S)}",
         "severity": "high",
-        "title": "Apps bus is not linked to the platform bus — app alerts cannot reach the inbox",
+        "title": ("Apps bus is down — app alerts cannot reach the inbox" if down else
+                  "Apps bus is not linked to the platform bus — app alerts cannot reach the inbox"),
         "description": (
-            "The apps bus (nats-apps) has had no leaf connection to the platform "
-            f"bus for {snap['unlinked_for_s'] // 60} minute(s). Installed apps are "
-            "connected and running, but nothing they publish crosses to core: no "
-            "app alerts, no domain events, and the platform's detections do not "
-            "reach them. Check `docker logs opennvr_nats_apps` for "
-            "'Leafnode Error' / 'Authorization Violation' (the leaf link "
-            "authenticates with INTERNAL_API_KEY — nats-apps and nats must "
-            "see the same value) and `docker logs opennvr_nats` for "
-            "'authentication error' on port 7422. docs/APP_CREDENTIALS.md → "
-            "\"When alerts stop\"."
-        ),
+            (f"The apps bus (nats-apps) has not answered its monitoring endpoint for "
+             f"{snap['unlinked_for_s'] // 60} minute(s) ({snap['error']}) — most likely the "
+             "container is restarting on a config it cannot parse: "
+             "`docker compose ps nats-apps` and `docker logs opennvr_nats_apps`. "
+             "Apps cannot resolve or reach it ('Temporary failure in name resolution' "
+             "in their logs) and reconnect forever; nothing they publish reaches core. ")
+            if down else
+            (f"The apps bus (nats-apps) has had no leaf connection to the platform "
+             f"bus for {snap['unlinked_for_s'] // 60} minute(s). Installed apps are "
+             "connected and running, but nothing they publish crosses to core: no "
+             "app alerts, no domain events, and the platform's detections do not "
+             "reach them. Check `docker logs opennvr_nats_apps` for "
+             "'Leafnode Error' / 'Authorization Violation' (the leaf link "
+             "authenticates with INTERNAL_API_KEY — nats-apps and nats must "
+             "see the same value) and `docker logs opennvr_nats` for "
+             "'authentication error' on port 7422. ")
+        ) + "docs/APP_CREDENTIALS.md → \"When alerts stop\".",
         "source": {"kind": "platform", "name": "nats-apps"},
         "tags": ["apps-bus", "leaf-link", "infrastructure"],
         "evidence": snap,
@@ -178,12 +187,17 @@ def check_once(url: str, db=None) -> dict[str, Any]:
     verdict = observe(result)
     try:
         if verdict["transition"] == "lost":
-            logger.error("apps bus: NO leaf connection to the platform bus for %ds — app alerts "
-                         "and platform detections are not crossing (%s)", GRACE_S, url)
+            snap = state()
+            if snap["reachable"] is False:
+                logger.error("apps bus: nats-apps has not answered %s for %ds (%s) — is the "
+                             "container restarting? apps cannot reach the bus", url, GRACE_S, snap["error"])
+            else:
+                logger.error("apps bus: NO leaf connection to the platform bus for %ds — app alerts "
+                             "and platform detections are not crossing (%s)", GRACE_S, url)
         elif verdict["transition"] == "restored":
             logger.info("apps bus: leaf link to the platform bus restored (%s)",
                         ", ".join(state()["remotes"]) or "?")
-        elif "error" in result:
+        elif "error" in result and verdict["transition"] is None and not verdict["alert"]:
             logger.debug("apps bus: monitor %s unreachable: %s", url, result["error"])
         if verdict["alert"]:
             from services.alerts_inbox import apply_alert

--- a/server/tests/test_apps_bus_watch.py
+++ b/server/tests/test_apps_bus_watch.py
@@ -55,13 +55,22 @@ def test_template_has_no_dollar_variable_in_the_leaf_url():
     assert "@@INTERNAL_API_KEY_URL@@" in live
 
 
+def test_include_is_relative_to_the_rendered_file():
+    # nats-server joins EVERY include path onto the config file's
+    # directory — an absolute include never opens. The entrypoint renders
+    # next to users.conf so a bare "users.conf" is the only correct form.
+    live = _config_lines(TEMPLATE.read_text())
+    includes = [l for l in live.splitlines() if l.strip().startswith("include")]
+    assert includes == ['include "users.conf"']
+
+
 @pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
 def test_render_puts_the_hex_key_in_the_leaf_url():
     out = _render("c0ffee1234deadbeef")
     assert 'url: "nats://opennvr-apps-bus:c0ffee1234deadbeef@nats:7422"' in out
     live = _config_lines(out)
     assert "@@INTERNAL_API_KEY_URL@@" not in live and "$INTERNAL_API_KEY" not in live
-    assert 'include "/var/lib/opennvr/nats/users.conf"' in out
+    assert 'include "users.conf"' in out
 
 
 @pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
@@ -118,12 +127,20 @@ def test_unlinked_counts_only_after_the_grace_period_and_alerts_hourly():
     assert w.state()["linked"] is True and w.state()["remotes"] == ["opennvr-nats"]
 
 
-def test_unreachable_monitor_is_not_treated_as_unlinked():
+def test_unreachable_monitor_counts_as_an_outage_after_the_grace_period():
+    # nats-apps restarting on a config it cannot parse: every app logs
+    # "Temporary failure in name resolution" forever. Same outage, same alert.
     t0 = 2_000_000.0
-    for i in range(10):
-        assert w.observe({"error": "ConnectError: boom"}, now=t0 + i * 60) == {"transition": None, "alert": False}
+    assert w.observe({"error": "ConnectError: boom"}, now=t0) == {"transition": None, "alert": False}
+    assert w.observe({"error": "ConnectError: boom"}, now=t0 + 60) == {"transition": None, "alert": False}
+    assert w.observe({"error": "ConnectError: boom"}, now=t0 + w.GRACE_S) == {"transition": "lost", "alert": True}
     snap = w.state()
     assert snap["reachable"] is False and snap["linked"] is None and "boom" in snap["error"]
+    env_ = w.alert_envelope(now=t0 + w.GRACE_S)
+    assert env_["title"].startswith("Apps bus is down") and "restarting" in env_["description"]
+    # it comes back linked → restored
+    assert w.observe({"linked": True, "remotes": ["opennvr-nats"]}, now=t0 + w.GRACE_S + 30) == \
+        {"transition": "restored", "alert": False}
 
 
 def test_check_once_writes_the_inbox_alert(monkeypatch, env):


### PR DESCRIPTION
…nclude relative to the config file, absolute paths too

Your diagnostics: opennvr_nats_apps 'Restarting (1)' with
  error parsing include file '/var/lib/opennvr/nats/users.conf',
  open /tmp/var/lib/opennvr/nats/users.conf: no such file or directory
and, before #431 moved the rendered config to /tmp, the same from /etc/nats. nats-server joins EVERY include path onto the directory of the config file, so the absolute include never opened, the server exited on parse, restart: unless-stopped looped it forever, and a container that never comes up has no DNS entry — the 'socket.gaierror: Temporary failure in name resolution' for nats-apps every SDK app has logged since the apps bus landed. Nothing ever reached the inbox because the bus was never there.

- render the config NEXT TO the users file (/var/lib/opennvr/nats/ apps.conf, mode 600); template includes a bare "users.conf"; mkdir before render; a test pins the include relative
- verified against nats-server 2.10 in the container's exact layout from an EMPTY volume: server up, leaf link up, users-file reload, LPR alert crossing to the platform bus
- watchdog: nats-apps not answering /leafz for the grace period now counts as the same outage as a dead leaf link (error log + high inbox alert 'Apps bus is down' naming the restart loop), not a debug line
- docs 'When alerts stop': check the container is up first