### PR TITLE
fix(plates): one timestamp per plate read, and it is when the car was…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,33 @@ Reporters are credited in [SECURITY.md](SECURITY.md#reporters).
 
 ### Fixed
 
+- **A plate read showed two different times (#451).** The Vehicles page
+  dated a read by `events.started_at` — the *visit's* start — while the
+  Alarms inbox dated the same read by the app's `fired_at`, stamped when
+  the LPR app finished deciding. The gap was the rest of the track plus
+  OCR, the agreement vote, the bus hop and dispatch: seconds, growing
+  with backlog, so the two pages disagreed by more the busier a gate got.
+  Neither value scrubbed to the frame the plate is legible in, and on a
+  merged track `started_at` is the moment a *different* car arrived.
+
+  A plate read is now dated once, by the capture time of the look the
+  read won on, carried end to end: Tier-0 converts the candidate's
+  monotonic frame stamp to wall clock (`detect_pipeline/captime.py`) and
+  ships it with the crop; core stores it as `events.observed_at` and
+  passes it to KAI-C, which echoes it into `plate.recognized.v1` as the
+  additive `observed_at`; the LPR app forwards it in its alert evidence
+  and core's inbox keeps it as `app_alerts.observed_at`. Both pages, the
+  CSV export and the app-facing events query now read it, falling back
+  to the old fields only for rows that predate it.
+
+  `fired_at` is kept and still orders the alarm inbox — sorting by
+  observed time would stop the inbox being append-only, letting a slow
+  read insert its alarm above ones already on the guard's screen. Where
+  the two differ by a second or more, the lag is shown in the row's
+  tooltip rather than hidden. No backfill: a swept frame's capture time
+  is not recoverable, and inventing one would put a processing time in
+  the column that exists to not be one.
+
 - **camera-agent: ⚙ on an app skill muted the app instead of opening the
   App Catalog.** The ⚙ link and the ✕ button both carried `sk-x`, and ⚙
   was rendered first, so `querySelector(".sk-x")` bound the "mute"

--- a/app/src/components/AlertBell.tsx
+++ b/app/src/components/AlertBell.tsx
@@ -180,6 +180,10 @@ function useAudioBlocked(active: boolean): boolean {
   return blocked
 }
 
+// Fed the alarm's observed_at where there is one, so "3m ago" means the
+// car was there three minutes ago rather than "we finished deciding three
+// minutes ago". Under OCR backlog those differ, and a bell disagreeing
+// with the row it links to is the same bug in miniature (#451).
 function timeAgo(iso: string | null): string {
   if (!iso) return ''
   const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000)
@@ -363,7 +367,8 @@ export function AlertBell() {
                   <div className="flex-1 min-w-0">
                     <div className="truncate font-medium">{a.title}</div>
                     <div className="text-[11px] text-[var(--text-dim)] truncate">
-                      {[a.source_name, a.camera_id, timeAgo(a.fired_at)]
+                      {[a.source_name, a.camera_id,
+                        timeAgo(a.observed_at ?? a.fired_at)]
                         .filter(Boolean)
                         .join(' · ')}
                     </div>

--- a/app/src/services/alertsInboxService.ts
+++ b/app/src/services/alertsInboxService.ts
@@ -27,6 +27,10 @@ export type InboxAlert = {
   id: number
   alert_id: string
   fired_at: string | null
+  // When the thing the alert is ABOUT was seen, when the producer knew
+  // it. Null otherwise — show fired_at then. fired_at remains the sort
+  // key server-side, so the inbox stays append-only.
+  observed_at: string | null
   severity: 'low' | 'medium' | 'high' | 'critical'
   title: string
   description: string | null
@@ -38,6 +42,32 @@ export type InboxAlert = {
   tags: string[]
   acknowledged_at: string | null
   acknowledged_by: number | null
+}
+
+// When the thing happened, not when the app noticed.
+//
+// `observed_at` is when the thing the alert is ABOUT was seen; `fired_at`
+// is when the producing app finished deciding, which trails it by however
+// long inference and the bus took. Showing fired_at as THE time is what
+// made one plate read display two different clocks — the alarm tables and
+// the vehicle list disagreed by seconds that grew with OCR backlog (#451).
+//
+// fired_at still ORDERS the inbox (the server sorts by id, i.e. arrival),
+// so a slow read cannot insert its alarm above ones already on screen.
+export function alarmSeenAt(a: InboxAlert): string {
+  const seen = a.observed_at ?? a.fired_at
+  return seen ? new Date(seen).toLocaleString() : '—'
+}
+
+// Tooltip for the cell above. When the two differ by a noticeable margin
+// the lag rides along: it is a useful health signal, and hiding it would
+// be the same dishonesty in the other direction.
+export function alarmSeenTitle(a: InboxAlert): string | undefined {
+  if (!a.observed_at || !a.fired_at) return undefined
+  const lagMs = new Date(a.fired_at).getTime() - new Date(a.observed_at).getTime()
+  if (!Number.isFinite(lagMs) || lagMs < 1000) return undefined
+  const at = new Date(a.fired_at).toLocaleTimeString()
+  return `Alerted ${Math.round(lagMs / 1000)}s later, at ${at}`
 }
 
 export type RingMode = 'none' | 'ping' | 'continuous'

--- a/app/src/views/Alarms.tsx
+++ b/app/src/views/Alarms.tsx
@@ -24,6 +24,8 @@ import { playTestSound } from '../components/AlertBell'
 import { useAuth } from '../auth/AuthContext'
 import { api } from '../lib/api'
 import {
+  alarmSeenAt,
+  alarmSeenTitle,
   alertsInboxService,
   type InboxAlert,
   type RingConfig,
@@ -271,7 +273,7 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
               <th className="px-3 py-2">Alarm</th>
               <th className="px-3 py-2">Source</th>
               <th className="px-3 py-2">Camera</th>
-              <th className="px-3 py-2">Fired</th>
+              <th className="px-3 py-2">Seen</th>
               <th className="px-3 py-2">Status</th>
               <th className="px-3 py-2" />
             </tr>
@@ -312,8 +314,9 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
                 <td className="px-3 py-2 text-[var(--text-dim)]">
                   {a.camera_id || '—'}
                 </td>
-                <td className="px-3 py-2 text-[var(--text-dim)]">
-                  {a.fired_at ? new Date(a.fired_at).toLocaleString() : '—'}
+                <td className="px-3 py-2 text-[var(--text-dim)]"
+                    title={alarmSeenTitle(a)}>
+                  {alarmSeenAt(a)}
                 </td>
                 <td className="px-3 py-2">
                   {a.acknowledged_at ? (

--- a/app/src/views/Vehicles.tsx
+++ b/app/src/views/Vehicles.tsx
@@ -36,7 +36,12 @@ import {
 import { apiService } from '../lib/apiService'
 import { useAuth } from '../auth/AuthContext'
 import { Link } from 'react-router-dom'
-import { alertsInboxService, type InboxAlert } from '../services/alertsInboxService'
+import {
+  alarmSeenAt,
+  alarmSeenTitle,
+  alertsInboxService,
+  type InboxAlert,
+} from '../services/alertsInboxService'
 import { extractApiError } from '../lib/apiError'
 import { AuthedImage } from '../components/AuthedImage'
 import { Modal } from '../components/Modal'
@@ -57,6 +62,10 @@ type PlateEvent = {
   plate_text?: string | null
   started_at?: string | null
   ended_at?: string | null
+  // When the PLATE was seen: the capture time of the look the read won
+  // on. Null on rows with no plate and on reads made before the platform
+  // recorded it — use plateSeenAt(), never this directly.
+  observed_at?: string | null
   has_evidence?: boolean
   evidence_url?: string | null
   // TRUE means there are two distinct images to show: the crop the plate
@@ -452,11 +461,33 @@ const RANGE_PRESETS = [
   { key: '30d', label: '30 days', hours: 24 * 30 },
 ] as const
 
+// When this row's plate was seen, as an ISO string - the ONE timestamp
+// a plate read is dated by.
+//
+// observed_at is the capture time of the look the read won on; it is the
+// only time on the row that provably belongs to the vehicle whose number
+// was read. started_at is the VISIT's start, and a visit is not always
+// one vehicle: track association merges a departing car with the one
+// arriving behind it, so on a merged track started_at is the moment a
+// different car arrived. It is the fallback only because rows written
+// before the platform recorded observed_at have nothing better (#451).
+function plateSeenIso(e: PlateEvent): string | null {
+  return e.observed_at ?? e.started_at ?? null
+}
+
+function plateSeenAt(e: PlateEvent): string | null {
+  const iso = plateSeenIso(e)
+  return iso ? new Date(iso).toLocaleString() : null
+}
+
 function toCsv(rows: PlateEvent[], cameraName: (id: number) => string): string {
   const esc = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`
   const head = 'plate,camera,seen_at,left_at,label'
+  // seen_at is the READ's time, not the visit's start: an export is
+  // evidence, and its timestamp has to scrub to the frame the plate is
+  // legible in.
   const body = rows.map((r) =>
-    [r.plate_text, cameraName(r.camera_id), r.started_at, r.ended_at, r.label]
+    [r.plate_text, cameraName(r.camera_id), plateSeenIso(r), r.ended_at, r.label]
       .map(esc).join(','))
   return [head, ...body].join('\n')
 }
@@ -1062,7 +1093,7 @@ export function Vehicles() {
                         })()}
                       </td>
                       <td className="px-3 py-1.5 text-[var(--text-dim)]">
-                        {e.started_at ? new Date(e.started_at).toLocaleString() : '—'}
+                        {plateSeenAt(e) ?? '—'}
                       </td>
                       <td className="px-3 py-1.5">
                         {inDeny ? <Badge variant="destructive" title={monitors.find((m) => m.plate === p)?.note}>monitored</Badge>
@@ -1383,7 +1414,7 @@ function EvidenceDialog({
   const [showVehicleAnyway, setShowVehicleAnyway] = useState(false)
   const reads = e.payload?.plate_reads
   const singleRead = !!plate && (reads === 1 || reads === undefined)
-  const seen = e.started_at ? new Date(e.started_at).toLocaleString() : null
+  const seen = plateSeenAt(e)
   // One stage, no chooser: the frame the plate was READ from. The scene
   // is the visit's best-thumbnail moment, which a merged track can take
   // off a DIFFERENT car, so offering it just gave the operator a
@@ -2419,7 +2450,7 @@ function VehicleAlarmsTab() {
               <th className="px-2 py-1.5">Severity</th>
               <th className="px-2 py-1.5">Alarm</th>
               <th className="px-2 py-1.5">Camera</th>
-              <th className="px-2 py-1.5">Fired</th>
+              <th className="px-2 py-1.5">Seen</th>
               <th className="px-2 py-1.5">Status</th>
               <th className="px-2 py-1.5" />
             </tr>
@@ -2448,8 +2479,9 @@ function VehicleAlarmsTab() {
                   )}
                 </td>
                 <td className="px-2 py-1.5 text-[var(--text-dim)]">{a.camera_id || '—'}</td>
-                <td className="px-2 py-1.5 text-[var(--text-dim)]">
-                  {a.fired_at ? new Date(a.fired_at).toLocaleString() : '—'}
+                <td className="px-2 py-1.5 text-[var(--text-dim)]"
+                    title={alarmSeenTitle(a)}>
+                  {alarmSeenAt(a)}
                 </td>
                 <td className="px-2 py-1.5">
                   {a.acknowledged_at

--- a/detect-pipeline/detect_pipeline/captime.py
+++ b/detect-pipeline/detect_pipeline/captime.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Frame capture time — monotonic frame stamps as wall clock.
+
+Frames carry ``Frame.ts``, a ``time.monotonic()`` reading taken when the
+frame was fully decoded (``frame_source``). Monotonic is the right clock
+for the pipeline's own gaps and gates — it cannot jump when NTP steps
+the wall clock — but it is meaningless outside this process, so nothing
+downstream could ever say WHEN a plate was read.
+
+Everything downstream stamped its own arrival instead: the visit poster,
+the attempt poster, KAI-C's publish, the app's alert. Each of those is a
+processing time, so the operator-visible "when was this car here" drifted
+with OCR backlog, and the same read showed a different time on every
+page.
+
+This converts a monotonic reading to wall clock by measuring its AGE:
+
+    wall = time.time() - (time.monotonic() - mono_ts)
+
+Deliberately not a stored anchor captured at stream start. An anchor's
+error is the wall-clock drift accumulated since it was taken (unbounded
+over a long uptime, and stepped by every NTP correction); this form's
+error is only the drift over the frame's age, which is milliseconds. It
+also needs no re-anchoring when ffmpeg restarts.
+
+What this is NOT: the moment light hit the sensor. It excludes the
+camera's own exposure/encode delay and the network hop, and includes our
+decode buffer — so it lands within the decode pipeline of true capture,
+not on it. That is deliberate: the camera's own clock is the only source
+for true capture time, and IP camera clocks drift freely and are rarely
+NTP-synced, so trusting them would put each camera's private idea of
+time into the evidence store.
+"""
+from __future__ import annotations
+
+import time
+
+
+def capture_wall(mono_ts: float, *, _mono=time.monotonic, _wall=time.time) -> float:
+    """Wall-clock seconds for a ``time.monotonic()`` frame stamp.
+
+    The clocks are injectable for tests only; production always reads the
+    two real clocks back to back.
+    """
+    return _wall() - (_mono() - float(mono_ts))

--- a/detect-pipeline/detect_pipeline/events_poster.py
+++ b/detect-pipeline/detect_pipeline/events_poster.py
@@ -31,6 +31,7 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from .captime import capture_wall
 from .metrics import record_visit_dropped, record_visit_posted
 
 log = logging.getLogger("detect_pipeline.events")
@@ -71,6 +72,20 @@ class Visit:
     # off or the tracker was never fed pixels. Appended LAST, same rule
     # candidate_jpegs followed, so positional constructions keep meaning.
     scene_jpeg: bytes | None = None
+    # Wall-clock capture time of each entry in ``candidate_jpegs``, same
+    # order. The read that wins core's consensus sweep takes its
+    # observed_at from here — the moment in the video the winning look
+    # came from, which is the only time on the row that provably belongs
+    # to the vehicle whose number was read. Empty (never partial) when
+    # the ring could not supply stamps. Appended LAST, same rule as
+    # above, so positional constructions keep meaning.
+    candidate_ts: tuple = ()
+    # Wall-clock capture time of the frame ``jpeg`` was cut from. When a
+    # visit ships no candidates — every visit on a camera without the LPR
+    # skill — core's sweep OCRs that evidence crop instead, and this is the
+    # only time that read can honestly carry. Appended LAST, same rule as
+    # above, so positional constructions keep meaning.
+    evidence_ts: float | None = None
 
 
 def _core_camera_id(v: Visit) -> int:
@@ -218,6 +233,10 @@ class VisitPoster:
         }
         if v.jpeg:
             body["evidence_jpeg_b64"] = base64.b64encode(v.jpeg).decode("ascii")
+            # Dates the crop above, and only it. Core uses this when the
+            # visit ships no candidates and its sweep reads that crop.
+            if v.evidence_ts is not None:
+                body["evidence_ts"] = float(v.evidence_ts)
         # Omitted entirely when absent (not sent as null), so a core that
         # predates the field never sees a key it has no opinion about.
         if v.scene_jpeg:
@@ -226,6 +245,11 @@ class VisitPoster:
             body["candidate_jpegs_b64"] = [
                 base64.b64encode(j).decode("ascii") for j in v.candidate_jpegs
             ]
+            # Sent only when it lines up 1:1 with the crops: core zips the
+            # two, and a short list would hand a read someone else's
+            # timestamp. A missing list just means no observed_at.
+            if len(v.candidate_ts) == len(v.candidate_jpegs):
+                body["candidate_ts"] = [float(t) for t in v.candidate_ts]
         req = urllib.request.Request(
             f"{self.core_url}{EVENTS_PATH}",
             data=json.dumps(body).encode("utf-8"),
@@ -269,7 +293,7 @@ class VisitLifecycle:
                 v = self._live[tr.id] = {
                     "start": now_wall, "label": tr.label, "score": float(tr.score),
                     "stationary": False, "confirmed": False, "crop": None,
-                    "ring": None, "scene": None,
+                    "crop_ts": None, "ring": None, "scene": None,
                 }
             v["end"] = now_wall
             v["label"] = tr.label
@@ -282,6 +306,11 @@ class VisitLifecycle:
             crop = getattr(tr, "best_crop", None)
             if crop is not None:
                 v["crop"] = crop
+                # Kept in lockstep with the crop: a stamp from an older
+                # best frame would date the read by a look it did not
+                # come from. getattr default, like best_crop itself —
+                # test doubles and older trackers lack the field.
+                v["crop_ts"] = getattr(tr, "best_crop_ts", None)
             # getattr with a default, like best_crop above: test doubles and
             # any older tracker simply do not carry the field.
             scene = getattr(tr, "best_scene_jpeg", None)
@@ -329,6 +358,7 @@ class VisitLifecycle:
             except Exception:
                 jpeg = None  # a visit without a photo still beats no history
         candidate_jpegs: list[bytes] = []
+        candidate_ts: list[float] = []
         ring = v.get("ring")
         if ring is not None:
             try:
@@ -338,11 +368,19 @@ class VisitLifecycle:
                     encoded = _encode_jpeg(cand.crop)
                     if encoded:
                         candidate_jpegs.append(encoded)
+                        # Monotonic on the ring (the tracker's clock) —
+                        # converted here, while the reading is fresh, so
+                        # the age it is measured against is the encode,
+                        # not core's ingest.
+                        candidate_ts.append(capture_wall(cand.ts))
             except Exception:
                 # Candidates are an enhancement; the visit itself (and its
                 # single-crop enrichment fallback) must never be lost to a
                 # bad encode.
                 candidate_jpegs = candidate_jpegs or []
+                # Never ship a partial stamp list — see _post.
+                if len(candidate_ts) != len(candidate_jpegs):
+                    candidate_ts = []
         return Visit(
             camera_id=self.camera_id,
             nvr_camera_id=self.nvr_camera_id,
@@ -354,6 +392,13 @@ class VisitLifecycle:
             stationary=v["stationary"],
             jpeg=jpeg,
             candidate_jpegs=tuple(candidate_jpegs),
+            candidate_ts=tuple(candidate_ts),
+            # Converted here, like the candidate stamps: the age measured
+            # is this call, not core's ingest. None when the tracker never
+            # recorded one (older tracker, or a visit with no crop).
+            evidence_ts=(capture_wall(v["crop_ts"])
+                         if jpeg is not None and v.get("crop_ts") is not None
+                         else None),
             # Already bytes — deliberately NOT re-encoded here (unlike crop
             # and the candidates, which arrive as pixels).
             scene_jpeg=v.get("scene"),

--- a/detect-pipeline/detect_pipeline/plate_attempts.py
+++ b/detect-pipeline/detect_pipeline/plate_attempts.py
@@ -35,6 +35,7 @@ import time
 import urllib.request
 from dataclasses import dataclass
 
+from .captime import capture_wall
 from .platecands import VEHICLE_LABELS, EarlyAttemptPolicy
 
 log = logging.getLogger("detect_pipeline.plates")
@@ -49,7 +50,12 @@ class Attempt:
     camera_id: str            # platform handle ("cam1") — for logs/metrics
     nvr_camera_id: int | None  # core's numeric Camera.id — what core keys on
     track_id: str
-    ts: float                 # wall clock of submission (visit-window match)
+    # Wall clock of the CAPTURE this crop was cut from, not of submission.
+    # Core parks it as the read's observed_at (the operator-visible "when
+    # was this car here") and matches it against the visit window, and
+    # both want the moment in the video, not the moment we got round to
+    # posting it. Submission time drifted with the attempt queue.
+    ts: float
     jpeg: bytes
 
 
@@ -150,12 +156,18 @@ class EarlyPlateAttempts:
         nvr_camera_id: int | None = None,
         max_attempts: int = 2,
         clock=None,
+        capture_clock=None,
     ) -> None:
         self.poster = poster
         self.camera_id = camera_id
         self.nvr_camera_id = nvr_camera_id
         self.max_attempts = max_attempts
         self._clock = clock or time.monotonic
+        # Candidate stamps are monotonic (the tracker's clock); this turns
+        # one into the wall clock the rest of the platform speaks.
+        # Injectable so a test driving a fake monotonic clock does not get
+        # a wall time derived from it.
+        self._capture_clock = capture_clock or capture_wall
         self._policies: dict = {}
         self.attempts_submitted = 0
 
@@ -191,7 +203,7 @@ class EarlyPlateAttempts:
                 camera_id=self.camera_id,
                 nvr_camera_id=self.nvr_camera_id,
                 track_id=str(tr.id),
-                ts=time.time(),
+                ts=self._capture_clock(best.ts),
                 jpeg=jpeg,
             ))
             # Budget is consumed even when the queue was full — an

--- a/detect-pipeline/detect_pipeline/tracking.py
+++ b/detect-pipeline/detect_pipeline/tracking.py
@@ -104,6 +104,12 @@ class Track:
     # BGR crop of the best frame, retained only when the tracker is fed pixels
     # (the Tier-1 gate dispatches THIS on escalation — see gate/dispatch, PR B #10).
     best_crop: object | None = field(default=None, repr=False, compare=False)
+    # Monotonic capture stamp of the frame best_crop came from, set with it.
+    # A visit whose camera has no LPR skill ships no plate candidates, so
+    # core's sweep OCRs THIS crop — and without a time of its own that read
+    # got no observed_at at all, which is every read on a default install
+    # (#451). Same clock as the candidate ring, so both convert alike.
+    best_crop_ts: float | None = field(default=None, compare=False)
     # Multi-frame OCR: top-K plate-readability-scored crops spread across
     # the pass (vehicle labels on LPR cameras only — None everywhere else,
     # so non-LPR deployments pay zero memory or scoring cost).
@@ -364,6 +370,7 @@ class Tracker:
                 crop = _crop_bgr(bgr, det.box, margin=self.crop_margin)
                 if crop is not None:
                     tr.best_crop = crop
+                    tr.best_crop_ts = self._clock()
                     # Gated on the crop, so the two evidence images always
                     # describe the SAME frame — a scene whose crop was
                     # rejected would be an inconsistent pair.

--- a/detect-pipeline/test/test_captime.py
+++ b/detect-pipeline/test/test_captime.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Capture time — the one timestamp a plate read is dated by (#451).
+
+The failure these exist for: nothing downstream could say WHEN a vehicle
+was seen, because frames carry a monotonic stamp that means nothing
+outside the pipeline process. So every hop stamped its own arrival
+instead, and one plate read ended up displayed with a different time on
+every page — drifting further apart the more OCR backlog there was.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from detect_pipeline.captime import capture_wall
+from detect_pipeline.platecands import CandidateRing
+
+
+# ── monotonic -> wall ──────────────────────────────────────────────
+
+
+def test_capture_wall_dates_a_frame_by_its_age():
+    # A frame read 2s ago is 2s before now, whatever the two clocks'
+    # absolute values are (monotonic's epoch is arbitrary by contract).
+    wall = capture_wall(1_000.0, _mono=lambda: 1_002.0, _wall=lambda: 5_000.0)
+    assert wall == 4_998.0
+
+
+def test_capture_wall_is_immune_to_clock_offset_not_just_drift():
+    # The same age gives the same answer no matter how far apart the two
+    # clocks' origins are — this is why it measures age rather than
+    # storing an anchor at stream start.
+    a = capture_wall(10.0, _mono=lambda: 11.0, _wall=lambda: 1_700_000_000.0)
+    b = capture_wall(9_999_990.0, _mono=lambda: 9_999_991.0,
+                     _wall=lambda: 1_700_000_000.0)
+    assert a == b == 1_699_999_999.0
+
+
+def test_capture_wall_of_the_frame_being_read_now_is_now():
+    assert capture_wall(50.0, _mono=lambda: 50.0, _wall=lambda: 123.0) == 123.0
+
+
+# ── the early attempt carries the LOOK's time, not the post's ──────
+
+
+class _FakePoster:
+    def __init__(self):
+        self.submitted = []
+
+    def submit(self, attempt):
+        self.submitted.append(attempt)
+        return True
+
+
+class _FakeTrack:
+    def __init__(self, id, label="car", confirmed=True, ring=None):
+        self.id = id
+        self.label = label
+        self.confirmed = confirmed
+        self.plate_ring = ring
+
+
+def _ring_at(ts, score=100.0):
+    ring = CandidateRing(min_gap_s=0.0)
+    ring.offer(ts, score, np.zeros((8, 8, 3), np.uint8))
+    return ring
+
+
+def test_attempt_is_dated_by_the_crop_not_by_the_submission():
+    """The whole point: an attempt queued behind others must still say
+    when its picture was taken."""
+    from detect_pipeline.plate_attempts import EarlyPlateAttempts
+
+    poster = _FakePoster()
+    ea = EarlyPlateAttempts(
+        poster, "cam1", nvr_camera_id=1, clock=lambda: 500.0,
+        # The candidate was captured at monotonic 480; "now" is 500, so
+        # the look is 20s old and its wall time is 20s before wall-now.
+        capture_clock=lambda ts: 1_000.0 + (ts - 480.0),
+    )
+    assert ea.observe([_FakeTrack(1, ring=_ring_at(480.0))]) == 1
+    assert poster.submitted[0].ts == 1_000.0
+
+
+def test_two_looks_of_one_car_are_dated_apart():
+    from detect_pipeline.plate_attempts import EarlyPlateAttempts
+
+    poster = _FakePoster()
+    # The policy's own clock has to advance past min_retry_gap_s, or the
+    # second look never earns an attempt to be dated.
+    ticks = iter([100.0, 160.0])
+    ea = EarlyPlateAttempts(
+        poster, "cam1", nvr_camera_id=1, max_attempts=2,
+        clock=lambda: next(ticks), capture_clock=lambda ts: ts,
+    )
+    ea.observe([_FakeTrack(1, ring=_ring_at(10.0, score=10.0))])
+    # A much better look later in the track earns the second attempt.
+    ea.observe([_FakeTrack(1, ring=_ring_at(40.0, score=900.0))])
+    assert [a.ts for a in poster.submitted] == [10.0, 40.0]

--- a/detect-pipeline/test/test_events_poster.py
+++ b/detect-pipeline/test/test_events_poster.py
@@ -338,3 +338,71 @@ def test_visit_still_takes_its_original_positional_arguments():
     v = _visit(b"crop")
     assert v.camera_id == "3" and v.jpeg == b"crop"
     assert v.scene_jpeg is None and v.candidate_jpegs == ()
+
+
+# ── candidate capture times (#451) ─────────────────────────────────
+
+
+def test_post_carries_the_candidates_capture_times():
+    """Core dates the winning read by these — without them a plate row
+    falls back to the visit's START, which on a merged track is when a
+    DIFFERENT car arrived."""
+    posted = {}
+
+    def opener(req, timeout=None):
+        posted["body"] = json.loads(req.data.decode())
+        return _Resp()
+
+    p = VisitPoster("http://core", api_key="k", opener=opener)
+    p._post(replace(_visit(b"crop"),
+                    candidate_jpegs=(b"a", b"b"),
+                    candidate_ts=(11.5, 12.5)))
+    assert posted["body"]["candidate_ts"] == [11.5, 12.5]
+    assert len(posted["body"]["candidate_jpegs_b64"]) == 2
+
+
+def test_post_drops_stamps_that_do_not_line_up_with_the_crops():
+    """A short list is worse than none: core zips the two, so every read
+    past the gap would inherit a different look's timestamp."""
+    posted = {}
+
+    def opener(req, timeout=None):
+        posted["body"] = json.loads(req.data.decode())
+        return _Resp()
+
+    p = VisitPoster("http://core", api_key="k", opener=opener)
+    p._post(replace(_visit(b"crop"),
+                    candidate_jpegs=(b"a", b"b"),
+                    candidate_ts=(11.5,)))
+    assert "candidate_ts" not in posted["body"]
+    assert len(posted["body"]["candidate_jpegs_b64"]) == 2
+
+
+def test_finished_visit_dates_each_candidate_it_ships():
+    """The stamps come off the ring, so they describe the LOOK, not the
+    moment the visit closed."""
+    import numpy as np
+
+    from detect_pipeline.platecands import CandidateRing
+
+    ring = CandidateRing(min_gap_s=0.0)
+    ring.offer(T0 + 1, 10.0, np.zeros((8, 8, 3), np.uint8))
+    ring.offer(T0 + 2, 90.0, np.zeros((8, 8, 3), np.uint8))
+
+    class _Car:
+        id = 1
+        label = "car"
+        score = 0.9
+        confirmed = True
+        best_crop = None
+        plate_ring = ring
+
+    lc = VisitLifecycle("3")
+    lc.observe([_Car()], T0)
+    lc.observe([_Car()], T0 + 3)
+    done = lc.observe([], T0 + 4)
+    assert len(done) == 1
+    v = done[0]
+    # One stamp per shipped crop, and none of them is the visit's end.
+    assert len(v.candidate_ts) == len(v.candidate_jpegs) == 2
+    assert all(isinstance(t, float) for t in v.candidate_ts)

--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -166,7 +166,20 @@ empty/failed reads do not fire).
 | `event_id` | int \| null | Timeline visit row this read enriches, when initiated from a visit. |
 | `plate_box` | `[x1,y1,x2,y2]` \| absent | Optional. Where the adapter localised the plate, in the pixel space of the crop it was given. KAI-C does not publish a read whose box abuts the crop edge (a **partial** read), whose localiser scored below `KAI_C_PLATE_MIN_DETECTION_CONFIDENCE` (default 0.6), or whose localiser looked and found no plate (`KAI_C_PLATE_REQUIRE_LOCALISATION`, default on) — so every subscriber sees the same gate. The box is still forwarded for consumers with stricter policies. Consumers may use it to reject **partial** reads: a crop whose edge cuts through the plate still OCRs the surviving characters at high confidence, so `confidence` cannot distinguish `K884` (a fragment of `K884RS`) from a whole plate — only the geometry can. Absent when the adapter reports no localisation. |
 | `plate_box_confidence` | number \| absent | Optional. How sure the adapter's localiser was that it had found a plate at all — distinct from `confidence`, which scores the characters. Consumers reject **false localisations** with it: a manufacturer badge reads as plausible characters (the Audi four rings OCR as `C00D`) at plausible read confidence, from a box in the middle of the crop, so neither `confidence` nor `plate_box` can catch it — but the localiser scored it 0.38 where genuine plates score 0.85+. Absent from OCR-only adapters and from producers that predate the field (consumers then have no opinion to apply). |
+| `observed_at` | string \| absent | Optional. ISO-8601 UTC capture time of the **look this read came off** — when the plate was seen, as distinct from when anything processed it. Supplied by the initiator and echoed verbatim (KAI-C never mints one: it has no knowledge of the initiating system's clocks). This is the authoritative observation time for a read; see the note under the table on why the envelope's `ts` is not. Consumers that display or export a read MUST prefer it, falling back only for producers that predate it. Absent when the initiator did not know the capture time — e.g. a read taken from a stored evidence frame rather than a timestamped candidate look. |
 | `plate_box_image` | `[width,height]` \| absent | Optional. The size of the image `plate_box` is measured in — exactly the bytes the adapter OCR'd. Multi-frame OCR sends plate *candidate* crops whose size differs from the visit's evidence frame, so a consumer judging the box against the evidence file would measure in the wrong image; when this field is present it is the only correct denominator. Absent from adapters that predate it (consumers then fall back to the evidence file's size, correct for single-evidence producers). |
+
+> **`observed_at` vs the envelope's `ts`.** The envelope contract above
+> defines `ts` as the wall-clock time of the *observation*. For
+> `plate.recognized.v1` the current implementation does not meet that:
+> `kai_c/domain_events.py::_envelope` stamps `ts` at publish, so it
+> trails the observation by however long OCR and queueing took — a lag
+> that grows with backlog and is therefore worst exactly when a gate is
+> busiest. Rather than redefine `ts` for every producer mid-flight, the
+> observation time is carried explicitly in `observed_at`, which is
+> additive and unambiguous. Treat `ts` as "when this was published" for
+> this schema, and `observed_at` as "when it happened". Consumers that
+> date a read by `ts` are measuring our pipeline, not the world.
 
 #### Producer convergence (Phase 0 exit criterion)
 

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -854,6 +854,7 @@ class PlateAlerter(Detector):
             camera_id, plate,
             confidence=confidence,
             vehicle_label=payload.get("vehicle_label"),
+            observed_at=payload.get("observed_at"),
             correlation_id=event.get("correlation_id"),
             monitor=monitor,
             registry_entry=registry_entry if registry_active else None,
@@ -920,6 +921,7 @@ class PlateAlerter(Detector):
         confidence: float | None,
         vehicle_label: str | None,
         correlation_id: str | None,
+        observed_at: str | None = None,
         monitor: dict[str, Any] | None = None,
         registry_entry: dict[str, str] | None = None,
         registry_expired: bool = False,
@@ -979,6 +981,14 @@ class PlateAlerter(Detector):
                 "plate_text": plate,
                 "confidence": confidence,
                 "vehicle_label": vehicle_label,
+                # WHEN the plate was seen, forwarded from the platform's
+                # event. fired_at is when THIS app got round to deciding,
+                # which lags the read by however long OCR and the bus
+                # took — so an operator comparing the alarm with the
+                # vehicle list saw two times for one read. Optional: an
+                # older platform sends nothing and the inbox falls back.
+                "observed_at": observed_at
+                if isinstance(observed_at, str) and observed_at else None,
                 "in_allowlist": plate in allowlist,
                 # Kept name for consumers: "on the bad list" now means
                 # "has a monitor rule" (denylist is monitor shorthand).

--- a/examples/license-plate-recognition/tests/test_observed_at_forwarding.py
+++ b/examples/license-plate-recognition/tests/test_observed_at_forwarding.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The alert carries WHEN the plate was seen, not just when we decided.
+
+An Alert's ``fired_at`` is stamped as this app builds it — after the read
+crossed the bus and this handler ran. The operator inbox showed that as
+the alarm's only time, so one plate read appeared at one moment on the
+Alarms page and a different one in the vehicle list, drifting apart by
+however long OCR and delivery took (#451).
+
+The platform now puts the look's capture time in the event payload; this
+app forwards it in the alert's evidence, where core's inbox picks it up.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from license_plate_recognition import AppConfig, PlateAlerter
+
+SEEN = "2026-08-29T09:59:52+00:00"
+
+
+def _alerter() -> PlateAlerter:
+    return PlateAlerter(AppConfig(nats_url="nats://test:4222"), MagicMock())
+
+
+def _envelope(**payload_extra):
+    return {
+        "id": "evt_0123456789ab",
+        "schema": "plate.recognized.v1",
+        "correlation_id": "corr-1",
+        "camera_id": "cam-1",
+        # Publish time — deliberately NOT the capture time, so a test
+        # that read the wrong field would show up as a wrong value.
+        "ts": "2026-08-29T10:00:00+00:00",
+        "producer": "kai-c",
+        "payload": {
+            "plate_text": "ABC1234",
+            "confidence": 0.9,
+            "vehicle_label": "car",
+            "event_id": 42,
+            **payload_extra,
+        },
+    }
+
+
+def _evidence_of(envelope) -> dict:
+    fired = _alerter().handle_event(envelope)
+    assert len(fired) == 1
+    return fired[0].evidence
+
+
+def test_the_alert_forwards_the_capture_time():
+    assert _evidence_of(_envelope(observed_at=SEEN))["observed_at"] == SEEN
+
+
+def test_the_capture_time_is_not_the_alerts_own_fired_at():
+    """The two must stay distinguishable: that gap IS the pipeline lag
+    the single-timestamp display was hiding."""
+    alert = _alerter().handle_event(_envelope(observed_at=SEEN))[0]
+    assert alert.evidence["observed_at"] == SEEN
+    assert alert.fired_at != SEEN
+
+
+def test_a_platform_that_sends_no_capture_time_forwards_none():
+    """Optional by contract: an older platform publishes no observed_at,
+    the field lands as None, and core's inbox falls back to fired_at."""
+    assert _evidence_of(_envelope())["observed_at"] is None
+
+
+def test_a_junk_capture_time_is_not_forwarded_as_one():
+    """This app does not parse the value — it relays a wire string — but
+    it must not pass a non-string through as though it were a timestamp."""
+    for junk in (12345, {"a": 1}, [], "", None):
+        assert _evidence_of(_envelope(observed_at=junk))["observed_at"] is None

--- a/kai-c/kai_c/domain_events.py
+++ b/kai-c/kai_c/domain_events.py
@@ -138,6 +138,7 @@ def _normalise_fast_plate_ocr(
     camera_id: str,
     correlation_id: Optional[str],
     event_id: Optional[int],
+    observed_at: Optional[str] = None,
 ) -> Normalised:
     """``fast_plate_ocr`` completion → ``plate.recognized.v1``.
 
@@ -170,6 +171,16 @@ def _normalise_fast_plate_ocr(
         "vehicle_label": None,
         "event_id": event_id,
     }
+    # Additive optional field: WHEN the look this read came off was
+    # captured, ISO-8601 UTC, exactly as the initiator sent it.
+    #
+    # The envelope's own ``ts`` cannot answer this — it is publish time,
+    # so a consumer had no way to date a read except by when the message
+    # reached it, and that drifts with OCR backlog. Echoed like
+    # ``event_id``, never interpreted: KAI-C does not know this system's
+    # clocks and must not invent a value when the initiator omits one.
+    if isinstance(observed_at, str) and observed_at:
+        payload["observed_at"] = observed_at[:40]
     # Additive optional field (EVENT_CONTRACTS.md "additive-only"): the
     # plate box the adapter localised, in the OCR'd crop's pixel space.
     # Consumers use it to reject PARTIAL reads — a crop whose edge cuts
@@ -221,6 +232,7 @@ def normalise_completion(
     camera_id: Optional[str],
     correlation_id: Optional[str] = None,
     event_id: Optional[int] = None,
+    observed_at: Optional[str] = None,
 ) -> Normalised:
     """Domain event for one successful completion, or None.
 
@@ -246,6 +258,7 @@ def normalise_completion(
             camera_id=camera_id,
             correlation_id=correlation_id,
             event_id=event_id,
+            observed_at=observed_at,
         )
     except Exception:  # noqa: BLE001 — normalisation must never hurt the caller
         logger.warning(

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -1279,6 +1279,7 @@ async def _publish_inference_completed(
     latency_ms: int,
     body: Dict[str, Any],
     event_id: Optional[int] = None,
+    observed_at: Optional[str] = None,
 ) -> None:
     """Build an ``InferenceCompletedEvent`` from the response body the
     adapter returned and publish it on NATS. Shared by HTTP and WS
@@ -1351,6 +1352,7 @@ async def _publish_inference_completed(
         camera_id=camera_id,
         correlation_id=correlation_id,
         event_id=event_id,
+        observed_at=observed_at,
     )
     if normalised is not None:
         subject, envelope = normalised
@@ -1473,6 +1475,12 @@ async def v1_infer(
         # EVENT_CONTRACTS.md, plate.recognized.v1). Plucked like
         # camera_id: a top-level request param, echoed never interpreted.
         raw_event_id = payload.get("event_id") if isinstance(payload, dict) else None
+        # ``observed_at`` rides along the same way: when the frame this
+        # inference ran on was captured, ISO-8601 UTC. Plucked and echoed,
+        # never interpreted — see EVENT_CONTRACTS.md, plate.recognized.v1.
+        raw_observed_at = (
+            payload.get("observed_at") if isinstance(payload, dict) else None
+        )
         asyncio.create_task(_publish_inference_completed(
             adapter_name=adapter_name,
             adapter=adapter,
@@ -1483,6 +1491,8 @@ async def v1_infer(
             event_id=raw_event_id
             if isinstance(raw_event_id, int) and not isinstance(raw_event_id, bool)
             else None,
+            observed_at=raw_observed_at
+            if isinstance(raw_observed_at, str) else None,
         ))
         return body
 

--- a/kai-c/test/test_domain_events.py
+++ b/kai-c/test/test_domain_events.py
@@ -249,3 +249,46 @@ def test_plate_box_confidence_is_omitted_when_absent_or_malformed():
             "fast_plate_ocr", dict(PLATE_RESULT, plate_detection=bad),
             camera_id="cam1", correlation_id=None, event_id=7)
         assert "plate_box_confidence" not in env["payload"], bad
+
+
+# ── observed_at: the read's own time, echoed (#451) ────────────────
+
+
+def test_observed_at_is_echoed_into_the_payload():
+    """The envelope's ts is PUBLISH time, so a consumer could only date a
+    read by when the message reached it — which drifts with OCR backlog.
+    observed_at is when the look was captured, passed by the initiator
+    and echoed verbatim, exactly like event_id."""
+    out = normalise_completion(
+        "fast_plate_ocr", PLATE_RESULT,
+        camera_id="cam-front", correlation_id="corr-1", event_id=42,
+        observed_at="2026-09-03T09:59:52+00:00",
+    )
+    assert out is not None
+    _subject, env = out
+    assert env["payload"]["observed_at"] == "2026-09-03T09:59:52+00:00"
+    # Publish time is still its own field, and is NOT the same moment.
+    assert env["ts"] != env["payload"]["observed_at"]
+
+
+def test_observed_at_is_omitted_when_the_initiator_sent_none():
+    """Additive-only: a producer that does not know the capture time
+    publishes a payload without the key, and KAI-C must not invent one —
+    it has no idea what this system's clocks say."""
+    out = normalise_completion(
+        "fast_plate_ocr", PLATE_RESULT,
+        camera_id="cam-front", correlation_id="corr-1", event_id=42,
+    )
+    assert out is not None
+    assert "observed_at" not in out[1]["payload"]
+
+
+@pytest.mark.parametrize("junk", [123, "", None, {"a": 1}, []])
+def test_junk_observed_at_is_dropped_not_published(junk):
+    out = normalise_completion(
+        "fast_plate_ocr", PLATE_RESULT,
+        camera_id="cam-front", correlation_id="corr-1", event_id=42,
+        observed_at=junk,
+    )
+    assert out is not None
+    assert "observed_at" not in out[1]["payload"]

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/event_types.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/event_types.py
@@ -130,11 +130,18 @@ class PlateRecognized(TypedPayload):
     plate_box: list[float] | None = None
     plate_box_confidence: float | None = None
     plate_box_image: list[int] | None = None
+    # ISO-8601 UTC capture time of the look this read came off: WHEN the
+    # plate was seen, as opposed to when anything processed it. Prefer it
+    # over the envelope's ts, which for this schema is publish time and
+    # so trails the read by the OCR + delivery lag (EVENT_CONTRACTS.md).
+    # None from producers that predate it.
+    observed_at: str | None = None
 
     def to_payload(self) -> dict[str, Any]:
         out = super().to_payload()
-        # The optional geometry fields are "absent", not null, when unknown.
-        for name in ("plate_box", "plate_box_confidence", "plate_box_image"):
+        # The optional fields are "absent", not null, when unknown.
+        for name in ("plate_box", "plate_box_confidence", "plate_box_image",
+                     "observed_at"):
             if out.get(name) is None:
                 out.pop(name, None)
         return out

--- a/server/migrations/versions/c5e9a3b7d104_add_observed_at.py
+++ b/server/migrations/versions/c5e9a3b7d104_add_observed_at.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""add events.observed_at and app_alerts.observed_at
+
+One timestamp for "when was this vehicle here", separate from every
+stamp the platform makes while processing the read (#451).
+
+Both columns are nullable with no backfill: the capture time of a frame
+that has already been swept is not recoverable, and inventing one would
+put a processing time in the very column that exists to not be one.
+Readers fall back to started_at / fired_at for those rows.
+
+Revision ID: c5e9a3b7d104
+Revises: b4d8e2a91c7f
+Create Date: 2026-09-09
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c5e9a3b7d104"
+down_revision = "b4d8e2a91c7f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("events") as b:
+        b.add_column(sa.Column("observed_at", sa.DateTime(timezone=True),
+                               nullable=True))
+    with op.batch_alter_table("app_alerts") as b:
+        b.add_column(sa.Column("observed_at", sa.DateTime(timezone=True),
+                               nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("app_alerts") as b:
+        b.drop_column("observed_at")
+    with op.batch_alter_table("events") as b:
+        b.drop_column("observed_at")

--- a/server/migrations/versions/d7f1c4b820ae_index_events_seen_at.py
+++ b/server/migrations/versions/d7f1c4b820ae_index_events_seen_at.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""index events by when the read happened
+
+The plate aggregations range over coalesce(observed_at, started_at) —
+"when was this vehicle here" (#451). That expression cannot use
+ix_events_cam_start: the planner matched camera_id and then tested the
+range against every row the camera ever recorded, and events holds every
+track, people included.
+
+    before  SEARCH events USING INDEX ix_events_cam_start
+                (camera_id=? AND started_at>?)
+    after   SEARCH events USING INDEX ix_events_cam_start (camera_id=?)
+
+An expression index restores the seek. Not partial (WHERE plate_text IS
+NOT NULL) even though every caller filters on plate_text: two of them
+filter by equality to a plate rather than IS NOT NULL, and whether a
+planner infers one from the other is a per-dialect subtlety this does not
+need to bet on.
+
+Revision ID: d7f1c4b820ae
+Revises: c5e9a3b7d104
+Create Date: 2026-09-09
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d7f1c4b820ae"
+down_revision = "c5e9a3b7d104"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_events_cam_seen", "events",
+        ["camera_id", sa.text("coalesce(observed_at, started_at)")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_events_cam_seen", table_name="events")

--- a/server/models.py
+++ b/server/models.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -485,6 +486,15 @@ class TimelineEvent(Base):
     __tablename__ = "events"
     __table_args__ = (
         Index("ix_events_cam_start", "camera_id", "started_at"),
+        # The plate aggregations range over WHEN A READ HAPPENED, which is
+        # coalesce(observed_at, started_at) (services.timeline_service.
+        # SEEN_AT). That expression cannot use the index above — the planner
+        # matched camera_id and then filtered the range against every row the
+        # camera ever recorded, and this table holds every track, people
+        # included. Mirrors ix_events_cam_start so the same queries seek the
+        # same way (#451).
+        Index("ix_events_cam_seen", "camera_id",
+              text("coalesce(observed_at, started_at)")),
         # One visit = one (camera, track, start): ingest retries are
         # idempotent. NULLs (alarm/alert rows) never collide by SQL semantics.
         Index("uq_events_visit", "camera_id", "track_id", "started_at",
@@ -529,6 +539,27 @@ class TimelineEvent(Base):
     # plate came off. This image is the only one on the row that is
     # guaranteed to show the car the number belongs to.
     plate_frame_path = Column(String(500), nullable=True)
+    # When the plate was SEEN — the capture time of the frame the winning
+    # read came from, as opposed to when any part of the platform got
+    # round to processing it.
+    #
+    # started_at cannot answer this. It is the visit's start, and a visit
+    # is not always one vehicle: track association merges a departing car
+    # with the one arriving behind it, so on a merged track started_at is
+    # the moment a DIFFERENT car arrived — the same defect that makes
+    # plate_frame_path the only trustworthy image on the row. This column
+    # is that image's timestamp, so the picture and the time agree.
+    #
+    # Why it is not a processing time: OCR latency varies with backlog and
+    # track length, so a processing stamp is wrong by an amount that grows
+    # exactly when the gate is busiest; it does not scrub to the right
+    # second of recording; and re-running the enrichment sweep would
+    # restamp history as "now". This value is stable under reprocessing.
+    #
+    # NULL for non-plate rows, for rows read from the evidence frame
+    # (no candidate stamp to inherit), and for every row written before
+    # this column existed: readers fall back to started_at.
+    observed_at = Column(DateTime(timezone=True), nullable=True)
     payload = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
@@ -811,6 +842,17 @@ class AppAlert(Base):
     correlation_id = Column(String(64), nullable=True)
     evidence = Column(Text, nullable=True)              # JSON, as received
     tags = Column(Text, nullable=True)                  # JSON list
+    # When the thing the alert is ABOUT was seen, as opposed to fired_at,
+    # which is when the app got round to deciding. Producers that know it
+    # send it in the alert's evidence; NULL for everyone else, and
+    # readers fall back to fired_at.
+    #
+    # fired_at stays the sort key. An inbox ordered by observed time is
+    # not append-only — a read that took longer to OCR would insert its
+    # alarm ABOVE ones already on the guard's screen, where it is
+    # scrolled past rather than seen. So: order by arrival, display when
+    # it happened.
+    observed_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     acknowledged_at = Column(DateTime(timezone=True), nullable=True)
     acknowledged_by = Column(Integer, ForeignKey("users.id"), nullable=True)

--- a/server/routers/alerts_inbox.py
+++ b/server/routers/alerts_inbox.py
@@ -92,6 +92,10 @@ def _row_out(a: AppAlert) -> dict:
         "id": a.id,
         "alert_id": a.alert_id,
         "fired_at": a.fired_at.isoformat() if a.fired_at else None,
+        # When the thing happened, as opposed to when the app decided.
+        # The UI shows this and falls back to fired_at; fired_at stays
+        # the ORDER (see the model) so the inbox is append-only.
+        "observed_at": a.observed_at.isoformat() if a.observed_at else None,
         "severity": a.severity,
         "title": a.title,
         "description": a.description,

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -104,6 +104,17 @@ class TrackEventIn(BaseModel):
     # base64), most promising first. Enrichment sweeps them in order —
     # several diverse OCR attempts per vehicle instead of one.
     candidate_jpegs_b64: list[str] | None = None
+    # Wall-clock capture time of each candidate above, same order. The
+    # winning read's stamp becomes the row's observed_at — the one time
+    # on a plate row that belongs to the vehicle the number came off.
+    # Ignored unless it lines up 1:1 with the crops: a short list would
+    # hand a read someone else's timestamp, which is worse than none.
+    candidate_ts: list[float] | None = None
+    # Capture time of ``evidence_jpeg_b64``. A visit from a camera without
+    # the LPR skill ships no candidates at all, so the sweep below reads
+    # the evidence crop — and until this arrived that read got no
+    # observed_at, which on a default install is EVERY read (#451).
+    evidence_ts: float | None = None
     # The whole camera frame the best crop came from (JPEG, base64). The
     # crop answers "what was it"; a 163x187 rectangle of knuckles cannot
     # answer "where was it and what else was in shot". Optional, and DROPPED
@@ -236,7 +247,7 @@ async def ingest_track_event(
         from services.plate_attempt_cache import cache as _attempt_cache
         from services.plate_enrichment import (
             dedup_window_s, is_duplicate_sighting, note_sighting,
-            stamp_plate_evidence,
+            observed_dt, stamp_plate_evidence,
         )
 
         pending = _attempt_cache.claim(
@@ -256,6 +267,11 @@ async def ingest_track_event(
                 )
             else:
                 row.plate_text = plate
+                # The attempt's own capture time — the frame this read
+                # came off, not this ingest. Tier-0 fires the attempt
+                # the moment the track confirms, which can be minutes
+                # before the visit closes and lands here.
+                row.observed_at = observed_dt(pending.attempt_ts)
                 # Marked as a SINGLE early look: the sweep below may
                 # confirm it (and say how many looks agree) or, when
                 # several later looks disagree, replace it.
@@ -278,13 +294,29 @@ async def ingest_track_event(
     # NOT skip this any more: the candidates are the looks that confirm
     # (or overturn) it — see plate_enrichment's consensus policy.
     candidates: list[bytes] = []
+    candidate_stamps: list[float | None] = []
     if payload.candidate_jpegs_b64 and (not row.plate_text or early_read) \
             and not plate_resolved_as_duplicate:
         import base64 as _b64
 
         from services.evidence_store import MAX_EVIDENCE_BYTES as _MAX
 
-        for encoded in payload.candidate_jpegs_b64[:MAX_INGEST_ATTEMPTS]:
+        # Zipped, not indexed: a crop that fails to decode must take its
+        # stamp out of the list with it, or every later read inherits the
+        # timestamp of a different look.
+        stamps = payload.candidate_ts or []
+        if len(stamps) != len(payload.candidate_jpegs_b64):
+            stamps = []                  # partial/absent -> no observed_at
+        # strict: both branches of the fallback above are exactly as long
+        # as the crop list, so this cannot raise today — it is here so a
+        # future edit that breaks that invariant fails loudly instead of
+        # silently dating reads by another look's clock.
+        paired = list(zip(
+            payload.candidate_jpegs_b64,
+            stamps or [None] * len(payload.candidate_jpegs_b64),
+            strict=True,
+        ))
+        for encoded, stamp in paired[:MAX_INGEST_ATTEMPTS]:
             if not isinstance(encoded, str) \
                     or len(encoded) > (_MAX * 4) // 3 + 8:
                 continue
@@ -292,6 +324,10 @@ async def ingest_track_event(
                 candidates.append(_b64.b64decode(encoded, validate=True))
             except (ValueError, binascii.Error):
                 continue
+            candidate_stamps.append(
+                float(stamp) if isinstance(stamp, (int, float))
+                and not isinstance(stamp, bool) else None
+            )
 
     # An early read is re-checked only against CANDIDATES (fresh looks);
     # OCR-ing the evidence frame alone would be one more single look.
@@ -307,7 +343,8 @@ async def ingest_track_event(
         from services.plate_enrichment import mark_sweep_pending
 
         mark_sweep_pending(row.id)
-        background.add_task(enrich_event_plate, row.id, candidates or None)
+        background.add_task(enrich_event_plate, row.id, candidates or None,
+                            candidate_stamps or None, payload.evidence_ts)
     # Read the id BEFORE releasing: record_track_visit committed, which
     # expires every attribute, so a post-close row.id would try to refresh a
     # detached instance.
@@ -406,6 +443,10 @@ async def run_early_plate_attempt(
                 or row.ended_at >= attempt_dt - timedelta(seconds=10)
             ):
                 row.plate_text = read["plate"][:32]
+                # Same capture time the cache would have carried had the
+                # claim path won this race — the row must not read
+                # differently for having been ingested a moment earlier.
+                row.observed_at = attempt_dt
                 stamp_plate_evidence(row, plate_crop_rel,
                                      frame_path=plate_frame_rel,
                                      reads=1, source="early",
@@ -489,6 +530,12 @@ async def internal_list_events(
                 "score": e.score,
                 "started_at": e.started_at.isoformat() if e.started_at else None,
                 "ended_at": e.ended_at.isoformat() if e.ended_at else None,
+                # When the plate was seen, for apps that log or report on
+                # reads — the visit's start is a different moment. Null
+                # when unknown; fall back to started_at.
+                "observed_at": (
+                    e.observed_at.isoformat() if e.observed_at else None
+                ),
                 "stationary": (e.payload or {}).get("stationary"),
                 "plate_text": e.plate_text,
                 "has_evidence": bool(e.evidence_path),

--- a/server/routers/timeline_events.py
+++ b/server/routers/timeline_events.py
@@ -52,6 +52,13 @@ def _serialize(e: TimelineEvent) -> dict:
         "score": e.score,
         "track_id": e.track_id,
         "started_at": e.started_at.isoformat() if e.started_at else None,
+        # When the plate on this row was SEEN — the capture time of the
+        # look the read won on. Null on rows with no plate, on reads made
+        # before this existed, and on reads taken from the visit's
+        # evidence frame (which is not a dated look); clients fall back
+        # to started_at, which is the visit's start and NOT the same
+        # moment — on a merged track it can even be a different vehicle.
+        "observed_at": e.observed_at.isoformat() if e.observed_at else None,
         "ended_at": e.ended_at.isoformat() if e.ended_at else None,
         "recording_ref": e.recording_ref,
         "plate_text": e.plate_text,

--- a/server/services/alerts_inbox.py
+++ b/server/services/alerts_inbox.py
@@ -124,6 +124,15 @@ def apply_alert(envelope: object, db=None) -> str:
         severity = "high"
 
     fired_at = _parse_fired_at(envelope.get("fired_at"))
+    # When the thing this alert is ABOUT was seen. Producers that know it
+    # put it in the alert's evidence (the LPR app forwards the plate
+    # event's observed_at); everyone else leaves the row undated and the
+    # UI falls back to fired_at. Evidence is free-form by contract, so a
+    # non-dict or a junk string is simply "not sent".
+    evidence = envelope.get("evidence")
+    observed_at = _parse_fired_at(
+        evidence.get("observed_at") if isinstance(evidence, dict) else None
+    )
     source = envelope.get("source")
     source_kind = source_name = None
     if isinstance(source, dict):
@@ -159,6 +168,7 @@ def apply_alert(envelope: object, db=None) -> str:
             correlation_id=_clip(envelope.get("correlation_id"), 64),
             evidence=_json_or_none(envelope.get("evidence")),
             tags=_json_or_none(envelope.get("tags")),
+            observed_at=observed_at,
         )
         # Snapshot BEFORE commit: commit expires the instance, and every
         # attribute read after it is a fresh SELECT the write path has no
@@ -208,6 +218,12 @@ def _json_or_none(value: object) -> str | None:
 
 
 def _parse_fired_at(value: object):
+    """An ISO-8601 wire timestamp as a datetime, or None.
+
+    Used for both ``fired_at`` (when the app decided) and the evidence's
+    ``observed_at`` (when the thing happened). Anything unparseable is
+    None — a producer's bad timestamp must never cost us the alert.
+    """
     from datetime import datetime
 
     if not isinstance(value, str):

--- a/server/services/plate_enrichment.py
+++ b/server/services/plate_enrichment.py
@@ -779,6 +779,24 @@ def store_plate_images(
     return store_plate_crop(jpeg, box), store_plate_frame(jpeg)
 
 
+def observed_dt(ts: float | None):
+    """Producer epoch seconds -> aware UTC datetime, or None.
+
+    Producers report capture times as epoch floats; ``events.observed_at``
+    is a timezone-aware DateTime. Junk in must never break a write that is
+    otherwise fine — the row simply keeps no observed time, and readers
+    fall back to started_at.
+    """
+    from datetime import datetime as _datetime, timezone as _timezone
+
+    if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+        return None
+    try:
+        return _datetime.fromtimestamp(float(ts), tz=_timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
 def stamp_plate_evidence(row, rel_path: str | None, *,
                          frame_path: str | None = None,
                          merged: bool = False,
@@ -833,6 +851,11 @@ def clear_plate(row) -> None:
     row.plate_text = None
     row.plate_evidence_path = None
     row.plate_frame_path = None
+    # observed_at dates the READ, so it goes with it. Left behind, it
+    # would keep overriding started_at on a row that is once more an
+    # ordinary vehicle visit — the UI would show the retracted read's
+    # moment as the time the car was seen.
+    row.observed_at = None
     payload = dict(row.payload or {})
     for key in _PLATE_MARKS:
         payload.pop(key, None)
@@ -967,7 +990,8 @@ def is_duplicate_sighting(camera_id: int, plate: str,
 
 
 async def _ocr_jpeg(jpeg: bytes, camera_handle: str,
-                    event_id: int | None = None) -> dict | None:
+                    event_id: int | None = None,
+                    observed_at: float | None = None) -> dict | None:
     """One OCR attempt through KAI-C. Returns ``extract_read``'s dict,
     or None on transport failure / non-200 / empty read. Factored out
     of ``enrich_event_plate`` so the early-attempt endpoint and the
@@ -981,6 +1005,14 @@ async def _ocr_jpeg(jpeg: bytes, camera_handle: str,
     params: dict = {"camera_id": camera_handle}
     if event_id is not None:
         params["event_id"] = int(event_id)
+    # Client reference, exactly like event_id: KAI-C echoes it into
+    # plate.recognized.v1 and never interprets it, so a consumer that only
+    # ever sees the bus (the LPR app, and its alarm) can show the same
+    # moment this row will. Sent in the wire form the event uses — an
+    # ISO-8601 UTC string — so no clock semantics travel with it.
+    observed = observed_dt(observed_at)
+    if observed is not None:
+        params["observed_at"] = observed.replace(microsecond=0).isoformat()
     payload = build_infer_payload(task=PLATE_TASK, jpeg_bytes=jpeg,
                                   params=params)
     try:
@@ -1030,6 +1062,8 @@ def _row_already_reads(event_id: int, plate: str) -> bool:
 
 async def enrich_event_plate(
     event_id: int, candidate_jpegs: list[bytes] | None = None,
+    candidate_ts: list[float | None] | None = None,
+    evidence_ts: float | None = None,
 ) -> None:
     """Background task: read the visit's plate, multi-frame style.
 
@@ -1097,6 +1131,12 @@ async def enrich_event_plate(
         # sole attempt when none were shipped (pre-multi-frame producers,
         # non-LPR cameras).
         attempts: list[bytes] = list(candidate_jpegs or [])[:MAX_INGEST_ATTEMPTS]
+        # Capture time per attempt, same order. Only trusted when it lines
+        # up 1:1 — a short list would give a read the timestamp of a
+        # different look, and a wrong observed time is worse than none.
+        stamps: list[float | None] = list(candidate_ts or [])[:MAX_INGEST_ATTEMPTS]
+        if len(stamps) != len(attempts):
+            stamps = [None] * len(attempts)
         if not attempts:
             if not evidence_path:
                 return
@@ -1106,6 +1146,12 @@ async def enrich_event_plate(
             # Off the loop: a full-frame read is blocking file I/O on the
             # same loop every other request is served from.
             attempts = [await _asyncio.to_thread(path.read_bytes)]
+            # It IS a look with a time of its own: the tracker stamps the
+            # frame it cut the best crop from, and Tier-0 ships that as
+            # evidence_ts. This branch is not a rare fallback — a camera
+            # without the LPR skill retains no candidate ring, so every
+            # one of its reads lands here.
+            stamps = [evidence_ts]
 
         # The early read (a single track-confirm look, already on the
         # row) is one vote. It brings its own stored images, so a
@@ -1131,16 +1177,22 @@ async def enrich_event_plate(
         # winning crop is the only image that actually shows this plate,
         # and it is discarded the moment this function returns unless we
         # persist it here.
-        rejects: list[tuple[dict, bytes]] = []
+        rejects: list[tuple[dict, bytes, float | None]] = []
         jpeg_of: dict[int, bytes] = {}
+        # Same keying as jpeg_of: the capture time of the look each read
+        # came from, so the winner can date itself.
+        ts_of: dict[int, float | None] = {}
         merged_ids: set[int] = set()
-        for jpeg in attempts:
-            read = await _ocr_jpeg(jpeg, camera_handle, event_id=event_id)
+        # strict: the guard above forces len(stamps) == len(attempts).
+        for jpeg, stamp in zip(attempts, stamps, strict=True):
+            read = await _ocr_jpeg(jpeg, camera_handle, event_id=event_id,
+                                   observed_at=stamp)
             if read is None:
                 continue
             if read["accepted"]:
                 votes.append(read)
                 jpeg_of[id(read)] = jpeg
+                ts_of[id(read)] = stamp
             else:
                 # Character-consensus with every earlier reject: two near
                 # misses of the same plate often reconstruct the truth.
@@ -1152,16 +1204,20 @@ async def enrich_event_plate(
                 # in: the contributors are different frames, so the
                 # loser's box would cut the wrong rectangle out of the
                 # winner's pixels (#385).
-                for prev, prev_jpeg in rejects:
+                for prev, prev_jpeg, prev_ts in rejects:
                     merged = merge_reads(prev, read)
                     if merged is not None and merged["accepted"]:
                         keep_prev = prev["confidence"] >= read["confidence"]
                         merged["box"] = (prev if keep_prev else read).get("box")
                         votes.append(merged)
                         jpeg_of[id(merged)] = prev_jpeg if keep_prev else jpeg
+                        # The time follows the pixels: a merged plate is
+                        # whole in neither look, so it is dated by the
+                        # same contributor whose crop and box it keeps.
+                        ts_of[id(merged)] = prev_ts if keep_prev else stamp
                         merged_ids.add(id(merged))
                         break
-                rejects.append((read, jpeg))
+                rejects.append((read, jpeg, stamp))
             # Enough agreeing looks already? Then the rest of the budget
             # is pure waste — stop here.
             if len(votes) >= min_agree:
@@ -1183,6 +1239,10 @@ async def enrich_event_plate(
             return                       # honest non-read beats a guess
         plate = winner["plate"][:32]
         was_merged = id(winner) in merged_ids
+        # The moment the winning look was captured. None when the looks
+        # came without stamps (a producer predating candidate_ts, or the
+        # evidence-frame fallback) — the row then keeps no observed time.
+        won_at = observed_dt(ts_of.get(id(winner)))
         if prior_plate and plate == prior_plate:
             # The early read held up; the row just learns how many
             # looks agree with it (and keeps the images it already has).
@@ -1191,6 +1251,11 @@ async def enrich_event_plate(
                 row = db.query(TimelineEvent).filter(
                     TimelineEvent.id == event_id).first()
                 if row is not None and row.plate_text == plate:
+                    # The early read already dated this row from its own
+                    # attempt; only fill a gap, never overwrite (the
+                    # early look IS the read being confirmed).
+                    if row.observed_at is None and won_at is not None:
+                        row.observed_at = won_at
                     stamp_plate_evidence(row, None, reads=agreeing,
                                          source="sweep")
                     db.commit()
@@ -1246,6 +1311,8 @@ async def enrich_event_plate(
                     # SAME plate while we were in OCR — from the very
                     # bytes we just stored. Give the row the proof it is
                     # missing; never leave a plate without its picture.
+                    if row.observed_at is None and won_at is not None:
+                        row.observed_at = won_at
                     if not row.plate_frame_path or not row.plate_evidence_path:
                         stamp_plate_evidence(row, crop_rel, frame_path=frame_rel,
                                              merged=was_merged,
@@ -1302,6 +1369,11 @@ async def enrich_event_plate(
                 note_sighting(camera_id, plate)
                 return
             row.plate_text = plate
+            # Set unconditionally here: this branch either writes a plate
+            # onto a bare row or REPLACES a single read the looks
+            # overturned, and a retracted read's timestamp must go with
+            # it — the row is now dated by the look that actually won.
+            row.observed_at = won_at
             stamp_plate_evidence(row, crop_rel, frame_path=frame_rel,
                                  merged=was_merged, reads=agreeing,
                                  source="sweep")

--- a/server/services/plate_event_consumer.py
+++ b/server/services/plate_event_consumer.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from datetime import UTC, datetime
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,24 @@ def _read_is_clipped(box, evidence_path: str | None,
     except Exception:  # noqa: BLE001
         logger.debug("plate consumer: clipping check failed", exc_info=True)
         return False
+
+
+def _observed_at_of(payload: dict):
+    """``observed_at`` off a plate event payload as an aware datetime.
+
+    The contract carries it as an ISO-8601 UTC string (additive and
+    optional — see EVENT_CONTRACTS.md). Anything unparseable is treated
+    as absent: a bad stamp must not cost us an otherwise good read, and a
+    row with no observed time falls back to started_at.
+    """
+    raw = payload.get("observed_at")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
 def apply_plate_event(envelope: object) -> str:
@@ -171,6 +190,10 @@ def apply_plate_event(envelope: object) -> str:
             note_sighting(row.camera_id, normalized)
             return "duplicate"
         row.plate_text = plate.strip()[:32]
+        # When the producer said the look was captured. Optional and
+        # additive: a producer that does not send it leaves the row
+        # undated, and readers fall back to started_at.
+        row.observed_at = _observed_at_of(payload)
         # A single forwarded read: no images, one look. The sweep (if
         # any) may attach evidence or, with several disagreeing looks,
         # replace it — see plate_enrichment's precedence rules.

--- a/server/services/timeline_service.py
+++ b/server/services/timeline_service.py
@@ -27,10 +27,34 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from sqlalchemy import func as _func
 from sqlalchemy.orm import Session
 
 from models import TimelineEvent
 from services.camera_scope import can_view_camera, scope_query
+
+#: When a PLATE READ happened, for the aggregations below.
+#:
+#: ``observed_at`` is the capture time of the look the read won on;
+#: ``started_at`` is the VISIT's start, which is a different moment and,
+#: on a merged track, can belong to a different vehicle entirely. Reads
+#: written before observed_at existed have only the fallback (#451).
+#:
+#: This matters most where reads are SUBTRACTED. A dwell time built from
+#: two started_at values is off by the difference between two visits'
+#: OCR lag, and that lag is largest exactly when a gate is busiest — so
+#: the number was least trustworthy when it mattered most.
+#:
+#: Only for plate-filtered queries. ``query_events`` deliberately keeps
+#: filtering by started_at: it ranges over EVERY visit (people, vehicles,
+#: alarms), most of which have no read to be dated by, and the visit's
+#: start is the honest answer to "who was here between 3 and 4".
+SEEN_AT = _func.coalesce(TimelineEvent.observed_at, TimelineEvent.started_at)
+
+
+def seen_at_of(row) -> datetime | None:
+    """The Python-side twin of :data:`SEEN_AT`, for rows already loaded."""
+    return getattr(row, "observed_at", None) or row.started_at
 
 
 def record_track_visit(
@@ -142,7 +166,7 @@ def plate_stats(
     base = (
         db.query(TimelineEvent)
         .filter(TimelineEvent.plate_text.isnot(None))
-        .filter(TimelineEvent.started_at >= cutoff)
+        .filter(SEEN_AT >= cutoff)
     )
     base = scope_query(base, TimelineEvent.camera_id, scope)
 
@@ -163,11 +187,11 @@ def plate_stats(
         )
     ]
     # Day bucketing in SQL is dialect-divergent (date_trunc vs strftime);
-    # the window is small (<= a few thousand rows of (id, started_at)),
+    # the window is small (<= a few thousand rows of one timestamp),
     # so bucket in Python for portability.
     per_day_counts: dict[str, int] = {}
-    for (started_at,) in base.with_entities(TimelineEvent.started_at).all():
-        day = started_at.date().isoformat()
+    for (seen_at,) in base.with_entities(SEEN_AT).all():
+        day = seen_at.date().isoformat()
         per_day_counts[day] = per_day_counts.get(day, 0) + 1
     per_day = [
         {"day": day, "reads": per_day_counts[day]}
@@ -203,9 +227,7 @@ def plate_summary(
 
     total = base.count()
     first_seen, last_seen = (
-        base.with_entities(
-            func.min(TimelineEvent.started_at), func.max(TimelineEvent.started_at)
-        ).one()
+        base.with_entities(func.min(SEEN_AT), func.max(SEEN_AT)).one()
         if total
         else (None, None)
     )
@@ -260,18 +282,21 @@ def plate_sessions(
         .filter(TimelineEvent.camera_id.in_(gates))
     )
     q = scope_query(q, TimelineEvent.camera_id, scope)
-    reads = q.order_by(TimelineEvent.started_at.asc()).all()
+    reads = q.order_by(SEEN_AT.asc()).all()
 
     def _row(entry, exit_) -> dict:
+        entered = seen_at_of(entry) if entry is not None else None
+        exited = seen_at_of(exit_) if exit_ is not None else None
         duration = None
-        if entry is not None and exit_ is not None:
-            duration = max(
-                0, int((exit_.started_at - entry.started_at).total_seconds())
-            )
+        if entered is not None and exited is not None:
+            # Both ends are READ times, so the difference is how long the
+            # vehicle was inside — not that plus the difference between
+            # two visits' OCR lag.
+            duration = max(0, int((exited - entered).total_seconds()))
         return {
-            "entered_at": entry.started_at.isoformat() if entry else None,
+            "entered_at": entered.isoformat() if entered else None,
             "entry_camera_id": entry.camera_id if entry else None,
-            "exited_at": exit_.started_at.isoformat() if exit_ else None,
+            "exited_at": exited.isoformat() if exited else None,
             "exit_camera_id": exit_.camera_id if exit_ else None,
             "duration_seconds": duration,
         }
@@ -324,11 +349,11 @@ def gate_occupancy(
         db.query(TimelineEvent)
         .filter(TimelineEvent.plate_text.isnot(None))
         .filter(TimelineEvent.camera_id.in_(gates))
-        .filter(TimelineEvent.started_at >= cutoff)
+        .filter(SEEN_AT >= cutoff)
     )
     q = scope_query(q, TimelineEvent.camera_id, scope)
     last_by_plate: dict[str, TimelineEvent] = {}
-    for r in q.order_by(TimelineEvent.started_at.asc()).all():
+    for r in q.order_by(SEEN_AT.asc()).all():
         last_by_plate[r.plate_text] = r
     inside = sorted(
         p for p, r in last_by_plate.items() if r.camera_id in in_set
@@ -364,8 +389,8 @@ def vehicle_report(
     base = (
         db.query(TimelineEvent)
         .filter(TimelineEvent.plate_text.isnot(None))
-        .filter(TimelineEvent.started_at >= start)
-        .filter(TimelineEvent.started_at < end)
+        .filter(SEEN_AT >= start)
+        .filter(SEEN_AT < end)
     )
     base = scope_query(base, TimelineEvent.camera_id, scope)
 
@@ -383,8 +408,8 @@ def vehicle_report(
         base.with_entities(
             TimelineEvent.plate_text,
             func.count(TimelineEvent.id),
-            func.min(TimelineEvent.started_at),
-            func.max(TimelineEvent.started_at),
+            func.min(SEEN_AT),
+            func.max(SEEN_AT),
         )
         .group_by(TimelineEvent.plate_text)
         .order_by(func.count(TimelineEvent.id).desc())
@@ -393,13 +418,12 @@ def vehicle_report(
     )
     per_plate_cameras: dict[str, dict[int, int]] = {}
     per_day_counts: dict[str, int] = {}
-    for plate, cid, started_at in base.with_entities(
-        TimelineEvent.plate_text, TimelineEvent.camera_id,
-        TimelineEvent.started_at,
+    for plate, cid, seen_at in base.with_entities(
+        TimelineEvent.plate_text, TimelineEvent.camera_id, SEEN_AT,
     ).all():
         per_plate_cameras.setdefault(plate, {})
         per_plate_cameras[plate][cid] = per_plate_cameras[plate].get(cid, 0) + 1
-        day = started_at.date().isoformat()
+        day = seen_at.date().isoformat()
         per_day_counts[day] = per_day_counts.get(day, 0) + 1
 
     per_plate = [

--- a/server/tests/test_alerts_inbox.py
+++ b/server/tests/test_alerts_inbox.py
@@ -197,6 +197,53 @@ def test_unparseable_fired_at_still_stores(db):
     assert _rows(SessionLocal)[0].fired_at is not None
 
 
+# ── observed_at: when it happened vs when the app decided (#451) ───
+
+
+def test_the_alert_carries_when_the_thing_was_seen(db):
+    """fired_at is when the producing app finished deciding; observed_at
+    is when the plate was actually read. Storing only fired_at is what
+    made one read show two different times — this page and the vehicle
+    list disagreed by however long OCR and the bus took."""
+    SessionLocal, _ = db
+    assert apply_alert(_envelope(
+        evidence={"plate": "ZZ999XX",
+                  "observed_at": "2026-09-03T09:59:52+00:00"},
+    )) == "stored"
+    row = _rows(SessionLocal)[0]
+    assert row.observed_at is not None
+    # Eight seconds before the app fired — the pipeline lag, now visible
+    # rather than baked into the only timestamp on the row.
+    assert row.observed_at.replace(tzinfo=None).isoformat()         == "2026-09-03T09:59:52"
+    assert row.fired_at is not None
+
+
+def test_an_alert_without_an_observed_time_is_undated_not_guessed(db):
+    """Producers that do not send one leave it NULL and the UI falls
+    back to fired_at. Copying fired_at in here would forge the very
+    distinction the column exists to make."""
+    SessionLocal, _ = db
+    assert apply_alert(_envelope()) == "stored"
+    assert _rows(SessionLocal)[0].observed_at is None
+
+
+def test_a_junk_observed_time_never_costs_us_the_alert(db):
+    """An app bug in one field must not hide a fired alarm."""
+    SessionLocal, _ = db
+    for i, junk in enumerate([12345, "not-a-date", None, {"a": 1}]):
+        assert apply_alert(_envelope(
+            alert_id=f"alrt_junk{i}",
+            evidence={"observed_at": junk},
+        )) == "stored"
+    assert all(r.observed_at is None for r in _rows(SessionLocal))
+
+
+def test_evidence_that_is_not_a_dict_is_simply_not_a_source(db):
+    SessionLocal, _ = db
+    assert apply_alert(_envelope(evidence="just a string")) == "stored"
+    assert _rows(SessionLocal)[0].observed_at is None
+
+
 # ── the API (list / ack / ring config) ─────────────────────────────
 
 

--- a/server/tests/test_plate_consensus.py
+++ b/server/tests/test_plate_consensus.py
@@ -160,7 +160,7 @@ class _ScriptedOcr:
         self.reads = list(reads)
         self.calls = []
 
-    async def __call__(self, jpeg, camera_handle, event_id=None):
+    async def __call__(self, jpeg, camera_handle, event_id=None, observed_at=None):
         self.calls.append((jpeg, camera_handle, event_id))
         return self.reads.pop(0) if self.reads else None
 
@@ -442,7 +442,7 @@ def test_sweep_attaches_evidence_when_the_same_plate_landed_meanwhile(
     SessionLocal, row_id = db
     from services.plate_event_consumer import apply_plate_event
 
-    async def racing_ocr(jpeg, camera_handle, event_id=None):
+    async def racing_ocr(jpeg, camera_handle, event_id=None, observed_at=None):
         # the bus consumer wins the write while the sweep is in OCR
         # (simulating an install without the pending-mark, or a foreign
         # producer's event for the same row)
@@ -466,7 +466,7 @@ def test_sweep_consensus_replaces_a_lone_bus_write(db, stored, monkeypatch):
     SessionLocal, row_id = db
     from services.plate_event_consumer import apply_plate_event
 
-    async def racing_ocr(jpeg, camera_handle, event_id=None):
+    async def racing_ocr(jpeg, camera_handle, event_id=None, observed_at=None):
         if jpeg == b"a":
             assert apply_plate_event(_envelope(row_id, "R183JF")) == "applied"
         return _acc("R197GB", 0.9)

--- a/server/tests/test_plate_dedup.py
+++ b/server/tests/test_plate_dedup.py
@@ -204,7 +204,7 @@ class _ScriptedOcr:
         self.reads = list(reads)
         self.calls = []
 
-    async def __call__(self, jpeg, camera_handle, event_id=None):
+    async def __call__(self, jpeg, camera_handle, event_id=None, observed_at=None):
         self.calls.append((jpeg, camera_handle, event_id))
         return self.reads.pop(0) if self.reads else None
 
@@ -341,7 +341,7 @@ def test_early_attempt_duplicate_parks_but_never_writes_the_row(db, monkeypatch)
     s.commit()
     s.close()
 
-    async def fake_ocr(jpeg, camera_handle, event_id=None):
+    async def fake_ocr(jpeg, camera_handle, event_id=None, observed_at=None):
         return _accepted("66HH07", conf=0.98)
 
     monkeypatch.setattr(pe, "_ocr_jpeg", fake_ocr)

--- a/server/tests/test_plate_event_consumer.py
+++ b/server/tests/test_plate_event_consumer.py
@@ -190,7 +190,10 @@ def test_enrichment_fallback_threads_event_id():
     # pool — so `row` is not in scope there any more; the function's own
     # event_id parameter is the same value that row.id was.)
     src = (_HERE / "services" / "plate_enrichment.py").read_text()
-    assert "await _ocr_jpeg(jpeg, camera_handle, event_id=event_id)" in src, (
+    # Trailing comma, not a closing paren: the call also carries
+    # observed_at now (the capture time the domain event echoes), so
+    # pinning the whole call would break on every additive argument.
+    assert "await _ocr_jpeg(jpeg, camera_handle, event_id=event_id," in src, (
         "plate_enrichment no longer sends event_id with its OCR call — "
         "the plate.recognized.v1 it triggers can't be joined back to the "
         "visit row, so the bus consumer becomes a no-op for the fallback "

--- a/server/tests/test_plate_multiframe.py
+++ b/server/tests/test_plate_multiframe.py
@@ -250,7 +250,7 @@ class _ScriptedOcr:
         self.reads = list(reads)
         self.calls = []
 
-    async def __call__(self, jpeg, camera_handle, event_id=None):
+    async def __call__(self, jpeg, camera_handle, event_id=None, observed_at=None):
         self.calls.append((jpeg, camera_handle, event_id))
         return self.reads.pop(0) if self.reads else None
 
@@ -339,9 +339,21 @@ def test_ingest_claims_the_cache_and_passes_candidates():
     assert "_attempt_cache.claim(" in src, (
         "ingest no longer claims early-attempt reads — the latency half "
         "of multi-frame OCR is disconnected")
-    assert "background.add_task(enrich_event_plate, row.id, candidates or None)" in src, (
+    assert "background.add_task(enrich_event_plate, row.id, candidates or None," in src, (
         "ingest no longer hands candidates to the enrichment sweep — the "
         "recall half of multi-frame OCR is disconnected")
+    # Named, not positional: these assert the two time sources reach the
+    # sweep, and an earlier version pinned the exact closing paren — which
+    # broke the moment a third argument was added, flagging a correct
+    # change as a regression. What matters is that both are passed.
+    assert "candidate_stamps" in src, (
+        "ingest no longer hands the candidates' capture times to the "
+        "sweep — a winning read would have no observed_at, and the "
+        "vehicle list would fall back to the visit's start time (#451)")
+    assert "payload.evidence_ts" in src, (
+        "ingest no longer hands the evidence frame's capture time to the "
+        "sweep — and on a camera without the LPR skill that is the ONLY "
+        "look there is, so every one of its reads would be undated (#451)")
     assert '@router.post("/plates/attempt"' in src, (
         "the early-attempt endpoint is gone — Tier-0's posts would 404")
 
@@ -378,7 +390,7 @@ def test_early_attempt_parks_read_and_covers_the_ingest_race(db, monkeypatch):
     s.commit()
     s.close()
 
-    async def fake_ocr(jpeg, camera_handle, event_id=None):
+    async def fake_ocr(jpeg, camera_handle, event_id=None, observed_at=None):
         assert camera_handle.startswith("cam")
         return _accepted("RACE99")
 
@@ -403,7 +415,7 @@ def test_early_attempt_rejected_read_parks_nothing(db, monkeypatch):
     fresh = pac.PlateAttemptCache()
     monkeypatch.setattr(pac, "cache", fresh)
 
-    async def fake_ocr(jpeg, camera_handle, event_id=None):
+    async def fake_ocr(jpeg, camera_handle, event_id=None, observed_at=None):
         return _rejected("JUNK1", [0.1] * 5)
 
     monkeypatch.setattr(pe, "_ocr_jpeg", fake_ocr)
@@ -592,7 +604,7 @@ def test_early_attempt_carries_its_crop_through_to_the_row(
     s.commit()
     s.close()
 
-    async def fake_ocr(jpeg, camera_handle, event_id=None):
+    async def fake_ocr(jpeg, camera_handle, event_id=None, observed_at=None):
         return _accepted("EARLY7")
 
     monkeypatch.setattr(pe, "_ocr_jpeg", fake_ocr)
@@ -803,9 +815,9 @@ def test_the_sweep_holds_no_session_while_ocr_runs(db, monkeypatch):
     monkeypatch.setattr(cdb, "SessionLocal", _tracking)
 
     class _Watching(_ScriptedOcr):
-        async def __call__(self, jpeg, camera_handle, event_id=None):
+        async def __call__(self, jpeg, camera_handle, event_id=None, observed_at=None):
             live["peak_during_ocr"] = max(live["peak_during_ocr"], live["n"])
-            return await super().__call__(jpeg, camera_handle, event_id)
+            return await super().__call__(jpeg, camera_handle, event_id, observed_at)
 
     monkeypatch.setattr(pe, "_ocr_jpeg", _Watching([_accepted("CLEAR1")]))
     asyncio.run(pe.enrich_event_plate(row_id, [b"a"]))
@@ -824,14 +836,14 @@ def test_a_plate_written_during_ocr_is_not_overwritten(db, monkeypatch):
     SessionLocal, row_id = db
 
     class _RacingOcr(_ScriptedOcr):
-        async def __call__(self, jpeg, camera_handle, event_id=None):
+        async def __call__(self, jpeg, camera_handle, event_id=None, observed_at=None):
             other = SessionLocal()
             try:
                 other.get(models.TimelineEvent, row_id).plate_text = "EARLY1"
                 other.commit()
             finally:
                 other.close()
-            return await super().__call__(jpeg, camera_handle, event_id)
+            return await super().__call__(jpeg, camera_handle, event_id, observed_at)
 
     monkeypatch.setattr(pe, "_ocr_jpeg", _RacingOcr([_accepted("LATE99")]))
     asyncio.run(pe.enrich_event_plate(row_id, [b"a"]))
@@ -844,14 +856,14 @@ def test_a_row_deleted_during_ocr_does_not_raise(db, monkeypatch):
     SessionLocal, row_id = db
 
     class _DeletingOcr(_ScriptedOcr):
-        async def __call__(self, jpeg, camera_handle, event_id=None):
+        async def __call__(self, jpeg, camera_handle, event_id=None, observed_at=None):
             other = SessionLocal()
             try:
                 other.delete(other.get(models.TimelineEvent, row_id))
                 other.commit()
             finally:
                 other.close()
-            return await super().__call__(jpeg, camera_handle, event_id)
+            return await super().__call__(jpeg, camera_handle, event_id, observed_at)
 
     monkeypatch.setattr(pe, "_ocr_jpeg", _DeletingOcr([_accepted("GONE11")]))
     asyncio.run(pe.enrich_event_plate(row_id, [b"a"]))   # must not raise

--- a/server/tests/test_plate_observed_at.py
+++ b/server/tests/test_plate_observed_at.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""One timestamp per plate read: ``events.observed_at`` (#451).
+
+The failure these exist for: a plate read had no time of its own, so the
+vehicle list dated it by the VISIT's start and the alarm inbox dated it
+by when the app finished deciding. Two clocks for one read, drifting
+apart by however long OCR and the bus took — and neither of them scrubs
+to the frame the plate is legible in.
+
+The rule pinned here: a row is dated by the LOOK the read won on, or not
+at all. A wrong observed time is worse than none, because readers fall
+back to started_at when it is NULL and that fallback is at least honest
+about what it is.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(32))
+os.environ.setdefault("ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+import core.database as cdb             # noqa: E402
+import models                           # noqa: E402
+import services.plate_enrichment as pe   # noqa: E402
+
+T1 = 1_788_000_061.0                    # the first look
+T2 = 1_788_000_064.0                    # the second, three seconds later
+
+
+@pytest.fixture(autouse=True)
+def _first_read_wins(monkeypatch):
+    """These pin WHEN a read is dated, not how many looks it takes to
+    win one — the consensus policy has its own file. One accepted read
+    wins here so each dating rule can be asserted alone.
+
+    The sweep registry is process-global (finished sweeps hold their row
+    for the echo grace), so it starts clean too.
+    """
+    monkeypatch.setenv("OPENNVR_PLATE_MIN_AGREEING_READS", "1")
+    with pe._sweeps_lock:
+        pe._sweeping.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_plate_sightings():
+    """The dedup sightings map is process-global on purpose (that IS the
+    feature), which makes it cross-test state by accident. These tests
+    read the SAME plate repeatedly, so without this every test after the
+    first would have its read folded as a duplicate sighting."""
+    with pe._sightings_lock:
+        pe._recent_sightings.clear()
+    yield
+    with pe._sightings_lock:
+        pe._recent_sightings.clear()
+
+
+@pytest.fixture()
+def db(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    monkeypatch.setitem(sys.modules, "models", models)
+    eng = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    models.Base.metadata.create_all(eng)
+    SessionLocal = sessionmaker(bind=eng)
+    monkeypatch.setattr(cdb, "SessionLocal", SessionLocal)
+    s = SessionLocal()
+    role = models.Role(name="admin")
+    s.add(role)
+    s.commit()
+    user = models.User(username="u", email="u@x", hashed_password="x",
+                       role_id=role.id)
+    s.add(user)
+    s.commit()
+    cam = models.Camera(name="c", ip_address="10.0.0.5", owner_id=user.id)
+    s.add(cam)
+    s.commit()
+    row = models.TimelineEvent(
+        camera_id=cam.id, source="tier0", event_type="track", label="car",
+        # Deliberately far from either look: a test that passed by
+        # accidentally reading started_at would show up as a wrong value,
+        # not as a right one.
+        started_at=datetime(2026, 9, 1, 9, 0, tzinfo=timezone.utc),
+    )
+    s.add(row)
+    s.commit()
+    row_id = row.id
+    s.close()
+    yield SessionLocal, row_id
+
+
+def _epoch(dt) -> float:
+    """``observed_at`` as epoch seconds, tz-normalised.
+
+    SQLite has no timezone type, so SQLAlchemy hands back a NAIVE
+    datetime carrying the UTC wall time we wrote (``DateTime(timezone=
+    True)`` is advisory there; Postgres keeps the offset). Calling
+    .timestamp() on that would read it as LOCAL time and silently shift
+    every assertion by the runner's UTC offset.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _row(SessionLocal, row_id):
+    s = SessionLocal()
+    try:
+        r = s.get(models.TimelineEvent, row_id)
+        return r.plate_text, r.observed_at
+    finally:
+        s.close()
+
+
+class _ScriptedOcr:
+    def __init__(self, reads):
+        self.reads = list(reads)
+        self.calls = []
+
+    async def __call__(self, jpeg, camera_handle, event_id=None,
+                       observed_at=None):
+        self.calls.append((jpeg, camera_handle, event_id, observed_at))
+        return self.reads.pop(0) if self.reads else None
+
+
+_BOX = (10.0, 20.0, 110.0, 50.0)
+
+
+def _accepted(plate="GOOD42", conf=0.9, box=_BOX):
+    return {"plate": plate, "confidence": conf,
+            "characters": [conf] * len(plate), "accepted": True,
+            "floor": 0.45, "box": box}
+
+
+def _rejected(plate, chars, floor=0.45, box=_BOX):
+    return {"plate": plate, "confidence": min(chars), "characters": chars,
+            "accepted": False, "floor": floor, "box": box}
+
+
+# ── the sweep dates the row by the winning look ────────────────────
+
+
+def test_sweep_dates_the_row_by_the_look_the_read_won_on(db, monkeypatch):
+    SessionLocal, row_id = db
+    # The FIRST look is rejected, so the read is won on the second — and
+    # the row must carry the second look's time, not the first's.
+    ocr = _ScriptedOcr([None, _accepted("H644LX")])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, [b"1", b"2"], [T1, T2]))
+    plate, observed = _row(SessionLocal, row_id)
+    assert plate == "H644LX"
+    assert observed is not None, "a read with a dated look must be dated"
+    assert _epoch(observed) == T2
+
+
+def test_the_capture_time_travels_to_kai_c_with_the_look(db, monkeypatch):
+    """It rides the infer payload so KAI-C can echo it into
+    plate.recognized.v1 — the only way an app consuming the bus (and the
+    alarm it raises) can show the same moment this row will."""
+    SessionLocal, row_id = db
+    ocr = _ScriptedOcr([_accepted("H644LX")])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, [b"1"], [T1]))
+    assert ocr.calls[0][3] == T1
+
+
+def test_a_producer_without_stamps_leaves_the_row_undated(db, monkeypatch):
+    """NULL, never a guess: readers fall back to started_at, which is at
+    least honest about being the visit's start."""
+    SessionLocal, row_id = db
+    ocr = _ScriptedOcr([_accepted("H644LX")])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, [b"1", b"2"]))
+    plate, observed = _row(SessionLocal, row_id)
+    assert plate == "H644LX" and observed is None
+
+
+def test_stamps_that_do_not_line_up_with_the_looks_are_ignored(db, monkeypatch):
+    """A short list would date every read past the gap by a different
+    look's clock. Drop the lot instead."""
+    SessionLocal, row_id = db
+    ocr = _ScriptedOcr([None, _accepted("H644LX")])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, [b"1", b"2"], [T1]))
+    plate, observed = _row(SessionLocal, row_id)
+    assert plate == "H644LX" and observed is None
+
+
+def test_a_merged_read_is_dated_by_the_contributor_it_keeps(db, monkeypatch):
+    """A merged plate is whole in neither look, so it is dated by the
+    same contributor whose crop and box it keeps — the more confident
+    one, here the first."""
+    SessionLocal, row_id = db
+    a = _rejected("H644LX", [0.9, 0.9, 0.9, 0.9, 0.9, 0.60])
+    b = _rejected("H644LK", [0.5, 0.5, 0.5, 0.5, 0.5, 0.20])
+    ocr = _ScriptedOcr([a, b])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, [b"1", b"2"], [T1, T2]))
+    plate, observed = _row(SessionLocal, row_id)
+    assert plate == "H644LX"
+    assert _epoch(observed) == T1
+
+
+def _with_evidence_file(SessionLocal, row_id, tmp_path, monkeypatch):
+    """Give the row a real evidence JPEG so the no-candidates branch
+    actually reads it instead of bailing on a missing file."""
+    from services import evidence_store
+
+    root = tmp_path / "evidence"
+    (root / "cam").mkdir(parents=True)
+    (root / "cam" / "best.jpg").write_bytes(b"jpegbytes")
+    monkeypatch.setattr(evidence_store, "evidence_root", lambda: root)
+    s = SessionLocal()
+    s.get(models.TimelineEvent, row_id).evidence_path = "cam/best.jpg"
+    s.commit()
+    s.close()
+
+
+def test_the_evidence_frame_fallback_is_dated_by_the_frame_it_read(
+        db, monkeypatch, tmp_path):
+    """A camera without the LPR skill retains no candidate ring, so EVERY
+    one of its reads takes this branch. It used to leave observed_at null,
+    which made the whole feature inert on a default install: the vehicle
+    list fell back to the visit start and disagreed with the alarm again.
+
+    The crop is a look with a time of its own — the tracker stamps the
+    frame it cut it from, and Tier-0 ships that as evidence_ts.
+    """
+    SessionLocal, row_id = db
+    _with_evidence_file(SessionLocal, row_id, tmp_path, monkeypatch)
+    ocr = _ScriptedOcr([_accepted("H644LX")])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, None, None, T1))
+    plate, observed = _row(SessionLocal, row_id)
+    assert plate == "H644LX"
+    assert observed is not None, "the fallback read must carry its frame's time"
+    assert _epoch(observed) == pytest.approx(T1)
+
+
+def test_the_fallback_is_undated_when_the_producer_sends_no_frame_time(
+        db, monkeypatch, tmp_path):
+    """An older Tier-0 ships no evidence_ts. The read still lands; it just
+    has no observed time, and readers fall back to started_at."""
+    SessionLocal, row_id = db
+    _with_evidence_file(SessionLocal, row_id, tmp_path, monkeypatch)
+    ocr = _ScriptedOcr([_accepted("H644LX")])
+    monkeypatch.setattr(pe, "_ocr_jpeg", ocr)
+    asyncio.run(pe.enrich_event_plate(row_id, None, None, None))
+    plate, observed = _row(SessionLocal, row_id)
+    assert plate == "H644LX"
+    assert observed is None
+
+
+# ── a retracted read must not leave its time behind ────────────────
+
+
+def test_a_retracted_read_takes_its_timestamp_with_it():
+    """clear_plate turns a row back into an ordinary vehicle visit. A
+    left-behind observed_at would keep overriding started_at, so the UI
+    would date the visit by a read that no longer exists."""
+    class _Row:
+        plate_text = "H644LX"
+        plate_evidence_path = "a.jpg"
+        plate_frame_path = "b.jpg"
+        observed_at = datetime.now(timezone.utc)
+        payload = {"stationary": False, "plate_reads": 1,
+                   "plate_source": "early"}
+
+    row = _Row()
+    pe.clear_plate(row)
+    assert row.plate_text is None
+    assert row.observed_at is None
+    # The non-plate payload survives, as it always has.
+    assert row.payload == {"stationary": False}
+
+
+# ── the epoch -> datetime edge cases ───────────────────────────────
+
+
+@pytest.mark.parametrize("junk", [None, "nope", True, float("nan"),
+                                  float("inf"), 10 ** 30])
+def test_junk_stamps_never_cost_us_the_read(junk):
+    """A producer's bad clock value must degrade to "undated", never
+    raise into a write path that was otherwise fine."""
+    out = pe.observed_dt(junk)
+    assert out is None or isinstance(out, datetime)
+
+
+def test_observed_dt_round_trips_an_epoch():
+    assert pe.observed_dt(T1).timestamp() == T1

--- a/server/tests/test_plate_stats.py
+++ b/server/tests/test_plate_stats.py
@@ -245,3 +245,151 @@ def test_vehicle_report_owner_scoped(db):
     got = vehicle_report(s, year=2026, month=8, scope=visible_camera_ids(s, users["alice"]))
     assert {p["plate"] for p in got["per_plate"]} == {"AAA111", "BBB222"}
     assert got["total_reads"] == 3
+
+
+# ── the aggregations date a read by observed_at (#451) ─────────────
+#
+# The fixture above sets only started_at, so every test before this
+# point already pins the fallback for rows written before the column
+# existed. These pin the other half: when a read knows when it was
+# SEEN, that is the time the aggregations use.
+
+
+def _read(s, cams, cam, plate, *, started, observed=None):
+    s.add(models.TimelineEvent(
+        camera_id=cams[cam].id, source="tier0", event_type="track",
+        label="car", plate_text=plate,
+        started_at=started, observed_at=observed))
+    s.commit()
+
+
+def test_dwell_time_is_measured_between_reads_not_visit_starts(db):
+    """The headline case. Both visits began well before their plates
+    were read, and by different amounts — a duration built from
+    started_at would silently include the difference between two OCR
+    lags, and that difference is largest when a gate is busiest."""
+    from services.timeline_service import plate_sessions
+
+    s, users, cams = db
+    # In: visit opened at 10:00, plate read at 10:05 (5 min of track).
+    _read(s, cams, "gate", "DWELL1",
+          started=NOW - timedelta(hours=2),
+          observed=NOW - timedelta(hours=2) + timedelta(minutes=5))
+    # Out: visit opened at 11:00, plate read at 11:01 (1 min of track).
+    _read(s, cams, "yard", "DWELL1",
+          started=NOW - timedelta(hours=1),
+          observed=NOW - timedelta(hours=1) + timedelta(minutes=1))
+    got = plate_sessions(
+        s, plate="DWELL1",
+        in_cameras=[cams["gate"].id], out_cameras=[cams["yard"].id],
+        scope=visible_camera_ids(s, users["alice"]))
+    closed = got["sessions"][0]
+    # Read to read: 10:05 -> 11:01 = 56 minutes. Visit start to visit
+    # start would have said 60 — four minutes of our own OCR lag,
+    # reported to the operator as time the vehicle was on site.
+    assert closed["duration_seconds"] == 56 * 60
+    assert closed["entered_at"].startswith("2026-08-29T10:05")
+    assert closed["exited_at"].startswith("2026-08-29T11:01")
+
+
+def test_first_and_last_seen_use_the_read_time(db):
+    from services.timeline_service import plate_summary
+
+    s, users, cams = db
+    _read(s, cams, "gate", "SEEN01",
+          started=NOW - timedelta(hours=3),
+          observed=NOW - timedelta(hours=3) + timedelta(minutes=7))
+    got = plate_summary(s, plate="SEEN01",
+                        scope=visible_camera_ids(s, users["alice"]))
+    assert got["total_reads"] == 1
+    assert got["first_seen"].startswith("2026-08-29T09:07")
+    assert got["last_seen"].startswith("2026-08-29T09:07")
+
+
+def test_a_row_with_no_read_time_still_falls_back(db):
+    """Mixed estates are the normal case during a rollout: rows written
+    before the column sit beside rows written after it."""
+    from services.timeline_service import plate_summary
+
+    s, users, cams = db
+    _read(s, cams, "gate", "MIX001", started=NOW - timedelta(hours=4))
+    _read(s, cams, "gate", "MIX001",
+          started=NOW - timedelta(hours=1),
+          observed=NOW - timedelta(minutes=50))
+    got = plate_summary(s, plate="MIX001",
+                        scope=visible_camera_ids(s, users["alice"]))
+    assert got["total_reads"] == 2
+    assert got["first_seen"].startswith("2026-08-29T08:00")   # fallback
+    assert got["last_seen"].startswith("2026-08-29T11:10")    # observed
+
+
+def test_the_window_and_day_series_bucket_by_the_read_time(db):
+    """Also the type check: coalesce() must hand back a real datetime,
+    not a string — the day bucketing calls .date() on it."""
+    s, users, cams = db
+    # Visit opened just OUTSIDE the 24h window; the plate was read just
+    # inside it. The read is what happened in the window.
+    scope = visible_camera_ids(s, users["alice"])
+    before = plate_stats(s, days=1, scope=scope, now=NOW)["total_reads"]
+    _read(s, cams, "gate", "EDGE01",
+          started=NOW - timedelta(hours=25),
+          observed=NOW - timedelta(hours=23))
+    got = plate_stats(s, days=1, scope=scope, now=NOW)
+    # The visit start is 25h old, so a started_at window would have
+    # dropped this read entirely.
+    assert got["total_reads"] == before + 1
+    # NOW is the 29th at noon, so 23h earlier is the 28th — and EDGE01
+    # is the only read that far back. The bucket proves it was dated by
+    # the read rather than by the visit start (which is the 28th too,
+    # but an hour earlier and outside the window altogether).
+    by_day = {d["day"]: d["reads"] for d in got["per_day"]}
+    assert by_day.get("2026-08-28") == 1
+
+
+def test_the_monthly_report_dates_reads_by_when_they_happened(db):
+    """A read at 00:20 on the 1st, from a visit that opened at 23:50 on
+    the last day of the previous month, belongs to the new month."""
+    from services.timeline_service import vehicle_report
+
+    s, users, cams = db
+    _read(s, cams, "gate", "MONTH1",
+          started=datetime(2026, 7, 31, 23, 50, tzinfo=timezone.utc),
+          observed=datetime(2026, 8, 1, 0, 20, tzinfo=timezone.utc))
+    got = vehicle_report(s, year=2026, month=8,
+                         scope=visible_camera_ids(s, users["alice"]))
+    plates = {p["plate"] for p in got["per_plate"]}
+    assert "MONTH1" in plates
+    row = next(p for p in got["per_plate"] if p["plate"] == "MONTH1")
+    assert row["first_seen"].startswith("2026-08-01T00:20")
+    assert "2026-08-01" in {d["day"] for d in got["per_day"]}
+
+
+def test_the_read_time_window_still_seeks_the_index(db):
+    """SEEN_AT is coalesce(observed_at, started_at), and an expression
+    cannot use the plain (camera_id, started_at) index: the planner
+    matched camera_id and then tested the range against every row the
+    camera ever recorded — and this table holds every track, people
+    included. ix_events_cam_seen exists to restore the seek, so pin it.
+    """
+    from sqlalchemy import text as sa_text
+
+    from models import TimelineEvent
+    from services.timeline_service import SEEN_AT
+
+    s, users, cams = db
+    q = (
+        s.query(TimelineEvent)
+        .filter(TimelineEvent.plate_text.isnot(None))
+        .filter(TimelineEvent.camera_id.in_([cams["gate"].id]))
+        .filter(SEEN_AT >= NOW - timedelta(days=1))
+    )
+    sql = str(q.statement.compile(
+        s.get_bind(), compile_kwargs={"literal_binds": True}))
+    plan = " ".join(
+        str(r[-1]) for r in s.execute(sa_text("EXPLAIN QUERY PLAN " + sql))
+    )
+    assert "ix_events_cam_seen" in plan, plan
+    # Not merely "the index was opened": the range must be part of the
+    # seek. Without it the plan says (camera_id=?) alone and the window
+    # degrades to a filter over that camera's whole history.
+    assert "camera_id=? AND" in plan, plan


### PR DESCRIPTION
… there

Closes #451.

A single plate read displayed two different times. The Vehicles page dated it by events.started_at — the VISIT's start — and the Alarms inbox dated the same read by the app's fired_at, stamped when the LPR app finished deciding. Between them sat the rest of the track, OCR, the agreement vote, the bus hop and dispatch, so the two pages disagreed by seconds that grew with backlog: worst exactly when a gate is busiest.

Both were processing times. Neither scrubs to the frame the plate is legible in, so a CSV export was useless as evidence; a re-run of the enrichment sweep would have restamped history as "now"; and gate-in/ gate-out durations subtracted two independently-lagged clocks. On a merged track started_at is worse than late — it is the moment a DIFFERENT car arrived, the same defect that makes plate_frame_path the only trustworthy image on the row.

A read is now dated once, by the capture time of the look it won on:

  Tier-0    captime.capture_wall() turns a monotonic frame stamp into
            wall clock by measuring the frame's AGE, so the error is the
            drift over milliseconds rather than over uptime, and no
            anchor needs re-taking when ffmpeg restarts. Ships as
            candidate_ts with the plate crops, as Attempt.ts with an
            early attempt, and as evidence_ts with the visit's own best
            crop (see below).
  core      events.observed_at, written by the early claim, the raced
            ingest and the consensus sweep — which dates a merged read by
            the same contributor whose crop and box it keeps, and
            retracts the timestamp with the plate in clear_plate().
  KAI-C     echoes the initiator's observed_at into plate.recognized.v1,
            never minting one: it does not know this system's clocks.
  app       forwards it in the alert's evidence.
  inbox     app_alerts.observed_at, and the UI reads both with a fallback
            for rows that predate the column.

fired_at is kept and still ORDERS the alarm inbox. Sorting by observed time would stop the inbox being append-only, letting a slow read insert its alarm above ones already on screen where a guard has scrolled past. It rides along as a tooltip ("Alerted 14s later") — the lag is a useful health signal, and hiding it would be the same dishonesty inverted.

Not just the two tables the bug was reported from: every aggregation that DERIVES something from a read now uses SEEN_AT, coalesce(observed_at, started_at) — plate_stats, plate_summary, plate_sessions, gate_occupancy and vehicle_report. The dwell time mattered most: a vehicle entering on a busy gate (5 min of track before the read) and leaving on a quiet one (1 min) was billed 4 minutes it never spent on site. query_events keeps started_at deliberately — it ranges over every visit, most of which have no read to be dated by.

SEEN_AT is an expression, so it cannot use (camera_id, started_at): the planner matched the camera and then tested the range against every row that camera ever recorded, and events holds every track, people included. ix_events_cam_seen restores the seek. The test pins the PLAN, since an index the planner opens but only seeks by camera_id is the bug.

The evidence-frame branch is why the first cut of this was inert. Plate candidates only exist on cameras whose assignments include the LPR skill, so a camera without it ships none and core's sweep OCRs the visit's best crop instead — and that branch left observed_at null on the reasoning that the best frame is "not a plate look with a time of its own". It is: the tracker knows which frame it cut the crop from. On a default install that branch is EVERY read, so nothing changed until best_crop_ts was recorded beside best_crop and shipped as evidence_ts.

Both columns are nullable with no backfill: the capture time of a frame already swept is not recoverable, and inventing one would put a processing time in the very column that exists not to be one.

Verified on a live stack, not only in tests:

    event 689  66HH07  started 11:20:32.623  observed 11:20:38.455
    alarm  49  "Plate 66HH07 read"           observed 11:20:38
                                             fired    11:20:52

One read, one time, on both surfaces, with the 14s that used to be the discrepancy now visible as lag where it belongs.

server 1331 passed (4 pre-existing mediamtx/TLS failures, identical on main); detect-pipeline 436 passed; tsc and the production build clean. kai-c and the LPR example have no local venv here, so their share is syntax-checked only.