### PR TITLE
feat(camera-agent): greet when the page opens, with the time of day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **camera-agent: greets when the page opens, with the time of day.**
+  The introduction used to wait for Talk; now it plays as soon as the
+  page has loaded (after auth resolves) — text at once and, because
+  browsers refuse audio before a gesture, the spoken greeting is held
+  and played on the first tap, click, or Talk when autoplay is blocked.
+  It opens "Good morning / afternoon / evening" from the operator's own
+  clock (`GET /intro?hour=`), falling back to the site's; 22:00–05:00
+  says "Hello".
+
 - **camera-agent demo: the ⛓ pipeline line under each reply now shows
   what every stage cost** — `stt 0.4s → llm 1.2s → search_history (cam1)
   35ms → llm 0.9s → tts 0.3s · 2.9s`, slowest stage emphasised, total at

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -993,14 +993,37 @@ def _frames_for(runtime, max_frames: int = 3) -> list[dict]:
     return out
 
 
-def greeting_for(name: str | None = None) -> str:
+def time_of_day_salutation(hour: int | None = None) -> str:
+    """"Good morning" / "Good afternoon" / "Good evening" for ``hour``
+    (0–23; the OPERATOR's local hour when the browser sent one, else this
+    process's local clock — the site's TZ under compose). Late night
+    (00:00–04:59) says "Hello" rather than a "Good morning" nobody means."""
+    from datetime import datetime as _dt
+
+    if hour is None:
+        hour = _dt.now().hour
+    try:
+        hour = int(hour) % 24
+    except (TypeError, ValueError):
+        hour = _dt.now().hour
+    if 5 <= hour < 12:
+        return "Good morning"
+    if 12 <= hour < 17:
+        return "Good afternoon"
+    if 17 <= hour < 22:
+        return "Good evening"
+    return "Hello"
+
+
+def greeting_for(name: str | None = None, hour: int | None = None) -> str:
     # No persona name by design — the agent introduces itself by the product
     # name, "the OpenNVR Agent" (formerly "Camera Agent"), described as your
     # camera agent. (``name`` is accepted for call-site compat.)
-    # Short by design: this is SPOKEN (Piper) before the first
-    # interaction — every extra word delays the user's first question.
+    # Short by design: this is SPOKEN (Piper) when the page opens — every
+    # extra word delays the user's first question. Opens with the time of
+    # day like a person would.
     return (
-        "Hi, I'm the OpenNVR Agent — your camera agent. "
+        f"{time_of_day_salutation(hour)}, I'm the OpenNVR Agent — your camera agent. "
         "Ask me anything about your cameras; I can also set alarms, "
         "watches, and reports."
     )
@@ -6149,9 +6172,12 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
         return JSONResponse({"delivered": ok, "channels": runtime.notifier.status()["channels"]})
 
     @app.get("/intro")
-    async def _intro() -> JSONResponse:
-        """The agent's greeting — text always; audio when Piper is reachable."""
-        greeting = greeting_for(runtime.agent_name)
+    async def _intro(hour: int | None = None) -> JSONResponse:
+        """The agent's greeting — text always; audio when Piper is reachable.
+        ``?hour=<0-23>`` is the operator's local hour (the browser's clock)
+        so a remote operator hears the right time of day; without it the
+        site's clock decides."""
+        greeting = greeting_for(runtime.agent_name, hour)
         audio_b64 = None
         try:
             audio = await runtime.piper.synthesize(greeting)

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -2171,10 +2171,25 @@
     function pickMimeType(){ for(const t of ["audio/webm;codecs=opus","audio/webm","audio/ogg;codecs=opus","audio/mp4"])
       if(window.MediaRecorder&&MediaRecorder.isTypeSupported(t))return t; return ""; }
 
