### PR TITLE
feat(camera-agent): thinks aloud before a slow tool — from the call's…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **camera-agent: thinks aloud before a slow tool.** When a voice
+  question needs a slow tool the agent says what it is about to do —
+  "Let me check the gate camera for vehicles between 2 and 3", "Let me
+  check the plate reads for 6 6 H H 0 7 in the last hour" — built from
+  the tool call's own arguments (no LLM), Piper-synthesised in parallel
+  with the tool and cached by text, pushed over the page's `/updates`
+  socket the moment the tool is known; the answer cuts it if it lands
+  first. At most once per turn, never for instant lookups, and only when
+  the expected wait (the agent's own recent stage timings) is at least
+  `filler_min_ms`. Typed questions get the line as a status only.
+  `thinking_aloud`, `filler_min_ms`, `filler_source: template | model`
+  (the model writes the line in the same first pass, template as
+  fallback); `GET /thinking-aloud` shows the decisions. `/updates` now
+  wakes immediately for pushed lines instead of only on its 2 s tick.
+
 ### Changed
 
 - **camera-agent: greets when the page opens, with the time of day.**

--- a/examples/camera-agent/Dockerfile
+++ b/examples/camera-agent/Dockerfile
@@ -93,6 +93,7 @@ COPY examples/camera-agent/serializer.py      ./serializer.py
 COPY examples/camera-agent/services.py        ./services.py
 COPY examples/camera-agent/tools.py           ./tools.py
 COPY examples/camera-agent/turns.py           ./turns.py
+COPY examples/camera-agent/fillers.py         ./fillers.py
 COPY examples/camera-agent/footage_index.py   ./footage_index.py
 COPY examples/camera-agent/monitor_host.py    ./monitor_host.py
 COPY examples/camera-agent/system_check.py    ./system_check.py

--- a/examples/camera-agent/MODELS_AND_LATENCY.md
+++ b/examples/camera-agent/MODELS_AND_LATENCY.md
@@ -211,6 +211,37 @@ verdict is the floor of the "you stop → agent starts" latency; the Whisper
 transcript for the turn is usually still in flight at that point, so it
 rarely adds to the wall clock.
 
+## Thinking aloud (`fillers.py`)
+
+A person who has to look something up says what they are about to do,
+then goes quiet and does it. The agent knows *what it is about to do* the
+moment the first LLM pass returns a tool call — the tool and its
+arguments — and that is the only moment worth filling: the tool, the
+second LLM pass and TTS are the slow part. So when a voice question needs
+a slow tool it says, from the call's own arguments, "Let me check the
+gate camera for vehicles between 2 and 3" / "Let me take a look at the
+front door camera — is the door open" / "Let me check the plate reads for
+6 6 H H 0 7 in the last hour", and the line plays while the tool runs.
+
+What it costs: no LLM (one sentence shape per tool, slots filled from the
+arguments the model already extracted), one short Piper synthesis run in
+parallel with the tool and cached by text, one message on the page's
+`/updates` socket. Nothing is added to the answer's path; the answer cuts
+the line if it lands first. On a CPU-only box Piper is the CPU hog, so
+the parallel synthesis is the one real cost — cached lines are free, and
+typed questions never synthesise (status text only).
+
+When it speaks: at most once per turn, never for instant lookups or
+control verbs (`recent_events`, `create_alarm`…), and only when the
+expected wait — the agent's own recent medians for that tool + the second
+LLM pass + TTS, seeded from defaults — is at least `filler_min_ms`
+(1500). On a GPU box where a history search plus reply takes a second,
+it stays quiet. `GET /thinking-aloud` lists the recent decisions with
+their reasons. `filler_source: model` asks the LLM to write the line in
+the *same* first pass (about ten extra output tokens) and falls back to
+the template when the model's line is missing, long, or is the answer
+itself — worth trying with your model; the template is the safe default.
+
 ## Recommended model choices
 
 | Role | Default (snappy) | Upgrade (quality, slower) | Why |

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -207,6 +207,18 @@ class AppConfig:
     interrupt_min_ms: float = 300.0
     interrupt_min_words: int = 2
     interrupt_addressee: bool = True
+    # Thinking aloud (fillers.py): when a voice question needs a slow tool,
+    # the agent says what it is about to do ("let me check the gate camera
+    # between 2 and 3") while it does it. One sentence shape per tool with
+    # the tool call's own arguments slotted in — no LLM; Piper synthesis
+    # cached by text and run in parallel with the tool; at most one per
+    # turn; only when the expected wait (this site's own recent stage
+    # timings) is at least filler_min_ms. filler_source "model" asks the
+    # LLM to write the line in the SAME first pass (a few extra output
+    # tokens), template as fallback.
+    thinking_aloud: bool = True
+    filler_min_ms: float = 1500.0
+    filler_source: str = "template"
     # Reasoning toggle for "thinking" models (Qwen3 etc.). Leave None for
     # non-thinking models (no effect). Set False to force snappy, non-thinking
     # tool-calling (appends Qwen3's ``/no_think`` switch); True to allow it.
@@ -2956,6 +2968,9 @@ def load_config(path: str | Path) -> AppConfig:
         interrupt_min_words=_int("interrupt_min_words", 2),
         interrupt_addressee=(True if raw.get("interrupt_addressee") is None
                              else bool(raw.get("interrupt_addressee"))),
+        thinking_aloud=(True if raw.get("thinking_aloud") is None else bool(raw.get("thinking_aloud"))),
+        filler_min_ms=_float("filler_min_ms", 1500.0),
+        filler_source=_str("filler_source", "template"),
         enabled_tools=(
             list(raw["enabled_tools"])
             if isinstance(raw.get("enabled_tools"), list)
@@ -3293,6 +3308,17 @@ class CameraAgentRuntime:
         # was said over the agent, how long, and whether it yielded — the
         # evidence to tune the gate from. GET /interruptions.
         self.interruption_log: deque = deque(maxlen=200)
+        # Thinking aloud (fillers.py) + the push channel the demo page
+        # listens on (/updates): a "working" line is published the moment
+        # the first tool call is known, so the page can speak it while
+        # the tool runs.
+        from fillers import ThinkingAloud
+        self.thinking = ThinkingAloud(
+            min_ms=float(getattr(cfg, "filler_min_ms", 1500.0)),
+            source=str(getattr(cfg, "filler_source", "template") or "template"),
+            enabled=bool(getattr(cfg, "thinking_aloud", True)),
+        )
+        self._update_subscribers: set = set()
         self._configure_tools()
         self.tool_handlers = {
             "describe_camera": self.tools.describe_camera,
@@ -3484,6 +3510,42 @@ class CameraAgentRuntime:
                 if v in ("siren", "pulse", "chime", "silent"):
                     merged[k] = v
         return merged
+
+    # ── push channel for the page (/updates) ─────────────────────────
+    def subscribe_updates(self) -> "asyncio.Queue":
+        q: asyncio.Queue = asyncio.Queue(maxsize=32)
+        self._update_subscribers.add(q)
+        return q
+
+    def unsubscribe_updates(self, q: "asyncio.Queue") -> None:
+        self._update_subscribers.discard(q)
+
+    def publish_update(self, payload: dict[str, Any]) -> None:
+        for q in list(self._update_subscribers):
+            try:
+                q.put_nowait(payload)
+            except asyncio.QueueFull:
+                pass
+
+    async def say_working(self, text: str, *, voice: bool) -> None:
+        """Push a "working" line to the page — with audio for a voice turn
+        (Piper, cached by text, run here in parallel with the tool the
+        line announces); text only for a typed question. Never raises."""
+        audio_b64 = None
+        if voice:
+            try:
+                cache = self.thinking.audio
+                audio_b64 = cache.get(text)
+                if audio_b64 is None:
+                    audio = await self.piper.synthesize(text)
+                    if audio:
+                        audio_b64 = base64.b64encode(audio).decode("ascii")
+                        if len(cache) >= 64:
+                            cache.pop(next(iter(cache)))
+                        cache[text] = audio_b64
+            except Exception as exc:  # noqa: BLE001 — the line is optional
+                logger.debug("thinking aloud: TTS unavailable (%s); text only", exc)
+        self.publish_update({"working": {"text": text, "audio_b64": audio_b64, "ts": time.time()}})
 
     ANNOUNCE_LEVELS = ("all", "important", "none")
 
@@ -5178,6 +5240,13 @@ class CameraAgentRuntime:
         # Disable Qwen3-style "thinking" for snappy tool-calling when the
         # operator opted out. Only appended when llm_think is explicitly False,
         # so non-thinking models (qwen2.5, llama3.2, …) are unaffected.
+        if getattr(self.cfg, "filler_source", "template") == "model" and getattr(self.cfg, "thinking_aloud", True):
+            prompt += (
+                "\n\nWhen you call a tool, also write ONE short sentence (under twelve "
+                "words) telling the user what you are about to check — for example "
+                "'Let me look at the gate camera between two and three.' Never guess "
+                "the answer in that sentence."
+            )
         if self.cfg.llm_think is False:
             prompt += "\n\n/no_think"
         return prompt
@@ -5823,6 +5892,16 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             "addressee": bool(getattr(cfg, "interrupt_addressee", True)),
             "recent": list(runtime.interruption_log)[-50:],
         }
+
+    @app.get("/thinking-aloud")
+    async def _thinking_aloud() -> dict[str, Any]:
+        """The thinking-aloud gate and its recent decisions (viewer tier):
+        which tools got a line, which were too quick to need one."""
+        t = runtime.thinking
+        return {"enabled": t.enabled, "min_ms": t.min_ms, "source": t.source,
+                "expected_ms": {k: int(t.expected_wait_ms(k)) for k in
+                                ("describe_camera", "search_history", "search_footage", "recent_plates")},
+                "recent": list(t.recent)}
 
     @app.get("/alarm-defaults")
     async def _alarm_defaults() -> dict[str, Any]:
@@ -6486,11 +6565,13 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 runtime, demo_history, text, preferred_camera=camera_hint,
                 tool_definitions=runtime.tools_for_tier(
                     getattr(request.state, "agent_tier", "admin")),
+                speak_progress="text",
             )
             # Capture "what I saw" while the pin is still visible — a
             # racing thumbnail fetch may have overwritten the cache seed,
             # and the chat must show the frame the answer was ABOUT.
             frames = _frames_for(runtime)
+            runtime.thinking.record_stages(runtime.last_turn_trace)
         except LLMTurnError as exc:
             # The diagnosis IS the message (issue #344): "model X not found,
             # try pulling it first" must reach the operator, not the log.
@@ -6656,6 +6737,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 runtime, demo_history, question, preferred_camera=camera_hint,
                 tool_definitions=runtime.tools_for_tier(
                     getattr(request.state, "agent_tier", "admin")),
+                speak_progress="voice",
             ), name="converse-turn")
             _inflight["turn"] = turn
             try:
