### PR TITLE
fix(alerts): the alarm poll must keep running in a background tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Alarms stayed silent while the tab was in the background.** A
+  high or critical alarm rings `continuous` by default, but the bell's
+  inbox poll used React Query's `refetchInterval` without
+  `refetchIntervalInBackground`, and the library gates interval
+  refetches on `focusManager.isFocused()` — i.e.
+  `document.visibilityState !== 'hidden'`. Switch to another tab and
+  the poll stopped dead: the bell never learned an alarm had arrived,
+  so nothing sounded until the operator came back and looked, which
+  is the one moment an alarm is not needed. The poll now runs in the
+  background, so a plate that trips an alarm sounds it while OpenNVR
+  sits behind another tab.
+
 - **Occupancy: the Configure button did nothing.** Moving the
   action from a link to the catalog into an in-place modal wired up
   the state and the import but never rendered `AppConfigModal`, so

--- a/app/src/components/AlertBell.tsx
+++ b/app/src/components/AlertBell.tsx
@@ -206,6 +206,13 @@ export function AlertBell() {
       return data as { alerts: InboxAlert[]; unacked_count: number }
     },
     refetchInterval: POLL_MS,
+    // The alarm poll MUST keep running in a background tab. React Query
+    // gates interval refetches on `focusManager.isFocused()` — which is
+    // `document.visibilityState !== 'hidden'` — so by default an operator
+    // who switches tabs stops fetching entirely: the siren never learns
+    // there is anything to sound, and the alarm only fires when they come
+    // back and look. That is the exact opposite of what an alarm is for.
+    refetchIntervalInBackground: true,
   })
 
   const ringCfg = useQuery({


### PR DESCRIPTION
QA: a high-severity plate alarm never sounded while OpenNVR sat in a background tab for ten minutes, then rang as soon as the tab was brought back — with the triggering plate read five minutes old.

The bell polls the inbox with React Query's refetchInterval but never set refetchIntervalInBackground. query-core gates the interval fetch on `refetchIntervalInBackground || focusManager.isFocused()`, and the focus manager is `document.visibilityState !== 'hidden'`, so hiding the tab stopped the poll outright. No poll, no new alert, no sirenMode, no sound; returning to the tab let the next tick fetch and the backlog rang at once. The alarm was therefore audible only when the operator was already looking at the screen.

The poll now runs while hidden. Once the siren does sound, the tab is audible and stays exempt from Chrome's intensive timer throttling, so the 1.6s ring cadence holds.

tsc --noEmit and vite build both clean.