### PR TITLE
fix(camera-agent): installed apps are managed in the catalog, not rem…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **camera-agent: removing an installed app's skill said "skill can't
+  be enabled yet".** Installed catalog apps appear in the skills rail
+  read-only — they are enabled/disabled in the App Catalog — but the
+  rail offered ✕ and the server answered with the enable-time message.
+  The rail now shows ⚙ linking to the app's catalog page, and
+  `POST /skills/app:<id>/disable` answers 409 naming the app and where
+  it is managed (`manage_url` on the skill entry).
+- **camera-agent: every relayed app alert was read aloud.** New
+  `announce_app_alerts` policy — `important` (default: high/critical
+  only), `all`, `none` — settable in the UI (Automations → ⚙, persisted)
+  or config; every alert still lands in the feed with a chime, the
+  voice UI speaks only those the server marks `announce`. Relayed text
+  no longer repeats the title when the summary already starts with it.
+
 - **OpenNVR Agent showed "unreachable" in the App Catalog while it
   worked.** It registered its contract URL as
   `https://<container id>:9100` — under compose the container's

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -287,6 +287,12 @@ class AppConfig:
     # arms its after-hours person alarm as  person: siren . An explicit
     # ring on the alarm always wins; this only decides the DEFAULT.
     alarm_ring_defaults: dict[str, str] | None = None
+    # Which relayed APP alerts the voice UI speaks aloud (they always land
+    # in the feed with a chime): "all", "important" (high/critical only —
+    # the default, so a plate reader's every read is shown, not narrated),
+    # or "none". Operator-editable in the UI (Automations → ⚙); the UI
+    # choice persists in the state file and wins over this.
+    announce_app_alerts: str = "important"
 
     # Public base URL of THIS agent (e.g. "https://agent.nvr.example"), used
     # only to put a tap-to-open deep link (/demo/camera/{id}) into outgoing
@@ -2934,6 +2940,7 @@ def load_config(path: str | Path) -> AppConfig:
         auth_mode=str(raw.get("auth_mode") or "none").strip().lower(),
         agent_public_url=raw.get("agent_public_url"),
         agent_contract_url=raw.get("agent_contract_url"),
