### PR TITLE
fix/catalog card actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The plate app and the page it lights up had unrelated names.** The App
+  Catalog said "License Plate Recognition" and the sidebar said
+  "Vehicles", with nothing to connect them. Both now carry ANPR — the
+  name most of the world uses (UK, EU, India, AU; the US says LPR/ALPR) —
+  as "ANPR — License Plate Recognition" in the catalog and the app's own
+  dashboard, and "Vehicles (ANPR)" in the nav and page header. "Vehicles"
+  stays the head noun because the page is wider than the OCR: plate reads,
+  the vehicle register, monitoring and alarms. The app id, the
+  `license_plate_recognition` AI task and its skill label are unchanged —
+  those are keys and the technical capability, not product names.
+
 - **A running app was reported "skill: degraded — app unreachable at last
   contact".** `installed_apps.status` and `last_seen` were only ever
   written by boot registration and the on-demand "Check" probe, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A freshly installed app needed a manual Refresh to appear under
+  Installed.** The poll that watches the reconciler and invalidates
+  `['apps']` lived inside the install dialog, so dismissing the dialog —
+  the natural thing to do while the reconciler works — killed the only
+  thing that would have refreshed the groups. Accepted intents are now
+  tracked by the page and keep polling after the dialog closes. The
+  invalidation also moved out of `refetchInterval` (an observer computing
+  its next delay, with no promise about terminal states) into an effect
+  keyed on the status transition.
+
+- **Enabling an app did not say where it had gone.** It redirected to the
+  app's own page, which answered "what does it do" but not "where do I
+  find this again". Enable now leaves you on the catalog and states the
+  surface: an external app shows the URL it runs at, as a link; an app
+  providing a vertical says it is listed under Applications and links to
+  the page; anything else points at its own dashboard. The nav and the
+  catalog read one shared `APP_VERTICALS` table, so the promise and the
+  menu entry cannot disagree.
+
 - **App Catalog cards: clipped status pill, and results that were not
   the catalog's to show.** The action row was a non-wrapping flex with
   the enabled/disabled badge pinned to it by `ml-auto`, so a card

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The app card's "Network" panel never said what it was.** It showed a
+  bare list of hostnames and an input, with the guarantee behind it —
+  apps run on an isolated network and reach the outside only through
+  OpenNVR's egress proxy, which refuses and reports anything not
+  declared or allowed — left entirely implicit. The panel now explains
+  that in two lines, and the pre-install provenance line says "no
+  outside connections" with a tooltip covering the same ground instead
+  of the jargon "no network egress" / "outside the stack".
+
 - **The plate app and the page it lights up had unrelated names.** The App
   Catalog said "License Plate Recognition" and the sidebar said
   "Vehicles", with nothing to connect them. Both now carry ANPR — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A running app was reported "skill: degraded — app unreachable at last
+  contact".** `installed_apps.status` and `last_seen` were only ever
+  written by boot registration and the on-demand "Check" probe, and
+  nothing re-runs that probe — so one failure (an app still starting, a
+  blip) pinned the skill badge to degraded for as long as the app ran,
+  and an app nobody probed decayed to "no recent contact" after ten
+  minutes. Meanwhile the SDK polls `GET /apps/{id}/config` every ~10s from
+  inside the running app and core discarded that. That poll is now a
+  heartbeat (throttled to one write per 30s, and only for the app's own
+  key — the site's internal key is held by companion services too), and
+  the skill view trusts contact newer than 60s over an older failed
+  probe. A genuinely dead app still degrades: the live window is far
+  tighter than the ten-minute staleness cutoff.
+
 - **App Catalog: "Check" could never report a healthy app.** The chip read
   `health.status`, but the SDK's `health_snapshot()` speaks `ready` (spec
   §03) and never sets a `status` string — so every SDK-built app came back

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **App Catalog: "Check" could never report a healthy app.** The chip read
+  `health.status`, but the SDK's `health_snapshot()` speaks `ready` (spec
+  §03) and never sets a `status` string — so every SDK-built app came back
+  "unknown", and "unreachable" only ever appeared because core writes that
+  string itself on a failed probe. The one app that looked healthy was the
+  hand-written camera-agent, which happens to emit `status`. `GET
+  /apps/{id}/status` now publishes the verdict it was already computing
+  (`ok`, or `degraded` when reachable but not ready), leaving an app's own
+  `status` untouched when it sets one; the chip falls back to `ready` for
+  older cores. A non-object `/health` body no longer 500s the probe, and
+  the button reads "Check health" with a tooltip saying what it does and
+  why it is on demand.
+
 - **A freshly installed app needed a manual Refresh to appear under
   Installed.** The poll that watches the reconciler and invalidates
   `['apps']` lived inside the install dialog, so dismissing the dialog —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **App Catalog is its own item in the sidebar.** It sat under "AI &
+  Detections", which miscategorised it — plenty of apps are not AI (the
+  notifier, the barrier, the agent) — and buried the place apps come
+  from inside a collapsed section. It now renders as a flat link
+  directly below Applications, or immediately under Cameras when no app
+  vertical is enabled, so it is one click precisely when nothing is
+  installed yet. Nav groups gained a `flat` mode for a destination that
+  is one page rather than a section; sticky header offsets count headers
+  instead of groups so a flat entry leaves no gap in the stack.
+
 - **The app card's "Network" panel never said what it was.** It showed a
   bare list of hostnames and an input, with the guarantee behind it —
   apps run on an isolated network and reach the outside only through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **App Catalog cards: clipped status pill, and results that were not
+  the catalog's to show.** The action row was a non-wrapping flex with
+  the enabled/disabled badge pinned to it by `ml-auto`, so a card
+  carrying several manifest actions pushed the badge past the card edge
+  and collided it with Uninstall. Status is state, not an action: it now
+  sits beside the health chip in the (wrapping) header, and the button
+  row wraps. The card also no longer renders `LiveStateViews` — an app's
+  output belongs to the app, and `/app-catalog/<id>` already renders the
+  same `state_schema` as a polling dashboard, with first-class verticals
+  on top of that. Because the card shared the `['app-status', id]` query
+  key with those pages, visiting Vehicles or Occupancy filled the cache
+  and the catalog sprouted plate tables nobody asked for.
+
 - **Alarms stayed silent while the tab was in the background.** A
   high or critical alarm rings `continuous` by default, but the bell's
   inbox poll used React Query's `refetchInterval` without

