### PR TITLE
feat(camera-agent): mute an installed app in the agent without stoppi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **camera-agent: mute an installed app in the agent.** ✕ on an app
+  entry in the skills rail now mutes it *in the agent only* — its
+  alerts are not relayed or spoken, it is not listed by `list_apps`,
+  and `app_status` / `recent_app_alerts` say so — while the app keeps
+  running for the rest of OpenNVR. Add it back from **+** any time;
+  persisted like every other toggle, cleared by Restore defaults. ⚙
+  still opens the app in the App Catalog for the real enable/disable/
+  uninstall. (`disabled_skills` accepts `app:<id>`.)
+
 ### Fixed
 
 - **camera-agent: removing an installed app's skill said "skill can't

--- a/examples/camera-agent/GUIDE.md
+++ b/examples/camera-agent/GUIDE.md
@@ -317,6 +317,18 @@ embedding. It is not listed under the sidebar's **Applications** group —
 that group holds the first-class pages (Vehicles, Occupancy) an app
 *provides*; the agent's page is its own.
 
+## Muting an app in the agent
+
+Installed catalog apps show in the skills rail next to the agent's own
+skills. ✕ on one **mutes it in the agent only**: its alerts are no
+longer relayed into the feed or spoken, it drops out of `list_apps`, and
+`app_status` / `recent_app_alerts` answer "muted in this agent". The app
+itself keeps running for the rest of OpenNVR — its own page, the inbox,
+other consumers. Add it back from **+** at any time; the mute is
+persisted like every other toggle and cleared by **Restore defaults**.
+The ⚙ next to it opens the app in the App Catalog, which remains the
+place to enable, disable or uninstall the app for real.
+
 ## Faces
 
 Off by default — it needs the InsightFace recognition adapter, which

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -3717,6 +3717,7 @@ class CameraAgentRuntime:
                 for e in (manifest.get("emits") or [])
                 if isinstance(e, dict) and e.get("name")
             ]