+        announce_app_alerts=_str("announce_app_alerts", "important"),
         alarm_ring_defaults=(
             {str(k).strip().lower(): str(v).strip().lower()
              for k, v in raw["alarm_ring_defaults"].items()}
@@ -3241,6 +3248,7 @@ class CameraAgentRuntime:
         # LAST layer over config + built-ins in ring_defaults(); durable
         # via persist()/load_state like the skill toggles.
         self._ring_overrides: dict[str, str] = {}
+        self._announce_app_alerts: str | None = None   # UI override of cfg
         self._configure_tools()
         self.tool_handlers = {
             "describe_camera": self.tools.describe_camera,
@@ -3432,6 +3440,33 @@ class CameraAgentRuntime:
                 if v in ("siren", "pulse", "chime", "silent"):
                     merged[k] = v
         return merged
+
+    ANNOUNCE_LEVELS = ("all", "important", "none")
+
+    def announce_app_alerts(self) -> str:
+        """Effective policy for speaking relayed app alerts: the UI
+        override when one was saved, else config, else "important"."""
+        for v in (self._announce_app_alerts, getattr(self.cfg, "announce_app_alerts", None)):
+            v = str(v or "").strip().lower()
+            if v in self.ANNOUNCE_LEVELS:
+                return v
+        return "important"
+
+    def set_announce_app_alerts(self, level: str) -> str:
+        level = str(level or "").strip().lower()
+        if level not in self.ANNOUNCE_LEVELS:
+            raise ValueError("announce_app_alerts must be all|important|none")
+        self._announce_app_alerts = level
+        self.persist()
+        return level
+
+    def should_announce_app_alert(self, severity: str | None) -> bool:
+        policy = self.announce_app_alerts()
+        if policy == "all":
+            return True
+        if policy == "none":
+            return False
+        return str(severity or "").strip().lower() in ("high", "critical")
 
     def set_ring_overrides(self, overrides: dict[str, str]) -> dict[str, str]:
         """Replace the UI-edited overrides (sanitized), persist, return
@@ -3698,7 +3733,11 @@ class CameraAgentRuntime:
                 "enabled": True,
                 "available": True,
                 "read_only": True,
-                "hint": "",
+                "hint": "installed app — enable, disable or uninstall it in the App Catalog",
+                # Where the operator manages it (the app's catalog page).
+                "manage_url": (
+                    f"{self.cfg.opennvr_ui_url.rstrip('/')}/app-catalog/{app_id}"
+                    if getattr(self.cfg, "opennvr_ui_url", None) else None),
                 "backing_tasks": [],
                 "tasks_available": True,
             })
@@ -3974,6 +4013,7 @@ class CameraAgentRuntime:
             # comes back on the next restart (its tools re-advertised).
             "disabled_skills": sorted(self.disabled_skills),
             "ring_overrides": dict(self._ring_overrides),
+            "announce_app_alerts": self._announce_app_alerts,
         }
         try:
             d = os.path.dirname(self.cfg.state_path) or "."
@@ -4010,6 +4050,9 @@ class CameraAgentRuntime:
             self._ring_overrides = {
                 str(k).lower(): str(v).lower() for k, v in ro.items()
                 if str(v).lower() in ("siren", "pulse", "chime", "silent")}
+        aa = data.get("announce_app_alerts")
+        if isinstance(aa, str) and aa.lower() in self.ANNOUNCE_LEVELS:
+            self._announce_app_alerts = aa.lower()
         restored_disabled: list[str] = []
         for sid in (data.get("disabled_skills") or []):
             if self.set_skill_enabled(sid, False):
@@ -4255,7 +4298,12 @@ class CameraAgentRuntime:
         self.monitors._notifications.append({
             "id": self.monitors._next_note_id,
             "source": f"app:{alert.app_id}",
-            "text": f"{alert.title} — {alert.summary}",
+            "text": relay_text(alert.title, alert.summary),
+            "severity": str(alert.severity or "info"),
+            "camera": alert.camera_id,
+            # The feed always shows it (with a chime); whether the voice
+            # UI also SPEAKS it follows the site's announce policy.
+            "announce": self.should_announce_app_alert(alert.severity),
             "ts": now,
         })
         self.monitors._next_note_id += 1
@@ -5250,6 +5298,22 @@ def turn_vad_params(cfg: Any) -> Any:
 AGENT_VERSION = "1.0.0"
 
 
+def relay_text(title: str | None, summary: str | None) -> str:
+    """One line for the feed / the voice: ``title — summary``, unless the
+    summary already restates the title (SDK alerts often do: "Monitored
+    plate X seen — Monitored plate X seen: License plate…"), in which
+    case the summary alone."""
+    t = " ".join(str(title or "").split())
+    m = " ".join(str(summary or "").split())
+    if not m:
+        return t
+    if not t:
+        return m
+    if m.lower().startswith(t.lower().rstrip(".:")):
+        return m
+    return f"{t} — {m}"
+
+
 def agent_scheme(cfg: Any) -> str:
     return "https" if getattr(cfg, "tls_certfile", None) else "http"
 
@@ -5606,7 +5670,8 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         (the editor edits ONLY the overrides; config/built-ins show as
         inherited)."""
         return {"defaults": runtime.ring_defaults(),
-                "overrides": dict(runtime._ring_overrides)}
+                "overrides": dict(runtime._ring_overrides),
+                "announce_app_alerts": runtime.announce_app_alerts()}
 
     @app.put("/alarm-defaults")
     async def _put_alarm_defaults(request: Request) -> JSONResponse:
@@ -5616,14 +5681,21 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             body = await request.json()
         except Exception:
             body = {}
-        overrides = (body or {}).get("overrides")
+        body = body or {}
+        overrides = body.get("overrides", dict(runtime._ring_overrides))
         if not isinstance(overrides, dict):
             return JSONResponse({"error": "overrides must be a mapping of "
                                           "target -> siren|pulse|chime|silent"},
                                 status_code=400)
+        if "announce_app_alerts" in body:
+            try:
+                runtime.set_announce_app_alerts(body.get("announce_app_alerts"))
+            except ValueError as exc:
+                return JSONResponse({"error": str(exc)}, status_code=400)
         merged = runtime.set_ring_overrides(overrides)
         return JSONResponse({"defaults": merged,
-                             "overrides": dict(runtime._ring_overrides)})
+                             "overrides": dict(runtime._ring_overrides),
+                             "announce_app_alerts": runtime.announce_app_alerts()})
 
     @app.get("/events")
     async def _events() -> dict[str, Any]:
