### PR TITLE
fix(apps-bus): core could not write the users file — the shared volum…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Apps bus refused every app: core could never write the users
+  file.** The `opennvr_nats_auth` volume is created root-owned by
+  `nats-apps` when it seeds `users.conf`, and core runs as `opennvr`
+  (uid 1000) — so its atomic tempfile-and-rename in that directory
+  failed on every start and every key issue, the bus only ever knew
+  the `_no_apps_yet` seed user, and logged `authentication error -
+  User "license-plate-recognition"` (and the same for every other app)
+  once the server was actually up. Core's `docker-entrypoint.sh` now
+  takes ownership of `/var/lib/opennvr/nats` like the other shared
+  volumes, `apps-entrypoint.sh` hands the directory and the seed to
+  uid 1000 from its side (so start order never matters), and a failed
+  write is an ERROR naming the cause instead of a warning. Also: the
+  rendered `apps.conf` no longer repeats the key inside a comment.
+
 - **Apps bus never started: `nats-apps` restart-looped on its `include`
   path, and every app failed to resolve it.** nats-server joins *every*
   `include` onto the config file's own directory — an absolute path

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,6 +24,17 @@ if [ -d "/app/kai-c-state" ]; then
     chown -R opennvr:opennvr /app/kai-c-state 2>/dev/null || true
 fi
 
+# Apps-bus users file (opennvr_nats_auth volume, shared with nats-apps).
+# nats-apps runs as root and creates the directory root:root 755 when it
+# seeds users.conf, so core (uid opennvr) could never replace the seed
+# with the real per-app users: every app's own NATS user stayed unknown
+# to the bus and it refused them all ("authentication error - User
+# <app>"). Core writes atomically (tempfile + rename in this directory),
+# so it needs to own the directory, not just the file.
+if [ -d "/var/lib/opennvr/nats" ]; then
+    chown -R opennvr:opennvr /var/lib/opennvr/nats 2>/dev/null || true
+fi
+
 # Recordings tree: MediaMTX used to run as root, so segment dirs it created
 # under the shared mount were root-owned — unlinkable by the backend
 # (uid 1000), which broke retention aging and the camera hard-delete purge

--- a/nats/apps-entrypoint.sh
+++ b/nats/apps-entrypoint.sh
@@ -50,6 +50,11 @@ if [ "${1:-}" = "--render" ]; then
 fi
 
 mkdir -p "$(dirname "$USERS")"
+# core (uid 1000 in its image) rewrites the users file in this directory
+# by tempfile + rename; this server runs as root and would otherwise leave
+# the directory root-owned and core locked out. Best effort — core's own
+# entrypoint does the same from its side.
+chown 1000:1000 "$(dirname "$USERS")" 2>/dev/null || true
 render > "$RENDERED"
 chmod 600 "$RENDERED" 2>/dev/null || true
 if grep -v '^[[:space:]]*#' "$RENDERED" | grep -q -e '@@INTERNAL_API_KEY_URL@@' -e '$INTERNAL_API_KEY'; then
@@ -65,6 +70,7 @@ authorization {
   ]
 }
 SEED
+  chown 1000:1000 "$USERS" 2>/dev/null || true
 fi
 
 # Fail fast with nats-server's own parse error rather than a restart loop.

--- a/nats/apps.conf
+++ b/nats/apps.conf
@@ -19,9 +19,10 @@
 # "$INTERNAL_API_KEY", so the leaf link would present that string as its
 # password and the platform server would refuse it forever — with both
 # buses up, every app "connected", and no alert ever crossing to the
-# inbox. apps-entrypoint.sh renders @@INTERNAL_API_KEY_URL@@ (the key,
-# percent-encoded for a URL) into /var/lib/opennvr/nats/apps.conf — the
-# users file's own directory — and starts from that.
+# inbox. apps-entrypoint.sh renders the key (percent-encoded for a URL)
+# over the placeholder in the leaf URL below, into
+# /var/lib/opennvr/nats/apps.conf — the users file's own directory — and
+# starts from that.
 #
 # The include below MUST stay relative: nats-server joins EVERY include
 # path onto the config file's directory, an absolute one included

--- a/server/services/nats_users.py
+++ b/server/services/nats_users.py
@@ -160,7 +160,11 @@ def write_users_conf(db, path: str | os.PathLike | None = None) -> bool:
         os.chmod(tmp, 0o640)
         os.replace(tmp, target)
     except OSError as exc:
-        logger.warning("could not write the apps-bus users file %s: %s", target, exc)
+        logger.error("could not write the apps-bus users file %s: %s — the apps bus "
+                     "keeps its previous users and refuses every app whose key is not "
+                     "in it. Usually ownership: the directory must be writable by the "
+                     "user core runs as (docker-entrypoint.sh chowns it on start)",
+                     target, exc)
         return False
     logger.info("apps-bus users file written: %d app(s) → %s",
                 sum(1 for r in rows if getattr(r, "nats_password_bcrypt", None)), target)

--- a/server/tests/test_apps_bus_watch.py
+++ b/server/tests/test_apps_bus_watch.py
@@ -55,6 +55,23 @@ def test_template_has_no_dollar_variable_in_the_leaf_url():
     assert "@@INTERNAL_API_KEY_URL@@" in live
 
 
+def test_core_entrypoint_takes_ownership_of_the_users_volume():
+    # core runs as uid opennvr; nats-apps (root) creates the shared volume
+    # directory. Without this chown core can never replace the seed users
+    # file and the bus refuses every app.
+    text = (REPO / "docker-entrypoint.sh").read_text()
+    assert "chown -R opennvr:opennvr /var/lib/opennvr/nats" in text
+    live = _config_lines(ENTRYPOINT.read_text())
+    assert 'chown 1000:1000 "$(dirname "$USERS")"' in live
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh")
+def test_rendered_comment_does_not_carry_the_key():
+    out = _render("c0ffee1234deadbeef")
+    comments = "\n".join(l for l in out.splitlines() if l.strip().startswith("#"))
+    assert "c0ffee1234deadbeef" not in comments
+
+
 def test_include_is_relative_to_the_rendered_file():
     # nats-server joins EVERY include path onto the config file's
     # directory — an absolute include never opens. The entrypoint renders


### PR DESCRIPTION
…e was root-owned, so the bus refused every app

Your diagnostics after #432: nats-apps Up, leaf link up, and then
  authentication error - User "license-plate-recognition"
  authentication error - User "occupancy-counting"
  authentication error - User "footage-search"
with users.conf on the volume still the '_no_apps_yet' seed. nats-apps runs as root and creates /var/lib/opennvr/nats root:root 755; core runs as opennvr (uid 1000) and writes the users file by tempfile + rename in that directory, which fails with EACCES on every start and every key issue — so the bus only ever knew the seed user.

- docker-entrypoint.sh (core): chown -R opennvr:opennvr /var/lib/opennvr/nats on start, like the other shared volumes
- apps-entrypoint.sh: chown the directory and the seed file to 1000:1000 from its side too, so the two containers' start order never matters
- nats_users.write_users_conf: a failed write is an ERROR naming the ownership cause, not a warning
- apps.conf: the template comment no longer carries the placeholder, so the rendered file does not repeat the key in a comment
- tests: entrypoints take ownership; rendered comments carry no key