+            muted = self.app_muted(app_id)
             entries.append({
                 "id": f"app:{app_id}",
                 "source": "app",           # clearly marks the app door origin
@@ -3728,12 +3729,17 @@ class CameraAgentRuntime:
                         else "installed app",
                 "summary": summary,
                 "emits": emits,
-                # Installed + enabled by an operator ⇒ enabled. The agent
-                # can query it (read-only); it can't toggle or configure it.
-                "enabled": True,
+                # Installed + enabled by an operator in the catalog ⇒ the
+                # agent may use it; ✕ here MUTES it in the agent only (no
+                # relay, not listed, not queried) — the app keeps running
+                # for the rest of OpenNVR. Re-add it from "+" any time.
+                "enabled": not muted,
                 "available": True,
-                "read_only": True,
-                "hint": "installed app — enable, disable or uninstall it in the App Catalog",
+                "read_only": False,
+                "hint": ("muted in the agent — add it back from + any time; the "
+                         "app itself keeps running" if muted else
+                         "installed app — ✕ mutes it in the agent only; enable, "
+                         "disable or uninstall the app itself in the App Catalog"),
                 # Where the operator manages it (the app's catalog page).
                 "manage_url": (
                     f"{self.cfg.opennvr_ui_url.rstrip('/')}/app-catalog/{app_id}"
@@ -3746,6 +3752,20 @@ class CameraAgentRuntime:
     def set_skill_enabled(self, skill_id: str, enabled: bool) -> bool:
         """Turn a skill on/off and reconfigure the toolset. Returns False if the
         skill is unknown or can't be enabled (backend not configured)."""
+        if skill_id.startswith("app:"):
+            # An installed catalog app, muted or unmuted IN THE AGENT only:
+            # the app keeps running for the rest of OpenNVR (its own page,
+            # the inbox); the agent just stops relaying its alerts and
+            # stops counting it among the apps it queries. Same durable
+            # toggle set as the agent's own skills, same Restore defaults.
+            app_id = skill_id[4:].strip()
+            if not app_id or not self._app_known(app_id):
+                return False
+            if enabled:
+                self.disabled_skills.discard(skill_id)
+            else:
+                self.disabled_skills.add(skill_id)
+            return True
         if skill_id not in SKILL_TOOLS:
             return False
         if enabled:
@@ -3757,6 +3777,20 @@ class CameraAgentRuntime:
             self.disabled_skills.add(skill_id)
         self._configure_tools()
         return True
+
+    def _app_known(self, app_id: str) -> bool:
+        """Is ``app_id`` an installed app as far as the registry cache
+        knows? With the registry unreachable (cache None) the answer is
+        yes — a stale state file must still be able to restore a mute."""
+        registry = getattr(self, "app_registry", None)
+        apps = getattr(registry, "apps_cached", None) if registry is not None else None
+        if apps is None:
+            return True
+        return any(str(a.get("id") or "") == app_id for a in apps)
+
+    def app_muted(self, app_id: str | None) -> bool:
+        """Muted in the agent: alerts not relayed, not listed, not queried."""
+        return bool(app_id) and f"app:{app_id}" in self.disabled_skills
 
     def hardware_recommendation(self) -> dict[str, Any]:
         """What the ENABLED skills run on vs. what makes them fast — the
@@ -4170,8 +4204,15 @@ class CameraAgentRuntime:
         apps = await self.app_registry.list_apps()
         if apps is None:
             return self._APP_REGISTRY_UNREACHABLE
-        enabled = [a for a in apps if a.get("enabled")]
+        muted = [a for a in apps if a.get("enabled") and self.app_muted(str(a.get("id") or ""))]
+        enabled = [a for a in apps if a.get("enabled") and not self.app_muted(str(a.get("id") or ""))]
         if not enabled:
+            if muted:
+                return (
+                    "Every installed app is muted in this agent "
+                    f"({', '.join(str(a.get('name') or a.get('id')) for a in muted)}). "
+                    "The operator can add one back from the skills panel."
+                )
             if apps:
                 return (
                     "There are catalog apps installed, but none are currently "
@@ -4203,6 +4244,9 @@ class CameraAgentRuntime:
         app_id = str(args.get("app_id") or "").strip()
         if not app_id:
             return "Tell me which app — I need its id (from list_apps)."
+        if self.app_muted(app_id):
+            return (f"App '{app_id}' is muted in this agent — I don't relay or "
+                    "query it. The operator can add it back from the skills panel.")
         status = await self.app_registry.app_status(app_id)
         if status is None:
             return self._APP_REGISTRY_UNREACHABLE
@@ -4246,9 +4290,13 @@ class CameraAgentRuntime:
         else:
             app_id = str(app_arg).strip() or None
 
-        alerts = self.context.recent_app_alerts(
-            app_id=app_id, window_seconds=window
-        )
+        if app_id and self.app_muted(app_id):
+            return (f"App '{app_id}' is muted in this agent — its alerts aren't "
+                    "relayed here. The operator can add it back from the skills panel.")
+        alerts = [
+            a for a in self.context.recent_app_alerts(app_id=app_id, window_seconds=window)
+            if not self.app_muted(str(a.app_id))
+        ]
         if not alerts:
             scope = f"'{app_id}'" if app_id else "any app"
             mins = int(window / 60) or 1
@@ -4286,6 +4334,9 @@ class CameraAgentRuntime:
         side is rate-limited."""
         import time as _t
 
+        if self.app_muted(str(alert.app_id)):
+            logger.debug("app alert dropped (muted in the agent): app:%s", alert.app_id)
+            return
         now = _t.time()
         key = (str(alert.app_id), str(alert.camera_id))
         if now - self._app_relay_last.get(key, 0.0) < self.monitors._cooldown:
@@ -5951,19 +6002,11 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             return JSONResponse({"error": "action must be enable or disable"},
                                 status_code=400)
         await runtime.kaic_capabilities.refresh()   # 60s TTL; never raises
-        if skill_id.startswith("app:"):
-            # An installed catalog app shows up as a skill so the operator
-            # can SEE it; enabling/disabling it is the App Catalog's job
-            # (operator permission, audit) — the agent only reads apps.
-            skill = next((s for s in runtime.skills_payload() if s["id"] == skill_id), None)
-            name = skill["name"] if skill else skill_id[4:]
-            return JSONResponse({
-                "error": f"{name} is an installed app, managed in the App Catalog",
-                "hint": (f"Disable or uninstall {name} from OpenNVR → App Catalog; "
-                         "the agent only reads installed apps."),
-                "url": (skill or {}).get("manage_url"),
-            }, status_code=409)
         ok = runtime.set_skill_enabled(skill_id, action == "enable")
+        if not ok and skill_id.startswith("app:"):
+            return JSONResponse({"error": f"no installed app {skill_id[4:]!r} — "
+                                          "install and enable it in the App Catalog first"},
+                                status_code=404)
         if not ok:
             # Unknown skill, or its backend isn't configured yet.
             skill = next((s for s in runtime.skills_payload() if s["id"] == skill_id), None)

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -2655,13 +2655,14 @@
       const rb=$("skillRestore"); if(rb) rb.hidden=!_skills.some(s=>!s.enabled&&s.available);
       if(!on.length) el.innerHTML='<div class="empty-note">No skills enabled — tap + to add.</div>';
       for(const s of on){ const d=document.createElement("div"); d.className="skill";
-        // An installed catalog app is shown here so the operator can SEE
-        // it; it is enabled/disabled in the App Catalog (operator
-        // permission, audit) — so a link there, not a remove button.
-        const ctl = s.read_only
-          ? (s.manage_url?`<a class="sk-x sk-manage" href="${s.manage_url}" target="_blank" rel="noopener" title="Managed in the App Catalog — open it">⚙</a>`
-                         :`<span class="sk-x sk-manage" title="Managed in the App Catalog">⚙</span>`)
-          : `<button class="sk-x" title="Remove skill">✕</button>`;
+        // An installed catalog app: ✕ MUTES it in the agent only (no relay,
+        // not listed, not queried — the app keeps running for the rest of
+        // OpenNVR; add it back from +). ⚙ opens the app in the App Catalog,
+        // where the app itself is enabled, disabled or uninstalled.
+        const manage = (s.source==="app" && s.manage_url)
+          ? `<a class="sk-x sk-manage" href="${s.manage_url}" target="_blank" rel="noopener" title="Open in the App Catalog (enable/disable/uninstall the app itself)">⚙</a>` : "";
+        const ctl = s.read_only ? manage
+          : manage+`<button class="sk-x" title="${s.source==="app"?"Mute in the agent (the app keeps running)":"Remove skill"}">✕</button>`;
         d.innerHTML=`<span class="sk-ic">${s.icon}</span><span class="sk-body"><span class="sk-nm"></span><span class="sk-uses"></span></span>${ctl}`;
         d.querySelector(".sk-nm").textContent=s.name;
         d.querySelector(".sk-uses").textContent="uses "+s.uses;
@@ -2757,7 +2758,8 @@
         const d=await r.json().catch(()=>({}));
         if(!r.ok){ addMsg("Couldn't "+action+" skill: "+(d.hint||d.error||("HTTP "+r.status)),"sys"); return; }
         _skills=d.skills||_skills; renderSkills(); loadHardware();
-        addMsg((action==="enable"?"Enabled":"Removed")+" a skill — the agent reconfigured its tools.","sys");
+        if(id.startsWith("app:")) addMsg(action==="enable"?"App added back — the agent relays and queries it again.":"App muted in the agent — its alerts won't be relayed here and it won't be queried. The app itself keeps running; add it back from + any time.","sys");
+        else addMsg((action==="enable"?"Enabled":"Removed")+" a skill — the agent reconfigured its tools.","sys");
       }catch(err){ addMsg("Couldn't "+action+" skill: "+err.message,"sys"); } }
     // One-click undo for an over-pruned agent: clears every runtime toggle
     // server-side (fresh-boot state). Backend-gated skills stay gated.

--- a/examples/camera-agent/tests/test_app_alert_relay.py
+++ b/examples/camera-agent/tests/test_app_alert_relay.py
@@ -717,3 +717,53 @@ def test_alarm_defaults_endpoint_carries_the_announce_policy():
     tc.put("/alarm-defaults", json={"announce_app_alerts": "all"})
     d = tc.get("/alarm-defaults").json()
     assert d["overrides"] == {"snake": "siren"} and d["announce_app_alerts"] == "all"
+
+
+# ── muting an app in the agent ─────────────────────────────────────────
+
+
+def test_muted_app_is_not_relayed_listed_or_queried():
+    rt = _runtime(nats_url="nats://x")
+
+    class _Reg:
+        apps_cached = [
+            {"id": "lpr", "name": "LPR", "enabled": True, "manifest": {"summary": "plates"}},
+            {"id": "ppe", "name": "PPE", "enabled": True, "manifest": {"summary": "helmets"}},
+        ]
+
+        async def list_apps(self):
+            return self.apps_cached
+
+        async def app_status(self, app_id):
+            return {"health": {"status": "ok"}, "state": {"n": 1}}
+
+    rt.app_registry = _Reg()
+    rt.monitors._cooldown = 0
+    assert rt.set_skill_enabled("app:lpr", False) is True
+    assert rt.app_muted("lpr") and not rt.app_muted("ppe")
+
+    # relay: dropped for the muted app, still pushed for the other
+    rt._relay_app_alert(_sev("lpr", "Monitored plate seen", "high"))
+    rt._relay_app_alert(_sev("ppe", "PPE violation", "high"))
+    assert [n["source"] for n in rt.monitors.notifications()] == ["app:ppe"]
+
+    # tools: the muted app is not listed, answers "muted", and its
+    # alerts are filtered out of the recent-alerts view
+    out = asyncio.run(rt._handle_list_apps({}))
+    assert "PPE" in out and "LPR" not in out
+    assert "muted" in asyncio.run(rt._handle_app_status({"app_id": "lpr"}))
+    assert "ok" in asyncio.run(rt._handle_app_status({"app_id": "ppe"}))
+    rt.context.record_app_alert(_sev("lpr", "plate", "high"))
+    rt.context.record_app_alert(_sev("ppe", "helmet", "high"))
+    out = asyncio.run(rt._handle_recent_app_alerts({}))
+    assert "app:ppe" in out and "app:lpr" not in out
+    assert "muted" in asyncio.run(rt._handle_recent_app_alerts({"app_id": "lpr"}))
+
+    # unmute: everything flows again
+    assert rt.set_skill_enabled("app:lpr", True) is True
+    rt._relay_app_alert(_sev("lpr", "Monitored plate seen", "high"))
+    assert rt.monitors.notifications()[-1]["source"] == "app:lpr"
+    assert "LPR" in asyncio.run(rt._handle_list_apps({}))
+    # every app muted → an honest answer, not "none installed"
+    rt.set_skill_enabled("app:lpr", False); rt.set_skill_enabled("app:ppe", False)
+    assert "muted in this agent" in asyncio.run(rt._handle_list_apps({}))

--- a/examples/camera-agent/tests/test_app_door.py
+++ b/examples/camera-agent/tests/test_app_door.py
@@ -325,7 +325,7 @@ def test_skills_payload_includes_app_entries_when_installed_and_reachable():
     assert entry["name"] == "Loitering Detection"
     assert entry["uses"].startswith("installed app — ")
     assert entry["enabled"] is True
-    assert entry["read_only"] is True
+    assert entry["read_only"] is False   # ✕ mutes it in the agent; the app keeps running
     assert entry["emits"] == ["loitering"]
     # A disabled installed app is NOT surfaced as a skill.
     assert "app:occupancy-counting" not in skills

--- a/examples/camera-agent/tests/test_demo_skills_ui.py
+++ b/examples/camera-agent/tests/test_demo_skills_ui.py
@@ -451,10 +451,11 @@ def test_leaving_the_camera_screen_cancels_a_pending_grace_timer():
     assert "_clearWhepGrace();" in fn
 
 
-def test_app_backed_skill_cannot_be_toggled_here_and_points_at_the_catalog():
-    """An installed catalog app appears as a read-only skill; the ✕ used
-    to answer "skill can't be enabled yet" — wrong verb, wrong place. Now:
-    a 409 that names the app and where it is managed."""
+def test_app_backed_skill_is_muted_in_the_agent_not_disabled_in_the_catalog(tmp_path):
+    """An installed catalog app appears as a skill. ✕ mutes it IN THE
+    AGENT (no relay, not listed, not queried), persisted like any other
+    toggle and reversible from +; the app itself keeps running — the
+    catalog stays the place to enable/disable/uninstall it (manage_url)."""
     from fastapi.testclient import TestClient
 
     from camera_agent import AppConfig, CameraAgentRuntime, build_app
@@ -462,6 +463,7 @@ def test_app_backed_skill_cannot_be_toggled_here_and_points_at_the_catalog():
 
     cfg = AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t",
                     opennvr_api_url="http://core:8000", opennvr_ui_url="https://nvr.local",
+                    state_path=str(tmp_path / "state.json"),
                     cameras=[CameraSpec(camera_id="c", frame_url="http://x", role="f")])
     rt = CameraAgentRuntime(cfg)
 
@@ -470,16 +472,25 @@ def test_app_backed_skill_cannot_be_toggled_here_and_points_at_the_catalog():
                         "enabled": True, "manifest": {"summary": "Reads plates"}}]
     rt.app_registry = _Reg()
     entry = next(s for s in rt.skills_payload() if s["id"] == "app:license-plate-recognition")
