### PR TITLE
feat(camera-agent): interruptions like a person's — a gated start str…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **camera-agent: interruptions like a person's on the streaming
+  pipeline.** New `turns.py` start strategy for the 1.8 user aggregator:
+  while the agent speaks, a phrase interrupts it only if it is real
+  speech (a Silero VAD pair) of at least `interrupt_min_ms`, holds at
+  least `interrupt_min_words` words once backchannels ("yeah", "okay",
+  "mm-hm") are stripped, and reads as addressed to the agent (its name,
+  a question, a request or correction, the site's own vocabulary —
+  camera names, gate, plate) rather than a remark to someone else;
+  anything else is dropped and the agent keeps talking. While the agent
+  is silent the first sound of speech opens the turn as before, so
+  Smart Turn end-of-turn is untouched. `interruptions: gated` (default)
+  | `eager` | `off`; every decision with its reason at
+  `GET /interruptions`. Proven through the real pipeline: "yeah okay"
+  over the speaking agent → no interruption, no LLM turn; "no wait,
+  show the gate camera" → InterruptionFrame and the turn.
+
 ### Fixed
 
 - **camera-agent demo: a couple of words from anyone cut the agent off.**

--- a/examples/camera-agent/Dockerfile
+++ b/examples/camera-agent/Dockerfile
@@ -92,6 +92,7 @@ COPY examples/camera-agent/frame_sources.py   ./frame_sources.py
 COPY examples/camera-agent/serializer.py      ./serializer.py
 COPY examples/camera-agent/services.py        ./services.py
 COPY examples/camera-agent/tools.py           ./tools.py
+COPY examples/camera-agent/turns.py           ./turns.py
 COPY examples/camera-agent/footage_index.py   ./footage_index.py
 COPY examples/camera-agent/monitor_host.py    ./monitor_host.py
 COPY examples/camera-agent/system_check.py    ./system_check.py

--- a/examples/camera-agent/MODELS_AND_LATENCY.md
+++ b/examples/camera-agent/MODELS_AND_LATENCY.md
@@ -109,6 +109,36 @@ So if the demo page "stopped speaking when someone said a couple of random
 words", that was the client barge-in gate (now *firm* by default, see
 below), not Smart Turn.
 