--- a/app/src/lib/appVerticals.ts
+++ b/app/src/lib/appVerticals.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 OpenNVR
+ * This file is part of OpenNVR.
+ *
+ * OpenNVR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenNVR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// The first-class verticals: capability → the page it lights up in the
+// "Applications" nav group. ONE table, two consumers — the shell builds
+// the nav from it, and the catalog tells an operator where an app they
+// just enabled will appear. When those two disagree the catalog promises
+// a menu entry that never arrives, so they must read the same row.
+//
+// Adding a vertical = one row here + its route + its page.
+
+/** The shape both consumers need off a manifest; deliberately loose so
+ *  callers can pass their own fuller manifest type. */
+export type VerticalManifest = {
+  provides?: string[] | null
+  requires_tasks?: string[] | null
+} | null | undefined
+
+export type AppVertical = {
+  /** manifest.provides entry that lights this page up. */
+  capability: string
+  /** Route, and the label shown under Applications. */
+  to: string
+  label: string
+  /** Manifests that predate `provides` — matched on what they require
+   *  instead. Kept so an install from before the field still gets its
+   *  page (and its "you'll find it here" message). */
+  legacy?: (m: NonNullable<VerticalManifest>) => boolean
+}
+
+export const APP_VERTICALS: AppVertical[] = [
+  {
+    capability: 'vehicles',
+    to: '/vehicles',
+    label: 'Vehicles',
+    legacy: (m) => (m.requires_tasks ?? []).includes('license_plate_recognition'),
+  },
+  { capability: 'occupancy', to: '/occupancy', label: 'Occupancy' },
+]
+
+/** Does this manifest provide `vertical`? Capability first, legacy
+ *  predicate second. */
+export function manifestProvides(manifest: VerticalManifest, vertical: AppVertical): boolean {
+  if (!manifest) return false
+  if ((manifest.provides ?? []).includes(vertical.capability)) return true
+  return vertical.legacy ? vertical.legacy(manifest) : false
+}
+
+/** The first-class page this app owns, or null if it has none — in which
+ *  case the app's home is its own /app-catalog/<id> dashboard. */
+export function verticalFor(manifest: VerticalManifest): AppVertical | null {
+  return APP_VERTICALS.find((v) => manifestProvides(manifest, v)) ?? null
+}

--- a/app/src/lib/appVerticals.ts
+++ b/app/src/lib/appVerticals.ts
@@ -47,7 +47,14 @@ export const APP_VERTICALS: AppVertical[] = [
   {
     capability: 'vehicles',
     to: '/vehicles',
-    label: 'Vehicles',
+    // "ANPR" is the internationally recognised name for this (UK, EU,
+    // India, AU; "LPR"/"ALPR" is the US synonym) and it is the token the
+    // catalog app carries too, so an operator can tell that the
+    // "ANPR — License Plate Recognition" app they installed is what lit
+    // this page up. "Vehicles" stays the head noun because the page is
+    // wider than the OCR: plate reads, the vehicle register, monitoring
+    // and alarms.
+    label: 'Vehicles (ANPR)',
     legacy: (m) => (m.requires_tasks ?? []).includes('license_plate_recognition'),
   },
   { capability: 'occupancy', to: '/occupancy', label: 'Occupancy' },

--- a/app/src/shell/AppShell.tsx
+++ b/app/src/shell/AppShell.tsx
@@ -21,12 +21,13 @@ import { DeviceBlockedOverlay } from '../components/DeviceBlockedOverlay'
 import { Menu, Monitor, Camera, Car, Users, Settings as SettingsIcon, Bell, Maximize, Minimize, LogOut, User as UserIcon, Sun, Moon, MonitorPlay, RefreshCcw, FileSearch, Brain, FileCheck, AlertTriangle, Plug, LifeBuoy, KeyRound, Shield, Network, Cpu, Boxes, Cloud, Database, ChevronDown, Layers } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { apiService } from '../lib/apiService'
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useFullscreen } from '../hooks/useFullscreen'
 import { useClickOutside } from '../hooks/useClickOutside'
 import { useAuth } from '../auth/AuthContext'
 import { useTheme } from '../hooks/useTheme'
 import { usePermissions, NAV_PERMISSIONS } from '../hooks/usePermissions'
+import { APP_VERTICALS, manifestProvides } from '../lib/appVerticals'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { CameraStatusProvider } from '../hooks/useCameraStatus'
 import { SystemAlertBanner } from '../components/SystemAlertBanner'
@@ -159,30 +160,36 @@ export function AppShell() {
     refetchInterval: 120_000,
   })
   // The curated first-class pages, capability-keyed on manifest
-  // `provides` (with a legacy predicate for manifests that predate the
-  // field). Adding a vertical = one row here + its page — the nav
-  // scales with what THIS install enabled, never with catalog size.
+  // `provides` from the shared APP_VERTICALS table (with its legacy
+  // predicate for manifests that predate the field). The catalog reads
+  // that same table to tell an operator where a freshly enabled app will
+  // show up — one row, so the promise and the menu cannot disagree.
+  // Adding a vertical = one row there + its page.
   const apps = appsNav.data ?? []
-  const providesEnabled = (capability: string, legacy?: (m: any) => boolean) =>
-    apps.some((a) => a.enabled && (
-      (a.manifest?.provides ?? []).includes(capability) ||
-      (legacy ? legacy(a.manifest ?? {}) : false)
-    ))
-  const lprEnabled = providesEnabled('vehicles',
-    (m) => (m.requires_tasks ?? []).includes('license_plate_recognition'))
-  const occupancyEnabled = providesEnabled('occupancy')
+  const enabledVerticals = APP_VERTICALS.filter((v) =>
+    apps.some((a) => a.enabled && manifestProvides(a.manifest, v))
+  )
+  // Icons live here (the nav owns its own presentation), keyed by route.
+  const verticalIcon: Record<string, ReactNode> = {
+    '/vehicles': <Car size={16} />,
+    '/occupancy': <Users size={16} />,
+  }
+  const enabledRoutes = enabledVerticals.map((v) => v.to).join(',')
 
   const visibleGroups = useMemo(
     () => {
       const groups = NAV_GROUPS.map((g) => ({ ...g, items: g.items.filter((i) => canView(i.perm)) })).filter((g) => g.items.length > 0)
-      const appItems = [
-        ...(lprEnabled && canView('/vehicles')
-          ? [{ to: '/vehicles', label: 'Vehicles', icon: <Car size={16} />, perm: '/vehicles' as const }]
-          : []),
-        ...(occupancyEnabled && canView('/occupancy')
-          ? [{ to: '/occupancy', label: 'Occupancy', icon: <Users size={16} />, perm: '/occupancy' as const }]
-          : []),
-      ]
+      const appItems = enabledVerticals
+        // `v.to in NAV_PERMISSIONS` first: a vertical added to the table
+        // without its permission row would otherwise ask canView about an
+        // unknown path and get an undefined requirement — fail closed.
+        .filter((v) => v.to in NAV_PERMISSIONS && canView(v.to as keyof typeof NAV_PERMISSIONS))
+        .map((v) => ({
+          to: v.to,
+          label: v.label,
+          icon: verticalIcon[v.to] ?? <Boxes size={16} />,
+          perm: v.to as keyof typeof NAV_PERMISSIONS,
+        }))
       if (appItems.length > 0) {
         // Right after the pinned NVR group: these are operational pages.
         groups.splice(1, 0, { key: 'applications', label: 'Applications', items: appItems })
@@ -190,7 +197,7 @@ export function AppShell() {
       return groups
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hasPermission, lprEnabled, occupancyEnabled]
+    [hasPermission, enabledRoutes]
   )
   const pinnedGroups = visibleGroups.filter((g) => g.pinned)
   const menuGroups = visibleGroups.filter((g) => !g.pinned)

--- a/app/src/shell/AppShell.tsx
+++ b/app/src/shell/AppShell.tsx
@@ -48,6 +48,11 @@ type NavGroup = {
   label: string
   /** pinned groups render their items directly — no header, never collapsible */
   pinned?: boolean
+  /** flat groups scroll with the rest of the menu but render as bare
+   *  links — no header, nothing to expand. For a destination that is one
+   *  page, not a section: a collapsible header hiding a single item is
+   *  a click for nothing. */
+  flat?: boolean
   items: NavItem[]
 }
 
@@ -73,7 +78,6 @@ const NAV_GROUPS: NavGroup[] = [
       { to: '/byom', label: 'AI Models (BYOM)', icon: <Boxes size={16} />, perm: '/byom' },
       { to: '/ai-detection-results', label: 'Detection Results', icon: <Database size={16} />, perm: '/byom' },
       { to: '/ai-adapters', label: 'AI Adapters', icon: <Layers size={16} />, perm: '/ai-engine' },
-      { to: '/app-catalog', label: 'App Catalog', icon: <Boxes size={16} />, perm: '/ai-engine' },
     ],
   },
   {
@@ -190,9 +194,27 @@ export function AppShell() {
           icon: verticalIcon[v.to] ?? <Boxes size={16} />,
           perm: v.to as keyof typeof NAV_PERMISSIONS,
         }))