-    assert entry["read_only"] is True
+    assert entry["enabled"] is True and entry["read_only"] is False
     assert entry["manage_url"] == "https://nvr.local/app-catalog/license-plate-recognition"
-    assert "App Catalog" in entry["hint"]
 
     tc = TestClient(build_app(rt))
     r = tc.post("/skills/app:license-plate-recognition/disable")
-    assert r.status_code == 409
-    body = r.json()
-    assert "License Plate Recognition" in body["error"] and "App Catalog" in body["error"]
-    assert body["url"] == "https://nvr.local/app-catalog/license-plate-recognition"
-    assert "can't be enabled yet" not in body["error"]
-    # the app entry is still there — nothing was toggled
-    assert any(s["id"] == "app:license-plate-recognition" for s in rt.skills_payload())
+    assert r.status_code == 200, r.text
+    entry = next(s for s in r.json()["skills"] if s["id"] == "app:license-plate-recognition")
+    assert entry["enabled"] is False and "muted" in entry["hint"]
+    assert rt.app_muted("license-plate-recognition")
+    # persisted: a fresh runtime restores the mute even before the registry answers
+    rt2 = CameraAgentRuntime(cfg)
+    rt2.load_state()
+    assert rt2.app_muted("license-plate-recognition")
+    # and back
+    assert tc.post("/skills/app:license-plate-recognition/enable").status_code == 200
+    assert not rt.app_muted("license-plate-recognition")
+    # an app the catalog does not know cannot be toggled
+    assert tc.post("/skills/app:nope/disable").status_code == 404
+    # Restore defaults clears a mute like any other toggle
+    tc.post("/skills/app:license-plate-recognition/disable")
+    tc.post("/skills/restore")
+    assert not rt.app_muted("license-plate-recognition")


### PR DESCRIPTION
…ng the app

An operator may use the LPR app from its own page and the inbox and still not want the agent relaying or narrating its every read — until they do. Until now the only switch was the catalog's Disable, which stops the app for everyone.

- disabled_skills accepts app:<id>: set_skill_enabled mutes/unmutes an installed app in the agent (known to the registry cache; a stale state file restores a mute before the registry answers)
- muted: _relay_app_alert drops its alerts (feed, voice, webhooks); list_apps omits it (an honest line when every app is muted); app_status and recent_app_alerts answer 'muted in this agent'; the recent-alerts view filters its records
- skills rail: ✕ mutes (hint says the app keeps running), the entry moves to + as addable, ⚙ still opens the app in the App Catalog; POST /skills/app:<id>/{enable,disable} 200, 404 for an unknown app; persisted, Restore defaults clears it
- GUIDE.md 'Muting an app in the agent'; tests for relay/list/status/ alerts under mute, persistence, restore. Suite 869 passed.