+### Interruptions on the streaming pipeline (`turns.py`)
+
+On `/ws` the question "should the agent yield?" is answered the way a
+person answers it, from four cues the pipeline already has — and only
+while the agent is speaking (when it is silent the first sound of speech
+opens the turn, so Smart Turn's end-of-turn detection is untouched):
+
+| cue | source | rule (config) |
+|---|---|---|
+| it is speech | Silero VAD start/stop pair | a cough or a chair never makes one |
+| it lasts | the pair's span | ≥ `interrupt_min_ms` (300) |
+| it has words | Whisper transcript, backchannels stripped | ≥ `interrupt_min_words` (2); "yeah", "okay", "mm-hm" count for nothing |
+| it is for the agent | `addressed_to_agent()` | its name, a question, a request/correction ("no, wait", "show", "the other"), the site's own words (camera names, gate, plate…) — vs a third-person aside ("he said lunch is at one") or a long narrative with none of those |
+
+A phrase that passes all four interrupts (an `InterruptionFrame`; the
+reply is cut and the phrase becomes the next user turn); anything else is
+dropped from the aggregation and the agent keeps talking. If the agent
+has already gone quiet by the time the transcript lands, the addressee
+test is skipped — nobody was being interrupted. Every decision is logged
+(`interruption accepted/ignored (<reason>): '<text>'`) and kept in
+`GET /interruptions` with the text, duration and reason, which is the
+evidence to tune the three knobs from on your own site. `interruptions:
+eager` restores plain VAD barge-in; `off` lets the agent always finish.
+
+Cost: the decision needs the transcript, so on CPU it lands ~0.2 s (VAD
+stop) + Whisper's time after the interrupter pauses — a *firm* yield, not
+an instant one. What it does not do: read gaze, or know voices — a
+wake-word mode and per-operator voice enrolment are the two stronger
+addressee signals, both possible later on the same gate.
+
 Two layers handle the demo page:
 
 - **Client VAD (browser).** The mic uses `echoCancellation` + `noiseSuppression`

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -195,6 +195,18 @@ class AppConfig:
     turn_detector: str = "auto"
     turn_cpu_threads: int | None = None
     turn_timer_secs: float = 0.8
+    # Interruptions on the streaming (/ws) pipeline — turns.py. "gated"
+    # (default): while the agent speaks, only a phrase that is real speech
+    # of at least interrupt_min_ms, holds interrupt_min_words words once
+    # backchannels ("mm-hm", "okay") are stripped, and — when
+    # interrupt_addressee is on — reads as said TO the agent, cuts it off;
+    # everything else is ignored and the agent keeps talking. "off": the
+    # agent always finishes (the pre-1.8 behaviour). "eager": any speech
+    # interrupts (plain VAD).
+    interruptions: str = "gated"
+    interrupt_min_ms: float = 300.0
+    interrupt_min_words: int = 2
+    interrupt_addressee: bool = True
     # Reasoning toggle for "thinking" models (Qwen3 etc.). Leave None for
     # non-thinking models (no effect). Set False to force snappy, non-thinking
     # tool-calling (appends Qwen3's ``/no_think`` switch); True to allow it.
@@ -2916,6 +2928,11 @@ def load_config(path: str | Path) -> AppConfig:
         turn_detector=_str("turn_detector", "auto"),
         turn_cpu_threads=(int(raw["turn_cpu_threads"]) if raw.get("turn_cpu_threads") else None),
         turn_timer_secs=_float("turn_timer_secs", 0.8),
+        interruptions=_str("interruptions", "gated"),
+        interrupt_min_ms=_float("interrupt_min_ms", 300.0),
+        interrupt_min_words=_int("interrupt_min_words", 2),
+        interrupt_addressee=(True if raw.get("interrupt_addressee") is None
+                             else bool(raw.get("interrupt_addressee"))),
         enabled_tools=(
             list(raw["enabled_tools"])
             if isinstance(raw.get("enabled_tools"), list)
@@ -3249,6 +3266,10 @@ class CameraAgentRuntime:
         # via persist()/load_state like the skill toggles.
         self._ring_overrides: dict[str, str] = {}
         self._announce_app_alerts: str | None = None   # UI override of cfg
+        # Interruption decisions on the streaming pipeline (turns.py): what
+        # was said over the agent, how long, and whether it yielded — the
+        # evidence to tune the gate from. GET /interruptions.
+        self.interruption_log: deque = deque(maxlen=200)
         self._configure_tools()
         self.tool_handlers = {
             "describe_camera": self.tools.describe_camera,
@@ -5211,7 +5232,7 @@ def describe_turn_profile(cfg: Any) -> str:
             f"no turn model; {p['cores']} core(s) available ({p['reason']})")
 
 
-def build_user_turn_params(cfg: Any) -> Any:
+def build_user_turn_params(cfg: Any, runtime: Any = None) -> Any:
     """The user aggregator's parameters — where turn-taking lives in
     Pipecat 1.8. Silero VAD opens a turn; **Smart Turn v3** (the
     bundled semantic end-of-turn model, CPU) closes it; the aggregator's
@@ -5227,6 +5248,7 @@ def build_user_turn_params(cfg: Any) -> Any:
     from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
     profile = turn_hardware_profile(cfg)
+    start = build_interruption_strategy(cfg, runtime=runtime)
     if profile["detector"] == "smart":
         from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
         from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
@@ -5251,11 +5273,60 @@ def build_user_turn_params(cfg: Any) -> Any:
     return LLMUserAggregatorParams(
         vad_analyzer=SileroVADAnalyzer(params=turn_vad_params(cfg)),
         user_turn_strategies=UserTurnStrategies(
-            start=[VADUserTurnStartStrategy(enable_interruptions=False)],
+            start=[start],
             stop=[stop],
         ),
         user_turn_stop_timeout=float(getattr(cfg, "turn_stop_timeout_secs", 6.0)),
     )
+
+
+def interruption_gate(cfg: Any, runtime: Any = None) -> "Any":
+    """The rule set for ``turns.GatedInterruptionStartStrategy`` from
+    config: thresholds, the agent's name, and the site's own vocabulary
+    (camera ids, names and roles) so "the gate camera" reads as addressed
+    to the agent."""
+    from turns import InterruptionGate
+
+    site: list[str] = []
+    for cam in (getattr(cfg, "cameras", None) or []):
+        for attr in ("camera_id", "name", "role"):
+            v = getattr(cam, attr, None)
+            if v:
+                site.append(str(v))
+    site += ["camera", "cameras", "gate", "plate", "plates", "alarm", "alarms",
+             "recording", "recordings", "footage", "monitor", "watch", "zone"]
+    return InterruptionGate(
+        min_ms=float(getattr(cfg, "interrupt_min_ms", 300.0)),
+        min_words=max(1, int(getattr(cfg, "interrupt_min_words", 2))),
+        addressee=bool(getattr(cfg, "interrupt_addressee", True)),
+        agent_name=str(getattr(cfg, "agent_name", "") or ""),
+        site_words=tuple(site),
+    )
+
+
+def build_interruption_strategy(cfg: Any, runtime: Any = None) -> Any:
+    """The user-turn START strategy for the streaming pipeline, by the
+    ``interruptions`` setting: gated (turns.py), eager (plain VAD, any
+    speech interrupts) or off (the agent always finishes)."""
+    from pipecat.turns.user_start import VADUserTurnStartStrategy
+
+    mode = str(getattr(cfg, "interruptions", "gated") or "gated").strip().lower()
+    if mode == "off":
+        return VADUserTurnStartStrategy(enable_interruptions=False)
+    if mode == "eager":
+        return VADUserTurnStartStrategy(enable_interruptions=True)
+    if mode != "gated":
+        logger.warning("interruptions=%r is not gated|eager|off; using gated", mode)
+    from turns import make_start_strategy
+
+    gate = interruption_gate(cfg, runtime)
+    log = getattr(runtime, "interruption_log", None) if runtime is not None else None
+
+    def _record(event: dict[str, Any]) -> None:
+        if log is not None:
+            log.append({"ts": time.time(), **event})
+
+    return make_start_strategy(gate, on_decision=_record)
 
 
 def build_core_processors(runtime: CameraAgentRuntime, *, user_params: Any = None) -> tuple[list, Any]:
@@ -5287,7 +5358,7 @@ def build_core_processors(runtime: CameraAgentRuntime, *, user_params: Any = Non
         {"role": "system", "content": runtime.build_system_prompt()},
     ])
     aggregators = LLMContextAggregatorPair(
-        context, user_params=user_params or build_user_turn_params(runtime.cfg),
+        context, user_params=user_params or build_user_turn_params(runtime.cfg, runtime),
     )
     return [stt, aggregators.user(), llm, tts, aggregators.assistant()], context
 
@@ -5714,6 +5785,21 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 {"error": "no recordings for this camera yet", "recordings": []},
                 status_code=200), None
         return None, (token, path)
+
+    @app.get("/interruptions")
+    async def _interruptions() -> dict[str, Any]:
+        """The interruption gate on the streaming pipeline and its recent
+        decisions (viewer tier: look only). Tune from evidence: every
+        phrase spoken over the agent is here with why it did or did not
+        interrupt."""
+        cfg = runtime.cfg
+        return {
+            "mode": str(getattr(cfg, "interruptions", "gated")),
+            "min_ms": float(getattr(cfg, "interrupt_min_ms", 300.0)),
+            "min_words": int(getattr(cfg, "interrupt_min_words", 2)),
+            "addressee": bool(getattr(cfg, "interrupt_addressee", True)),
+            "recent": list(runtime.interruption_log)[-50:],
+        }
 
     @app.get("/alarm-defaults")
     async def _alarm_defaults() -> dict[str, Any]:

--- a/examples/camera-agent/config.docker.yml
+++ b/examples/camera-agent/config.docker.yml
@@ -138,6 +138,18 @@ turn_max_secs: 8.0
 #   turn_cpu_threads: onnxruntime threads for one verdict; leave unset for
 #     auto (1 thread — measured fastest up to 7 cores — 2 from 8 cores).
 turn_detector: auto
+# Interruptions on the streaming (/ws) pipeline — like a person's. While the
+# agent speaks, only a phrase that is real speech of ≥ interrupt_min_ms,
+# holds ≥ interrupt_min_words words once backchannels ("mm-hm", "okay") are
+# stripped, and reads as said TO the agent (its name, a question, a
+# request or correction, the site's own words — cameras, gate, plate…)
+# cuts it off; a cough, "yeah", or a remark to someone else does not.
+# GET /interruptions lists every decision with its reason — tune from that.
+#   interruptions: gated (default) | eager (any speech interrupts) | off
+interruptions: gated
+interrupt_min_ms: 300
+interrupt_min_words: 2
+interrupt_addressee: true
 # turn_cpu_threads: 1
 # turn_timer_secs: 0.8
 # Context window. The default (4096) no longer fits this config's toolset:

--- a/examples/camera-agent/config.example.yml
+++ b/examples/camera-agent/config.example.yml
@@ -99,6 +99,18 @@ turn_max_secs: 8.0
 #   turn_cpu_threads: onnxruntime threads for one verdict; leave unset for
 #     auto (1 thread — measured fastest up to 7 cores — 2 from 8 cores).
 turn_detector: auto
+# Interruptions on the streaming (/ws) pipeline — like a person's. While the
+# agent speaks, only a phrase that is real speech of ≥ interrupt_min_ms,
+# holds ≥ interrupt_min_words words once backchannels ("mm-hm", "okay") are
+# stripped, and reads as said TO the agent (its name, a question, a
+# request or correction, the site's own words — cameras, gate, plate…)
+# cuts it off; a cough, "yeah", or a remark to someone else does not.
+# GET /interruptions lists every decision with its reason — tune from that.
+#   interruptions: gated (default) | eager (any speech interrupts) | off
+interruptions: gated
+interrupt_min_ms: 300
+interrupt_min_words: 2
+interrupt_addressee: true
 # turn_cpu_threads: 1
 # turn_timer_secs: 0.8
 

--- a/examples/camera-agent/tests/test_interruptions.py
+++ b/examples/camera-agent/tests/test_interruptions.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interruptions like a person's: noise, backchannels and remarks to
+someone else don't stop the agent; a real phrase addressed to it does."""
+from __future__ import annotations
+
+import pytest
+
+from turns import DEFAULT_BACKCHANNELS, InterruptionGate, addressed_to_agent, strip_backchannels
+
+
+def test_backchannels_are_stripped_not_counted():
+    assert strip_backchannels("yeah okay so which gate".split()) == ["so", "which", "gate"]
+    assert strip_backchannels("mm hm".split()) == []
+    assert strip_backchannels(["uh-huh", "right"]) == []
+    assert "okay" in DEFAULT_BACKCHANNELS
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("no wait, the other gate", True),          # correction
+    ("can you show the front door?", True),     # request / question
+    ("what did it read on cam one", True),      # question word
+    ("stop, that's wrong", True),               # imperative
+    ("hey Ada, hold on", True),                 # named
+    ("he said the delivery comes at five", False),        # aside, third person
+    ("I'll grab a coffee, do you want one", False),       # to someone else
+    ("we should probably move the meeting to thursday afternoon then", False),  # long narrative
+    ("the plate reader missed one", True),      # site vocabulary
+])
+def test_addressee_heuristic(text, expected):
+    verdict, why = addressed_to_agent(text, agent_name="Ada", site_words=["plate", "front door", "cam1"])
+    assert verdict is expected, (text, why)
+
+
+def test_gate_combines_duration_words_and_addressee():
+    g = InterruptionGate(min_ms=300, min_words=2, addressee=True, agent_name="Ada",
+                         site_words=("gate", "cam1"))
+    assert g.judge("no wait the other gate", 900)[0] is True
+    # too short to be speech aimed at anyone
+    ok, why = g.judge("no wait the other gate", 120)
+    assert ok is False and "too short" in why
+    # "yeah" / "okay" mean keep going
+    ok, why = g.judge("yeah okay", 700)
+    assert ok is False and "backchannel" in why
+    # one real word is not a floor-taking attempt
+    ok, why = g.judge("okay wait", 700)
+    assert ok is False and "1 word" in why
+    # a remark to someone else in the room
+    ok, why = g.judge("he said we should go to lunch", 1500)
+    assert ok is False and "not addressed" in why
+    # the agent already silent: addressee no longer required
+    ok, why = g.judge("he said we should go to lunch", 1500, require_addressee=False)
+    assert ok is True
+    # unknown duration (no VAD pair) is not held against it
+    assert g.judge("can you repeat that", None)[0] is True
+    # the evidence ring
+    assert len(g.recent) == 7 and g.recent[-1]["interrupt"] is True
+
+
+def test_gate_with_addressee_off_is_words_and_duration_only():
+    g = InterruptionGate(min_ms=300, min_words=2, addressee=False)
+    assert g.judge("he said we should go to lunch", 1500)[0] is True
+    assert g.judge("yeah", 1500)[0] is False
+
+
+def test_config_and_site_words_reach_the_gate():
+    import camera_agent as ca
+    from context import CameraSpec
+
+    cfg = ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t", agent_name="Ada",
+                       interrupt_min_ms=450, interrupt_min_words=3, interrupt_addressee=False,
+                       cameras=[CameraSpec(camera_id="cam1", frame_url="http://x", role="loading dock")])
+    g = ca.interruption_gate(cfg)
+    assert (g.min_ms, g.min_words, g.addressee, g.agent_name) == (450.0, 3, False, "Ada")
+    assert "loading dock" in g.site_words and "cam1" in g.site_words
+
+
+def test_config_loads_interruption_knobs(tmp_path):
+    import camera_agent as ca
+
+    (tmp_path / "c.yml").write_text(
+        "kaic_url: http://k\nkaic_api_key: x\nsystem_prompt: t\n"
+        "interruptions: eager\ninterrupt_min_ms: 500\ninterrupt_min_words: 3\ninterrupt_addressee: false\n")
+    cfg = ca.load_config(str(tmp_path / "c.yml"))
+    assert cfg.interruptions == "eager" and cfg.interrupt_min_ms == 500.0
+    assert cfg.interrupt_min_words == 3 and cfg.interrupt_addressee is False
+    # defaults
+    (tmp_path / "d.yml").write_text("kaic_url: http://k\nkaic_api_key: x\nsystem_prompt: t\n")
+    cfg = ca.load_config(str(tmp_path / "d.yml"))
+    assert cfg.interruptions == "gated" and cfg.interrupt_addressee is True
+
+
+def test_interruptions_endpoint_reports_the_gate_and_decisions():
+    from fastapi.testclient import TestClient
+
+    import camera_agent as ca
+    from context import CameraSpec
+
+    cfg = ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+                       cameras=[CameraSpec(camera_id="c", frame_url="http://x", role="f")])
+    rt = ca.CameraAgentRuntime(cfg)
+    rt.interruption_log.append({"ts": 1, "text": "yeah", "interrupt": False, "reason": "backchannel only"})
+    body = TestClient(ca.build_app(rt)).get("/interruptions").json()
+    assert body["mode"] == "gated" and body["min_words"] == 2
+    assert body["recent"][-1]["reason"] == "backchannel only"
+
+
+# ── the real Pipecat objects ───────────────────────────────────────────
+
+pipecat = pytest.importorskip("pipecat")
+
+
+def _cfg(**over):
+    import camera_agent as ca
+    from context import CameraSpec
+
+    return ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t", agent_name="Ada",
+                        cameras=[CameraSpec(camera_id="cam1", frame_url="http://x", role="gate")], **over)
+
+
+def test_strategy_selection_by_mode():
+    import camera_agent as ca
+    from pipecat.turns.user_start import VADUserTurnStartStrategy
+
+    gated = ca.build_interruption_strategy(_cfg())
+    assert type(gated).__name__ == "GatedInterruptionStartStrategy"
+    off = ca.build_interruption_strategy(_cfg(interruptions="off"))
+    assert isinstance(off, VADUserTurnStartStrategy) and off._enable_interruptions is False
+    eager = ca.build_interruption_strategy(_cfg(interruptions="eager"))
+    assert isinstance(eager, VADUserTurnStartStrategy) and eager._enable_interruptions is True
+    params = ca.build_user_turn_params(_cfg())
+    assert type(params.user_turn_strategies.start[0]).__name__ == "GatedInterruptionStartStrategy"
+
+
+@pytest.mark.asyncio
+async def test_strategy_decisions_with_the_real_frames():
+    """Drive the strategy with Pipecat frames directly: silent agent →
+    VAD opens the turn at once; speaking agent → a backchannel and an
+    aside are dropped (aggregation reset, no turn), a real addressed
+    phrase opens the turn WITH an interruption."""
+    import time
+
+    import camera_agent as ca
+    from pipecat.frames.frames import (
+        BotStartedSpeakingFrame, BotStoppedSpeakingFrame, TranscriptionFrame,
+        VADUserStartedSpeakingFrame, VADUserStoppedSpeakingFrame,
+    )
+
+    rt = ca.CameraAgentRuntime(_cfg())
+    strat = ca.build_interruption_strategy(_cfg(), runtime=rt)
+    started, resets = [], []
+
+    async def on_started(s, params):
+        started.append(params.enable_interruptions)
+        await strat.handle_user_turn_started()
+
+    async def on_reset(s):
+        resets.append(True)
+
+    strat.add_event_handler("on_user_turn_started", on_started)
+    strat.add_event_handler("on_reset_aggregation", on_reset)
+
+    async def speech(text, secs, *, bot):
+        t0 = time.time()
+        await strat.process_frame(VADUserStartedSpeakingFrame(timestamp=t0))
+        await strat.process_frame(VADUserStoppedSpeakingFrame(stop_secs=0.2, timestamp=t0 + secs + 0.2))
+        await strat.process_frame(TranscriptionFrame(text=text, user_id="u", timestamp=""))
+
+    # agent silent: VAD start opens the turn immediately, no interruption flag
+    await strat.process_frame(VADUserStartedSpeakingFrame(timestamp=time.time()))
+    assert started == [False]
+    await strat.handle_user_turn_stopped()
+
+    # agent speaking
+    await strat.process_frame(BotStartedSpeakingFrame())
+    await speech("yeah okay", 0.6, bot=True)                   # backchannel → ignored
+    await speech("he said lunch is at one", 1.4, bot=True)     # aside → ignored
+    await speech("no", 0.15, bot=True)                         # too short → ignored
+    assert started == [False] and len(resets) == 3
+    await speech("no wait, show the gate camera", 1.1, bot=True)   # addressed → interrupts
+    assert started == [False, True]
+    await strat.handle_user_turn_stopped()
+    await strat.process_frame(BotStoppedSpeakingFrame())
+
+    log = list(rt.interruption_log)
+    assert [e["interrupt"] for e in log] == [False, False, False, True]
+    assert "backchannel" in log[0]["reason"] and "not addressed" in log[1]["reason"]
+    assert "too short" in log[2]["reason"] and log[3]["speech_ms"] >= 1000
+
+
+@pytest.mark.asyncio
+async def test_real_pipeline_ignores_backchannel_and_yields_to_an_addressed_phrase():
+    """Through the real 1.8 processors (STT → user aggregator → LLM → TTS)
+    with the agent marked as speaking: 'yeah okay' produces no
+    interruption and no LLM turn; 'no wait, show the gate camera' produces
+    an InterruptionFrame and a turn."""
+    import math
+    import struct
+    import time
+    import types
+
+    import camera_agent as ca
+    from pipecat.frames.frames import (
+        BotStartedSpeakingFrame, InputAudioRawFrame, InterruptionFrame,
+        VADUserStartedSpeakingFrame, VADUserStoppedSpeakingFrame,
+    )
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.task import PipelineParams
+    from pipecat.tests.utils import SleepFrame, run_test
+
+    def tone(seconds, rate=16000):
+        n = int(seconds * rate)
+        return struct.pack(f"<{n}h", *(int(8000 * math.sin(2 * math.pi * 220 * i / rate)) for i in range(n)))
+
+    class Whisper:
+        def __init__(self):
+            self.answers = ["yeah okay", "no wait, show the gate camera"]
+            self.calls = 0
+
+        async def transcribe(self, audio):
+            self.calls += 1
+            return self.answers[min(self.calls - 1, len(self.answers) - 1)]
+
+    class Ollama:
+        def __init__(self):
+            self.calls = []
+
+        async def chat(self, *, messages, tools, temperature, max_tokens):
+            self.calls.append([dict(m) for m in messages])
+            return {"message": {"content": "Switching to the gate camera."}}
+
+    class Piper:
+        async def synthesize(self, text):
+            n = int(0.05 * 22050)
+            pcm = struct.pack(f"<{n}h", *([0] * n))
+            import io
+            import wave
+            buf = io.BytesIO()
+            with wave.open(buf, "wb") as w:
+                w.setnchannels(1)
+                w.setsampwidth(2)
+                w.setframerate(22050)
+                w.writeframes(pcm)
+            return buf.getvalue()
+
+    cfg = _cfg()
+    cfg.turn_stop_secs = 0.3
+    cfg.turn_stop_timeout_secs = 2.0
+    rt = types.SimpleNamespace(cfg=cfg, whisper=Whisper(), ollama=Ollama(), piper=Piper(),
+                               tool_definitions=[], tool_handlers={},
+                               build_system_prompt=lambda: "You are the camera agent.",
+                               interruption_log=__import__("collections").deque(maxlen=50))
+    core, _context = ca.build_core_processors(rt)
+
+    def utterance(seconds):
+        t0 = time.time()
+        out = [VADUserStartedSpeakingFrame(timestamp=t0)]
+        for _ in range(int(seconds / 0.2)):
+            out.append(InputAudioRawFrame(audio=tone(0.2), sample_rate=16000, num_channels=1))
+            out.append(SleepFrame(sleep=0.02))
+        out.append(VADUserStoppedSpeakingFrame(stop_secs=0.2, timestamp=time.time() + seconds + 0.2))
+        out.append(SleepFrame(sleep=1.0))   # STT + gate
+        return out
+
+    frames = [BotStartedSpeakingFrame(), SleepFrame(sleep=0.05)]
+    frames += utterance(0.8)     # "yeah okay"
+    frames += utterance(1.2)     # "no wait, show the gate camera"
+    frames.append(SleepFrame(sleep=2.5))
+
+    down, up = await run_test(
+        Pipeline(core), frames_to_send=frames,
+        pipeline_params=PipelineParams(audio_in_sample_rate=16000, audio_out_sample_rate=22050),
+        start_timeout=10.0,
+    )
+    assert rt.whisper.calls >= 2
+    log = list(rt.interruption_log)
+    assert [e["interrupt"] for e in log] == [False, True], log
+    interruptions = [f for f in list(down) + list(up) if isinstance(f, InterruptionFrame)]
+    assert interruptions, "the addressed phrase should have interrupted the speaking agent"
+    # exactly one LLM turn, and it was the addressed phrase — the
+    # backchannel never became a user message
+    assert len(rt.ollama.calls) == 1
+    user_msgs = [m["content"] for m in rt.ollama.calls[0] if m.get("role") == "user"]
+    assert user_msgs and "gate camera" in user_msgs[-1] and "yeah okay" not in " ".join(user_msgs)