+      // Right after the pinned NVR group (i.e. under Cameras): these are
+      // operational pages, not settings.
+      let at = 1
       if (appItems.length > 0) {
-        // Right after the pinned NVR group: these are operational pages.
-        groups.splice(1, 0, { key: 'applications', label: 'Applications', items: appItems })
+        groups.splice(at, 0, { key: 'applications', label: 'Applications', items: appItems })
+        at += 1
+      }
+      // App Catalog sits with the apps, not under "AI & Detections" —
+      // plenty of apps are not AI at all (the notifier, the barrier, the
+      // agent), and the catalog is where the pages above come FROM. Flat
+      // and directly below Applications, so it stays one click even when
+      // no app is installed yet — which is exactly when someone needs to
+      // find it.
+      const catalog: NavItem = {
+        to: '/app-catalog', label: 'App Catalog',
+        icon: <Boxes size={16} />, perm: '/ai-engine',
+      }
+      if (canView(catalog.perm)) {
+        groups.splice(at, 0, {
+          key: 'app-catalog', label: 'App Catalog', flat: true, items: [catalog],
+        })
       }
       return groups
     },
@@ -201,6 +223,14 @@ export function AppShell() {
   )
   const pinnedGroups = visibleGroups.filter((g) => g.pinned)
   const menuGroups = visibleGroups.filter((g) => !g.pinned)