@@ -6719,6 +6801,7 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                         "adapter (docker logs, /health); text-only reply")
         _mark("tts", t3)
         timings["total"] = int((_t.perf_counter() - t0) * 1000)
+        runtime.thinking.record_stages(runtime.last_turn_trace, timings)
         # Log the per-stage breakdown so a slow turn can be diagnosed straight
         # from the agent logs (grep "converse: timings_ms") instead of only the
         # browser's Network tab: transcode / stt / llm / tts / total, in ms.
@@ -6768,8 +6851,18 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
             set_camera_scope(await _scope_for(_tok, _user))
         await websocket.accept()
         last: str | None = None
+        inbox = runtime.subscribe_updates()
         try:
             while True:
+                # Anything published (a "working" line while a tool runs)
+                # goes out at once; the panel diff below every 2 s.
+                try:
+                    pushed = await asyncio.wait_for(inbox.get(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pushed = None
+                if pushed is not None:
+                    await websocket.send_text(json.dumps(pushed, default=str))
+                    continue
                 alarms = runtime.alarms.list()
                 payload = {
                     "tasks": {"tasks": runtime.tasks.list()},
@@ -6797,11 +6890,12 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 if text != last:
                     await websocket.send_text(text)
                     last = text
-                await asyncio.sleep(2.0)
         except Exception:
             # Disconnect (or send on a closed socket) ends the loop; the page
             # reconnects with backoff and polls in the meantime.
             return
+        finally:
+            runtime.unsubscribe_updates(inbox)
 
     @app.websocket("/ws")
     async def _ws(websocket: WebSocket) -> None:
@@ -7278,9 +7372,12 @@ async def _run_conversation_turn(
     max_iterations: int = 4,
     preferred_camera: str | None = None,
     tool_definitions: list[dict[str, Any]] | None = None,
+    speak_progress: str | None = None,
 ) -> str:
     """Run the tool-calling LLM loop for one user utterance and return the
-    final spoken reply. ``history`` holds prior user/assistant text turns
+    final spoken reply. ``speak_progress``: "voice" / "text" for an
+    interactive turn (the agent may think aloud — fillers.py — before a
+    slow tool; audio only for voice), None for background work. ``history`` holds prior user/assistant text turns
     (tool internals are kept turn-local, not persisted).
 
     Anti-fabrication guard: small CPU models sometimes answer a camera
@@ -7322,6 +7419,29 @@ async def _run_conversation_turn(
     # explains itself. Overwritten each turn (turns are serialized).
     trace: list[dict[str, Any]] = []
     runtime.last_turn_trace = trace
+    thinking = getattr(runtime, "thinking", None)
+    if thinking is not None:
+        thinking.new_turn()
+
+    def _think_aloud(call: dict[str, Any], model_line: str) -> None:
+        """Say what the first slow tool is about to do — in parallel with it."""
+        if thinking is None or not speak_progress:
+            return
+        func = call.get("function") or {}
+        name = str(func.get("name") or "")
+        raw = func.get("arguments")
+        try:
+            args = json.loads(raw) if isinstance(raw, str) and raw.strip() else (raw if isinstance(raw, dict) else {})
+        except (json.JSONDecodeError, ValueError):
+            args = {}
+        try:
+            line = thinking.line_for(name, args, cameras=runtime.visible_cameras(), model_line=model_line)
+        except Exception:  # noqa: BLE001
+            line = None
+        if line:
+            logger.info("thinking aloud (%s): %r", name, line)
+            asyncio.create_task(runtime.say_working(line, voice=(speak_progress == "voice")),
+                                name="thinking-aloud")
 
     final = ""
     grounded = False   # did any tool actually run this turn?
@@ -7356,6 +7476,7 @@ async def _run_conversation_turn(
                 "role": "assistant", "content": content, "tool_calls": tool_calls,
             })
             for call in tool_calls:
+                _think_aloud(call, content)
                 name, result = await _invoke_tool(runtime, call)
                 logger.info("converse: tool %s -> %s", name, result[:120])
                 tools_called += 1
@@ -7402,6 +7523,7 @@ async def _run_conversation_turn(
                 "id": "forced-0", "type": "function",
                 "function": {"name": tool_name, "arguments": tool_args},
             }
+            _think_aloud(call, "")
             name, result = await _invoke_tool(runtime, call)
             logger.info("converse: FORCED grounding (%s) on %s -> %s",
                         tool_name, cam, result[:120])

--- a/examples/camera-agent/config.docker.yml
+++ b/examples/camera-agent/config.docker.yml
@@ -150,6 +150,18 @@ interruptions: gated
 interrupt_min_ms: 300
 interrupt_min_words: 2
 interrupt_addressee: true
+# Thinking aloud: when a voice question needs a slow tool, the agent says
+# what it is about to do while it does it — "Let me check the gate camera
+# for vehicles between 2 and 3" — built from the tool call's own arguments
+# (no LLM), Piper-synthesised in parallel with the tool and cached by
+# text, at most once per turn, and only when the expected wait (this
+# site's own recent stage timings) is at least filler_min_ms. Typed
+# questions get the line as a status only. GET /thinking-aloud shows the
+# decisions. filler_source "model" asks the LLM to write the line in the
+# same first pass (a few extra tokens) with the template as fallback.
+thinking_aloud: true
+filler_min_ms: 1500
+filler_source: template
 # turn_cpu_threads: 1
 # turn_timer_secs: 0.8
 # Context window. The default (4096) no longer fits this config's toolset:

--- a/examples/camera-agent/config.example.yml
+++ b/examples/camera-agent/config.example.yml
@@ -111,6 +111,18 @@ interruptions: gated
 interrupt_min_ms: 300
 interrupt_min_words: 2
 interrupt_addressee: true
+# Thinking aloud: when a voice question needs a slow tool, the agent says
+# what it is about to do while it does it — "Let me check the gate camera
+# for vehicles between 2 and 3" — built from the tool call's own arguments
+# (no LLM), Piper-synthesised in parallel with the tool and cached by
+# text, at most once per turn, and only when the expected wait (this
+# site's own recent stage timings) is at least filler_min_ms. Typed
+# questions get the line as a status only. GET /thinking-aloud shows the
+# decisions. filler_source "model" asks the LLM to write the line in the
+# same first pass (a few extra tokens) with the template as fallback.
+thinking_aloud: true
+filler_min_ms: 1500
+filler_source: template
 # turn_cpu_threads: 1
 # turn_timer_secs: 0.8
 

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -1347,7 +1347,7 @@
     async function ask(){
       const inp=$("askInput"), q=inp.value.trim(); if(!q) return;
       inp.value=""; addMsg(q,"user"); setStatus("Thinking…"); setAvatar("thinking");
-      $("askBtn").disabled=true;
+      $("askBtn").disabled=true; _askInFlight=true;
       // A pinned frame scopes the turn to its camera and rides along so the
       // agent answers about the EXACT frame the user clicked. One-shot:
       // cleared after the send either way.
@@ -1361,7 +1361,7 @@
         else { if(d.reply) addMsg(d.reply,"agent",d.frames); addFlow(d.trace,null,d.latency_ms); showWorking(d.cameras_used); showLatency({total:d.latency_ms}); }
         setStatus("Ready. Type a question.","");
       }catch(err){ addMsg("Request failed: "+err.message,"sys"); setStatus("Error","error"); }
-      finally{ $("askBtn").disabled=false; setAvatar("idle"); }
+      finally{ $("askBtn").disabled=false; _askInFlight=false; setAvatar("idle"); }
     }
     // ── the camera roster: a live view, not a boot snapshot ─────────────
     // This used to run exactly ONCE, at page load, and the /updates socket
@@ -2218,6 +2218,20 @@
     function stopCapture(){ if(!recorder||recorder.state==="inactive")return; capturing=false; loudFrames=0;
       setAvatar("thinking"); setStatus("Thinking…"); recorder.stop(); }
 
+    // ── thinking aloud ──
+    // The server publishes a "working" line the moment it knows which slow
+    // tool the turn needs ("Let me check the gate camera between 2 and 3").
+    // Voice turn: speak it while the tool runs; the answer cuts it if it
+    // lands first. Typed turn: status line only. Ignored when no turn is in
+    // flight (a late line after Stop) or while the agent is already speaking.
+    let _fillerSrc=null, _askInFlight=false;
+    async function onWorking(w){ if(!w||!w.text||!(busy||_askInFlight)) return;
+      setStatus(w.text,"active");
+      if(!w.audio_b64||!sessionActive||speaking) return;
+      try{ speaking=true; setAvatar("speaking"); _fillerSrc=true; await speak(w.audio_b64); }
+      catch{} finally{ _fillerSrc=null; speaking=false; if(busy) setAvatar("thinking"); } }
+    function cutFiller(){ if(_fillerSrc){ stopSpeaking(); _fillerSrc=null; speaking=false; } }
+
     async function onUtterance(){ const blob=new Blob(chunks,{type:recorder.mimeType||"audio/webm"});
       if(blob.size<1200){ if(sessionActive){setAvatar("listening");setStatus("Listening… speak your question.","active");} return; }
       busy=true; const gen=++turnGen; inflightCtl=new AbortController();
@@ -2245,6 +2259,7 @@
         addFlow(data.trace,data.timings_ms);
         if(data.reply && !data.audio_b64 && data.tts_error && !ttsWarned){ ttsWarned=true;
           addMsg("🔇 Voice replies are unavailable — the speech (Piper) adapter isn't responding, so replies are text-only until it recovers. Check: docker logs opennvr_piper_adapter","sys"); }
+        cutFiller();                                    // the answer outranks "let me check…"
         if(data.audio_b64 && gen===turnGen){ speaking=true; setAvatar("speaking"); await speak(data.audio_b64); speaking=false; }
         if(sessionActive){ setAvatar("listening"); setStatus("Listening… ask a follow-up, or tap Stop.","active"); }
       }catch(err){ if(gen!==turnGen || err.name==="AbortError") return;  // user cancelled — not an error
@@ -2605,6 +2620,7 @@
       _updWs=ws;
       ws.onmessage=(ev)=>{ let d; try{ d=JSON.parse(ev.data); }catch{ return; }
         _updLive=true; _updBackoff=1500;
+        if(d.working) onWorking(d.working);
         if(d.tasks) pollTasks(d.tasks);
         if(d.monitors) pollMonitors(d.monitors);
         if(d.reports) pollReports(d.reports);

--- a/examples/camera-agent/fillers.py
+++ b/examples/camera-agent/fillers.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""What the agent says while it works — "let me check the gate camera".
+
+A person who has to look something up says what they are about to do,
+then goes quiet and does it. The agent knows *what it is about to do* the
+moment the first LLM pass returns a tool call — the tool and its
+arguments (camera, time window, label, plate) — and that is the only
+moment worth filling: what follows (the tool, the second LLM pass, TTS) is
+the slow part.
+
+So the sentence is not a paraphrase of the question; it states the
+action, from the tool call's own arguments — which are the question's
+context, already extracted. One sentence shape per tool, slots filled.
+No LLM is involved unless ``filler_source: model`` asks the model to
+write the line in the SAME first pass (a few extra output tokens, no
+extra call); even then a template is the fallback.
+
+Cost per turn: one short Piper synthesis (cached by text), run in
+parallel with the tool, and one message on the page's /updates socket.
+Nothing is added to the answer's own path, and the answer cuts the
+filler if it arrives first.
+
+Guardrails: only when the expected wait (the agent's own recent stage
+timings for that tool + the second LLM pass + TTS) is long enough to
+need it; at most one per turn; never the same opener twice running.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import re
+from collections import deque
+from datetime import datetime
+from typing import Any, Iterable
+
+logger = logging.getLogger("camera_agent.fillers")
+
+# Expected cost of a tool before any measurement exists (ms). Vision and
+# footage are slow; registry and ring lookups are not worth a sentence.
+DEFAULT_TOOL_MS: dict[str, int] = {
+    "describe_camera": 2500, "describe_window": 4000, "describe_event": 3000,
+    "detect_objects": 1200, "recognize_faces": 1500, "camera_snapshot": 300,
+    "search_footage": 1500, "search_history": 800,
+    "recent_events": 150, "recent_plates": 150,
+    "list_apps": 200, "app_status": 400, "recent_app_alerts": 100,
+    "list_people": 100,
+}
+DEFAULT_LLM_MS = 1500
+DEFAULT_TTS_MS = 600
+
+_OPENERS = ("Let me", "One moment, I'll", "Sure — I'll", "Okay, I'll")
+
+
+def humanize_camera(camera_id: str | None, cameras: Iterable[Any] = ()) -> str:
+    """"cam1" → "camera one"; a roster entry's role wins when it is short
+    ("front door", "gate")."""
+    if not camera_id:
+        return "the cameras"
+    cid = str(camera_id).strip()
+    if cid.lower() in ("all", "*", ""):
+        return "all cameras"
+    for cam in cameras:
+        if str(getattr(cam, "camera_id", "")) == cid:
+            role = str(getattr(cam, "role", "") or "").strip()
+            if role and len(role.split()) <= 3:
+                return f"the {role} camera" if "camera" not in role.lower() else f"the {role}"
+    m = re.fullmatch(r"(?i)cam(?:era)?[\s_-]*(\d+)", cid)
+    if m:
+        return f"camera {_number_words(int(m.group(1)))}"
+    return f"the {cid.replace('_', ' ').replace('-', ' ')} camera"
+
+
+def _number_words(n: int) -> str:
+    words = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+             "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen",
+             "seventeen", "eighteen", "nineteen", "twenty"]
+    return words[n] if 0 <= n < len(words) else str(n)
+
+
+def spell_plate(plate: str) -> str:
+    """"66HH07" → "6 6 H H 0 7" — spoken letter by letter, as people read plates."""
+    return " ".join(ch.upper() for ch in str(plate) if ch.isalnum())
+
+
+def _clock(iso: str | None) -> str | None:
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(iso).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    hour12 = dt.hour % 12 or 12
+    suffix = "am" if dt.hour < 12 else "pm"
+    return f"{hour12} {suffix}" if dt.minute == 0 else f"{hour12}:{dt.minute:02d} {suffix}"
+
+
+def time_window(args: dict[str, Any]) -> str:
+    start, end = _clock(args.get("start_time")), _clock(args.get("end_time"))
+    if start and end:
+        return f" between {start} and {end}"
+    if start:
+        return f" since {start}"
+    secs = args.get("window_seconds")
+    try:
+        secs = float(secs) if secs not in (None, "") else None
+    except (TypeError, ValueError):
+        secs = None
+    if secs:
+        if secs < 90:
+            return " in the last minute"
+        if secs < 3600:
+            return f" in the last {int(round(secs / 60))} minutes"
+        hours = secs / 3600
+        return " in the last hour" if hours < 1.5 else f" in the last {int(round(hours))} hours"
+    mins = args.get("within_minutes")
+    try:
+        mins = int(mins) if mins not in (None, "") else None
+    except (TypeError, ValueError):
+        mins = None
+    if mins:
+        return " in the last hour" if 45 <= mins <= 75 else f" in the last {mins} minutes"
+    return ""
+
+
+def template_line(tool: str, args: dict[str, Any], cameras: Iterable[Any] = (), opener: str = "Let me") -> str | None:
+    """The sentence for one tool call, or None when the tool is not worth
+    announcing (instant lookups, control verbs)."""
+    args = args or {}
+    cam = humanize_camera(args.get("camera_id") or args.get("camera"), cameras)
+    ids = args.get("camera_ids")
+    if isinstance(ids, list) and len(ids) > 1:
+        cam = "all cameras" if len(ids) >= 3 else " and ".join(humanize_camera(c, cameras) for c in ids[:2])
+    label = str(args.get("label") or "").strip().lower()
+    what = f" for {label}s" if label and not label.endswith("s") else (f" for {label}" if label else "")
+    plate = str(args.get("plate") or "").strip()
+    q = str(args.get("question") or "").strip().rstrip("?.!")
+    q_part = f" — {q[0].lower() + q[1:]}" if 0 < len(q.split()) <= 8 else ""
+    if tool == "describe_camera":
+        return f"{opener} take a look at {cam}{q_part}."
+    if tool == "detect_objects":
+        return f"{opener} check what's on {cam} right now."
+    if tool == "recognize_faces":
+        return f"{opener} see who is on {cam}."
+    if tool == "search_history":
+        if plate:
+            return f"{opener} check {cam} for plate {spell_plate(plate)}{time_window(args)}."
+        return f"{opener} check {cam}{what}{time_window(args)}."
+    if tool == "describe_window":
+        return f"{opener} look at what happened on {cam}{time_window(args)}{q_part}."
+    if tool == "describe_event":
+        return f"{opener} look at that event more closely{q_part}."
+    if tool == "search_footage":
+        kw = args.get("keywords")
+        kw = ", ".join(str(k) for k in kw[:3]) if isinstance(kw, list) and kw else ""
+        return f"{opener} search the footage{(' for ' + kw) if kw else ''}{time_window(args)}."
+    if tool == "recent_plates" and plate:
+        return f"{opener} check the plate reads for {spell_plate(plate)}{time_window(args)}."
+    if tool == "app_status":
+        app = str(args.get("app_id") or "").replace("-", " ")
+        return f"{opener} ask the {app} app." if app else None
+    if tool == "create_background_task":
+        return f"{opener} start that in the background and report back."
+    return None
+
+
+class ThinkingAloud:
+    """Per-runtime state: the opener rotation, the one-per-turn latch,
+    stage timings from recent turns, and a small audio cache."""
+
+    def __init__(self, *, min_ms: float = 1500.0, source: str = "template", enabled: bool = True):
+        self.enabled = enabled
+        self.min_ms = float(min_ms)
+        self.source = source if source in ("template", "model") else "template"
+        self._last_opener: str | None = None
+        self._said_this_turn = False
+        self.stage_ms: dict[str, deque] = {}
+        self.audio: dict[str, str] = {}          # text → base64 wav
+        self.recent: deque = deque(maxlen=30)     # decisions, for /interruptions-style tuning
+
+    # ── turn lifecycle ────────────────────────────────────────────────
+    def new_turn(self) -> None:
+        self._said_this_turn = False
+
+    def record_stages(self, trace: Iterable[dict[str, Any]], timings: dict[str, Any] | None = None) -> None:
+        """Feed the turn's trace (step/detail/ms) and /converse timings so
+        the next decision uses this site's real numbers."""
+        for step in trace or []:
+            ms = step.get("ms")
+            if isinstance(ms, (int, float)):
+                key = str(step.get("step") or "")
+                self.stage_ms.setdefault(key, deque(maxlen=20)).append(float(ms))
+        for key in ("tts", "stt"):
+            ms = (timings or {}).get(key)
+            if isinstance(ms, (int, float)):
+                self.stage_ms.setdefault(key, deque(maxlen=20)).append(float(ms))
+
+    def _median(self, key: str, default: float) -> float:
+        xs = sorted(self.stage_ms.get(key, ()))
+        if not xs:
+            return float(default)
+        return xs[len(xs) // 2]
+
+    def expected_wait_ms(self, tool: str) -> float:
+        return (self._median(tool, DEFAULT_TOOL_MS.get(tool, 500))
+                + self._median("llm", DEFAULT_LLM_MS)
+                + self._median("tts", DEFAULT_TTS_MS))
+
+    # ── the decision ──────────────────────────────────────────────────
+    def line_for(self, tool: str, args: dict[str, Any], *, cameras: Iterable[Any] = (),
+                 model_line: str | None = None) -> str | None:
+        """The sentence to speak before running ``tool`` — or None."""
+        if not self.enabled or self._said_this_turn:
+            return None
+        expected = self.expected_wait_ms(tool)
+        if expected < self.min_ms:
+            self.recent.append({"tool": tool, "said": None, "why": f"expected {int(expected)} ms < {int(self.min_ms)}"})
+            return None
+        text = None
+        why = "template"
+        if self.source == "model" and model_line:
+            candidate = " ".join(model_line.split()).strip()
+            n = len(candidate.split())
+            # A usable model line is short, a single sentence, and not the
+            # answer itself (no digits-heavy content, no "I see").
+            if 3 <= n <= 14 and candidate.count(".") <= 1 and not re.search(r"\d{2,}", candidate) \
+                    and not re.match(r"(?i)^(i see|there (is|are)|yes|no)\b", candidate):
+                text = candidate if candidate.endswith((".", "!")) else candidate + "."
+                why = "model"
+        if text is None:
+            opener = random.choice([o for o in _OPENERS if o != self._last_opener] or list(_OPENERS))
+            text = template_line(tool, args, cameras, opener)
+            if text:
+                self._last_opener = opener
+        if not text:
+            self.recent.append({"tool": tool, "said": None, "why": "no template for this tool"})
+            return None
+        self._said_this_turn = True
+        self.recent.append({"tool": tool, "said": text, "why": f"{why}; expected {int(expected)} ms"})
+        return text

--- a/examples/camera-agent/tests/test_thinking_aloud.py
+++ b/examples/camera-agent/tests/test_thinking_aloud.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Thinking aloud: the agent says what it is about to do — from the tool
+call's own arguments, no LLM — only when the wait is worth a sentence."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from fillers import (
+    DEFAULT_TOOL_MS, ThinkingAloud, humanize_camera, spell_plate, template_line, time_window,
+)
+
+
+class _Cam:
+    def __init__(self, camera_id, role):
+        self.camera_id, self.role = camera_id, role
+
+
+def test_slots_read_like_a_person():
+    cams = [_Cam("cam1", "front door"), _Cam("gate", "main gate camera")]
+    assert humanize_camera("cam1", cams) == "the front door camera"
+    assert humanize_camera("gate", cams) == "the main gate camera"
+    assert humanize_camera("cam2") == "camera two"
+    assert humanize_camera("all") == "all cameras"
+    assert spell_plate("66HH07") == "6 6 H H 0 7"
+    assert time_window({"start_time": "2026-09-08T14:00:00+05:30", "end_time": "2026-09-08T15:30:00+05:30"}) == \
+        " between 2 pm and 3:30 pm"
+    assert time_window({"window_seconds": 1800}) == " in the last 30 minutes"
+    assert time_window({"window_seconds": 86400}) == " in the last 24 hours"
+    assert time_window({"within_minutes": 60}) == " in the last hour"
+    assert time_window({}) == ""
+
+
+def test_one_sentence_shape_per_tool_with_the_calls_context():
+    cams = [_Cam("cam1", "front door"), _Cam("gate", "gate")]
+    assert template_line("search_history", {"camera_id": "gate", "label": "vehicle",
+                         "start_time": "2026-09-08T14:00:00", "end_time": "2026-09-08T15:00:00"}, cams) == \
+        "Let me check the gate camera for vehicles between 2 pm and 3 pm."
+    assert template_line("describe_camera", {"camera_id": "cam1", "question": "Is the door open?"}, cams) == \
+        "Let me take a look at the front door camera — is the door open."
+    assert template_line("recent_plates", {"plate": "66HH07", "window_seconds": 3600}) == \
+        "Let me check the plate reads for 6 6 H H 0 7 in the last hour."
+    assert template_line("search_footage", {"keywords": ["red truck"], "within_minutes": 30}) == \
+        "Let me search the footage for red truck in the last 30 minutes."
+    assert template_line("app_status", {"app_id": "occupancy-counting"}) == "Let me ask the occupancy counting app."
+    assert template_line("describe_camera", {"camera_ids": ["cam1", "gate"]}, cams, opener="Sure — I'll") == \
+        "Sure — I'll take a look at the front door camera and the gate camera."
+    # instant lookups and control verbs get no line
+    assert template_line("recent_events", {"camera_id": "cam1"}) is None
+    assert template_line("create_alarm", {"target": "person"}) is None
+
+
+def test_gate_speaks_only_when_the_wait_is_worth_it_and_once_per_turn():
+    t = ThinkingAloud(min_ms=1500)
+    t.new_turn()
+    # defaults: vision is slow → a line; a ring lookup is not → silence
+    assert t.line_for("describe_camera", {"camera_id": "cam1"}) is not None
+    assert t.line_for("search_history", {"camera_id": "cam1"}) is None      # second tool this turn: latch
+    t.new_turn()
+    assert t.line_for("recent_events", {"camera_id": "cam1"}) is None
+    assert t.recent[-1]["why"] == "no template for this tool"     # instant lookup: never announced
+    # this site's own numbers win: a fast vision box needs no filler
+    t.record_stages([{"step": "describe_camera", "ms": 300}] * 5 + [{"step": "llm", "ms": 200}] * 5,
+                    {"tts": 100})
+    t.new_turn()
+    assert t.expected_wait_ms("describe_camera") == 600
+    assert t.line_for("describe_camera", {"camera_id": "cam1"}) is None
+    assert "expected 600 ms < 1500" in t.recent[-1]["why"]
+    # and a slow history search on this site does get one
+    t.record_stages([{"step": "search_history", "ms": 2500}] * 5)
+    t.new_turn()
+    line = t.line_for("search_history", {"camera_id": "cam1", "label": "person"})
+    assert line and "camera one for persons" in line
+    # disabled → never
+    t.enabled = False
+    t.new_turn()
+    assert t.line_for("describe_camera", {"camera_id": "cam1"}) is None
+
+
+def test_openers_rotate():
+    t = ThinkingAloud(min_ms=0)
+    seen = set()
+    for _ in range(12):
+        t.new_turn()
+        seen.add(t.line_for("describe_camera", {"camera_id": "cam1"}).split(" take")[0])
+    assert len(seen) >= 2
+    # never the same opener twice in a row
+    t.new_turn()
+    a = t.line_for("describe_camera", {"camera_id": "cam1"})
+    t.new_turn()
+    b = t.line_for("describe_camera", {"camera_id": "cam1"})
+    assert a.split(" take")[0] != b.split(" take")[0]
+
+
+def test_model_line_is_used_only_when_it_is_a_usable_acknowledgement():
+    t = ThinkingAloud(min_ms=0, source="model")
+    t.new_turn()
+    assert t.line_for("describe_camera", {"camera_id": "cam1"}, model_line="Let me look at the gate camera for you") == \
+        "Let me look at the gate camera for you."
+    # too long, an answer, or empty → the template
+    for bad in ("", "I see a person standing by the gate with a red bag near the car",
+                "There are 3 people", "Yes, the gate is open."):
+        t.new_turn()
+        line = t.line_for("describe_camera", {"camera_id": "cam1"}, model_line=bad)
+        assert "take a look at camera one" in line, (bad, line)
+    # template mode ignores the model line entirely
+    t2 = ThinkingAloud(min_ms=0, source="template")
+    t2.new_turn()
+    assert "take a look at camera one" in t2.line_for("describe_camera", {"camera_id": "cam1"}, model_line="Let me look at the gate.")
+
+
+@pytest.mark.asyncio
+async def test_turn_publishes_a_working_line_before_the_slow_tool_and_only_for_interactive_turns():
+    """Through _run_conversation_turn with a fake LLM that calls
+    describe_camera: a voice turn publishes the line WITH audio while the
+    tool runs; a typed turn publishes text only; background work nothing."""
+    import camera_agent as ca
+    from context import CameraSpec
+
+    cfg = ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+                       cameras=[CameraSpec(camera_id="cam1", frame_url="http://x", role="front door")])
+    rt = ca.CameraAgentRuntime(cfg)
+    order: list[str] = []
+
+    class _Ollama:
+        def __init__(self):
+            self.n = 0
+
+        async def chat(self, *, messages, tools, temperature, max_tokens):
+            self.n += 1
+            if self.n % 2 == 1:
+                return {"message": {"content": "", "tool_calls": [
+                    {"id": "c1", "function": {"name": "describe_camera",
+                                              "arguments": json.dumps({"camera_id": "cam1"})}}]}}
+            return {"message": {"content": "A parked car by the door."}}
+
+    class _Piper:
+        async def synthesize(self, text):
+            order.append(f"tts:{text}")
+            return b"RIFFfakewav"
+
+    async def describe(args):
+        await asyncio.sleep(0.05)
+        order.append("tool")
+        return "A parked car."
+
+    rt.ollama = _Ollama()
+    rt.piper = _Piper()
+    rt.tool_handlers = {"describe_camera": describe}
+    rt.tool_definitions = [{"type": "function", "function": {"name": "describe_camera", "parameters": {}}}]
+    inbox = rt.subscribe_updates()
+
+    reply = await ca._run_conversation_turn(rt, [], "what is at the door", speak_progress="voice")
+    await asyncio.sleep(0.1)
+    assert "parked car" in reply.lower()
+    msg = inbox.get_nowait()
+    assert msg["working"]["text"].endswith("the front door camera.") and msg["working"]["audio_b64"]
+    assert order[0].startswith("tts:") and order[1] == "tool" or order == ["tool", f"tts:{msg['working']['text']}"]
+    assert rt.thinking.recent[-1]["said"] == msg["working"]["text"]
+
+    # typed: text only, no Piper
+    order.clear()
+    rt.ollama = _Ollama()
+    await ca._run_conversation_turn(rt, [], "what is at the door", speak_progress="text")
+    await asyncio.sleep(0.05)
+    msg = inbox.get_nowait()
+    assert msg["working"]["audio_b64"] is None and "tool" in order and not any(o.startswith("tts") for o in order)
+
+    # background: nothing published
+    rt.ollama = _Ollama()
+    await ca._run_conversation_turn(rt, [], "what is at the door")
+    await asyncio.sleep(0.05)
+    assert inbox.empty()
+    rt.unsubscribe_updates(inbox)
+
+
+def test_thinking_aloud_endpoint_and_page_wiring():
+    from pathlib import Path
+
+    from fastapi.testclient import TestClient
+
+    import camera_agent as ca
+    from context import CameraSpec
+
+    cfg = ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+                       cameras=[CameraSpec(camera_id="c", frame_url="http://x", role="f")])
+    body = TestClient(ca.build_app(ca.CameraAgentRuntime(cfg))).get("/thinking-aloud").json()
+    assert body["enabled"] is True and body["min_ms"] == 1500 and body["source"] == "template"
+    assert body["expected_ms"]["describe_camera"] == DEFAULT_TOOL_MS["describe_camera"] + 1500 + 600
+
+    html = (Path(__file__).resolve().parents[1] / "demo" / "index.html").read_text()
+    assert "if(d.working) onWorking(d.working);" in html
+    assert "cutFiller();" in html                      # the answer outranks the filler
+    assert "if(!w.audio_b64||!sessionActive||speaking) return;" in html   # typed turn: status only
+
+
+def test_model_source_adds_the_prompt_hint_only_when_on():
+    import camera_agent as ca
+    from context import CameraSpec
+
+    cams = [CameraSpec(camera_id="c", frame_url="http://x", role="f")]
+    off = ca.CameraAgentRuntime(ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t", cameras=cams))
+    assert "what you are about to check" not in off.build_system_prompt()
+    on = ca.CameraAgentRuntime(ca.AppConfig(kaic_url="http://k", kaic_api_key="x", system_prompt="t", cameras=cams,
+                                            filler_source="model"))
+    assert "what you are about to check" in on.build_system_prompt()


### PR DESCRIPTION
… own arguments, no LLM

A person who has to look something up says what they are about to do, then goes quiet and does it. The agent knows what it is about to do the moment the first LLM pass returns a tool call — the tool and its arguments — and that is the only moment worth filling: the tool, the second LLM pass and TTS are the slow part.

fillers.py: one sentence shape per tool with the arguments slotted in — 'Let me check the gate camera for vehicles between 2 and 3', 'Let me take a look at the front door camera — is the door open', 'Let me check the plate reads for 6 6 H H 0 7 in the last hour'. The arguments ARE the question's context, already extracted by the model, so the line fits the question without asking the model anything.

Cost per turn: one short Piper synthesis in parallel with the tool (cached by text), one message on the page's /updates socket. Nothing on the answer's path; the answer cuts the line if it lands first.

Guardrails: once per turn; never for instant lookups or control verbs; only when the expected wait — this site's own recent medians for the tool + the second LLM pass + TTS (seeded from defaults) — is at least filler_min_ms (1500), so a GPU box that answers in a second stays quiet; typed questions get the line as a status only; background work never speaks. filler_source 'model' asks the LLM to write the line in the SAME first pass (a few extra tokens) with the template as fallback when its line is missing, long, or is the answer.

- runtime.thinking (ThinkingAloud), subscribe/publish_update, say_working; /updates wakes at once for pushed lines instead of only on its 2 s tick; GET /thinking-aloud lists decisions
- _run_conversation_turn(speak_progress='voice'|'text'|None)
- demo page: onWorking speaks the line during a voice turn, shows it as status during a typed one, cutFiller() when the answer arrives
- Dockerfile copies fillers.py; config + MODELS_AND_LATENCY.md section
- tests (8): slots, per-tool shapes, the gate (defaults, site medians, once-per-turn, disabled), opener rotation, model-line acceptance, the real turn loop publishing with/without audio, endpoint + page wiring. Suite 898 passed.