@@ -5879,6 +5951,18 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             return JSONResponse({"error": "action must be enable or disable"},
                                 status_code=400)
         await runtime.kaic_capabilities.refresh()   # 60s TTL; never raises
+        if skill_id.startswith("app:"):
+            # An installed catalog app shows up as a skill so the operator
+            # can SEE it; enabling/disabling it is the App Catalog's job
+            # (operator permission, audit) — the agent only reads apps.
+            skill = next((s for s in runtime.skills_payload() if s["id"] == skill_id), None)
+            name = skill["name"] if skill else skill_id[4:]
+            return JSONResponse({
+                "error": f"{name} is an installed app, managed in the App Catalog",
+                "hint": (f"Disable or uninstall {name} from OpenNVR → App Catalog; "
+                         "the agent only reads installed apps."),
+                "url": (skill or {}).get("manage_url"),
+            }, status_code=409)
         ok = runtime.set_skill_enabled(skill_id, action == "enable")
         if not ok:
             # Unknown skill, or its backend isn't configured yet.
@@ -5886,6 +5970,9 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             if skill is None:
                 return JSONResponse({"error": f"unknown skill {skill_id!r}"},
                                     status_code=404)
+            if action == "disable":
+                return JSONResponse({"error": "skill can't be disabled", "hint": skill["hint"]},
+                                    status_code=409)
             return JSONResponse(
                 {"error": "skill can't be enabled yet", "hint": skill["hint"]},
                 status_code=409)

--- a/examples/camera-agent/config.example.yml
+++ b/examples/camera-agent/config.example.yml
@@ -276,6 +276,16 @@ system_prompt: |
 #     frame_url: http://192.168.1.50/cgi-bin/snapshot.cgi
 #     opennvr_camera_id: 3
 
+# Which alerts relayed from INSTALLED APPS the voice UI speaks aloud. They
+# always land in the feed with a chime; this only decides narration:
+#   important — high & critical only (default: a plate reader's every read
+#               is shown, not read out loud)
+#   all       — every app alert
+#   none      — never speak app alerts
+# The operator can change it live (Automations → ⚙); that choice persists
+# in the state file and wins over this value.
+announce_app_alerts: important
+
 # Per-site alert-level defaults by target (merged over the built-ins:
 # fire/smoke/flame/gas → siren). Levels: siren = CRITICAL, rings until
 # silenced · pulse = URGENT, loud ~1 min then stands down · chime =

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -328,6 +328,8 @@
       border:1px solid var(--stroke); border-radius:999px; padding:0 0.4rem;}
     .skill .sk-tool.off{opacity:0.45; text-decoration:line-through;}
     .skill .sk-x{background:transparent; border:none; color:var(--faint); cursor:pointer; font-size:0.95rem; flex:0 0 auto; padding:0 0.1rem;}
+    .skill .sk-manage{text-decoration:none; color:var(--faint);}
+    .skill a.sk-manage:hover{color:var(--text);}
     .skill .sk-x:hover{color:var(--danger);}
     #skillBrowse{margin-top:0.5rem; border-top:1px solid var(--stroke); padding-top:0.5rem;}
     #skillSearch,.addform input,.addform select{width:100%; background:rgba(0,0,0,0.28); color:var(--text);
@@ -809,6 +811,12 @@
             <div class="empty-note" id="ringInherited"></div>
             <div id="ringRows"></div>
             <button class="ghost" id="ringAddRow" type="button">+ add target</button>
+            <div class="rec-lbl">Speak alerts from installed apps</div>
+            <select id="announceApps" aria-label="Speak app alerts">
+              <option value="important">Important only — high &amp; critical (default)</option>
+              <option value="all">All — every app alert, e.g. each plate read</option>
+              <option value="none">Never — show in the feed with a chime, don't speak</option>
+            </select>
             <button class="ghost primary" id="ringSave" type="button">Save defaults</button>
           </div>
           <!-- One-click presets, rendered from GET /alarm-presets with HONEST