+  // Sticky headers dock at `index * 32`, but a flat group contributes no
+  // header — counting it would leave a 32px hole in the stack and push
+  // every header below it out of place. Offsets count headers, not groups.
+  const headerSlot = useMemo(() => {
+    let n = 0
+    return menuGroups.map((g) => (g.flat ? -1 : n++))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleGroups])
 
   const activeGroupKey = useMemo(() => {
     for (const g of NAV_GROUPS) {
@@ -337,6 +367,17 @@ export function AppShell() {
                   </div>
                 )
               }
+              // Flat: a single destination, so no header and nothing to
+              // collapse — it just sits in the list as a link.
+              if (group.flat) {
+                return (
+                  <div key={group.key} className="py-1 space-y-0.5">
+                    {group.items.map((item) => (
+                      <SideLink key={item.to} to={item.to} end={item.end} label={item.label} icon={item.icon} />
+                    ))}
+                  </div>
+                )
+              }
               // Sticky headers: headers and item lists are direct children of
               // the scroll container (sticky is bounded by its parent, so
               // nesting would defeat it). Headers passed while scrolling stack
@@ -344,7 +385,7 @@ export function AppShell() {
               return (
                 <Fragment key={group.key}>
                   <button
-                    style={{ top: gi * 32 }}
+                    style={{ top: headerSlot[gi] * 32 }}
                     className="sticky z-10 w-full h-8 flex items-center justify-between px-2.5 text-sm font-medium bg-[var(--bg-2)] text-[var(--text-dim)] hover:text-[var(--text)] hover:bg-[var(--panel-2)] rounded"
                     onClick={() => toggleGroup(group.key)}
                     aria-expanded={!collapsed}

--- a/app/src/views/Alarms.tsx
+++ b/app/src/views/Alarms.tsx
@@ -204,7 +204,7 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
         <div className="border border-[var(--border)] rounded p-3 space-y-2 md:col-span-2">
           <div className="font-medium">Arm vehicle alarms (LPR)</div>
           <div className="text-[12px] text-[var(--text-dim)]">
-            Vehicle alarm policy lives in the License Plate Recognition
+            Vehicle alarm policy lives in the ANPR — License Plate Recognition
             app:{' '}
             <Link
               to="/app-catalog/license-plate-recognition"

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -236,7 +236,9 @@ export type AppEgress = {
 }
 
 export type AppStatusResp = {
-  health?: { status?: string; [k: string]: any } | null
+  // `ready` is the SDK contract (spec §03); `status` is the string core
+  // normalises on top of it. Read status first, fall back to ready.
+  health?: { status?: string; ready?: boolean; [k: string]: any } | null
   state?: any
 }
 
@@ -956,8 +958,13 @@ function AppStatusChip({ appId }: { appId: string }) {
 
   if (!requested) {
     return (
-      <Button variant="ghost" className="text-xs px-2 py-1" onClick={() => setRequested(true)}>
-        <Activity size={12} /> Check
+      <Button
+        variant="ghost"
+        className="text-xs px-2 py-1"
+        onClick={() => setRequested(true)}
+        title="Ask the app for its health — core fetches the app's /health and /state on demand. Not automatic: probing every card on load would fan out one request per installed app."
+      >
+        <Activity size={12} /> Check health
       </Button>
     )
   }
@@ -965,7 +972,19 @@ function AppStatusChip({ appId }: { appId: string }) {
   if (statusQuery.isError) {
     return <Badge variant="destructive">{extractApiError(statusQuery.error, 'status check failed')}</Badge>
   }
-  const health = statusQuery.data?.health?.status ?? 'unknown'
+  // Core normalises `status` onto /health now. Still derive from the
+  // contract's own `ready` when it is absent, so a newer UI against an
+  // older core shows the truth instead of "unknown" — the SDK has always
+  // spoken `ready` (spec §03), and `status` is the convenience on top.
+  const rawHealth = statusQuery.data?.health
+  const health =
+    typeof rawHealth?.status === 'string'
+      ? rawHealth.status
+      : typeof rawHealth?.ready === 'boolean'
+        ? rawHealth.ready
+          ? 'ok'
+          : 'degraded'
+        : 'unknown'
   return (
     <span className="inline-flex items-center gap-1">
       <Badge variant={statusVariant(health)}>{health}</Badge>

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -1496,7 +1496,11 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
 
   return (
     <Card>
-      <CardHeader>
+      {/* flex-wrap locally rather than on the shared CardHeader: a long
+          app name plus category, version, pricing and the two status
+          pills overflows a narrow grid column, and clipping status is
+          how "disabled" ends up half-hidden behind Uninstall. */}
+      <CardHeader className="flex-wrap">
         <Boxes size={16} className="text-[var(--text-dim)]" />
         <Link to={`/app-catalog/${app.id}`} className="hover:underline">
           <CardTitle>{app.name}</CardTitle>
@@ -1504,7 +1508,14 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
         <Badge variant="info">{app.category}</Badge>
         <span className="text-xs text-[var(--text-dim)]">v{app.version}</span>
         <PricingBadge pricing={app.manifest?.pricing} note={app.manifest?.price_note} />
-        <div className="ml-auto">
+        {/* enabled/disabled is STATE, not an action — it belongs beside the
+            health chip, not pinned with ml-auto to the end of the button
+            row, where a card with several manifest actions pushed it off
+            the edge and clipped it against Uninstall. */}
+        <div className="ml-auto flex items-center gap-2">
+          <Badge variant={app.enabled ? 'success' : 'neutral'}>
+            {app.enabled ? 'enabled' : 'disabled'}
+          </Badge>
           <AppStatusChip appId={app.id} />
         </div>
       </CardHeader>
@@ -1538,11 +1549,17 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
           <div><RequiresBadge requires={requires} caps={caps} tier0={tier0} /></div>
         )}
 
-        {Array.isArray(app.manifest?.state_schema) && app.manifest.state_schema.length > 0 && (
-          <LiveStateViews appId={app.id} views={app.manifest.state_schema as StateViewSpec[]} />
-        )}
+        {/* Live results deliberately do NOT render here. The catalog is
+            the management surface — install, enable, configure, remove —
+            and an app's output belongs to the app: /app-catalog/<id>
+            (AppView) already renders the same state_schema as a polling
+            dashboard, and a first-class vertical has its own page on top
+            of that. Worse, this card shares the ['app-status', id] query
+            key with those pages, so merely visiting Vehicles or Occupancy
+            filled the cache and the card sprouted plate tables nobody
+            asked for. Card title → AppView is the route to results. */}
 
-        <div className="flex items-center gap-2 pt-1">
+        <div className="flex flex-wrap items-center gap-2 pt-1">
           {isAdmin && (
           <Button
             variant={app.enabled ? 'default' : 'primary'}
@@ -1583,9 +1600,6 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
           <Button variant="danger" onClick={confirmUninstall} disabled={uninstallInFlight}>
             <Trash2 size={14} /> {uninstallInFlight ? 'Uninstalling…' : 'Uninstall'}
           </Button>
-          <Badge variant={app.enabled ? 'success' : 'neutral'} className="ml-auto">
-            {app.enabled ? 'enabled' : 'disabled'}
-          </Badge>
         </div>
 
         {uninstallNote && <div className="text-sm text-amber-400">{uninstallNote}</div>}

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -23,7 +23,7 @@
 // manifest param schema — no app-specific UI code.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Activity, ArrowRight, BadgeCheck, Boxes, Check, Copy, Download, ExternalLink, KeyRound, RefreshCw, Settings2, Trash2 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
@@ -36,6 +36,7 @@ import { GeometryEditor } from './apps/GeometryEditor'
 import { ChipListEditor } from './apps/ChipListEditor'
 import { TimeWindowEditor } from './apps/TimeWindowEditor'
 import { taskProvider, type CapabilitiesLike, type Tier0Like } from '../lib/kaic'
+import { verticalFor } from '../lib/appVerticals'
 
 export type ManifestParam = {
   name: string
@@ -388,11 +389,6 @@ function useInstallStatusPoll(id: string, active: boolean) {
     retry: 0,
     refetchInterval: (query) => {
       const status = query.state.data?.status
-      if (status === 'applied') {
-        queryClient.invalidateQueries({ queryKey: ['apps'] })
-        queryClient.invalidateQueries({ queryKey: ['apps-index'] })
-        return false
-      }
       if (status !== 'pending') return false
       const started = startedAtRef.current
       if (started !== null && Date.now() - started > INSTALL_POLL_MAX_MS) {
@@ -402,7 +398,35 @@ function useInstallStatusPoll(id: string, active: boolean) {
       return 2000
     },
   })
+  // Refresh the groups from an EFFECT, not from inside refetchInterval.
+  // That callback is the observer computing its next delay — a spot React
+  // Query may call more than once per settle and never promises to call
+  // on a terminal status, so invalidating there made "the app appears
+  // under Installed" depend on scheduler timing. Keyed on the status
+  // transition instead, it fires exactly once when the reconciler lands.
+  const settledStatus = query.data?.status
+  useEffect(() => {
+    if (settledStatus !== 'applied') return
+    queryClient.invalidateQueries({ queryKey: ['apps'] })
+    queryClient.invalidateQueries({ queryKey: ['apps-index'] })
+  }, [settledStatus, queryClient])
   return { ...query, timedOut }
+}
+
+/** Headless: keeps an accepted install intent polling at PAGE level, so
+ *  the group refresh survives the operator closing the install dialog.
+ *  Mounted per pending id by AppCatalog; shares the modal's query key,
+ *  so this costs no extra requests while the dialog is still open. */
+function InstallWatcher({ id, onSettled }: { id: string; onSettled: () => void }) {
+  const { data, timedOut } = useInstallStatusPoll(id, true)
+  const status = data?.status
+  useEffect(() => {
+    if (timedOut || (status && status !== 'pending')) onSettled()
+    // onSettled is recreated per render by the parent; depending on it
+    // here would retrigger the effect endlessly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, timedOut])
+  return null
 }
 
 function InstallStatusNote({ status }: { status: InstallStatusResp }) {
@@ -1425,7 +1449,6 @@ function NetworkPanel({ app, isAdmin }: { app: RegisteredApp; isAdmin: boolean }
 
 function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp; caps: CapabilitiesLike; tier0: Tier0Like; skill?: SkillEntry; onConfigure: () => void }) {
   const queryClient = useQueryClient()
-  const navigate = useNavigate()
   const { showSuccess, showError } = useSnackbar()
   // Enable/disable is a site decision (superuser-only on the server;
   // uninstall keeps its own apps.install permission); everyone can open
@@ -1434,21 +1457,48 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
   const isAdmin = !!me?.is_superuser
   const [uninstallPollActive, setUninstallPollActive] = useState(false)
   const [uninstallNote, setUninstallNote] = useState<string | null>(null)
+  // Shown after THIS operator enables the app — a toast is gone in a few
+  // seconds and an external app's URL is something you need to read,
+  // click, or copy.
+  const [enableNote, setEnableNote] = useState(false)
   // Manifest-declared operator action currently open in its form modal.
   const [activeAction, setActiveAction] = useState<ManifestAction | null>(null)
 
   const requires = asStringList(app.manifest?.requires_tasks)
   const manifestActions = (app.manifest?.actions ?? []).filter((a) => a && a.name && a.label)
 
+  // Where this app surfaces once enabled, decided from the manifest:
+  // an external app is a product of its own at a URL; an internal app
+  // that provides a vertical gets a page under Applications; anything
+  // else lives on its own catalog dashboard.
+  const externalUrl =
+    app.manifest?.ui_mode === 'external' && app.manifest?.ui_url
+      ? resolveUiUrl(app.manifest.ui_url)
+      : null
+  const vertical = externalUrl ? null : verticalFor(app.manifest)
+
   const toggleMutation = useMutation({
     mutationFn: () => (app.enabled ? apiService.disableApp(app.id) : apiService.enableApp(app.id)),
     onSuccess: () => {
       const wasEnabling = !app.enabled
       queryClient.invalidateQueries({ queryKey: ['apps'] })
-      showSuccess(`${app.name} ${app.enabled ? 'disabled' : 'enabled'}`)
-      // First enable takes the operator straight to the app's own page so
-      // they land on its live dashboard and actions, not back on the grid.
-      if (wasEnabling) navigate(`/app-catalog/${app.id}`)
+      if (!wasEnabling) {
+        setEnableNote(false)
+        showSuccess(`${app.name} disabled`)
+        return
+      }
+      // Enabling used to redirect straight to the app's page, which
+      // answered "what does it do" but not "where do I find it again" —
+      // the operator was moved somewhere without being told why. Say
+      // where it now lives and let them choose to go.
+      showSuccess(
+        externalUrl
+          ? `${app.name} enabled — open it at ${externalUrl}`
+          : vertical
+            ? `${app.name} enabled — listed under Applications → ${vertical.label}`
+            : `${app.name} enabled — open it from its card`
+      )
+      setEnableNote(true)
     },
     onError: (e) => showError(extractApiError(e, `Failed to ${app.enabled ? 'disable' : 'enable'} ${app.name}.`)),
   })
@@ -1602,6 +1652,44 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
           </Button>
         </div>
 
+        {enableNote && app.enabled && (
+          <div className="rounded border border-[var(--border)] bg-[var(--bg-2)] p-3 text-sm space-y-2">
+            {externalUrl ? (
+              <>
+                <div className="text-[var(--text-dim)]">
+                  {app.name} runs as its own application. Open it at:
+                </div>
+                <a
+                  href={externalUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-xs break-all text-[var(--accent)] hover:underline"
+                >
+                  {externalUrl}
+                </a>
+              </>
+            ) : vertical ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[var(--text-dim)]">
+                  Listed in the sidebar under Applications →
+                </span>
+                <Link to={vertical.to} className="text-[var(--accent)] hover:underline">
+                  {vertical.label}
+                </Link>
+              </div>
+            ) : (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[var(--text-dim)]">
+                  This app has no page of its own — its dashboard lives on
+                </span>
+                <Link to={`/app-catalog/${app.id}`} className="text-[var(--accent)] hover:underline">
+                  its app page
+                </Link>
+              </div>
+            )}
+          </div>
+        )}
+
         {uninstallNote && <div className="text-sm text-amber-400">{uninstallNote}</div>}
         {uninstallPollActive && uninstallStatus.data && <InstallStatusNote status={uninstallStatus.data} />}
         {uninstallStatus.timedOut && (
@@ -1625,7 +1713,17 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
 // works. When the backend opts in AND the caller is permitted, the primary
 // "Install (one-click)" button POSTs an intent and we poll the reconciler; a
 // 403 quietly degrades to "run the command below instead."
-function InstallModal({ app, onClose }: { app: IndexApp; onClose: () => void }) {
+function InstallModal({
+  app,
+  onClose,
+  onAccepted,
+}: {
+  app: IndexApp
+  onClose: () => void
+  /** Fired when the backend accepts the intent, so the PAGE can keep
+   *  watching the reconciler even after this dialog is dismissed. */
+  onAccepted: (id: string) => void
+}) {
   const { showSuccess, showError } = useSnackbar()
   const [copied, setCopied] = useState<string | null>(null)
   const [pollActive, setPollActive] = useState(false)
@@ -1643,6 +1741,12 @@ function InstallModal({ app, onClose }: { app: IndexApp; onClose: () => void }) 
     onSuccess: () => {
       showSuccess('Install requested — the app will appear under Installed once the reconciler applies it')
       setPollActive(true)
+      // Hand the intent to the page too: closing this dialog unmounts the
+      // poll above, and that poll is what refreshes the groups. Without
+      // it, an operator who dismissed the dialog (the normal thing to do
+      // while the reconciler works) had to hit Refresh by hand before the
+      // app showed up under Installed.
+      onAccepted(app.id)
     },
     onError: (e) => {
       if (isForbidden(e)) {
@@ -1856,6 +1960,10 @@ export function AppCatalog() {
   const skillsQuery = useSkillsRegistry()
   const [configApp, setConfigApp] = useState<RegisteredApp | null>(null)
   const [installApp, setInstallApp] = useState<IndexApp | null>(null)
+  // Install intents the reconciler has not settled yet. Held at page
+  // level on purpose — the dialog that started them is usually closed
+  // long before the reconciler finishes.
+  const [pendingInstalls, setPendingInstalls] = useState<string[]>([])
 
   const tier0Query = useTier0()
   const apps = appsQuery.data ?? []
@@ -1962,7 +2070,23 @@ export function AppCatalog() {
       )}
 
       {configApp && <AppConfigModal key={configApp.id} app={configApp} onClose={() => setConfigApp(null)} />}
-      {installApp && <InstallModal key={installApp.id} app={installApp} onClose={() => setInstallApp(null)} />}
+      {installApp && (
+        <InstallModal
+          key={installApp.id}
+          app={installApp}
+          onClose={() => setInstallApp(null)}
+          onAccepted={(id) => setPendingInstalls((p) => (p.includes(id) ? p : [...p, id]))}
+        />
+      )}
+      {/* Outlives the dialog: these are what move a freshly installed app
+          into the Installed group without a manual Refresh. */}
+      {pendingInstalls.map((id) => (
+        <InstallWatcher
+          key={id}
+          id={id}
+          onSettled={() => setPendingInstalls((p) => p.filter((x) => x !== id))}
+        />
+      ))}
     </section>
   )
 }

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -187,8 +187,16 @@ function ProvenanceLine({ app }: { app: IndexApp }) {
         </a>
       )}
       {!external && (
-        <span title={egress.length ? 'Hosts this app connects to outside the stack' : 'This app never connects outside the stack'}>
-          {egress.length === 0 ? 'no network egress' : `connects to: ${egress.join(', ')}`}
+        <span
+          title={
+            egress.length
+              ? 'Apps run on an isolated network. These are the only hosts this one declared, reviewed with the listing; anything else it tries is blocked and reported after install.'
+              : 'Apps run on an isolated network with no route to your LAN or the internet, and this one declared no hosts at all — anything it tries is blocked and reported.'
+          }
+        >
+          {egress.length === 0
+            ? 'no outside connections'
+            : `connects to: ${egress.join(', ')}`}
         </span>
       )}
     </div>
@@ -1396,7 +1404,7 @@ function NetworkPanel({ app, isAdmin }: { app: RegisteredApp; isAdmin: boolean }
       <div className="flex items-center gap-2 flex-wrap">
         <span className="font-medium text-[var(--text)]">Network</span>
         {eg.enforced.length === 0 && denied.length === 0 ? (
-          <span className="text-[var(--text-dim)]">no connections outside the stack</span>
+          <span className="text-[var(--text-dim)]">nothing outside OpenNVR</span>
         ) : null}
         {listingHosts.map((h) => (
           <Badge key={`l-${h}`} variant="neutral" title="Declared in the catalog listing">{h}</Badge>
@@ -1423,6 +1431,18 @@ function NetworkPanel({ app, isAdmin }: { app: RegisteredApp; isAdmin: boolean }
           </span>
         )}
       </div>
+      {/* Say what this panel IS. It reads like a bare list of hostnames
+          otherwise, and the guarantee behind it — the reason to care
+          about an app's listed hosts BEFORE installing it — is invisible.
+          Two lines: the rule, then what to do about it. */}
+      <p className="text-[var(--text-dim)] leading-relaxed">
+        Apps run on an isolated network with no route to your camera
+        network or the internet. Everything above is what this app may
+        reach through the OpenNVR egress proxy — anything else is blocked
+        and reported here, so an app cannot quietly send footage or data
+        somewhere you did not approve.
+        {isAdmin && ' Allow a host only if you know why the app needs it.'}
+      </p>
       {denied.length > 0 && (
         <div className="space-y-1">
           <div className="text-[var(--text-dim)]">

--- a/app/src/views/Vehicles.tsx
+++ b/app/src/views/Vehicles.tsx
@@ -713,7 +713,7 @@ export function Vehicles() {
   return (
     <section className="space-y-4">
       <PageHeader
-        title="Vehicles"
+        title="Vehicles (ANPR)"
         description="License plate reads across your cameras — searched from the evidence store, whichever part of the platform ran the OCR. Watchlists apply live."
         actions={
           <div className="flex items-center gap-2">
@@ -1613,7 +1613,7 @@ function RegistryTab({
       <EmptyState
         icon={<Car size={28} />}
         title="The register needs an enabled LPR app"
-        description="Install and enable a License Plate Recognition app from the App Catalog — the vehicle register and the unknown-vehicle alarm live in that app and apply live."
+        description="Install and enable an ANPR — License Plate Recognition app from the App Catalog — the vehicle register and the unknown-vehicle alarm live in that app and apply live."
       />
     )
   }
@@ -1922,7 +1922,7 @@ function MonitoringTab({
       <EmptyState
         icon={<ShieldAlert size={28} />}
         title="Monitoring needs an enabled LPR app"
-        description="Install and enable a License Plate Recognition app from the App Catalog — monitors live in that app and apply live."
+        description="Install and enable an ANPR — License Plate Recognition app from the App Catalog — monitors live in that app and apply live."
       />
     )
   }

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -249,7 +249,11 @@ def registry_entry_active(entry: dict[str, str] | None, *, today: date | None = 
 
 MANIFEST = AppManifest(
     id="license-plate-recognition",
-    name="License Plate Recognition",
+    # ANPR is what most of the world calls this (UK, EU, India, AU; the
+    # US says LPR/ALPR), and the nav page it lights up carries the same
+    # token — "Vehicles (ANPR)". The spelled-out term stays for anyone
+    # who does not know the acronym. The id is a key and does not move.
+    name="ANPR — License Plate Recognition",
     version="2.5.0",
     category="vehicle",
     summary=(
@@ -1045,7 +1049,7 @@ class PlateAlerter(Detector):
             ", ".join(_html.escape(c) for c in scope)
             if scope else "all cameras (no assignment restriction)"
         )
-        return f"""<title>License Plate Recognition</title>
+        return f"""<title>ANPR — License Plate Recognition</title>
 <style>
  body {{ font: 14px system-ui, sans-serif; margin: 1.2rem; color: #1a1a1a;
         background: #fafafa; }}
@@ -1059,7 +1063,7 @@ class PlateAlerter(Detector):
  th {{ color: #6b6f76; font-weight: 500 }}
  .note {{ margin-top: 1rem; font-size: .85rem; color: #6b6f76 }}
 </style>
-<h1>License Plate Recognition</h1>
+<h1>ANPR — License Plate Recognition</h1>
 <div class="dim">Watching: {scope_line}</div>
 <div class="stats">
  <div><b>{len(allow)}</b><span class="dim">allowlist</span></div>

--- a/server/config/apps_index.yml
+++ b/server/config/apps_index.yml
@@ -227,7 +227,12 @@
     command: docker compose -f docker-compose.yml -f docker-compose.apps.yml --profile apps up -d intrusion-detection
 
 - id: license-plate-recognition
-  name: License Plate Recognition
+  # ANPR leads: it is the name most of the world uses for this (UK, EU,
+  # India, AU), with the spelled-out term kept for newcomers and for US
+  # readers who know it as LPR/ALPR. The nav page carries the same token
+  # ("Vehicles (ANPR)") so the app and the surface it lights up read as
+  # one thing. The id is unchanged — it is a key, not a label.
+  name: ANPR — License Plate Recognition
   summary: Reads license plates via a YOLOv8 to crop to fast-plate-ocr chain and routes severity through allow/deny watchlists.
   category: vehicle
   version: "1.0.0"

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -37,7 +37,7 @@ Routes (mounted under ``/api/v1``):
 import ipaddress
 import logging
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -81,6 +81,10 @@ STATUS_PROBE_TIMEOUT_S = 3.0
 # Actions can do real work (a footage query over SQLite); more generous
 # than a health probe, still bounded so a hung app can't pin a worker.
 ACTION_PROXY_TIMEOUT_S = 10.0
+# How often the app's own config poll is allowed to write `last_seen`.
+# The SDK polls every ~10s; the freshness windows that read this column
+# are minutes wide, so a write per poll would be pure DB churn.
+APP_SEEN_WRITE_EVERY = timedelta(seconds=30)
 
 
 # ── App Store index (the "discover" half of the catalog) ───────────
@@ -1003,6 +1007,26 @@ async def get_app_config(
     """
     _own_app_only(principal, app_id)
     row = _get_app_or_404(db, app_id)
+
+    # HEARTBEAT. The SDK polls this endpoint every ~10s from the running
+    # app, which is the best liveness signal the platform has — and core
+    # was throwing it away, leaving `last_seen` frozen at boot and the
+    # skill badge reporting "no recent contact" (or a sticky "unreachable"
+    # from one failed probe) for an app that had been talking to us all
+    # along. Only an AppPrincipal for THIS app counts: the site's internal
+    # key is held by companion services too, and their polling says
+    # nothing about whether the app is alive.
+    if isinstance(principal, AppPrincipal) and principal.app_id == app_id:
+        now = datetime.now(UTC)
+        prev = row.last_seen
+        if prev is not None and prev.tzinfo is None:
+            prev = prev.replace(tzinfo=UTC)
+        # Throttled: at a 10s poll this would otherwise commit on every
+        # request, per app, forever.
+        if prev is None or (now - prev) > APP_SEEN_WRITE_EVERY:
+            row.last_seen = now
+            db.commit()
+
     config = row.config_json or {}
     if isinstance(principal, User) and not principal.is_superuser:
         # A user sees the site-wide settings (read-only for them) but

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -1372,7 +1372,12 @@ async def get_app_status(
         try:
             health_resp = await client.get(f"{base_url}/health")
             health_resp.raise_for_status()
-            health = health_resp.json()
+            payload = health_resp.json()
+            # /health is contractually an object. An app that answers 200
+            # with a list or a bare scalar must not crash the probe (the
+            # dict access below would raise and 500 the whole endpoint) —
+            # keep the body for the operator under a key and carry on.
+            health = payload if isinstance(payload, dict) else {"body": payload}
             reachable = True
         except Exception:
             health = {"status": "unreachable"}
@@ -1389,6 +1394,15 @@ async def get_app_status(
     # a 200 rather than flagging a healthy app unreachable.
     ready = reachable and bool(health.get("ready", True))
     row.status = "ok" if ready else "unreachable"
+    # PUBLISH that verdict. The SDK's health_snapshot() speaks `ready`
+    # and never sets `status`, so a consumer reading health["status"] saw
+    # nothing for every SDK-built app and rendered it "unknown" — only
+    # hand-written apps (the camera-agent) that happen to emit a `status`
+    # string ever looked healthy, and the failure paths below are the
+    # only reason "unreachable" showed at all. Normalising here keeps ONE
+    # derivation of health: an app that sets its own `status` still wins.
+    if reachable and not isinstance(health.get("status"), str):
+        health["status"] = "ok" if ready else "degraded"
     if reachable:
         row.last_seen = datetime.now(UTC)
     db.commit()

--- a/server/services/skills_registry.py
+++ b/server/services/skills_registry.py
@@ -40,6 +40,16 @@ from typing import Any, Iterable, Optional
 #: re-registration; recency is the real signal.
 APP_STALE_AFTER = timedelta(minutes=10)
 
+#: Contact fresher than this OUTRANKS a stored "unreachable". That column
+#: is the verdict of the last on-demand /status probe and nothing ever
+#: re-runs it, so one failed probe — an app still booting, a blip — used
+#: to pin a healthy app to "degraded" forever. The app's config poll
+#: (~10s) is live proof to the contrary, so anything inside this window
+#: means the app is talking to us regardless of what that probe found.
+#: Kept far tighter than APP_STALE_AFTER: a genuinely dead app must not
+#: coast on a heartbeat from nine minutes ago.
+APP_LIVE_CONTACT_WITHIN = timedelta(seconds=60)
+
 #: Domain events per provider. Mirrors the KAI-C normaliser map
 #: (kai-c/kai_c/domain_events.py) and the App SDK alert dispatcher —
 #: both contracted in docs/EVENT_CONTRACTS.md. Keep the three in step:
@@ -140,12 +150,20 @@ def _adapter_skill(entry: Any, *,
 def _app_status(row: Any, now: datetime) -> tuple[str, Optional[str]]:
     if not row.enabled:
         return "dormant", "installed but not enabled"
-    if row.status == "unreachable":
-        return "degraded", "app unreachable at last contact"
     last_seen = row.last_seen
     if last_seen is not None and last_seen.tzinfo is None:
         last_seen = last_seen.replace(tzinfo=timezone.utc)
-    if last_seen is None or now - last_seen > APP_STALE_AFTER:
+    age = None if last_seen is None else now - last_seen
+    # Recency first. `row.status` is the last on-demand probe's verdict
+    # and nothing re-runs it, so it goes stale the moment it is written:
+    # an app that failed one probe while booting stayed "degraded" while
+    # it ran perfectly well for days. A heartbeat inside the live window
+    # is direct evidence the app is up, and it wins.
+    if age is not None and age <= APP_LIVE_CONTACT_WITHIN:
+        return "active", None
+    if row.status == "unreachable":
+        return "degraded", "app unreachable at last contact"
+    if age is None or age > APP_STALE_AFTER:
         return "degraded", "no recent contact from app"
     return "active", None
 

--- a/server/tests/test_apps_registry.py
+++ b/server/tests/test_apps_registry.py
@@ -790,11 +790,127 @@ def test_status_healthy_app_proxies_health_and_state(client, monkeypatch):
     assert resp.status_code == 200
     body = resp.json()
     assert body["health"]["ready"] is True
+    # The SDK's health_snapshot() never sets `status`, so core normalises
+    # its own verdict onto the payload. Without this the catalog chip read
+    # health["status"], found nothing, and rendered every SDK-built app
+    # "unknown" — a healthy app could not show healthy.
+    assert body["health"]["status"] == "ok"
     assert body["state"] == {"active_tracks": 2}
 
     row = client.get("/apps").json()[0]
     assert row["status"] == "ok"
     assert row["last_seen"] is not None
+
+
+def test_status_not_ready_app_reports_degraded(client, monkeypatch):
+    """Reachable but ready=false is 'degraded' — distinct from the
+    unreachable case, so an operator can tell 'starting up / broken
+    inside' from 'nothing is listening'."""
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class _NotReadyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url):
+            if url.endswith("/health"):
+                return _Resp({"ready": False, "uptime_s": 1})
+            return _Resp({})
+
+    _register(client)
+    monkeypatch.setattr(apps_router.httpx, "AsyncClient", _NotReadyClient)
+
+    body = client.get("/apps/loitering-detection/status").json()
+    assert body["health"]["status"] == "degraded"
+    assert client.get("/apps").json()[0]["status"] == "unreachable"
+
+
+def test_status_app_declaring_its_own_status_is_left_alone(client, monkeypatch):
+    """A hand-written app (the camera-agent) that already emits a status
+    string keeps it — core normalises only when the field is missing."""
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class _OwnStatusClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url):
+            if url.endswith("/health"):
+                return _Resp({"status": "starting", "ready": True})
+            return _Resp({})
+
+    _register(client)
+    monkeypatch.setattr(apps_router.httpx, "AsyncClient", _OwnStatusClient)
+
+    body = client.get("/apps/loitering-detection/status").json()
+    assert body["health"]["status"] == "starting"
+
+
+def test_status_non_object_health_does_not_500(client, monkeypatch):
+    """An app answering 200 with a non-object body must not crash the
+    probe — the dict access behind `ready` would raise otherwise."""
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class _ListClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url):
+            if url.endswith("/health"):
+                return _Resp(["not", "an", "object"])
+            return _Resp({})
+
+    _register(client)
+    monkeypatch.setattr(apps_router.httpx, "AsyncClient", _ListClient)
+
+    resp = client.get("/apps/loitering-detection/status")
+    assert resp.status_code == 200
+    assert resp.json()["health"]["body"] == ["not", "an", "object"]
 
 
 def test_status_unknown_app_is_404(client):

--- a/server/tests/test_apps_registry.py
+++ b/server/tests/test_apps_registry.py
@@ -913,6 +913,98 @@ def test_status_non_object_health_does_not_500(client, monkeypatch):
     assert resp.json()["health"]["body"] == ["not", "an", "object"]
 
 
+def _seen(client, app_id="loitering-detection"):
+    """last_seen for one row, as an aware datetime."""
+    from datetime import UTC, datetime
+
+    row = next(r for r in client.get("/apps").json() if r["id"] == app_id)
+    dt = datetime.fromisoformat(str(row["last_seen"]))
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def _backdate_last_seen(client, *, hours):
+    """Age every row's last_seen, so a heartbeat is unmistakable."""
+    from datetime import UTC, datetime, timedelta
+
+    from core.database import get_db
+    from models import InstalledApp
+
+    db = next(client.app.dependency_overrides[get_db]())
+    try:
+        for row in db.query(InstalledApp).all():
+            row.last_seen = datetime.now(UTC) - timedelta(hours=hours)
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_config_poll_from_the_app_is_a_heartbeat(client):
+    """The SDK polls GET /{id}/config every ~10s from the running app.
+    That is the platform's best liveness signal and core used to discard
+    it, so `last_seen` froze at boot and the skill badge decayed to
+    "no recent contact" for an app that had been talking to us all
+    along."""
+    from datetime import UTC, datetime, timedelta
+
+    from services.app_keys import AppPrincipal
+
+    _register(client)
+    # Age the row past every freshness window.
+    _backdate_last_seen(client, hours=3)
+    assert datetime.now(UTC) - _seen(client) > timedelta(hours=2)
+
+    client.app.dependency_overrides[apps_router.get_read_principal] = (
+        lambda: AppPrincipal(app_id="loitering-detection")
+    )
+    assert client.get("/apps/loitering-detection/config").status_code == 200
+
+    client.app.dependency_overrides[apps_router.get_read_principal] = (
+        lambda: _StubUser()
+    )
+    assert datetime.now(UTC) - _seen(client) < timedelta(minutes=1)
+
+
+def test_config_poll_by_a_user_is_not_a_heartbeat(client):
+    """A person opening the config form says nothing about whether the
+    app process is alive — only the app's own key refreshes last_seen.
+    The site's internal key is held by companion services too, so it
+    must not count either."""
+    from datetime import UTC, datetime, timedelta
+
+    _register(client)
+    _backdate_last_seen(client, hours=3)
+
+    # The default override IS a user principal.
+    assert client.get("/apps/loitering-detection/config").status_code == 200
+    assert datetime.now(UTC) - _seen(client) > timedelta(hours=2)
+
+    # And the bare internal-key path (principal None) is not a heartbeat.
+    client.app.dependency_overrides[apps_router.get_read_principal] = (
+        lambda: None
+    )
+    assert client.get("/apps/loitering-detection/config").status_code == 200
+    client.app.dependency_overrides[apps_router.get_read_principal] = (
+        lambda: _StubUser()
+    )
+    assert datetime.now(UTC) - _seen(client) > timedelta(hours=2)
+
+
+def test_another_apps_key_is_not_a_heartbeat(client):
+    """An app key may only touch its own row (_own_app_only), so it can
+    never refresh someone else's liveness."""
+    from services.app_keys import AppPrincipal
+
+    _register(client)
+    client.app.dependency_overrides[apps_router.get_read_principal] = (
+        lambda: AppPrincipal(app_id="some-other-app")
+    )
+    resp = client.get("/apps/loitering-detection/config")
+    client.app.dependency_overrides[apps_router.get_read_principal] = (
+        lambda: _StubUser()
+    )
+    assert resp.status_code == 403
+
+
 def test_status_unknown_app_is_404(client):
     assert client.get("/apps/ghost/status").status_code == 404
 

--- a/server/tests/test_skills_registry.py
+++ b/server/tests/test_skills_registry.py
@@ -33,6 +33,7 @@ os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
 os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
 from services.skills_registry import (  # noqa: E402
+    APP_LIVE_CONTACT_WITHIN,
     APP_STALE_AFTER,
     derive_skills,
 )
@@ -151,7 +152,10 @@ def test_app_lifecycle_dormant_active_degraded():
     rows = [
         _app_row("a-dormant", enabled=False),
         _app_row("a-active"),
-        _app_row("a-unreachable", status="unreachable"),
+        # A failed probe is only believed once the app has ALSO stopped
+        # checking in — see test_live_contact_outranks_a_stale_probe.
+        _app_row("a-unreachable", status="unreachable",
+                 last_seen=NOW - APP_STALE_AFTER - timedelta(seconds=1)),
         _app_row("a-stale",
                  last_seen=NOW - APP_STALE_AFTER - timedelta(seconds=1)),
         _app_row("a-never-seen", last_seen=None),
@@ -161,8 +165,37 @@ def test_app_lifecycle_dormant_active_degraded():
     assert _skill(view, "app:a-dormant")["status"] == "dormant"
     assert _skill(view, "app:a-active")["status"] == "active"
     assert _skill(view, "app:a-unreachable")["status"] == "degraded"
+    assert _skill(view, "app:a-unreachable")["reason"] == (
+        "app unreachable at last contact")
     assert _skill(view, "app:a-stale")["status"] == "degraded"
     assert _skill(view, "app:a-never-seen")["status"] == "degraded"
+
+
+def test_live_contact_outranks_a_stale_probe():
+    """The bug this guards: nothing re-runs the /status probe, so one
+    failure (an app still booting, a blip) pinned `status` to
+    "unreachable" forever and the skill badge read "degraded" for an app
+    that was demonstrably running. The app's own config poll refreshes
+    last_seen every ~10s; fresh contact wins."""
+    row = _app_row("a-live", status="unreachable",
+                   last_seen=NOW - timedelta(seconds=15))
+    view = derive_skills(tasks_registry=[], adapters_health={},
+                         adapters_caps={}, apps_rows=[row], now=NOW)
+    s = _skill(view, "app:a-live")
+    assert s["status"] == "active"
+    assert s["reason"] is None
+
+
+def test_dead_app_does_not_coast_on_an_old_heartbeat():
+    """The other side of it: contact just outside the live window no
+    longer excuses a failed probe, so a genuinely dead app is not held
+    'active' by a heartbeat from minutes ago."""
+    row = _app_row("a-dead", status="unreachable",
+                   last_seen=NOW - APP_LIVE_CONTACT_WITHIN
+                   - timedelta(seconds=5))
+    view = derive_skills(tasks_registry=[], adapters_health={},
+                         adapters_caps={}, apps_rows=[row], now=NOW)
+    assert _skill(view, "app:a-dead")["status"] == "degraded"
 
 
 def test_app_entry_shape():


### PR DESCRIPTION
- **ux(catalog): status belongs in the header, results belong to the app**
- **fix(catalog): installs land without a refresh, and enable says where the app went**
- **fix(apps): /status must publish the health verdict it already computes**
- **fix(apps): treat the app's config poll as the heartbeat it already is**
- **ux(anpr): one name for the plate app and the page it lights up**
- **ux(catalog): say what the Network panel is protecting**
- **ux(nav): App Catalog is its own item, next to the apps it installs**
