### PR TITLE
fix(camera-agent): barge-in needs sustained speech, not 70 ms of loud…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **camera-agent demo: a couple of words from anyone cut the agent off.**
+  The page's barge-in stopped playback after ~70 ms of mic above the
+  gate — a cough or an aside to someone in the room. Now *firm* by
+  default: ~550 ms of sustained speech well above the noise floor,
+  short dips tolerated; *eager* (the old rule) and *off* selectable
+  under the header, persisted per browser. MODELS_AND_LATENCY.md now
+  says plainly which voice path uses what: the demo page's Talk mode is
+  the browser's energy detector + `/converse`; Silero + Smart Turn v3
+  (and model-backed interruptions) live on the `/ws` streaming pipeline,
+  which the demo page does not use yet.
+
 ### Added
 
 - **camera-agent: mute an installed app in the agent.** ✕ on an app

--- a/examples/camera-agent/MODELS_AND_LATENCY.md
+++ b/examples/camera-agent/MODELS_AND_LATENCY.md
@@ -90,7 +90,26 @@ It reports p50/p95 per phase and quantifies how much background polling
 ## Turn detection & background-noise rejection
 
 A hands-free loop only feels good if it (a) ends the turn when you stop talking
-and (b) doesn't react to room noise. Two layers handle this:
+and (b) doesn't react to room noise.
+
+**Which path you are on matters.** The agent has two voice paths:
+
+* The **demo page's Talk mode** (`/demo`) records an utterance in the
+  browser and POSTs it to `/converse`. Turn-taking there is the browser's
+  own *energy* detector described below — there is no speech model on the
+  client. Smart Turn is **not** in this loop.
+* The **streaming pipeline** (`/ws`, Pipecat 1.8) is where Silero VAD +
+  **Smart Turn v3** live: semantic end-of-turn, and — for clients that opt
+  in — model-backed interruptions (`MinWordsUserTurnStartStrategy`: a reply
+  is only cut when the interrupter has actually said a few words). The demo
+  page does not use `/ws` yet; a client that streams 16 kHz PCM over it
+  gets the semantic behaviour.
+
+So if the demo page "stopped speaking when someone said a couple of random
+words", that was the client barge-in gate (now *firm* by default, see
+below), not Smart Turn.
+
+Two layers handle the demo page:
 
 - **Client VAD (browser).** The mic uses `echoCancellation` + `noiseSuppression`
   + `autoGainControl`, then an RMS energy gate that **adapts to the ambient
@@ -98,7 +117,13 @@ and (b) doesn't react to room noise. Two layers handle this:
   `max(floor, noiseFloor × 2.2)`, so steady background noise never crosses it,
   while soft speech still does. Endpointing stops the turn after ~900 ms of
   silence (min 350 ms, max 15 s), and capture is suppressed while the agent is
-  speaking so it never hears itself.
+  speaking so it never hears itself. **Barge-in** (talking over the agent)
+  is a separate gate on the same mic: *firm* (default) stops the reply only
+  after ~550 ms of sustained speech well above the noise floor (short dips
+  tolerated — speech has gaps), so a cough, a word to someone else, or a
+  chair scraping does not; *eager* stops on the first clear syllable (the
+  old ~70 ms rule); *off* always lets the agent finish. Set it under the
+  header ("interrupt when I talk over it"); persisted per browser.
 - **Server STT guard (`stt_noise_filter`, on by default).** Whisper hallucinates
   stock phrases from silence/noise — "Thank you.", "you", "Thanks for watching".
   `looks_like_noise()` drops these so a noisy room can't trigger a phantom turn;

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -633,6 +633,13 @@
               <p class="lede" id="lede">Type a question, tap the mic to dictate — or tap <strong>Talk</strong> for hands-free voice.</p>
               <label class="wakeopt" id="wakeOpt" title="When on, the agent only answers utterances that start with its name — side conversations are ignored. OFF by default: name matching depends on STT hearing the name right, and a missed match means a real question gets ignored.">
                 <input type="checkbox" id="wakeReq"> only answer “Hey <span id="wakeName">agent</span>…”</label>
+              <label class="wakeopt" id="bargeOpt" title="Interrupting the agent while it speaks. Firm (default): only sustained speech — about half a second of clear talking over it — stops the reply, so a cough, a word or two aside, or room noise does not. Eager: stops on the first clear syllable. Off: the agent always finishes; speak after it stops.">
+                interrupt when I talk over it:
+                <select id="bargeMode" aria-label="Barge-in">
+                  <option value="firm">firm — sustained speech only</option>
+                  <option value="eager">eager — first syllable</option>
+                  <option value="off">off — let it finish</option>
+                </select></label>
               <div class="micdot" id="micdot" hidden>mic live</div>
             </div>
           </div>
@@ -1142,6 +1149,21 @@
     // mouth from the live amplitude — so she visibly "speaks". If the user talks
     // clearly over her (mic well above the room floor), playback stops so they
     // can ask straight away (barge-in).