@@ -2422,7 +2430,10 @@
 
     // ── monitors ──
     async function pollMonitors(data){ if(!authReady())return; if(!data) try{ data=await (await fetch("/monitors")).json(); }catch{ return; }
-      for(const n of (data.notifications||[])){ if(!seenNotes[n.id]){ seenNotes[n.id]=true; addMsg(n.text,"agent"); playChime("notify"); await announce(n.text); } }
+      for(const n of (data.notifications||[])){ if(!seenNotes[n.id]){ seenNotes[n.id]=true; addMsg(n.text,"agent"); playChime("notify");
+          // App alerts carry announce=false under the site's "important
+          // only" / "never" policy: shown + chimed, not narrated.
+          if(n.announce!==false) await announce(n.text); } }
       renderMonitors(data.monitors||[]); }
     function renderMonitors(monitors){ const active=monitors.filter(m=>m.active);
       if(!active.length){ monitorListEl.innerHTML=""; updateAutoEmpty(); return; }
@@ -2644,7 +2655,14 @@
       const rb=$("skillRestore"); if(rb) rb.hidden=!_skills.some(s=>!s.enabled&&s.available);
       if(!on.length) el.innerHTML='<div class="empty-note">No skills enabled — tap + to add.</div>';
       for(const s of on){ const d=document.createElement("div"); d.className="skill";
-        d.innerHTML=`<span class="sk-ic">${s.icon}</span><span class="sk-body"><span class="sk-nm"></span><span class="sk-uses"></span></span><button class="sk-x" title="Remove skill">✕</button>`;
+        // An installed catalog app is shown here so the operator can SEE
+        // it; it is enabled/disabled in the App Catalog (operator
+        // permission, audit) — so a link there, not a remove button.
+        const ctl = s.read_only
+          ? (s.manage_url?`<a class="sk-x sk-manage" href="${s.manage_url}" target="_blank" rel="noopener" title="Managed in the App Catalog — open it">⚙</a>`
+                         :`<span class="sk-x sk-manage" title="Managed in the App Catalog">⚙</span>`)
+          : `<button class="sk-x" title="Remove skill">✕</button>`;
+        d.innerHTML=`<span class="sk-ic">${s.icon}</span><span class="sk-body"><span class="sk-nm"></span><span class="sk-uses"></span></span>${ctl}`;
         d.querySelector(".sk-nm").textContent=s.name;
         d.querySelector(".sk-uses").textContent="uses "+s.uses;
         // Tool-level honesty: list every tool this skill bundles; grey out
@@ -2660,7 +2678,7 @@
             tl.appendChild(c); }
           d.querySelector(".sk-body").appendChild(tl);
         }
-        d.querySelector(".sk-x").addEventListener("click",()=>{
+        if(!s.read_only) d.querySelector(".sk-x").addEventListener("click",()=>{
           if(CORE_SKILLS[s.id] && !window.confirm('Turn off "'+s.name+'"? The agent will no longer be able to '+CORE_SKILLS[s.id]+' until you add it back.')) return;
           toggleSkill(s.id,"disable"); });
         el.appendChild(d); }
@@ -2775,6 +2793,7 @@
       if(!d){ addMsg("Couldn't load alert defaults.","sys"); return; }
       const rows=$("ringRows"); rows.innerHTML="";
       for(const [k,v] of Object.entries(d.overrides||{})) rows.appendChild(_ringRow(k,v));
+      const an=$("announceApps"); if(an) an.value=d.announce_app_alerts||"important";
       const inherited=Object.entries(d.defaults||{}).filter(([k])=>!(k in (d.overrides||{})));
       $("ringInherited").textContent=inherited.length?
         ("Inherited: "+inherited.map(([k,v])=>k+" → "+v).join(", ")):"";
@@ -2786,8 +2805,9 @@
         for(const row of document.querySelectorAll("#ringRows .ringrow")){
           const t=row.querySelector("input").value.trim().toLowerCase();
           if(t) overrides[t]=row.querySelector("select").value; }
+        const announce_app_alerts=($("announceApps")||{}).value||"important";
         try{ const r=await fetch("/alarm-defaults",{method:"PUT",
-            headers:{"Content-Type":"application/json"},body:JSON.stringify({overrides})});
+            headers:{"Content-Type":"application/json"},body:JSON.stringify({overrides,announce_app_alerts})});
           const d=await r.json().catch(()=>({}));
           if(!r.ok){ addMsg("Couldn't save alert defaults: "+(d.error||("HTTP "+r.status)),"sys"); return; }
           window._ringDefaults=d.defaults||{};

