### PR TITLE
fix(occupancy): render the config modal the Configure button opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Occupancy: the Configure button did nothing.** Moving the
+  action from a link to the catalog into an in-place modal wired up
+  the state and the import but never rendered `AppConfigModal`, so
+  the click flipped a flag nothing read and the bundler tree-shook
+  the unused import away. The modal is rendered now, and closing it
+  invalidates `apps` and `app-status` so a new zone, entry line or
+  watch label shows on the board without a reload. Same fix revives
+  "Add car / truck to watch labels" in the vehicle-skill hint,
+  which was dead for the same reason.
+
 - **AI Adapters metrics: an idle adapter looked broken.** The panel
   printed "60 samples" next to all-dash percentiles — the samples were
   the once-a-minute `/metrics` scrapes, not inferences, and the dashes

--- a/app/src/views/Occupancy.tsx
+++ b/app/src/views/Occupancy.tsx
@@ -635,6 +635,21 @@ export function Occupancy() {
         </div>
       )}
 
+      {configOpen && occApp && (
+        <AppConfigModal
+          key={occApp.id}
+          app={occApp}
+          onClose={() => {
+            setConfigOpen(false)
+            // A new zone, entry line or watch label changes both the
+            // app's config and what the status board reports — refetch
+            // each so the page reflects the edit without a reload.
+            queryClient.invalidateQueries({ queryKey: ['apps'] })
+            queryClient.invalidateQueries({ queryKey: ['app-status', occApp.id] })
+          }}
+        />
+      )}
+
       {reportOpen && (
         <OccupancyReportOverlay
           cameraName={(id) => cameraName(`cam${id}`)}


### PR DESCRIPTION
Configure did nothing when clicked. Moving the action off a link to /app-catalog/<id> and into an in-place modal added the import and the open state but never rendered AppConfigModal, so the click set a flag nothing read and the unused import was tree-shaken out of the bundle. It has been dead since it landed rather than a recent regression.

The modal is rendered now, guarded on the resolved occupancy app and keyed by its id, matching how the catalog mounts the same form. Closing it invalidates apps and app-status so a freshly drawn zone, entry line or watch label reaches the board without a reload — the refresh the in-place move promised but never wired.

"Add car / truck to watch labels" in the vehicle-skill hint drove the same flag and was dead for the same reason; this revives it too.

tsc --noEmit and vite build both clean.