+    //
+    // Barge-in is deliberately NOT eager by default. This page's hands-free
+    // loop is an energy detector (no speech model on the client), so the
+    // only evidence that someone is talking TO the agent is how long and
+    // how loudly they keep talking. Four animation frames (~70 ms) above
+    // the gate — the old rule — stopped a reply on a cough, a word to
+    // someone else in the room, or a chair scraping. "firm" needs ~550 ms
+    // of speech, well above the noise floor, with short dips tolerated
+    // (natural speech has gaps); "eager" is the old behaviour; "off"
+    // never interrupts. Persisted per browser.
+    const BARGE_PRESETS={firm:{ms:550,margin:2.5,dipMs:150},eager:{ms:70,margin:1.7,dipMs:0},off:null};
+    let bargeMode=(function(){ try{ const v=localStorage.getItem("agent_barge_mode"); return v in BARGE_PRESETS?v:"firm"; }catch{ return "firm"; } })();
+    (function(){ const sel=$("bargeMode"); if(!sel) return; sel.value=bargeMode;
+      sel.addEventListener("change",()=>{ bargeMode=sel.value in BARGE_PRESETS?sel.value:"firm";
+        try{ localStorage.setItem("agent_barge_mode",bargeMode); }catch{} }); })();
     function setMouth(amp){ if(mouthEl) mouthEl.setAttribute("ry",(2+Math.min(1,amp*4)*14).toFixed(1)); }
     function stopSpeaking(){ if(currentSource){ try{currentSource.stop();}catch{} currentSource=null; }
       if(mouthRAF){ cancelAnimationFrame(mouthRAF); mouthRAF=null; } setMouth(0); }
@@ -1155,15 +1177,19 @@
           playbackAnalyser.connect(audioCtx.destination); }   // wire to speakers once
         const an=playbackAnalyser, abuf=new Float32Array(an.fftSize);
         const src=audioCtx.createBufferSource(); src.buffer=buf;
-        src.connect(an); currentSource=src; let bargeFrames=0;
+        src.connect(an); currentSource=src;
+        let bargeStart=0, bargeLastLoud=0;              // ms timestamps of the current over-talk run
         const tick=()=>{
           if(currentSource!==src){ fin(); return; }       // stopped (barge-in / reset)
           an.getFloatTimeDomainData(abuf); let s=0; for(let i=0;i<abuf.length;i++)s+=abuf[i]*abuf[i];
           setMouth(Math.sqrt(s/abuf.length));
-          if(analyser && sessionActive){                   // barge-in detection
-            const mic=rms(), gate=Math.max(START_RMS,noiseFloor*START_MARGIN)*1.7;
-            bargeFrames = mic>gate ? bargeFrames+1 : 0;
-            if(bargeFrames>=4){ stopSpeaking(); fin(); return; }
+          const preset=BARGE_PRESETS[bargeMode];
+          if(analyser && sessionActive && preset){         // barge-in detection
+            const now=performance.now();
+            const mic=rms(), gate=Math.max(START_RMS,noiseFloor*START_MARGIN)*preset.margin;
+            if(mic>gate){ if(!bargeStart) bargeStart=now; bargeLastLoud=now; }
+            else if(bargeStart && now-bargeLastLoud>preset.dipMs){ bargeStart=0; }   // the run ended
+            if(bargeStart && bargeLastLoud-bargeStart>=preset.ms){ stopSpeaking(); fin(); return; }
           }
           mouthRAF=requestAnimationFrame(tick);
         };

--- a/examples/camera-agent/tests/test_chat_talk_modes.py
+++ b/examples/camera-agent/tests/test_chat_talk_modes.py
@@ -290,3 +290,18 @@ def test_dictation_still_works_without_an_analyser():
     # never start — fall back to one segment for the session instead.
     tog = _fn("toggleDictate")
     assert "if(!dictAnalyser) dictSegStart();" in tog
+
+
+def test_barge_in_is_firm_by_default_and_configurable():
+    """Interrupting the speaking agent needs sustained speech, not ~70 ms
+    of loud mic: a cough or a word to someone else must not cut a reply.
+    The mode (firm / eager / off) is an operator choice persisted per
+    browser."""
+    html = _HTML
+    assert 'id="bargeMode"' in html
+    assert "BARGE_PRESETS" in html and "firm:{ms:550" in html
+    assert 'localStorage.getItem("agent_barge_mode")' in html
+    # the old frame-count rule is gone
+    assert "bargeFrames>=4" not in html
+    # default mode is firm
+    assert 'return v in BARGE_PRESETS?v:"firm"' in html


### PR DESCRIPTION
… mic

Reported: while the agent spoke, someone said a few random words and it stopped and went back to listening. That is not Smart Turn — the demo page's Talk mode records in the browser and POSTs to /converse; its turn-taking and barge-in are the client's energy gates. Silero + Smart Turn v3 live on the /ws streaming pipeline, which the demo page does not drive.

The barge-in rule was four animation frames (~70 ms) above 1.7x the noise gate. Now three modes, 'firm' by default: ~550 ms of continuous speech above 2.5x the gate, dips up to 150 ms tolerated (speech has gaps); 'eager' keeps the old rule; 'off' always lets the agent finish. A select under the header, persisted per browser (localStorage).

MODELS_AND_LATENCY.md states which path uses what, so the next tester knows what they are measuring.