--- a/examples/camera-agent/tests/test_app_alert_relay.py
+++ b/examples/camera-agent/tests/test_app_alert_relay.py
@@ -643,3 +643,77 @@ def test_subscriber_reconnects_after_connection_closes(monkeypatch):
         await asyncio.wait_for(task, timeout=2.0)
 
     asyncio.run(_drive())
+
+
+# ── what gets SPOKEN vs only shown ─────────────────────────────────────
+
+
+def _sev(app_id, title, severity, summary=None):
+    return AlertRecord(received_at=time.time(), app_id=app_id, camera_id="front-door",
+                       title=title, severity=severity, summary=summary or title)
+
+
+def test_relayed_alerts_carry_the_announce_policy():
+    """Default "important": every relayed app alert lands in the feed, but
+    only high/critical ones are marked for the voice UI to speak — a plate
+    reader's every read is shown with a chime, not narrated."""
+    rt = _runtime(nats_url="nats://x")
+    assert rt.announce_app_alerts() == "important"
+    rt._relay_app_alert(_sev("lpr", "Monitored plate 66HH07 seen", "medium"))
+    rt.monitors._cooldown = 0
+    rt._relay_app_alert(_sev("lpr", "Unknown vehicle K884RS", "info"))
+    rt._relay_app_alert(_sev("intrusion", "Intrusion at the gate", "high"))
+    notes = rt.monitors.notifications()
+    assert [n["announce"] for n in notes] == [False, False, True]
+    assert [n["severity"] for n in notes] == ["medium", "info", "high"]
+
+    rt.set_announce_app_alerts("all")
+    rt._relay_app_alert(_sev("lpr", "Monitored plate H644LX seen", "medium"))
+    assert rt.monitors.notifications()[-1]["announce"] is True
+    rt.set_announce_app_alerts("none")
+    rt._relay_app_alert(_sev("fire", "Fire", "critical"))
+    assert rt.monitors.notifications()[-1]["announce"] is False
+    with pytest.raises(ValueError):
+        rt.set_announce_app_alerts("loud")
+
+
+def test_announce_policy_persists_and_config_is_the_fallback(tmp_path):
+    cfg = AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+        state_path=str(tmp_path / "state.json"), announce_app_alerts="all",
+        cameras=[CameraSpec(camera_id="front-door", frame_url="http://x/1.jpg", role="front")],
+    )
+    rt = CameraAgentRuntime(cfg)
+    assert rt.announce_app_alerts() == "all"          # config
+    rt.set_announce_app_alerts("none")                # UI override, persisted
+    rt2 = CameraAgentRuntime(cfg)
+    rt2.load_state()
+    assert rt2.announce_app_alerts() == "none"
+
+
+def test_relay_text_does_not_repeat_the_title():
+    from camera_agent import relay_text
+    assert relay_text("Monitored plate 66HH07 seen",
+                      "Monitored plate 66HH07 seen: License plate '66HH07' read on camera cam1") == \
+        "Monitored plate 66HH07 seen: License plate '66HH07' read on camera cam1"
+    assert relay_text("PPE violation", "No helmet on worker 3") == "PPE violation — No helmet on worker 3"
+    assert relay_text("PPE violation", "") == "PPE violation"
+    assert relay_text("", "just a summary") == "just a summary"
+
+
+def test_alarm_defaults_endpoint_carries_the_announce_policy():
+    from fastapi.testclient import TestClient
+
+    from camera_agent import build_app
+
+    rt = _runtime()
+    tc = TestClient(build_app(rt))
+    assert tc.get("/alarm-defaults").json()["announce_app_alerts"] == "important"
+    r = tc.put("/alarm-defaults", json={"announce_app_alerts": "none"})
+    assert r.status_code == 200 and r.json()["announce_app_alerts"] == "none"
+    assert tc.put("/alarm-defaults", json={"announce_app_alerts": "loud"}).status_code == 400
+    # the ring overrides survive a save that only changed the policy
+    tc.put("/alarm-defaults", json={"overrides": {"snake": "siren"}})
+    tc.put("/alarm-defaults", json={"announce_app_alerts": "all"})
+    d = tc.get("/alarm-defaults").json()
+    assert d["overrides"] == {"snake": "siren"} and d["announce_app_alerts"] == "all"

