### PR TITLE
fix(adapters): an idle adapter's metrics looked broken — say '0 reque…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **AI Adapters metrics: an idle adapter looked broken.** The panel
+  printed "60 samples" next to all-dash percentiles — the samples were
+  the once-a-minute `/metrics` scrapes, not inferences, and the dashes
+  meant the adapter had served nothing in the window. KAI-C's rollup
+  now reports `requests` (the +Inf bucket delta over the window), the
+  header reads "60 scrapes · 0 requests", and the latency card says
+  "No inference requests in this window — nothing to measure yet"
+  instead of dashes.
+
 ### Added
 
 - **camera-agent: thinks aloud before a slow tool.** When a voice

--- a/app/src/views/AIAdapters.tsx
+++ b/app/src/views/AIAdapters.tsx
@@ -144,6 +144,8 @@ type AdapterMetricsResp = {
   series?: SeriesPoint[]
   fingerprint_changes: string[]
   samples: number
+  // Inferences actually served in the window (scrapes are `samples`).
+  requests?: number
   // SDK ≥1.2: model identity labels from adapter_model_info, and the
   // adapter's own domain series (detections by class, audio seconds,
   // realtime factor…) as windowed deltas keyed by series identity.
@@ -216,8 +218,17 @@ function outcomeBarClass(outcome: string): string {
   return 'bg-red-500'
 }
 
-function LatencyBars({ latency }: { latency: AdapterMetricsResp['latency_ms'] }) {
+function LatencyBars({ latency, requests }: { latency: AdapterMetricsResp['latency_ms']; requests?: number }) {
   const scale = latency?.p99 ?? 0
+  if (requests === 0 && latency?.p50 == null) {
+    // Scraped fine, asked nothing: dashes here read as "broken" — say what it is.
+    return (
+      <div className="text-xs text-[var(--text-dim)]">
+        No inference requests in this window — nothing to measure yet. Percentiles appear once something
+        (an app, the agent, a camera task) sends this adapter work.
+      </div>
+    )
+  }
   const rows = [
     { label: 'p50', value: latency?.p50 ?? null },
     { label: 'p95', value: latency?.p95 ?? null },
@@ -565,7 +576,8 @@ function AdapterMetricsSection({ name }: { name: string }) {
           ) : m ? (
             <div className="space-y-2">
               <div className="font-mono text-[11px] text-[var(--text-dim)]">
-                {formatWindow(m.window_s)}{m.samples != null ? ` · ${m.samples} samples` : ''}
+                {formatWindow(m.window_s)}{m.samples != null ? ` · ${m.samples} scrapes` : ''}
+                {m.requests != null ? ` · ${m.requests} request${m.requests === 1 ? '' : 's'}` : ''}
                 {m.model_info?.model ? (
                   <span>
                     {' · '}
@@ -582,7 +594,7 @@ function AdapterMetricsSection({ name }: { name: string }) {
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <MetricPanel title="Inference latency" decision="which model per camera; is the SLA breached">
-                  <LatencyBars latency={m.latency_ms} />
+                  <LatencyBars latency={m.latency_ms} requests={m.requests} />
                 </MetricPanel>
                 <MetricPanel title="Outcomes" decision="rollback / retire / investigate the adapter">
                   <OutcomesSplit outcomes={m.outcomes} />

--- a/kai-c/kai_c/metrics.py
+++ b/kai-c/kai_c/metrics.py
@@ -481,6 +481,7 @@ class MetricsRollup:
         outcomes: dict[str, int] = {}
         inflight: int | None = None
         queue_depth: int | None = None
+        requests = 0
 
         if samples:
             newest = samples[-1]
@@ -496,6 +497,8 @@ class MetricsRollup:
                 latency_ms[key] = round(seconds * 1000.0, 3) if seconds is not None else None
             inflight = newest.inflight
             queue_depth = newest.queue_depth
+            inf_count = buckets.get(math.inf)
+            requests = int(inf_count) if inf_count is not None else int(sum(outcomes.values()))
 
         # Per-sample series for the UI's sparklines ("over the period of
         # time"): point-in-time gauges verbatim; rate + interval p95
@@ -605,5 +608,12 @@ class MetricsRollup:
             },
             "series": series,
             "fingerprint_changes": fingerprint_changes,
+            # "samples" is the number of /metrics SCRAPES in the window (one a
+            # minute), not inferences — the UI used to print it as if it
+            # were, next to all-null percentiles. "requests" is what was
+            # actually served in the window: the +Inf bucket delta, else the
+            # outcome counters. 0 ⇒ the percentiles are null because there
+            # was nothing to measure, not because anything is broken.
             "samples": len(samples),
+            "requests": requests,
         }

--- a/kai-c/test/test_metrics.py
+++ b/kai-c/test/test_metrics.py
@@ -137,6 +137,7 @@ def test_rollup_snapshot_with_no_samples_is_all_null():
         "series": [],
         "fingerprint_changes": [],
         "samples": 0,
+        "requests": 0,
     }
 
 
@@ -178,6 +179,25 @@ def test_rollup_window_is_delta_between_oldest_and_newest():
     # Outcomes are windowed counts (35−10, 5−0); gauges are latest.
     assert snap["outcomes"] == {"ok": 25, "model_error": 5}
     assert snap["inflight"] == 4
+    assert snap["requests"] == 30          # +Inf bucket delta: what was actually served
+
+
+def test_idle_window_reports_zero_requests_not_broken_percentiles():
+    """An adapter scraped every minute but asked nothing: 60 samples,
+    0 requests, null percentiles — and the UI must say so."""
+    rollup = MetricsRollup()
+    idle = (
+        'adapter_infer_latency_seconds_bucket{le="0.05"} 10\n'
+        'adapter_infer_latency_seconds_bucket{le="+Inf"} 10\n'
+        'adapter_infer_total{outcome="ok"} 10\n'
+        "adapter_inflight_requests 0\n"
+    )
+    for _ in range(3):
+        rollup.record_sample("yolov8", parse_adapter_metrics(idle))
+    snap = rollup.snapshot("yolov8")
+    assert snap["samples"] == 3 and snap["requests"] == 0
+    assert snap["latency_ms"] == {"p50": None, "p95": None, "p99": None}
+    assert sum(snap["outcomes"].values()) == 0
 
 
 def test_rollup_counter_reset_falls_back_to_newest_cumulative():


### PR DESCRIPTION
…sts', not dashes next to '60 samples'

The AI Adapters metrics panel showed 'last 1h · 60 samples' with p50/p95/ p99 all '–', 0 detections, no outcomes. The samples are the once-a-minute /metrics scrapes, not inferences; the dashes are histogram_quantile on an empty bucket delta — the adapter served nothing in the window. Truthful, but it read as a fault.

- kai-c MetricsRollup.snapshot: 'requests' = the +Inf bucket delta over the window (outcome counters as fallback); 0 when idle
- UI: header '60 scrapes · 0 requests'; the latency card explains an idle window instead of drawing empty bars
- tests: requests on a windowed delta; an idle window → 0 requests, null percentiles