--- a/examples/camera-agent/turns.py
+++ b/examples/camera-agent/turns.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interruptions that behave like a person's.
+
+Smart Turn decides *when the user has finished*. This module decides the
+other thing: while the agent is speaking, is a sound in the room a person
+trying to take the floor from it — and should it yield?
+
+A human answers that from several cues at once: the sound is speech, it
+lasts more than a syllable, it isn't a backchannel ("mm-hm", "okay" —
+which means *keep going*), and it is addressed to them. The gate below
+recovers each cue from what the pipeline already has:
+
+* **speech** — Silero's VAD start/stop frames (a cough or a chair never
+  makes a VAD start/stop pair of any length);
+* **duration** — the VAD pair must span ``min_ms``;
+* **words** — the transcript must hold ``min_words`` real words once
+  backchannels are stripped;
+* **addressee** — :func:`addressed_to_agent`: does the phrase read as
+  something said *to* the agent (its name, second person, an imperative
+  or question, a correction, the site's own vocabulary) rather than a
+  remark to someone else in the room?
+
+Only a phrase that passes every gate interrupts; anything else is dropped
+from the aggregation and the agent keeps talking. When the agent is
+silent none of this applies — the first VAD start opens the turn exactly
+as before, so end-of-turn detection (Smart Turn) is untouched.
+
+The strategy is a :class:`BaseUserTurnStartStrategy`, so it plugs into the
+1.8 user aggregator like the built-ins; it replaces
+``VADUserTurnStartStrategy`` + ``MinWordsUserTurnStartStrategy`` because
+those two cannot be combined (the first start wins and a later one can't
+interrupt) and the min-words one alone starts every turn late.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger("camera_agent.turns")
+
+# Utterances that mean "I'm listening, go on" — never an interruption on
+# their own, and never counted as words.
+DEFAULT_BACKCHANNELS: frozenset[str] = frozenset({
+    "yeah", "yes", "yep", "yup", "ya", "ok", "okay", "kay", "mhm", "mm", "mmm",
+    "mm-hm", "mm-hmm", "uh-huh", "uhhuh", "uh", "um", "hmm", "hm", "aha",
+    "right", "sure", "true", "i see", "got it", "go on", "alright", "fine",
+    "cool", "nice", "wow", "oh", "ah", "huh", "really", "interesting",
+})
+
+# Words that mark speech as directed at the listener: second person,
+# attention-getters, corrections, requests and questions.
+_ADDRESSED_CUES: frozenset[str] = frozenset({
+    "you", "your", "yours", "please", "stop", "wait", "hold", "hang", "no",
+    "nope", "actually", "sorry", "excuse", "never", "listen", "hey", "hi",
+    "hello", "look", "check", "show", "tell", "open", "play", "pull", "go",
+    "give", "read", "find", "search", "describe", "what", "which", "where",
+    "when", "who", "how", "why", "can", "could", "would", "will", "is",
+    "are", "do", "does", "did", "other", "wrong", "not", "instead", "again",
+    "repeat", "louder", "quiet", "mute", "cancel", "enough", "thanks", "thank",
+})
+
+# Third-person / narrative openers: the speaker is telling someone else
+# about something, not talking to the agent.
+_ASIDE_OPENERS: tuple[str, ...] = (
+    "he ", "she ", "they ", "we ", "i think we", "i'll ", "i will ", "let's ",
+    "lets ", "did you see", "have you seen", "remember when", "yesterday ",
+    "last night", "my ", "our ", "the guy", "that guy", "this guy",
+)
+
+_WORD_RE = re.compile(r"[a-z0-9']+")
+
+
+def _words(text: str) -> list[str]:
+    return _WORD_RE.findall(text.lower().replace("’", "'"))
+
+
+def strip_backchannels(words: Iterable[str], backchannels: frozenset[str] = DEFAULT_BACKCHANNELS) -> list[str]:
+    """Words with the listening noises removed ("yeah okay so which gate"
+    → ["so", "which", "gate"])."""
+    out = []
+    ws = list(words)
+    i = 0
+    while i < len(ws):
+        two = " ".join(ws[i:i + 2])
+        if two in backchannels:
+            i += 2
+            continue
+        if ws[i] in backchannels:
+            i += 1
+            continue
+        out.append(ws[i])
+        i += 1
+    return out
+
+
+def addressed_to_agent(text: str, *, agent_name: str = "", site_words: Iterable[str] = ()) -> tuple[bool, str]:
+    """Does ``text`` read as something said TO the agent?
+
+    Returns ``(verdict, reason)``. Deliberately generous: the cost of a
+    missed interruption (the agent finishes a sentence it should not
+    have) is smaller than the cost of a false one (the agent stops
+    mid-answer for a remark to someone else), but the gate before this one
+    already removed noise and backchannels, so what reaches here is real
+    speech of a few words — the question is only *who it is for*.
+    """
+    raw = text.strip()
+    low = raw.lower()
+    words = _words(low)
+    if not words:
+        return False, "no words"
+    name_words = [w for w in _words(agent_name) if len(w) > 2]
+    if name_words and any(w in words for w in name_words):
+        return True, "named the agent"
+    if "?" in raw:
+        return True, "a question"
+    site = {w for s in site_words for w in _words(str(s)) if len(w) > 2}
+    if site and any(w in site for w in words):
+        return True, "site vocabulary"
+    if any(low.startswith(o) for o in _ASIDE_OPENERS):
+        return False, "an aside (third-person opener)"
+    if words[0] in _ADDRESSED_CUES or any(w in _ADDRESSED_CUES for w in words[:3]):
+        return True, "second person / request / correction"
+    if len(words) >= 8:
+        # A long, fluent sentence with none of the cues above is far more
+        # likely a conversation with someone else than a command.
+        return False, "long narrative without a cue"
+    return False, "no cue that it was for the agent"
+
+
+@dataclass
+class InterruptionGate:
+    """The rule set, and a small ring of recent decisions for diagnostics."""
+    min_ms: float = 300.0
+    min_words: int = 2
+    addressee: bool = True
+    agent_name: str = ""
+    site_words: tuple[str, ...] = ()
+    backchannels: frozenset[str] = DEFAULT_BACKCHANNELS
+    recent: deque = field(default_factory=lambda: deque(maxlen=50))
+
+    def judge(self, text: str, speech_ms: float | None, *, require_addressee: bool | None = None) -> tuple[bool, str]:
+        """``require_addressee`` overrides the configured addressee check
+        for one decision — off when the agent has already fallen silent by
+        the time the transcript lands (there is nobody else being
+        interrupted, so a real phrase is for the agent)."""
+        words = _words(text)
+        real = strip_backchannels(words, self.backchannels)
+        addressee = self.addressee if require_addressee is None else (self.addressee and require_addressee)
+        if speech_ms is not None and speech_ms < self.min_ms:
+            verdict, why = False, f"too short ({int(speech_ms)} ms < {int(self.min_ms)} ms)"
+        elif not real:
+            verdict, why = False, "backchannel only"
+        elif len(real) < self.min_words:
+            verdict, why = False, f"{len(real)} word(s) < {self.min_words}"
+        elif addressee:
+            verdict, why = addressed_to_agent(text, agent_name=self.agent_name, site_words=self.site_words)
+            why = ("addressed: " if verdict else "not addressed: ") + why
+        else:
+            verdict, why = True, "words and duration"
+        self.recent.append({"ts": time.time(), "text": text, "speech_ms": speech_ms,
+                            "interrupt": verdict, "reason": why})
+        return verdict, why
+
+
+def make_start_strategy(gate: InterruptionGate, *, on_decision: Callable[[dict[str, Any]], None] | None = None) -> Any:
+    """Build the Pipecat start strategy (imported lazily so this module
+    stays importable without Pipecat, like the rest of the agent)."""
+    from pipecat.frames.frames import (
+        BotStartedSpeakingFrame,
+        BotStoppedSpeakingFrame,
+        InterimTranscriptionFrame,
+        TranscriptionFrame,
+        VADUserStartedSpeakingFrame,
+        VADUserStoppedSpeakingFrame,
+    )
+    from pipecat.turns.types import ProcessFrameResult
+    from pipecat.turns.user_start import BaseUserTurnStartStrategy
+
+    class GatedInterruptionStartStrategy(BaseUserTurnStartStrategy):
+        """VAD opens a turn while the agent is silent; while it speaks, a
+        turn (and the interruption) opens only for a phrase that passes
+        the gate — see the module docstring."""
+
+        def __init__(self, gate: InterruptionGate, **kwargs):
+            super().__init__(enable_interruptions=True, **kwargs)
+            self._gate = gate
+            self._bot_speaking = False
+            self._turn_active = False
+            self._speech_start: float | None = None
+            self._speech_ms: float | None = None
+            self._spoke_over_bot = False
+
+        async def handle_user_turn_started(self):
+            self._turn_active = True
+            self._speech_start = None
+            self._speech_ms = None
+            self._spoke_over_bot = False
+
+        async def handle_user_turn_stopped(self):
+            self._turn_active = False
+
+        async def process_frame(self, frame):
+            if isinstance(frame, BotStartedSpeakingFrame):
+                self._bot_speaking = True
+            elif isinstance(frame, BotStoppedSpeakingFrame):
+                self._bot_speaking = False
+            elif isinstance(frame, VADUserStartedSpeakingFrame):
+                if self._turn_active:
+                    return ProcessFrameResult.CONTINUE
+                if not self._bot_speaking:
+                    # The agent is silent: the first sound of speech opens
+                    # the turn, exactly as VADUserTurnStartStrategy does, so
+                    # Smart Turn sees the whole utterance.
+                    await self.trigger_user_turn_started(enable_interruptions=False)
+                    return ProcessFrameResult.STOP
+                self._speech_start = getattr(frame, "timestamp", None) or time.time()
+                self._speech_ms = None
+                self._spoke_over_bot = True
+            elif isinstance(frame, VADUserStoppedSpeakingFrame):
+                if self._speech_start is not None:
+                    end = getattr(frame, "timestamp", None) or time.time()
+                    stop_secs = float(getattr(frame, "stop_secs", 0.0) or 0.0)
+                    self._speech_ms = max(0.0, (end - self._speech_start - stop_secs) * 1000.0)
+            elif isinstance(frame, TranscriptionFrame):
+                return await self._on_transcript(frame)
+            elif isinstance(frame, InterimTranscriptionFrame):
+                # Interim text is not judged: the gate wants the whole phrase.
+                return ProcessFrameResult.CONTINUE
+            return ProcessFrameResult.CONTINUE
+
+        async def _on_transcript(self, frame):
+            if self._turn_active:
+                return ProcessFrameResult.CONTINUE
+            text = (frame.text or "").strip()
+            if not text:
+                return ProcessFrameResult.CONTINUE
+            if not self._bot_speaking and not self._spoke_over_bot:
+                # A transcript with no VAD-started turn (very soft speech,
+                # or the turn ended before the STT answered): open the turn
+                # on the text alone, like the built-in fallback does.
+                await self.trigger_user_turn_started(enable_interruptions=False)
+                return ProcessFrameResult.STOP
+            verdict, why = self._gate.judge(text, self._speech_ms, require_addressee=self._bot_speaking)
+            event = {"text": text, "speech_ms": self._speech_ms, "interrupt": verdict,
+                     "reason": why, "bot_speaking": self._bot_speaking}
+            if on_decision:
+                try:
+                    on_decision(event)
+                except Exception:  # noqa: BLE001 — diagnostics never break the turn
+                    pass
+            self._speech_start = None
+            self._spoke_over_bot = False
+            if verdict:
+                logger.info("interruption accepted (%s): %r", why, text)
+                await self.trigger_user_turn_started(enable_interruptions=self._bot_speaking)
+                return ProcessFrameResult.STOP
+            logger.info("interruption ignored (%s): %r", why, text)
+            self._speech_ms = None
+            await self.trigger_reset_aggregation()
+            return ProcessFrameResult.CONTINUE
+
+    return GatedInterruptionStartStrategy(gate)


### PR DESCRIPTION
…ategy for the streaming pipeline

Smart Turn decides when the user has finished; this decides the other thing: while the agent speaks, is a sound in the room someone taking the floor from it? turns.py answers from four cues the pipeline already has — it is speech (a Silero VAD start/stop pair), it lasts (>= interrupt_min_ms), it has words (>= interrupt_min_words once backchannels like 'yeah', 'okay', 'mm-hm' are stripped), and it is FOR the agent (its name, a question, a request or correction, the site's own vocabulary — camera names, gate, plate — versus a third-person aside or a long narrative with none of those). Only a phrase that passes all four interrupts; the rest is dropped from the aggregation and the agent keeps talking. While the agent is silent the first sound of speech opens the turn exactly as before, so end-of-turn detection is untouched — and the built-in VAD + MinWords pair cannot express this (the first start wins, and MinWords alone starts every turn late).

- GatedInterruptionStartStrategy(BaseUserTurnStartStrategy) via make_start_strategy(gate); InterruptionGate holds the rules and a ring of decisions; addressed_to_agent() is the pure heuristic
- config: interruptions gated|eager|off, interrupt_min_ms (300), interrupt_min_words (2), interrupt_addressee (true); the gate learns the agent's name and the camera ids/names/roles as site words
- GET /interruptions: the gate + the last 50 decisions with reasons — the evidence to tune from; each decision also logged
- Dockerfile copies turns.py; MODELS_AND_LATENCY.md section
- tests (18): the heuristic, the gate, config plumbing, the strategy driven with real frames, and the REAL pipeline: 'yeah okay' over the speaking agent -> no interruption, no LLM turn; 'no wait, show the gate camera' -> InterruptionFrame and the turn. Suite 887 passed.