--- a/examples/camera-agent/tests/test_demo_skills_ui.py
+++ b/examples/camera-agent/tests/test_demo_skills_ui.py
@@ -449,3 +449,37 @@ def test_leaving_the_camera_screen_cancels_a_pending_grace_timer():
     fn = html[html.index("function stopWebrtc"):]
     fn = fn[:fn.index("// The same WebRTC")]
     assert "_clearWhepGrace();" in fn
+
+
+def test_app_backed_skill_cannot_be_toggled_here_and_points_at_the_catalog():
+    """An installed catalog app appears as a read-only skill; the ✕ used
+    to answer "skill can't be enabled yet" — wrong verb, wrong place. Now:
+    a 409 that names the app and where it is managed."""
+    from fastapi.testclient import TestClient
+
+    from camera_agent import AppConfig, CameraAgentRuntime, build_app
+    from context import CameraSpec
+
+    cfg = AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+                    opennvr_api_url="http://core:8000", opennvr_ui_url="https://nvr.local",
+                    cameras=[CameraSpec(camera_id="c", frame_url="http://x", role="f")])
+    rt = CameraAgentRuntime(cfg)
+
+    class _Reg:
+        apps_cached = [{"id": "license-plate-recognition", "name": "License Plate Recognition",
+                        "enabled": True, "manifest": {"summary": "Reads plates"}}]
+    rt.app_registry = _Reg()
+    entry = next(s for s in rt.skills_payload() if s["id"] == "app:license-plate-recognition")
+    assert entry["read_only"] is True
+    assert entry["manage_url"] == "https://nvr.local/app-catalog/license-plate-recognition"
+    assert "App Catalog" in entry["hint"]
+
+    tc = TestClient(build_app(rt))
+    r = tc.post("/skills/app:license-plate-recognition/disable")
+    assert r.status_code == 409
+    body = r.json()
+    assert "License Plate Recognition" in body["error"] and "App Catalog" in body["error"]
+    assert body["url"] == "https://nvr.local/app-catalog/license-plate-recognition"
+    assert "can't be enabled yet" not in body["error"]
+    # the app entry is still there — nothing was toggled
+    assert any(s["id"] == "app:license-plate-recognition" for s in rt.skills_payload())


### PR DESCRIPTION
…oved from the skills rail; app alerts are spoken by policy

Two things seen on a live stack with the LPR app relaying plate reads:

1. ✕ on the 'License Plate Recognition' skill answered "Couldn't disable skill: skill can't be enabled yet". App-backed entries are read-only by design (an installed app is enabled/disabled in the App Catalog, behind the operator permission and audit), but the rail offered a remove button and the server fell through to the enable-time message. The rail now shows ⚙ linking to the app's catalog page (manage_url on the entry); POST /skills/app:<id>/disable answers 409 naming the app and where it is managed; a non-app skill that cannot be disabled gets its own message.

2. Every relayed app alert was read aloud — a plate reader narrating each read. New announce_app_alerts policy: important (default: high/critical only), all, none — config or the UI (Automations → ⚙, persisted in the state file, wins over config). Every alert still lands in the feed with a chime; notifications carry announce + severity and the voice UI speaks only those marked. relay_text() no longer repeats the title when the summary already restates it ('Monitored plate X seen — Monitored plate X seen: …').

Tests: policy per severity, persistence + config fallback, relay text, /alarm-defaults round trip keeps ring overrides, 409 for app skills. camera-agent suite 867 passed.