+    // The greeting plays when the page OPENS, not when Talk is pressed — a
+    // person greets you when you walk in. ?hour= is this browser's local
+    // hour so a remote operator hears the right "Good morning". Browsers
+    // refuse audio before a user gesture: the text shows at once and, if
+    // playback is blocked, the audio is held and spoken on the first tap
+    // or click anywhere (or on Talk).
+    let _introAudio=null;
     async function playIntro(){ setStatus("Introducing…"); setAvatar("speaking");
-      try{ const d=await (await fetch("/intro")).json();
-        if(d.text) addMsg(d.text,"agent"); if(d.audio_b64){ speaking=true; setAvatar("speaking"); await speak(d.audio_b64); speaking=false; } }
-      catch{ addMsg("Hi, I'm the OpenNVR Agent.","agent"); } }
+      try{ const d=await (await fetch("/intro?hour="+new Date().getHours())).json();
+        if(d.text) addMsg(d.text,"agent");
+        if(d.audio_b64){ const ok=await trySpeak(d.audio_b64); if(!ok) _introAudio=d.audio_b64; } }
+      catch{ addMsg("Hi, I'm the OpenNVR Agent.","agent"); }
+      finally{ if(!sessionActive){ setAvatar("idle"); setStatus("Ready. Type, dictate, or tap Talk."); } } }
+    async function trySpeak(b64){
+      try{ ensureOutputAudio(); if(audioCtx.state!=="running") return false;
+        speaking=true; setAvatar("speaking"); await speak(b64); speaking=false; return true; }
+      catch{ speaking=false; return false; } }
+    async function playHeldIntro(){ if(!_introAudio) return; const a=_introAudio; _introAudio=null; await trySpeak(a); }
+    document.addEventListener("pointerdown",()=>{ if(_introAudio) playHeldIntro(); },{capture:true});
 
     // ── listening loop ──
     function vadTick(){ if(!sessionActive||speaking||busy||alarmRinging)return;
@@ -2249,6 +2264,7 @@
       if(_pinnedFrame){ clearPin(); addMsg("Unpinned — voice questions use live frames; type to ask about a pinned frame.","sys"); }
       talkBtn.innerHTML=IC.stop+" Stop"; talkBtn.classList.add("listening");
       if(!introPlayed){ introPlayed=true; await playIntro(); }
+      else if(_introAudio){ await playHeldIntro(); }   // page-open greeting the browser held back
       if(!sessionActive) return;
       micdotEl.hidden=false; setAvatar("listening"); setStatus("Listening… just speak.","active");
       if(!levelRAF) levelRAF=requestAnimationFrame(levelRing);
@@ -3015,7 +3031,8 @@
     // Resolve auth state (open /agent) BEFORE loading any gated data, so a
     // signed-out visitor doesn't fire a burst of 401s behind the login. After
     // sign-in the page reloads with a token and these run normally.
-    loadAgent().then(()=>{ if(authReady()){ loadCameras().then(()=>{ openDeepLinkedCamera(); loadHistory(); }); loadNotify(); loadAlarmPresets(); loadAlarmTargets(); loadSkills(); loadHardware(); loadEvents(); } connectUpdates(); });
+    loadAgent().then(()=>{ if(authReady()){ loadCameras().then(()=>{ openDeepLinkedCamera(); loadHistory(); }); loadNotify(); loadAlarmPresets(); loadAlarmTargets(); loadSkills(); loadHardware(); loadEvents();
+        if(!introPlayed){ introPlayed=true; playIntro(); } } connectUpdates(); });
     pollHealth(); setInterval(pollHealth, 15000);
     // Phone tab bar: pure show/hide via body[data-mtab]; boot on Chat.
     (function(){ const bar=$("mtabs"); if(!bar) return;

--- a/examples/camera-agent/tests/test_persona.py
+++ b/examples/camera-agent/tests/test_persona.py
@@ -212,3 +212,48 @@ def test_say_endpoint_text_only_when_tts_down(monkeypatch):
     client = TestClient(build_app(rt))
     r = client.post("/say", json={"text": "hello"})
     assert r.status_code == 200 and r.json()["audio_b64"] is None
+
+
+def test_greeting_opens_with_the_time_of_day():
+    import camera_agent as ca
+
+    assert ca.time_of_day_salutation(7) == "Good morning"
+    assert ca.time_of_day_salutation(11) == "Good morning"
+    assert ca.time_of_day_salutation(12) == "Good afternoon"
+    assert ca.time_of_day_salutation(16) == "Good afternoon"
+    assert ca.time_of_day_salutation(17) == "Good evening"
+    assert ca.time_of_day_salutation(21) == "Good evening"
+    assert ca.time_of_day_salutation(23) == "Hello"      # nobody means "good morning" at 2 am
+    assert ca.time_of_day_salutation(2) == "Hello"
+    assert ca.time_of_day_salutation("bogus") in ("Good morning", "Good afternoon", "Good evening", "Hello")
+    assert ca.greeting_for(hour=9).startswith("Good morning, I'm the OpenNVR Agent")
+    assert ca.greeting_for(hour=None).split(",")[0] in ("Good morning", "Good afternoon", "Good evening", "Hello")
+
+
+def test_intro_takes_the_operators_hour_and_the_page_greets_on_open():
+    from fastapi.testclient import TestClient
+    from pathlib import Path
+
+    import camera_agent as ca
+    from context import CameraSpec
+
+    cfg = ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+                       cameras=[CameraSpec(camera_id="c", frame_url="http://x", role="f")])
+    rt = ca.CameraAgentRuntime(cfg)
+
+    class _NoPiper:
+        async def synthesize(self, text):
+            raise RuntimeError("down")
+    rt.piper = _NoPiper()
+    tc = TestClient(ca.build_app(rt))
+    assert tc.get("/intro?hour=8").json()["text"].startswith("Good morning")
+    assert tc.get("/intro?hour=19").json()["text"].startswith("Good evening")
+    assert tc.get("/intro?hour=19").json()["audio_b64"] is None      # text always, audio when Piper is up
+
+    html = (Path(__file__).resolve().parents[1] / "demo" / "index.html").read_text()
+    # greets when the page opens (after auth resolves), not only on Talk
+    assert 'if(!introPlayed){ introPlayed=true; playIntro(); }' in html
+    # the browser's own hour rides along
+    assert '"/intro?hour="+new Date().getHours()' in html
+    # autoplay-safe: held audio is spoken on the first gesture or on Talk
+    assert "playHeldIntro" in html and 'addEventListener("pointerdown"' in html


### PR DESCRIPTION
A person greets you when you walk in, not when you press a button. The intro now plays once the page has loaded and auth has resolved: the text at once; the audio right away where the browser allows it, otherwise held and spoken on the first tap/click anywhere or on Talk (browsers refuse audio before a user gesture — that is why it lived behind Talk).

The greeting opens with the time of day — Good morning (05–11), Good afternoon (12–16), Good evening (17–21), Hello otherwise — from the operator's own clock (the page sends ?hour=<local hour>) so a remote operator hears the right one; the site's clock is the fallback.