### PR TITLE
feat(tables): paginate the plate-read and alarm tables, and share one

### DIFF
--- a/app/src/components/alarms/AlarmsTable.tsx
+++ b/app/src/components/alarms/AlarmsTable.tsx
@@ -1,0 +1,330 @@
+import type { ReactNode } from 'react'
+import { clsx } from 'clsx'
+import { Check } from 'lucide-react'
+import { Button, EmptyState, SeverityBadge } from '../ui'
+import { DataTable, type Column } from '../ui/DataTable'
+import {
+  alarmSeenAt, alarmSeenTitle, type InboxAlert,
+} from '../../services/alertsInboxService'
+
+/**
+ * The one alarm table. Both surfaces that show alarms render through it.
+ *
+ * They used to share their data layer and duplicate the entire
+ * presentation layer — severity pill, title+description cell, the Seen
+ * cell, the Ack button, the unacknowledged toggle — which is how they
+ * came to disagree about WHICH timestamp to show until #451 fixed both
+ * by hand. Anything genuinely different between them is a prop here;
+ * everything else is shared by construction.
+ */
+
+/** `cam3` / `cam-3` / `3` -> 3. The handle is a producer-supplied string
+ *  with no FK, so this is a parse, not a lookup. */
+export function cameraIdFromHandle(handle: string | null): number | null {
+  if (!handle) return null
+  const n = Number(String(handle).replace(/^cam-?/i, ''))
+  return Number.isFinite(n) ? n : null
+}
+
+export type AlarmsTableProps = {
+  rows: InboxAlert[]
+  /** Alerts & Incidents shows it; the Vehicles tab is one source already. */
+  showSource?: boolean
+  /** Resolves a camera handle to its display name. */
+  cameraLabel?: (handle: string | null) => string
+  onAck: (ids: number[]) => void
+  ackPending?: boolean
+  /** Ticked row ids. Omit the selection props for a read-only table. */
+  selected?: Set<number>
+  onToggle?: (id: number) => void
+  onToggleAll?: (on: boolean) => void
+  emptyTitle: string
+  emptyDescription?: string
+  emptyAction?: ReactNode
+  caption: string
+  isPending?: boolean
+  isFetching?: boolean
+  isError?: boolean
+  error?: unknown
+  onRetry?: () => void
+  footer?: ReactNode
+  toolbar?: ReactNode
+  fillHeight?: boolean
+}
+
+export function AlarmsTable({
+  rows, showSource = false, cameraLabel, onAck, ackPending = false,
+  selected, onToggle, onToggleAll,
+  emptyTitle, emptyDescription, emptyAction, caption,
+  isPending, isFetching, isError, error, onRetry, footer, toolbar,
+  fillHeight = true,
+}: AlarmsTableProps) {
+  const selectable = !!selected && !!onToggle
+  const pageIds = rows.map((a) => a.id)
+  const allOnPage = selectable && pageIds.every((id) => selected!.has(id))
+  const someOnPage = selectable && pageIds.some((id) => selected!.has(id))
+
+  const columns: Column<InboxAlert>[] = [
+    ...(selectable ? [{
+      key: 'select',
+      // A real checkbox in the header, with indeterminate set through a
+      // ref — the attribute does not exist in HTML, only the property.
+      header: (
+        <input
+          type="checkbox"
+          className="accent-[var(--accent)] align-middle"
+          aria-label="Select all on this page"
+          checked={pageIds.length > 0 && allOnPage}
+          ref={(el) => { if (el) el.indeterminate = someOnPage && !allOnPage }}
+          onChange={(e) => onToggleAll?.(e.target.checked)}
+        />
+      ),
+      width: 'w-10',
+      cell: (a: InboxAlert) => (
+        <input
+          type="checkbox"
+          className="accent-[var(--accent)] align-middle"
+          aria-label={`Select: ${a.title}`}
+          checked={selected!.has(a.id)}
+          onChange={() => onToggle?.(a.id)}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ),
+    } as Column<InboxAlert>] : []),
+    {
+      // Left gutter, like the reads table, and always visible: an action
+      // an operator performs on most rows should not require discovering
+      // it by hovering. It is a dim icon until you approach it, so it
+      // stays quiet without hiding.
+      key: 'ack', header: '', srHeader: 'Acknowledge',
+      width: 'w-10', className: 'whitespace-nowrap',
+      isAction: true,
+      cell: (a) => a.acknowledged_at ? null : (
+        <button
+          type="button"
+          title="Acknowledge this alarm"
+          aria-label={`Acknowledge: ${a.title}`}
+          className="rounded p-1 text-[var(--text-dim)] hover:bg-[var(--panel-2)] hover:text-[var(--text)]"
+          disabled={ackPending}
+          onClick={() => onAck([a.id])}
+        >
+          <Check size={15} />
+        </button>
+      ),
+    },
+    {
+      key: 'severity', header: 'Severity', width: 'w-[92px]',
+      cell: (a) => (
+        <SeverityBadge
+          severity={a.severity}
+          className={a.acknowledged_at ? 'opacity-60' : undefined}
+        />
+      ),
+    },
+    {
+      // The flexible column — no width, so it takes the slack. Its
+      // description truncates because under table-fixed a long one wraps
+      // and makes the row taller than its neighbours.
+      key: 'alarm', header: 'Alarm',
+      // One line, not two. The description was a second row of 11px text
+      // under every title, which doubled the row height to show a
+      // sentence that mostly restates the title. Inline and dim, it
+      // still reads as the detail it is — and twice as many alarms fit.
+      cell: (a) => (
+        <div
+          className="truncate"
+          title={a.description ? `${a.title} — ${a.description}` : a.title}
+        >
+          <span className={a.acknowledged_at ? 'font-normal' : 'font-semibold'}>
+            {a.title}
+          </span>
+          {a.description && (
+            <span className="ml-1.5 text-[var(--text-dim)]">
+              {/* The description already ends in a full stop, which
+                  would read as "(….)" once bracketed. */}
+              ({a.description.replace(/\.\s*$/, '')})
+            </span>
+          )}
+        </div>
+      ),
+    },
+    ...(showSource ? [{
+      key: 'source', header: 'Source', hideBelow: 'lg' as const,
+      width: 'w-[168px]', cellClassName: 'text-[var(--text-dim)] truncate',
+      cell: (a: InboxAlert) => a.source_name || '—',
+    }] : []),
+    {
+      key: 'camera', header: 'Camera', hideBelow: 'sm', width: 'w-[140px]',
+      className: 'truncate',
+      // The reads table resolves a friendly name and this printed the raw
+      // handle, so one screen called the same camera `Demo IN` and `cam1`.
+      cell: (a) => cameraLabel?.(a.camera_id) ?? (a.camera_id || '—'),
+    },
+    {
+      key: 'seen', header: 'Date & time', width: 'w-[164px]',
+      className: 'whitespace-nowrap',
+      cellClassName: 'text-[var(--text-dim)] tabular-nums',
+      cell: (a) => <span title={alarmSeenTitle(a)}>{alarmSeenAt(a)}</span>,
+    },
+  ]
+
+  return (
+    <DataTable<InboxAlert>
+      caption={caption}
+      columns={columns}
+      rows={rows}
+      rowKey={(a) => a.id}
+      // State lives in the ROW, not a column of words. An acknowledged
+      // alarm recedes and an unacknowledged one keeps full contrast —
+      // the same read-vs-unread cue a mail list uses, which frees the
+      // width a "Status" column was spending to repeat it.
+      // ONE VISUAL CHANNEL PER MEANING. That is the whole rule here,
+      // and breaking it is what made the earlier attempts look wrong:
+      //
+      //   text  = state        (acknowledged or not)
+      //   bg    = interaction  (hover, selection)
+      //
+      // Before this, three rules competed for the background — the
+      // zebra stripe, the hover, and an accent tint for state. Zebra and
+      // tint are both plain classes of equal specificity, so which one
+      // painted a given row came down to stylesheet order rather than
+      // intent, and the state cue appeared on some rows and not others.
+      //
+      // Text also survives both themes, which a background tint did not:
+      // --bg-2 is a hair off --panel in dark, and in light a grey wash
+      // would darken the row that needs the MOST attention.
+      striped={false}
+      rowClassName={(a) => clsx(
+        a.acknowledged_at
+          // Recedes on both grounds: the dim token plus a little
+          // transparency, which also takes the severity badge and the
+          // description down with it.
+          ? 'text-[var(--text-dim)] opacity-70'
+          : 'text-[var(--text)]',
+        // Selection outranks hover — the row you ticked must stay
+        // obviously ticked while the pointer moves over it.
+        selectable && selected!.has(a.id) && '!bg-[var(--accent)]/15',
+      )}
+      isPending={isPending}
+      isFetching={isFetching}
+      isError={isError}
+      error={error}
+      errorTitle="Could not load alarms"
+      onRetry={onRetry}
+      empty={<EmptyState title={emptyTitle} description={emptyDescription} action={emptyAction} />}
+      footer={footer}
+      toolbar={toolbar}
+      fillHeight={fillHeight}
+      fixed
+      dense
+      minWidth="min-w-[640px]"
+    />
+  )
+}
+
+/**
+ * The strip that appears once rows are ticked. Mail-client behaviour:
+ * selecting every row on the page offers to extend the action to
+ * everything the filter matches, because "select all" on page 1 of 46
+ * meaning 25 rows is the single most common bulk-action surprise.
+ *
+ * The escalation is not a bigger list of ids — those rows are not in the
+ * browser. It sends the FILTER to the server, which is what the ack
+ * endpoint's source_name/severity form is for.
+ */
+export function AlarmsSelectionBar({
+  count, allOnPage, allMatching, matchingTotal, label,
+  onSelectAllMatching, onClear, onAck, ackPending,
+}: {
+  count: number
+  allOnPage: boolean
+  allMatching: boolean
+  matchingTotal?: number
+  label?: string
+  onSelectAllMatching: () => void
+  onClear: () => void
+  onAck: () => void
+  ackPending?: boolean
+}) {
+  if (!count && !allMatching) return null
+  const noun = label ?? 'alarms'
+  return (
+    // Inline, not a strip of its own. A full-width bar appearing above
+    // the filters pushed the whole table down the moment a checkbox was
+    // ticked — the rows moving under the pointer that just clicked one.
+    // The filter row already had empty space between the chips and the
+    // pager, which is where a contextual action belongs.
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded border border-[var(--border)] bg-[var(--panel-2)] px-2 py-1 text-xs">
+      <span className="font-medium text-[var(--text)]">
+        {allMatching
+          ? `All ${matchingTotal ?? ''} ${noun} selected`
+          : `${count} selected`}
+      </span>
+      {!allMatching && allOnPage && typeof matchingTotal === 'number' && matchingTotal > count && (
+        <button type="button" onClick={onSelectAllMatching}
+                className="underline text-[var(--accent)] hover:brightness-110">
+          Select all {matchingTotal} {noun}
+        </button>
+      )}
+      <Button variant="outline" size="sm" disabled={ackPending} onClick={onAck}>
+        <Check size={13} /> Acknowledge
+      </Button>
+      <button type="button" onClick={onClear}
+              className="text-[var(--text-dim)] hover:text-[var(--text)]">
+        Clear
+      </button>
+    </div>
+  )
+}
+
+/**
+ * The filter set both alarm views show, so neither can grow a control
+ * the other lacks. It renders INSIDE the table's toolbar, beside the
+ * pagination — the same shape the plate-reads table uses — rather than
+ * as a separate bar above a separately-bordered table.
+ *
+ * Severity is a segmented control rather than a row of buttons for the
+ * same reason the reads table's time range is: it is one choice from a
+ * fixed set, and five outlined buttons read as five separate actions.
+ */
+export const ALARM_SEVERITIES = ['critical', 'high', 'medium', 'low'] as const
+
+export function AlarmsFilters({
+  onlyUnacked, onToggleUnacked, severity, onSeverity, children,
+}: {
+  onlyUnacked: boolean
+  onToggleUnacked: () => void
+  severity: string | null
+  onSeverity: (s: string | null) => void
+  children?: ReactNode
+}) {
+  return (
+    <>
+      <Button
+        size="sm"
+        variant={onlyUnacked ? 'default' : 'outline'}
+        aria-pressed={onlyUnacked}
+        onClick={onToggleUnacked}
+      >
+        Unacknowledged only
+      </Button>
+      <div className="flex overflow-hidden rounded border border-[var(--border)]"
+           role="group" aria-label="Severity">
+        {([null, ...ALARM_SEVERITIES] as const).map((sev) => (
+          <button
+            key={sev ?? 'all'}
+            type="button"
+            aria-pressed={severity === sev}
+            onClick={() => onSeverity(sev)}
+            className={`px-2.5 py-1 text-xs capitalize ${severity === sev
+              ? 'bg-[var(--panel-2)] font-semibold text-[var(--text)]'
+              : 'text-[var(--text-dim)] hover:text-[var(--text)]'}`}
+          >
+            {sev ?? 'All'}
+          </button>
+        ))}
+      </div>
+      {children}
+    </>
+  )
+}

--- a/app/src/components/alarms/useAlarmsList.ts
+++ b/app/src/components/alarms/useAlarmsList.ts
@@ -1,0 +1,66 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { alertsInboxService, type InboxPage } from '../../services/alertsInboxService'
+
+/** Every query key an ack should invalidate, wherever it was fired. */
+const ALARM_KEYS = ['alarms-page', 'vehicle-alarms', 'alerts-inbox-unacked']
+
+export function useAlarmsList(params: {
+  queryKeyPrefix: string
+  sourceName?: string
+  unacked?: boolean
+  severity?: string | null
+  page: number
+  pageSize: number
+  skip: number
+}) {
+  const { queryKeyPrefix, sourceName, unacked, severity, page, pageSize, skip } = params
+  const query = useQuery({
+    queryKey: [queryKeyPrefix, sourceName, unacked, severity, page, pageSize],
+    queryFn: async () => {
+      const { data } = await alertsInboxService.listInboxAlerts({
+        source_name: sourceName,
+        unacked: unacked || undefined,
+        severity: severity || undefined,
+        skip,
+        limit: pageSize,
+      })
+      return data as InboxPage
+    },
+    // Page 1 is the live inbox and must keep polling. Deeper pages are
+    // someone reading back through history, and the list is ordered
+    // newest-first — so every alarm that arrives while they read shifts
+    // every row down by one, under the cursor. Refreshing there is not a
+    // feature, it is the page moving while you look at it.
+    refetchInterval: page === 1 ? 10_000 : false,
+    // Otherwise the table empties on every page change and every poll.
+    placeholderData: keepPreviousData,
+  })
+
+  return {
+    rows: query.data?.alerts ?? [],
+    total: query.data?.total,
+    unackedCount: query.data?.unacked_count ?? 0,
+    isPending: query.isPending,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  }
+}
+
+export function useAckAlarms(onDone?: () => void) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (target: number[] | { source_name?: string; severity?: string }) =>
+      Array.isArray(target)
+        ? alertsInboxService.ackInboxAlerts(target)
+        : alertsInboxService.ackInboxAlertsMatching(target),
+    onSuccess: () => {
+      // Every alarm surface, not just the one that fired the ack. These
+      // used to be invalidated asymmetrically, so acking on one page left
+      // the other showing the alarm as live until its own poll came round.
+      ALARM_KEYS.forEach((key) => queryClient.invalidateQueries({ queryKey: [key] }))
+      onDone?.()
+    },
+  })
+}

--- a/app/src/components/ui/DataTable.tsx
+++ b/app/src/components/ui/DataTable.tsx
@@ -1,0 +1,384 @@
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { clsx } from 'clsx'
+import { ErrorCard, Skeleton, TBody, TD, TH, THead, TR } from './index'
+import { extractApiError } from '../../lib/apiError'
+
+/**
+ * A column, not a cell. Four things have to agree across the header and
+ * every body cell — the colSpan for the loading/empty rows, responsive
+ * hiding, alignment, and the skeleton's shape — and they can only agree
+ * if they are derived from one description of the column.
+ *
+ * NOTE for future readers: this is deliberately not @tanstack/react-table.
+ * That library's value is headless sorting/filtering/grouping, all of
+ * which happens on the server here, so it would add a whole peer concept
+ * for a component this size. It is not a dependency; please do not make
+ * it one on this component's account.
+ */
+export type Column<T> = {
+  key: string
+  header: ReactNode
+  cell: (row: T, index: number) => ReactNode
+  align?: 'left' | 'right' | 'center'
+  /** Tailwind width class, applied to the header cell. */
+  width?: string
+  /**
+   * Applied to the header AND every body cell — for anything structural
+   * that must match on both, like width, alignment or responsive hiding.
+   * NOT for colour or type: a cell's dim body text leaking onto the
+   * header made that one header read differently from its neighbours.
+   */
+  className?: string
+  /** Body cells only — colour, weight, numerals, truncation. */
+  cellClassName?: string
+  /** Hide below this breakpoint. */
+  hideBelow?: 'sm' | 'md' | 'lg'
+  /** For action columns: a visually empty header that still announces. */
+  srHeader?: string
+  /**
+   * This cell holds controls. A click inside it acts on the control and
+   * must NOT also activate the row — without this, hitting Ack on a
+   * row-clickable table would fire the row's own handler as the event
+   * bubbled.
+   */
+  isAction?: boolean
+}
+
+// Static strings: Tailwind v4 scans source text, so a class built by
+// concatenation would be purged out of the stylesheet.
+const HIDE_BELOW: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'hidden sm:table-cell',
+  md: 'hidden md:table-cell',
+  lg: 'hidden lg:table-cell',
+}
+
+const ALIGN: Record<'left' | 'right' | 'center', string> = {
+  left: 'text-left',
+  right: 'text-right',
+  center: 'text-center',
+}
+
+export type DataTableProps<T> = {
+  columns: Column<T>[]
+  rows: T[]
+  rowKey: (row: T) => string | number
+  /** Required: rendered as an sr-only <caption>. */
+  caption: string
+  isPending?: boolean
+  isFetching?: boolean
+  isError?: boolean
+  error?: unknown
+  errorTitle?: string
+  onRetry?: () => void
+  /** Shown in place of rows when there are none. */
+  empty?: ReactNode
+  skeletonRows?: number
+  striped?: boolean
+  rowClassName?: (row: T) => string
+  /** Rendered inside the bordered shell, under the table. */
+  footer?: ReactNode
+  /**
+   * Rendered inside the shell ABOVE the rows — the same pagination as
+   * the footer, so a long page can be walked from either end without
+   * scrolling to find the control.
+   */
+  toolbar?: ReactNode
+  /**
+   * Scroll the ROWS instead of the page: the body takes whatever height
+   * is left below it in the viewport and scrolls inside that, so the
+   * header stays put and the page does not grow a long outer scrollbar.
+   */
+  fillHeight?: boolean
+  /** Never shrink the scroller below this (px). */
+  minBodyHeight?: number
+  /**
+   * `table-layout: fixed` — column widths are obeyed instead of being
+   * derived from content. Pair it with a width on every column but one
+   * (the flexible one) and with `truncate` on any cell that can overflow:
+   * fixed layout WRAPS rather than expands, and a wrapped cell makes the
+   * row taller than its neighbours.
+   */
+  fixed?: boolean
+  /** Minimum table width before the scroller scrolls sideways. */
+  minWidth?: string
+  /**
+   * Tighter vertical padding, for tables whose job is to show as many
+   * rows as possible. Applied through the table element rather than by
+   * changing the shared TD/TH primitives, so the app's default density
+   * is untouched everywhere else.
+   */
+  dense?: boolean
+  /**
+   * Makes the whole row activatable, mail-client style. Rows get a
+   * pointer, a keyboard focus ring and Enter/Space handling — not just
+   * an onClick, which would be unreachable without a mouse.
+   */
+  onRowClick?: (row: T) => void
+}
+
+/**
+ * The height left between the scroller's top edge and the bottom of the
+ * window, minus whatever sits inside the shell below the rows.
+ *
+ * Measured rather than hard-coded: the distance from the viewport top
+ * changes with the filter bar wrapping, the stat tiles, and the page
+ * header, and a magic `calc(100vh - 420px)` would be wrong on the first
+ * layout that differs from the one it was tuned against.
+ */
+function useAvailableHeight(
+  enabled: boolean,
+  scrollerRef: React.RefObject<HTMLDivElement | null>,
+  footerRef: React.RefObject<HTMLDivElement | null>,
+  minHeight: number,
+) {
+  const [maxHeight, setMaxHeight] = useState<number>()
+
+  const measure = useCallback(() => {
+    const el = scrollerRef.current
+    if (!el) return
+    // Document-absolute on purpose, and it is scroll-INVARIANT: scroll
+    // down 200px and rect.top falls by 200 while scrollY rises by 200.
+    // Read the whole expression as "how tall may I be so the page does
+    // not scroll at all", which is this component's entire job.
+    const top = el.getBoundingClientRect().top + window.scrollY
+    // Walk from the SHELL, not the scroller. The pagination footer is the
+    // scroller's next sibling but the shell's child, so starting one
+    // level up skips it exactly once — it is already counted via
+    // footerRef. Counting it twice is what left ~100px of dead page
+    // under the table while the rows starved.
+    const shell = el.parentElement ?? el
+    const reserved = (footerRef.current?.offsetHeight ?? 0) + heightBelow(shell)
+    // clientHeight, NOT innerHeight: innerHeight includes the horizontal
+    // scrollbar gutter, so on any page that scrolls sideways it
+    // over-reports the layout viewport by ~15px — the table then claims
+    // 15px it does not have and the page grows a vertical scrollbar,
+    // which is the exact thing this is here to prevent. The extra pixel
+    // absorbs sub-pixel layout rounding.
+    const viewport = document.documentElement.clientHeight || window.innerHeight
+    const next = Math.max(minHeight, viewport - top - reserved - 1)
+    // Only commit a real change: writing the same number every time an
+    // observer fires would re-render on a loop.
+    setMaxHeight((prev) => (prev !== undefined && Math.abs(prev - next) < 2 ? prev : next))
+  }, [scrollerRef, footerRef, minHeight])
+
+  useLayoutEffect(() => {
+    if (!enabled) { setMaxHeight(undefined); return }
+    measure()
+  }, [enabled, measure])
+
+  useEffect(() => {
+    if (!enabled) return
+    window.addEventListener('resize', measure)
+    // Anything above the table changing height moves our top edge — a
+    // wrapping filter bar, a stat tile loading, the sidebar collapsing.
+    const ro = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(measure)
+      : null
+    ro?.observe(document.body)
+    return () => {
+      window.removeEventListener('resize', measure)
+      ro?.disconnect()
+    }
+  }, [enabled, measure])
+
+  return maxHeight
+}
+
+/**
+ * How much page sits BELOW the table — a card, a note, an ancestor's
+ * bottom padding — so the rows take the rest and the page itself never
+ * grows a scrollbar.
+ *
+ * Call it with the table's SHELL, not its scroller: the pagination
+ * footer lives inside the shell and is measured separately, and walking
+ * from the scroller counted it a second time.
+ *
+ * Two things `offsetHeight` alone would miss, both of which showed up as
+ * the table overhanging its space:
+ *  - margins, so anything spaced by `space-y-*` was under-counted;
+ *  - an ancestor's bottom padding, which no sibling walk can see (the
+ *    app shell's own `p-4` is 16px of it). Measuring it is what let the
+ *    hard-coded BOTTOM_GUTTER guess go away.
+ *
+ * Out-of-flow elements are skipped — a portalled modal or a fixed
+ * toolbar takes no space in the page and must not steal any from rows.
+ */
+function heightBelow(start: Element): number {
+  let total = 0
+  let node: Element | null = start
+  while (node && node !== document.body) {
+    for (let sib = node.nextElementSibling; sib; sib = sib.nextElementSibling) {
+      const cs = window.getComputedStyle(sib)
+      if (cs.position === 'fixed' || cs.position === 'absolute') continue
+      total += sib.getBoundingClientRect().height
+        + (parseFloat(cs.marginTop) || 0)
+        + (parseFloat(cs.marginBottom) || 0)
+    }
+    const parent: HTMLElement | null = node.parentElement
+    if (parent) {
+      total += parseFloat(window.getComputedStyle(parent).paddingBottom) || 0
+    }
+    node = parent
+  }
+  return total
+}
+
+/**
+ * The state machine here is the point, not the markup.
+ *
+ * Error takes precedence over empty, and `isError` is part of the props
+ * type rather than something a caller opts into. Two of the three tables
+ * this replaced never read their query's error flag at all, so a failed
+ * fetch rendered as "No alarms yet" — indistinguishable from a working
+ * system with nothing to report. Making the failure state structural is
+ * what stops that being rewritten by hand each time.
+ */
+export function DataTable<T>({
+  columns, rows, rowKey, caption,
+  isPending = false, isFetching = false, isError = false, error,
+  errorTitle = 'Could not load this list', onRetry,
+  empty, skeletonRows = 8, striped = true, rowClassName, footer, toolbar,
+  fillHeight = false, minBodyHeight = 220, fixed = false, minWidth,
+  onRowClick, dense = false,
+}: DataTableProps<T>) {
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const footerRef = useRef<HTMLDivElement>(null)
+  const maxHeight = useAvailableHeight(fillHeight, scrollerRef, footerRef, minBodyHeight)
+  // `width` belongs on BOTH cells. It used to be spread into the <TH>
+  // only, so nothing constrained the body and `table-layout: auto`
+  // sprayed the surplus into whichever columns had the longest content —
+  // which is why PLATE/CAMERA/SEEN floated in whitespace with the row
+  // actions stranded at the far edge.
+  const cls = (c: Column<T>) => clsx(
+    c.className,
+    c.width,
+    c.align && ALIGN[c.align],
+    c.hideBelow && HIDE_BELOW[c.hideBelow],
+  )
+
+  if (isError) {
+    return (
+      <ErrorCard
+        title={errorTitle}
+        message={extractApiError(error, 'Please try again.')}
+        onRetry={onRetry}
+      />
+    )
+  }
+
+  const head = (
+    // Sticky ONLY under `fillHeight`. Sticky positions against the
+    // nearest SCROLLING ancestor, so in a horizontal-only scroller there
+    // is nothing to stick to and the header just does not move — which
+    // is exactly what shipped the first time this was attempted. Give
+    // the same container a height and a vertical scroller and it works.
+    <THead>
+      <TR className="hover:bg-transparent border-b border-[var(--border)]">
+        {columns.map((c) => (
+          <TH
+            key={c.key}
+            className={clsx(
+              // A header has to out-rank the data or it stops reading as
+              // one. Uppercase at 11px in the dim token was doing that
+              // job through SHOUTING; plain 11px dim did not do it at
+              // all — it came out weaker than the rows beneath it.
+              // Weight and contrast instead: 12px semibold in the full
+              // text colour is unmistakably a label, and quiet, because
+              // it is smaller than the data it sits over.
+              cls(c), 'text-xs font-semibold normal-case tracking-normal text-[var(--text)]',
+              // The background is load-bearing, not decoration: rows
+              // scroll UNDER this, and a transparent header would show
+              // them through. The inset shadow keeps a divider visible
+              // where a collapsed border would be painted away.
+              fillHeight && 'sticky top-0 z-10 bg-[var(--bg-2)] shadow-[inset_0_-1px_0_var(--border)]',
+            )}
+          >
+            {c.srHeader ? <span className="sr-only">{c.srHeader}</span> : c.header}
+          </TH>
+        ))}
+      </TR>
+    </THead>
+  )
+
+  return (
+    // The shell is built here rather than with the shared `Table`
+    // wrapper because the footer has to sit INSIDE the border with the
+    // rows, and `Table` closes its own box around the table alone.
+    // Deliberately no `overflow-hidden` on the shell: it would clip the
+    // scroller it contains, which is the exact bug the Alerts &
+    // Incidents table shipped with.
+    <div className="border border-[var(--border)] rounded">
+      {toolbar && (
+        <div className="border-b border-[var(--border)]">{toolbar}</div>
+      )}
+      <div
+        ref={scrollerRef}
+        // thin-scroll is the app's existing panel scrollbar (index.css):
+        // 6px, rounded, themed, and always faintly visible. Its reason
+        // for an always-on thumb — content with no hover affordance to
+        // tell you it scrolls — is exactly a table's situation, and the
+        // default chrome scrollbar looked bolted on next to it.
+        className={clsx('overflow-x-auto thin-scroll', fillHeight && 'overflow-y-auto')}
+        style={fillHeight && maxHeight ? { maxHeight } : undefined}
+      >
+        <table className={clsx(
+          'w-full text-sm', fixed && 'table-fixed', minWidth,
+          dense && '[&_td]:py-1.5 [&_th]:py-1.5',
+        )}>
+        <caption className="sr-only">{caption}</caption>
+        {head}
+        {/* Keeps the frame and the footer mounted through every state, so
+            the page does not jump as a filter empties the list. */}
+        <TBody
+          striped={striped && !isPending}
+          aria-busy={isFetching && !isPending ? true : undefined}
+          className={clsx(isFetching && !isPending && 'opacity-70 transition-opacity')}
+        >
+          {isPending
+            ? Array.from({ length: skeletonRows }).map((_, i) => (
+                <TR key={`sk${i}`} className="hover:bg-transparent">
+                  {columns.map((c) => (
+                    <TD key={c.key} className={cls(c)}><Skeleton className="h-4" /></TD>
+                  ))}
+                </TR>
+              ))
+            : rows.length === 0
+              ? (
+                <TR className="hover:bg-transparent">
+                  <TD colSpan={columns.length} className="py-8">{empty}</TD>
+                </TR>
+              )
+              : rows.map((row, i) => (
+                <TR
+                  key={rowKey(row)}
+                  className={clsx(onRowClick && 'cursor-pointer', rowClassName?.(row))}
+                  onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  tabIndex={onRowClick ? 0 : undefined}
+                  onKeyDown={onRowClick ? (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      onRowClick(row)
+                    }
+                  } : undefined}
+                >
+                  {columns.map((c) => (
+                    <TD
+                      key={c.key}
+                      className={clsx(cls(c), c.cellClassName)}
+                      onClick={c.isAction ? (e) => e.stopPropagation() : undefined}
+                    >
+                      {c.cell(row, i)}
+                    </TD>
+                  ))}
+                </TR>
+              ))}
+        </TBody>
+        </table>
+      </div>
+      <div ref={footerRef} className={clsx(footer && 'border-t border-[var(--border)]')}>
+        {footer}
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/ui/Pagination.tsx
+++ b/app/src/components/ui/Pagination.tsx
@@ -1,0 +1,120 @@
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react'
+import { Button } from './index'
+
+export type PaginationProps = {
+  page: number
+  pageSize: number
+  /** Rows matching the filters. Undefined when the server did not say. */
+  total?: number
+  /** Only consulted when `total` is undefined. */
+  hasNext?: boolean
+  /** Rows on the current page, for an honest range label. */
+  rowCount?: number
+  pageSizeOptions?: number[]
+  onPageChange: (page: number) => void
+  onPageSizeChange: (size: number) => void
+  isFetching?: boolean
+  /** Plural noun for the range label: "1–25 of 312 reads". */
+  label?: string
+  /** Only one instance on a page should be a live region. */
+  announce?: boolean
+}
+
+export function Pagination({
+  page, pageSize, total, hasNext, rowCount,
+  pageSizeOptions = [25, 50, 100],
+  onPageChange, onPageSizeChange, isFetching = false, label,
+  announce = true,
+}: PaginationProps) {
+  const knownTotal = typeof total === 'number'
+  const shown = rowCount ?? 0
+  const from = shown ? (page - 1) * pageSize + 1 : 0
+  const to = shown ? from + shown - 1 : 0
+  const totalPages = knownTotal ? Math.max(1, Math.ceil(total / pageSize)) : undefined
+  const noun = label ? ` ${label}` : ''
+
+  // With a total, Next is arithmetic. Without one, only the caller can
+  // say — a full page is the hint, never a guess dressed up as a count.
+  const canPrev = page > 1 && !isFetching
+  const canNext = !isFetching && (totalPages ? page < totalPages : Boolean(hasNext))
+
+  const rangeText = !knownTotal
+    ? (shown ? `Showing ${from}–${to}` : 'No results')
+    : total === 0
+      ? `No${noun ? noun : ' results'}`
+      : `${from}–${to} of ${total}${noun}`
+
+  return (
+    // Everything sits right, reading count -> pages -> page size: what
+    // you are looking at, how to move, then how much to show.
+    //
+    // Prev/next only. Numbered pages are a lot of chrome for a list read
+    // newest-first, where "older" and "newer" is the whole interaction —
+    // the count says where you are and the chevrons move you. It also
+    // ends the strip growing wider as the result set does.
+    <nav
+      aria-label="Pagination"
+      className="flex flex-wrap items-center justify-end gap-x-3 gap-y-2 px-3 py-1.5 text-xs"
+    >
+      {/* Only ONE of the two instances announces, or a screen reader
+          hears the same range twice on every page change. */}
+      <span
+        role={announce ? 'status' : undefined}
+        aria-live={announce ? 'polite' : undefined}
+        className="text-[var(--text-dim)]"
+      >
+        {rangeText}
+      </span>
+
+      <div className="flex items-center gap-0.5">
+        {/* Chevrons, not words. The arrows need no translation and no
+            reading — and an icon-only control still needs a real name,
+            hence aria-label. Doubled chevrons jump to the ends, which is
+            what the numbered strip was really being used for. */}
+        <Button
+          variant="ghost" size="sm" aria-label="First page" title="First page"
+          className="px-1.5" disabled={!canPrev} onClick={() => onPageChange(1)}
+        >
+          <ChevronsLeft size={16} />
+        </Button>
+        <Button
+          variant="ghost" size="sm" aria-label="Previous page" title="Previous page"
+          className="px-1.5" disabled={!canPrev} onClick={() => onPageChange(page - 1)}
+        >
+          <ChevronLeft size={16} />
+        </Button>
+        <Button
+          variant="ghost" size="sm" aria-label="Next page" title="Next page"
+          className="px-1.5" disabled={!canNext} onClick={() => onPageChange(page + 1)}
+        >
+          <ChevronRight size={16} />
+        </Button>
+        {/* Only when the server told us the total — without it there is
+            no last page to jump to, and a control that guesses one would
+            be worse than none. */}
+        {totalPages !== undefined && (
+          <Button
+            variant="ghost" size="sm" aria-label="Last page" title={`Last page (${totalPages})`}
+            className="px-1.5" disabled={!canNext} onClick={() => onPageChange(totalPages)}
+          >
+            <ChevronsRight size={16} />
+          </Button>
+        )}
+      </div>
+
+      {/* Borderless too — it is a preference, not a field to fill in. */}
+      <label className="flex items-center text-[var(--text-dim)]">
+        <span className="sr-only">Rows per page</span>
+        <select
+          className="cursor-pointer rounded border-0 bg-transparent py-0.5 pl-1 pr-0 text-xs text-[var(--text-dim)] hover:text-[var(--text)]"
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value))}
+        >
+          {pageSizeOptions.map((n) => (
+            <option key={n} value={n}>{n} / page</option>
+          ))}
+        </select>
+      </label>
+    </nav>
+  )
+}

--- a/app/src/components/ui/Tabs.tsx
+++ b/app/src/components/ui/Tabs.tsx
@@ -37,7 +37,13 @@ export function Tabs({
   return (
     <div
       role="tablist"
-      className={clsx('flex gap-1 border-b border-[var(--border)] overflow-x-auto', className)}
+      // overflow-y-hidden is load-bearing, not tidiness. `overflow-x: auto`
+      // alone makes the computed overflow-y `auto` too — the CSS overflow
+      // spec says a non-visible value on one axis forces the other off
+      // `visible` — and the tabs' -mb-px then overflows the content box by
+      // exactly 1px. The browser drew a stray vertical scrollbar for it,
+      // floating in the middle of the tab strip.
+      className={clsx('flex gap-1 border-b border-[var(--border)] overflow-x-auto overflow-y-hidden', className)}
     >
       {tabs.map((t) => (
         <button

--- a/app/src/components/ui/index.tsx
+++ b/app/src/components/ui/index.tsx
@@ -44,7 +44,7 @@ export function CardContent({ children, className = '' }: { children: ReactNode;
 
 /* ----------------------------- Badge ---------------------------- */
 
-export type BadgeVariant = 'success' | 'warning' | 'destructive' | 'neutral' | 'info'
+export type BadgeVariant = 'success' | 'warning' | 'destructive' | 'neutral' | 'info' | 'critical'
 
 // Theme-token driven (see the --badge-* variables in index.css): the dark
 // theme keeps the translucent deep tints, the light theme swaps to pale
@@ -55,6 +55,33 @@ const BADGE_STYLES: Record<BadgeVariant, string> = {
   destructive: 'bg-[var(--badge-destructive-bg)] text-[var(--badge-destructive-text)]',
   neutral: 'bg-[var(--badge-neutral-bg)] text-[var(--badge-neutral-text)]',
   info: 'bg-[var(--badge-info-bg)] text-[var(--badge-info-text)]',
+  critical: 'bg-[var(--badge-critical-bg)] text-[var(--badge-critical-text)]',
+}
+
+/* ------------------------- SeverityBadge ------------------------ */
+
+// One severity pill for every alarm surface. Both alarm tables used to
+// carry their own identical Record<string,string> of raw palette classes
+// (`bg-red-600 text-white`, ...), which is the rule this file states at
+// the top not to do — and it showed: `bg-yellow-600 text-black` on the
+// light theme was close to unreadable. Four severities, four tokens.
+const SEVERITY_VARIANT: Record<string, BadgeVariant> = {
+  critical: 'critical',
+  high: 'destructive',
+  medium: 'warning',
+  low: 'neutral',
+}
+
+export function SeverityBadge({ severity, className = '' }: { severity?: string | null; className?: string }) {
+  const key = (severity ?? '').toLowerCase()
+  return (
+    <Badge
+      variant={SEVERITY_VARIANT[key] ?? 'neutral'}
+      className={clsx('uppercase text-[10px] tracking-wide', className)}
+    >
+      {severity || 'unknown'}
+    </Badge>
+  )
 }
 
 // Spreads span attributes so callers can attach a `title` — a badge that
@@ -75,13 +102,29 @@ const BUTTON_STYLES: Record<ButtonVariant, string> = {
   danger: 'border border-red-700/50 bg-red-900/30 text-red-300 hover:bg-red-900/50',
 }
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & { variant?: ButtonVariant }
+// Two sizes, because a page header full of default-size buttons competes
+// with the page title for weight. `sm` is for toolbars and header
+// actions; `md` stays the default everywhere else. A size PROP rather
+// than a className override: Tailwind utilities have equal specificity,
+// so passing `px-2` alongside the base `px-3` wins or loses on
+// stylesheet order, not on intent.
+export type ButtonSize = 'sm' | 'md'
 
-export function Button({ children, variant = 'default', className = '', type = 'button', ...rest }: ButtonProps) {
+const BUTTON_SIZES: Record<ButtonSize, string> = {
+  sm: 'gap-1.5 px-2 py-1 text-xs',
+  md: 'gap-2 px-3 py-1.5 text-sm',
+}
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant
+  size?: ButtonSize
+}
+
+export function Button({ children, variant = 'default', size = 'md', className = '', type = 'button', ...rest }: ButtonProps) {
   return (
     <button
       type={type}
-      className={clsx('inline-flex items-center gap-2 rounded px-3 py-1.5 text-sm disabled:opacity-50 disabled:cursor-not-allowed', BUTTON_STYLES[variant], className)}
+      className={clsx('inline-flex items-center rounded disabled:opacity-50 disabled:cursor-not-allowed', BUTTON_SIZES[size], BUTTON_STYLES[variant], className)}
       {...rest}
     >
       {children}
@@ -112,14 +155,28 @@ export function StatusDot({ status }: { status: Status }) {
 
 /* -------------------------- PageHeader -------------------------- */
 
+// The text column must SHRINK, not push. Without `min-w-0 flex-1` its
+// hypothetical size is max-content — a long description laid out on one
+// unbroken line — and flexbox wraps a line before it shrinks an item, so
+// any page with a sentence-length description shoved its actions onto a
+// second flex row. `justify-between` then parked that lone item at the
+// START, which is why several pages render their buttons bottom-LEFT
+// under the description instead of top-right. AIAdapters, AppCatalog and
+// Vehicles all had it; Occupancy was one button away from it.
+//
+// `ml-auto` (not `justify-between`) is what right-aligns the actions,
+// and it keeps working on the wrapped line at narrow widths. `shrink-0`
+// stops the buttons compressing into two-line labels before the row
+// wraps. `max-w-3xl` keeps a long description readable rather than
+// running the full width of a 2560px monitor.
 export function PageHeader({ title, description, actions }: { title: ReactNode; description?: ReactNode; actions?: ReactNode }) {
   return (
-    <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
-      <div>
+    <div className="flex flex-wrap items-start gap-3 mb-4">
+      <div className="min-w-0 flex-1">
         <h2 className="text-lg font-semibold text-[var(--text)]">{title}</h2>
-        {description && <p className="text-sm text-[var(--text-dim)] mt-0.5">{description}</p>}
+        {description && <p className="text-sm text-[var(--text-dim)] mt-0.5 max-w-3xl">{description}</p>}
       </div>
-      {actions && <div className="flex items-center gap-2">{actions}</div>}
+      {actions && <div className="ml-auto shrink-0 flex flex-wrap items-center gap-2">{actions}</div>}
     </div>
   )
 }
@@ -204,9 +261,12 @@ export function TR({ children, className = '', ...rest }: HTMLAttributes<HTMLTab
   )
 }
 
-export function TH({ children, className = '', ...rest }: ThHTMLAttributes<HTMLTableCellElement>) {
+// scope="col" is defaulted rather than left to callers: it is what makes
+// a screen reader announce the column name with each cell, and no caller
+// had ever passed it. Still overridable via the spread.
+export function TH({ children, className = '', scope = 'col', ...rest }: ThHTMLAttributes<HTMLTableCellElement>) {
   return (
-    <th className={clsx('px-3 py-2 font-medium whitespace-nowrap', className)} {...rest}>
+    <th scope={scope} className={clsx('px-3 py-2 font-medium whitespace-nowrap', className)} {...rest}>
       {children}
     </th>
   )

--- a/app/src/hooks/useDebounce.ts
+++ b/app/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * A value that settles `delay` ms after the input stops changing.
+ *
+ * Extracted from two identical inline copies (the Vehicles plate search
+ * and the Cameras search box). The reason it exists is worth keeping
+ * with it: a search box wired straight into a react-query key swaps that
+ * key on every keystroke, and since these tables do not blank-guard
+ * their results, a six-character plate meant six rounds of the table
+ * emptying and every row thumbnail remounting.
+ *
+ * 250 ms is the value both call sites already used.
+ */
+export function useDebounce<T>(value: T, delay = 250): T {
+  const [settled, setSettled] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setSettled(value), delay)
+    return () => clearTimeout(t)
+  }, [value, delay])
+  return settled
+}

--- a/app/src/hooks/usePagination.ts
+++ b/app/src/hooks/usePagination.ts
@@ -1,0 +1,56 @@
+import { useCallback, useMemo, useState } from 'react'
+
+/** Where a table's chosen page size is remembered, per table. */
+const sizeKey = (id: string) => `opennvr.pageSize.${id}`
+
+function readStoredSize(id: string | undefined, fallback: number): number {
+  if (!id) return fallback
+  try {
+    const raw = window.localStorage.getItem(sizeKey(id))
+    const n = raw ? Number(raw) : NaN
+    return Number.isFinite(n) && n > 0 ? n : fallback
+  } catch {
+    // Private modes throw on access rather than returning null.
+    return fallback
+  }
+}
+
+/**
+ * Page state for a server-paged table: 1-based `page`, a `pageSize` the
+ * operator can change, and the `skip` the API wants.
+ *
+ * `storageId` persists the chosen size for that table. Worth it because
+ * these tables used to show up to 200 rows in one scroll; someone who
+ * prefers 100 should say so once, not on every visit.
+ *
+ * Filters deliberately do NOT reset the page from inside here. Every
+ * caller resets explicitly in its own change handler, which is how the
+ * app's existing paginated views do it — an effect keyed on the filters
+ * would also fire on mount and would fight any future restore of page
+ * state from the URL.
+ */
+export function usePagination(initialPageSize = 25, storageId?: string) {
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSizeState] = useState(() =>
+    readStoredSize(storageId, initialPageSize))
+
+  const setPageSize = useCallback((size: number) => {
+    setPageSizeState(size)
+    // Row 1 of the new size, not the row that happened to be first
+    // before: the app's other paginated views behave this way, and a
+    // consistent surprise beats a clever one.
+    setPage(1)
+    if (storageId) {
+      try {
+        window.localStorage.setItem(sizeKey(storageId), String(size))
+      } catch {
+        // Not being able to remember a preference is not an error.
+      }
+    }
+  }, [storageId])
+
+  const reset = useCallback(() => setPage(1), [])
+  const skip = useMemo(() => (page - 1) * pageSize, [page, pageSize])
+
+  return { page, pageSize, skip, setPage, setPageSize, reset }
+}

--- a/app/src/hooks/useRowSelection.ts
+++ b/app/src/hooks/useRowSelection.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+/**
+ * Checkbox selection for a paged table, mail-client style.
+ *
+ * Two distinct states, and conflating them is the classic bug here:
+ *
+ *  - `selected` — specific rows the operator ticked, by id.
+ *  - `allMatching` — "everything the current filter matches", including
+ *    rows on pages nobody has loaded. It cannot be a set of ids because
+ *    those ids are not in the browser; it has to travel to the server as
+ *    the FILTER, which is why the ack endpoint takes one.
+ *
+ * Selection resets whenever the view changes. Carrying ticks across a
+ * filter change would let a bulk action hit rows the operator can no
+ * longer see, which is exactly the wrong surprise for a control that
+ * silences alarms.
+ */
+export function useRowSelection<T extends string | number>(resetKey: unknown) {
+  const [selected, setSelected] = useState<Set<T>>(() => new Set())
+  const [allMatching, setAllMatching] = useState(false)
+
+  const clear = useCallback(() => {
+    setSelected(new Set())
+    setAllMatching(false)
+  }, [])
+
+  // The key is a serialised view (filters + page), so any change to what
+  // is on screen drops the selection.
+  const key = useMemo(() => JSON.stringify(resetKey), [resetKey])
+  useEffect(() => { clear() }, [key, clear])
+
+  const toggle = useCallback((id: T) => {
+    setAllMatching(false)
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  /** Tick or untick every id on the current page. */
+  const toggleMany = useCallback((ids: T[], on: boolean) => {
+    setAllMatching(false)
+    setSelected((prev) => {
+      const next = new Set(prev)
+      ids.forEach((id) => (on ? next.add(id) : next.delete(id)))
+      return next
+    })
+  }, [])
+
+  return {
+    selected,
+    allMatching,
+    /** Escalate from "this page" to "everything the filter matches". */
+    selectAllMatching: () => setAllMatching(true),
+    toggle,
+    toggleMany,
+    clear,
+    has: (id: T) => selected.has(id),
+    count: selected.size,
+  }
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -21,6 +21,11 @@
   --badge-warning-text: #facc15;                /* yellow-400 */
   --badge-destructive-bg: rgba(127, 29, 29, 0.5); /* red-900/50 */
   --badge-destructive-text: #f87171;            /* red-400 */
+  /* Critical is the one badge that stays SOLID in both themes: it has to
+     out-shout `destructive` on a wall display, and a translucent tint
+     cannot. */
+  --badge-critical-bg: #dc2626;                 /* red-600 */
+  --badge-critical-text: #ffffff;
   --badge-neutral-bg: rgba(17, 24, 39, 0.5);    /* gray-900/50 */
   --badge-neutral-text: #9ca3af;                /* gray-400 */
   --badge-info-bg: rgba(30, 58, 138, 0.5);      /* blue-900/50 */
@@ -48,6 +53,8 @@
   --badge-warning-text: #a16207;                /* yellow-700 */
   --badge-destructive-bg: #fee2e2;              /* red-100 */
   --badge-destructive-text: #b91c1c;            /* red-700 */
+  --badge-critical-bg: #dc2626;                 /* red-600 */
+  --badge-critical-text: #ffffff;
   --badge-neutral-bg: #f3f4f6;                  /* gray-100 */
   --badge-neutral-text: #374151;                /* gray-700 */
   --badge-info-bg: #dbeafe;                     /* blue-100 */

--- a/app/src/lib/time.ts
+++ b/app/src/lib/time.ts
@@ -70,3 +70,40 @@ export function browserTz(): string {
     return 'UTC'
   }
 }
+
+/**
+ * A timestamp for a dense operator table: `10 Sep 06:50:23`, carrying the
+ * year only when it is not the current one.
+ *
+ * Always dated. An earlier version dropped the date for today's rows to
+ * save width, which read fine at a glance and badly in practice — a row
+ * showing `06:50:23` gives no clue whether it is from this morning or
+ * three weeks ago once the range is 7 or 30 days, and this column is
+ * exported as evidence. Pair it with `tabular-nums` so the digits line
+ * up down the column.
+ *
+ * Returns '' for a missing/unparseable value; callers show their own
+ * placeholder. `seenAtTitle` gives the full localised value for the
+ * cell's tooltip.
+ */
+export function formatSeenAt(iso: string | null | undefined, now = new Date()): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const time = d.toLocaleTimeString(undefined, {
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  })
+  const date = d.toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: 'short',
+    ...(d.getFullYear() === now.getFullYear() ? {} : { year: 'numeric' }),
+  })
+  return `${date} ${time}`
+}
+
+/** The unabbreviated timestamp, for the tooltip on a compact cell. */
+export function seenAtTitle(iso: string | null | undefined): string | undefined {
+  if (!iso) return undefined
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? undefined : d.toLocaleString()
+}

--- a/app/src/services/alertsInboxService.ts
+++ b/app/src/services/alertsInboxService.ts
@@ -17,6 +17,7 @@
  */
 
 import { api } from '../lib/api'
+import { formatSeenAt, seenAtTitle } from '../lib/time'
 
 // The operator alert inbox: app-emitted §11.5 alerts landed by the
 // core's opennvr.alerts.> consumer. The bell polls unacked rows, rings
@@ -54,20 +55,34 @@ export type InboxAlert = {
 //
 // fired_at still ORDERS the inbox (the server sorts by id, i.e. arrival),
 // so a slow read cannot insert its alarm above ones already on screen.
+export function alarmSeenIso(a: InboxAlert): string | null {
+  return a.observed_at ?? a.fired_at
+}
+
 export function alarmSeenAt(a: InboxAlert): string {
-  const seen = a.observed_at ?? a.fired_at
-  return seen ? new Date(seen).toLocaleString() : '—'
+  return formatSeenAt(alarmSeenIso(a)) || '—'
 }
 
 // Tooltip for the cell above. When the two differ by a noticeable margin
 // the lag rides along: it is a useful health signal, and hiding it would
 // be the same dishonesty in the other direction.
 export function alarmSeenTitle(a: InboxAlert): string | undefined {
-  if (!a.observed_at || !a.fired_at) return undefined
+  const full = seenAtTitle(alarmSeenIso(a))
+  if (!a.observed_at || !a.fired_at) return full
   const lagMs = new Date(a.fired_at).getTime() - new Date(a.observed_at).getTime()
-  if (!Number.isFinite(lagMs) || lagMs < 1000) return undefined
+  if (!Number.isFinite(lagMs) || lagMs < 1000) return full
   const at = new Date(a.fired_at).toLocaleTimeString()
-  return `Alerted ${Math.round(lagMs / 1000)}s later, at ${at}`
+  return `${full} · alerted ${Math.round(lagMs / 1000)}s later, at ${at}`
+}
+
+/** One page of the inbox. `total` matches the request's filters; and
+ *  `unacked_count` is the BELL BADGE — scoped, but blind to every filter
+ *  on the request, so ?severity=critical can return unacked_count 40
+ *  beside total 3. Do not put one where the other belongs. */
+export type InboxPage = {
+  alerts: InboxAlert[]
+  unacked_count: number
+  total?: number
 }
 
 export type RingMode = 'none' | 'ping' | 'continuous'
@@ -79,12 +94,20 @@ export const alertsInboxService = {
     severity?: string
     source_name?: string
     after_id?: number
+    before_id?: number
+    skip?: number
     limit?: number
   }) => api.get('/api/v1/alerts-inbox', { params }),
 
-  // ids omitted/undefined = acknowledge everything unacked.
+  // Three shapes, matching the server: ids acknowledges exactly those;
+  // a filter acknowledges every unacked alert in scope matching it ("all
+  // 39 vehicle alarms", not "the 25 on this page"); nothing at all
+  // acknowledges everything unacked in scope.
   ackInboxAlerts: (ids?: number[]) =>
     api.post('/api/v1/alerts-inbox/ack', ids ? { ids } : {}),
+
+  ackInboxAlertsMatching: (filters: { source_name?: string; severity?: string }) =>
+    api.post('/api/v1/alerts-inbox/ack', filters),
 
   getRingConfig: () => api.get('/api/v1/alerts-inbox/ring-config'),
   putRingConfig: (ring: RingConfig) =>

--- a/app/src/services/vehiclesService.ts
+++ b/app/src/services/vehiclesService.ts
@@ -23,11 +23,15 @@ import { api } from '../lib/api'
 // best-frame evidence photo — plus the aggregates endpoint for the
 // stat tiles. Owner-scoped server-side, same rule as everything else.
 export const vehiclesService = {
+  // The response is { events, count, total }: `count` is this page's
+  // length and `total` is how many reads match the filters, for the
+  // pager. `skip`/`limit` are the server's paging pair.
   getPlateEvents: (params: {
     plate?: string
     camera_id?: number
     from?: string
     to?: string
+    skip?: number
     limit?: number
   }) => api.get('/api/v1/events', { params: { has_plate: true, ...params } }),
 

--- a/app/src/views/Alarms.tsx
+++ b/app/src/views/Alarms.tsx
@@ -18,19 +18,23 @@
 
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { BellRing, CheckCheck, PhoneCall, Volume2 } from 'lucide-react'
+import { BellRing, PhoneCall, Volume2 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { playTestSound } from '../components/AlertBell'
 import { useAuth } from '../auth/AuthContext'
 import { api } from '../lib/api'
 import {
-  alarmSeenAt,
-  alarmSeenTitle,
   alertsInboxService,
   type InboxAlert,
   type RingConfig,
   type RingMode,
 } from '../services/alertsInboxService'
+import { Button, SeverityBadge } from '../components/ui'
+import { Pagination } from '../components/ui/Pagination'
+import { AlarmsFilters, AlarmsSelectionBar, AlarmsTable } from '../components/alarms/AlarmsTable'
+import { useAckAlarms, useAlarmsList } from '../components/alarms/useAlarmsList'
+import { usePagination } from '../hooks/usePagination'
+import { useRowSelection } from '../hooks/useRowSelection'
 
 // The Alarms page: every alarm the platform has raised, as a list, plus
 // the controls that decide how alarms SOUND and one-click proof that
@@ -42,13 +46,6 @@ import {
 const SEVERITIES = ['critical', 'high', 'medium', 'low'] as const
 const RING_MODES: RingMode[] = ['none', 'ping', 'continuous']
 
-const SEVERITY_STYLE: Record<string, string> = {
-  critical: 'bg-red-600 text-white',
-  high: 'bg-orange-600 text-white',
-  medium: 'bg-yellow-600 text-black',
-  low: 'bg-neutral-600 text-white',
-}
-
 export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
   const qc = useQueryClient()
   // The alarm POLICY (ring modes, actions, test alarms) is a site
@@ -58,18 +55,15 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
   const isAdmin = !!user?.is_superuser
   const [onlyUnacked, setOnlyUnacked] = useState(false)
   const [severityFilter, setSeverityFilter] = useState<string | null>(null)
+  const pager = usePagination(25, 'alerts-incidents')
 
-  const list = useQuery({
-    queryKey: ['alarms-page', onlyUnacked, severityFilter],
-    queryFn: async () => {
-      const { data } = await alertsInboxService.listInboxAlerts({
-        unacked: onlyUnacked || undefined,
-        severity: severityFilter ?? undefined,
-        limit: 200,
-      })
-      return data as { alerts: InboxAlert[]; unacked_count: number }
-    },
-    refetchInterval: 10_000,
+  const list = useAlarmsList({
+    queryKeyPrefix: 'alarms-page',
+    unacked: onlyUnacked,
+    severity: severityFilter,
+    page: pager.page,
+    pageSize: pager.pageSize,
+    skip: pager.skip,
   })
 
   const ringCfg = useQuery({
@@ -87,9 +81,18 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
     qc.invalidateQueries({ queryKey: ['alerts-inbox-page'] })
   }
 
-  const ack = useMutation({
-    mutationFn: (ids?: number[]) => alertsInboxService.ackInboxAlerts(ids),
-    onSuccess: invalidate,
+  // Ticks drop whenever the view changes — a bulk ack must never reach
+  // rows the operator can no longer see.
+  const sel = useRowSelection<number>({
+    unacked: onlyUnacked, severity: severityFilter,
+    page: pager.page, size: pager.pageSize,
+  })
+
+  const ack = useAckAlarms(() => {
+    sel.clear()
+    // Acking the last row of the last page would otherwise leave the
+    // operator staring at an empty page with no way back.
+    if (list.rows.length <= 1 && pager.page > 1) pager.setPage(pager.page - 1)
   })
 
   const saveRing = useMutation({
@@ -104,8 +107,8 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
     onSuccess: invalidate,
   })
 
-  const rows = list.data?.alerts ?? []
-  const unackedCount = list.data?.unacked_count ?? 0
+  const rows = list.rows
+  const unackedCount = list.unackedCount
   const ring = ringCfg.data?.ring
 
   return (
@@ -114,7 +117,7 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
         <div className="flex items-center gap-2">
           <BellRing size={18} />
           <h1 className="text-xl font-semibold">Alarms</h1>
-          {list.isLoading && (
+          {list.isPending && (
             <span className="text-xs text-[var(--text-dim)]">Loading…</span>
           )}
         </div>
@@ -184,14 +187,14 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
           </div>
           <div className="flex flex-wrap gap-2">
             {SEVERITIES.map((sev) => (
-              <button
+              <Button
                 key={sev}
-                className={`px-2 py-1 rounded text-sm ${SEVERITY_STYLE[sev]}`}
+                variant="outline"
                 disabled={testAlarm.isPending}
                 onClick={() => testAlarm.mutate(sev)}
               >
-                Test {sev}
-              </button>
+                Test <SeverityBadge severity={sev} />
+              </Button>
             ))}
           </div>
           {testAlarm.isError && (
@@ -228,120 +231,82 @@ export function Alarms({ embedded = false }: { embedded?: boolean } = {}) {
         {isAdmin && <AlarmActionsCard />}
       </div>
 
-      {/* Filters */}
-      <div className="flex flex-wrap items-center gap-2 text-sm">
-        <button
-          className={`px-2 py-1 rounded border ${onlyUnacked ? 'bg-[var(--panel-2)] border-[var(--border)]' : 'border-neutral-700'}`}
-          onClick={() => setOnlyUnacked((s) => !s)}
-        >
-          Unacknowledged only
-        </button>
-        <span className="text-[var(--text-dim)]">Severity:</span>
-        <button
-          className={`px-2 py-1 rounded border ${severityFilter === null ? 'bg-[var(--panel-2)] border-[var(--border)]' : 'border-neutral-700'}`}
-          onClick={() => setSeverityFilter(null)}
-        >
-          All
-        </button>
-        {SEVERITIES.map((sev) => (
-          <button
-            key={sev}
-            className={`px-2 py-1 rounded border capitalize ${severityFilter === sev ? 'bg-[var(--panel-2)] border-[var(--border)]' : 'border-neutral-700'}`}
-            onClick={() =>
-              setSeverityFilter((s) => (s === sev ? null : sev))
-            }
-          >
-            {sev}
-          </button>
-        ))}
-        {unackedCount > 0 && (
-          <button
-            className="ml-auto inline-flex items-center gap-1 px-2 py-1 rounded border border-neutral-700 hover:bg-[var(--panel-2)]"
-            onClick={() => ack.mutate(undefined)}
-          >
-            <CheckCheck size={13} /> Acknowledge all ({unackedCount})
-          </button>
-        )}
-      </div>
-
       {/* The list */}
-      <div className="border border-[var(--border)] rounded overflow-hidden">
-        <table className="w-full text-sm">
-          <thead className="bg-[var(--panel-2)] text-left">
-            <tr>
-              <th className="px-3 py-2">Severity</th>
-              <th className="px-3 py-2">Alarm</th>
-              <th className="px-3 py-2">Source</th>
-              <th className="px-3 py-2">Camera</th>
-              <th className="px-3 py-2">Seen</th>
-              <th className="px-3 py-2">Status</th>
-              <th className="px-3 py-2" />
-            </tr>
-          </thead>
-          <tbody>
-            {rows.length === 0 && (
-              <tr>
-                <td
-                  colSpan={7}
-                  className="px-3 py-6 text-center text-[var(--text-dim)]"
-                >
-                  {list.isLoading
-                    ? 'Loading…'
-                    : 'No alarms yet — arm a watchlist plate in the LPR app, or fire a test above'}
-                </td>
-              </tr>
-            )}
-            {rows.map((a) => (
-              <tr key={a.id} className="border-t border-[var(--border)]">
-                <td className="px-3 py-2">
-                  <span
-                    className={`px-1.5 py-0.5 rounded text-[10px] uppercase ${SEVERITY_STYLE[a.severity] ?? SEVERITY_STYLE.low}`}
-                  >
-                    {a.severity}
-                  </span>
-                </td>
-                <td className="px-3 py-2">
-                  <div className="font-medium">{a.title}</div>
-                  {a.description && (
-                    <div className="text-[11px] text-[var(--text-dim)]">
-                      {a.description}
-                    </div>
-                  )}
-                </td>
-                <td className="px-3 py-2 text-[var(--text-dim)]">
-                  {a.source_name || '—'}
-                </td>
-                <td className="px-3 py-2 text-[var(--text-dim)]">
-                  {a.camera_id || '—'}
-                </td>
-                <td className="px-3 py-2 text-[var(--text-dim)]"
-                    title={alarmSeenTitle(a)}>
-                  {alarmSeenAt(a)}
-                </td>
-                <td className="px-3 py-2">
-                  {a.acknowledged_at ? (
-                    <span className="text-[var(--text-dim)]">
-                      acked {new Date(a.acknowledged_at).toLocaleTimeString()}
-                    </span>
-                  ) : (
-                    <span className="text-red-400">unacked</span>
-                  )}
-                </td>
-                <td className="px-3 py-2 text-right">
-                  {!a.acknowledged_at && (
-                    <button
-                      className="px-2 py-0.5 rounded border border-neutral-700 hover:bg-[var(--panel-2)]"
-                      onClick={() => ack.mutate([a.id])}
-                    >
-                      Ack
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <AlarmsTable
+        caption="Alerts and incidents"
+        rows={rows}
+        showSource
+        selected={sel.selected}
+        onToggle={sel.toggle}
+        onToggleAll={(on) => sel.toggleMany(rows.map((a) => a.id), on)}
+        onAck={(ids) => ack.mutate(ids)}
+        isPending={list.isPending}
+        isFetching={list.isFetching}
+        isError={list.isError}
+        error={list.error}
+        onRetry={() => list.refetch()}
+        emptyTitle={severityFilter || onlyUnacked
+          ? 'No alarms match these filters'
+          : 'No alarms yet'}
+        emptyDescription="Arm a watchlist plate in the LPR app, or fire a test above."
+        emptyAction={(severityFilter || onlyUnacked) ? (
+          <Button variant="outline" onClick={() => {
+            setSeverityFilter(null); setOnlyUnacked(false); pager.setPage(1)
+          }}>Clear filters</Button>
+        ) : undefined}
+        toolbar={
+          <>
+            <div className="flex flex-wrap items-center gap-2 py-1.5 pl-3">
+              <AlarmsFilters
+                onlyUnacked={onlyUnacked}
+                onToggleUnacked={() => { setOnlyUnacked((v) => !v); pager.setPage(1) }}
+                severity={severityFilter}
+                onSeverity={(sev: string | null) => { setSeverityFilter(sev); pager.setPage(1) }}
+              />
+              <AlarmsSelectionBar
+                count={sel.count}
+                allOnPage={rows.length > 0 && rows.every((a) => sel.has(a.id))}
+                allMatching={sel.allMatching}
+                matchingTotal={list.total}
+                onSelectAllMatching={sel.selectAllMatching}
+                onClear={sel.clear}
+                onAck={() => ack.mutate(
+                  sel.allMatching
+                    ? (severityFilter ? { severity: severityFilter } : {})
+                    : [...sel.selected],
+                )}
+              />
+              <div className="ml-auto">
+                <Pagination
+                  page={pager.page}
+                  pageSize={pager.pageSize}
+                  total={list.total}
+                  rowCount={rows.length}
+                  hasNext={rows.length === pager.pageSize}
+                  isFetching={list.isFetching}
+                  label="alarms"
+                  onPageChange={pager.setPage}
+                  onPageSizeChange={pager.setPageSize}
+                  announce={false}
+                />
+              </div>
+            </div>
+          </>
+        }
+        footer={
+          <Pagination
+            page={pager.page}
+            pageSize={pager.pageSize}
+            total={list.total}
+            rowCount={rows.length}
+            hasNext={rows.length === pager.pageSize}
+            isFetching={list.isFetching}
+            label="alarms"
+            onPageChange={pager.setPage}
+            onPageSizeChange={pager.setPageSize}
+          />
+        }
+      />
     </div>
   )
 }

--- a/app/src/views/Vehicles.tsx
+++ b/app/src/views/Vehicles.tsx
@@ -28,14 +28,15 @@
 // catalog form uses.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  BellRing, BookUser, Car, Download, FileText, History, PhoneCall, Plus,
-  RefreshCw, Search, ShieldAlert, ShieldCheck, Trash2, Upload,
+  ArrowRight, BellRing, BookUser, Car, Download, FileText, Fingerprint, History,
+  PhoneCall, Plus, RefreshCw, ScanLine, Search, ShieldAlert, ShieldCheck, Trash2,
+  Upload, Volume2,
 } from 'lucide-react'
 import { apiService } from '../lib/apiService'
 import { useAuth } from '../auth/AuthContext'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import {
   alarmSeenAt,
   alarmSeenTitle,
@@ -45,11 +46,20 @@ import {
 import { extractApiError } from '../lib/apiError'
 import { AuthedImage } from '../components/AuthedImage'
 import { Modal } from '../components/Modal'
+import { Tabs } from '../components/ui/Tabs'
 import { useSnackbar } from '../components/Snackbar'
 import { useInView } from '../hooks/useInView'
+import { useDebounce } from '../hooks/useDebounce'
+import { usePagination } from '../hooks/usePagination'
+import { useRowSelection } from '../hooks/useRowSelection'
+import { AlarmsFilters, AlarmsSelectionBar, AlarmsTable, cameraIdFromHandle } from '../components/alarms/AlarmsTable'
+import { useAckAlarms, useAlarmsList } from '../components/alarms/useAlarmsList'
+import { DataTable, type Column } from '../components/ui/DataTable'
+import { Pagination } from '../components/ui/Pagination'
+import { formatSeenAt, seenAtTitle } from '../lib/time'
 import {
   Badge, Button, Card, CardContent,
-  EmptyState, ErrorCard, PageHeader, Skeleton,
+  EmptyState, PageHeader, Skeleton,
 } from '../components/ui'
 import type { RegisteredApp } from './AppCatalog'
 
@@ -461,6 +471,22 @@ const RANGE_PRESETS = [
   { key: '30d', label: '30 days', hours: 24 * 30 },
 ] as const
 
+// One request's worth of rows for the CSV, and the server's own ceiling
+// on /events. Beyond this the export says how much it left out rather
+// than pretending it is complete.
+const EXPORT_MAX = 500
+
+/** The app whose alarms the Vehicles tab shows. */
+const LPR_SOURCE = 'license-plate-recognition'
+
+// Where "Contact us" goes. Deliberately the project's own page rather
+// than the installed app's manifest `contact`/`website`: that field
+// describes the APP (its author, its repo), while this banner is the
+// platform offering to build a site solution. Reading the manifest also
+// meant the banner vanished entirely for any app that omitted the
+// field.
+const CONTACT_URL = 'https://opennvr.org/contact/'
+
 // When this row's plate was seen, as an ISO string - the ONE timestamp
 // a plate read is dated by.
 //
@@ -480,6 +506,51 @@ function plateSeenAt(e: PlateEvent): string | null {
   return iso ? new Date(iso).toLocaleString() : null
 }
 
+// One stat, as a chip. Bordered box at the app's own `rounded` (4px,
+// same as Card/Badge/Button) — NOT `rounded-full`, which appears nowhere
+// else in the product.
+//
+// Most of these are a shortcut as well as a number: "1 registered" is
+// the Vehicle register tab, "2 monitored" is Monitoring. A figure the
+// operator is already looking at is the most natural place to click, so
+// the chip is a real <button> when it has a destination — keyboard
+// reachable, with a hover and a focus ring — and a plain <span> when it
+// is only a number.
+//
+// font-mono + tabular-nums so a figure ticking over on the 60s poll
+// cannot change the chip's width mid-glance.
+function StatChip({ icon: Icon, value, label, onClick, title }: {
+  icon: typeof Fingerprint
+  value: number | string | undefined
+  label: string
+  onClick?: () => void
+  title?: string
+}) {
+  const body = (
+    <>
+      <Icon size={16} className="text-[var(--text-dim)] shrink-0" />
+      <span className="font-mono text-xl font-semibold leading-none tabular-nums text-[var(--text)]">
+        {value ?? '…'}
+      </span>
+      <span className="text-sm leading-none text-[var(--text-dim)]">{label}</span>
+    </>
+  )
+  const shell = 'flex flex-1 min-w-[9rem] items-center justify-center gap-2 rounded border border-[var(--border)] bg-[var(--bg-2)] px-3 py-2'
+  if (!onClick) {
+    return <span className={shell}>{body}</span>
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={`${shell} transition-colors hover:border-[var(--text-dim)] hover:bg-[var(--panel-2)]`}
+    >
+      {body}
+    </button>
+  )
+}
+
 function toCsv(rows: PlateEvent[], cameraName: (id: number) => string): string {
   const esc = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`
   const head = 'plate,camera,seen_at,left_at,label'
@@ -495,18 +566,16 @@ function toCsv(rows: PlateEvent[], cameraName: (id: number) => string): string {
 export function Vehicles() {
   const queryClient = useQueryClient()
   const { showSuccess, showError } = useSnackbar()
+  const navigate = useNavigate()
   const [plate, setPlate] = useState('')
-  // The input stays instant; the QUERY waits. Without this every keystroke
-  // swapped the events queryKey, and since there is no keepPreviousData the
-  // table blanked and re-rendered its rows — a six-character plate meant six
-  // rounds of image mounts. Same 250ms the camera search uses.
-  const [debouncedPlate, setDebouncedPlate] = useState('')
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedPlate(plate), 250)
-    return () => clearTimeout(t)
-  }, [plate])
+  // The input stays instant; the QUERY waits. The table now keeps the
+  // previous page while the next one loads, so this is no longer load
+  // bearing for flicker — it still spares the server a request per
+  // keystroke.
+  const debouncedPlate = useDebounce(plate)
   const [cameraId, setCameraId] = useState<number | ''>('')
   const [range, setRange] = useState<(typeof RANGE_PRESETS)[number]>(RANGE_PRESETS[0])
+  const reads = usePagination(25, 'plate-reads')
   const [preview, setPreview] = useState<PlateEvent | null>(null)
   const [tab, setTab] = useState<'reads' | 'registry' | 'monitoring' | 'alarms'>('reads')
   // The register, monitors, barrier and alarm mode are the LPR app's
@@ -527,6 +596,28 @@ export function Vehicles() {
     },
     retry: 0,
   })
+  // Counts for the Alarms tab label. Two limit=1 requests rather than
+  // reading a loaded page: the tab has to be right even when the Alarms
+  // tab has never been opened, and `unacked_count` on the response is
+  // deliberately filter-blind (it is the bell's badge, every source), so
+  // it cannot answer "unacknowledged VEHICLE alarms".
+  const alarmCounts = useQuery({
+    queryKey: ['vehicle-alarm-counts'],
+    queryFn: async () => {
+      const [all, unacked] = await Promise.all([
+        alertsInboxService.listInboxAlerts({ source_name: LPR_SOURCE, limit: 1 }),
+        alertsInboxService.listInboxAlerts({ source_name: LPR_SOURCE, unacked: true, limit: 1 }),
+      ])
+      return {
+        total: (all.data as any)?.total as number | undefined,
+        unacked: (unacked.data as any)?.total as number | undefined,
+      }
+    },
+    retry: 0,
+    refetchInterval: 30_000,
+    placeholderData: keepPreviousData,
+  })
+
   const appsQuery = useQuery({
     queryKey: ['apps'],
     queryFn: async () => {
@@ -543,19 +634,29 @@ export function Vehicles() {
     [range]
   )
 
+  const readFilters = {
+    plate: debouncedPlate.trim() || undefined,
+    camera_id: cameraId === '' ? undefined : cameraId,
+    from: fromIso,
+  }
   const eventsQuery = useQuery({
-    queryKey: ['plate-events', debouncedPlate, cameraId, range.key],
+    queryKey: ['plate-events', debouncedPlate, cameraId, range.key,
+               reads.page, reads.pageSize],
     queryFn: async () => {
       const { data } = await apiService.getPlateEvents({
-        plate: debouncedPlate.trim() || undefined,
-        camera_id: cameraId === '' ? undefined : cameraId,
-        from: fromIso,
-        limit: 200,
+        ...readFilters, skip: reads.skip, limit: reads.pageSize,
       })
-      return ((data as any)?.events ?? []) as PlateEvent[]
+      const body = data as { events?: PlateEvent[]; total?: number }
+      return { rows: body?.events ?? [], total: body?.total }
     },
     retry: 0,
-    refetchInterval: 30_000,
+    // Page 1 is a live view of the gate and should keep refreshing.
+    // Deeper pages are someone reading history, and refreshing under
+    // them shifts every row down as new reads arrive.
+    refetchInterval: reads.page === 1 ? 30_000 : false,
+    // Without this the table empties on every page change and every
+    // poll, remounting each row's thumbnail.
+    placeholderData: keepPreviousData,
   })
 
   // The tiles follow the SAME range selector as the reads list — a 7d
@@ -717,6 +818,51 @@ export function Vehicles() {
     onError: (e) => showError(extractApiError(e, 'Could not update the watchlist.')),
   })
 
+  // Register and monitor are SEPARATE lists on the app's config, so they
+  // are separate toggles: a resident's car can be registered and also
+  // worth alerting on. The Status badge still shows one value because it
+  // ranks them, but the underlying state is two booleans and pretending
+  // otherwise (an exclusive dropdown) meant setting one silently cleared
+  // the other.
+  //
+  // Turning a plate OFF the register discards owner/unit/model details
+  // that nothing else on the platform holds, so that direction asks
+  // first. Everything else here is retypable.
+  const toggleList = useMutation({
+    mutationFn: async ({ plateText, list, on }: {
+      plateText: string
+      list: 'registry' | 'monitor'
+      on: boolean
+    }) => {
+      if (!lprApp) throw new Error('No enabled LPR app to hold the watchlist.')
+      const cfg = { ...(lprApp.config ?? {}) } as Record<string, any>
+      const without = (entries: any[]) => entries.filter((entry) => {
+        const plate = typeof entry === 'string' ? entry : entry?.plate
+        return String(plate ?? '').toUpperCase() !== plateText
+      })
+      if (list === 'registry') {
+        cfg.registry = on ? [...without(registry), { plate: plateText }] : without(registry)
+      } else {
+        cfg.monitors = on
+          ? [...without(monitors), { plate: plateText, severity: 'high', active: true }]
+          : without(monitors)
+        // The legacy denylist is monitor shorthand — a plate leaving the
+        // monitored state has to leave there too, or it comes straight back.
+        if (Array.isArray(cfg.denylist)) cfg.denylist = without(cfg.denylist)
+      }
+      await apiService.updateAppConfig(lprApp.id, cfg)
+    },
+    onSuccess: (_d, v) => {
+      queryClient.invalidateQueries({ queryKey: ['apps'] })
+      showSuccess(v.list === 'registry'
+        ? (v.on ? `${v.plateText} registered — add owner details in the Vehicle register tab`
+          : `${v.plateText} removed from the vehicle register`)
+        : (v.on ? `${v.plateText} is now monitored — configure its alert in the Monitoring tab`
+          : `${v.plateText} is no longer monitored`))
+    },
+    onError: (e) => showError(extractApiError(e, 'Could not update the watchlist.')),
+  })
+
   // Replace the whole monitors list (Monitoring tab edits). The tab
   // edits the MERGED view (explicit monitors + denylist shorthand), so
   // every save migrates the legacy denylist into explicit monitors and
@@ -728,87 +874,360 @@ export function Vehicles() {
   const cameraName = (id: number) =>
     camerasQuery.data?.find((c) => c.id === id)?.name ?? `cam${id}`
 
-  const exportCsv = () => {
-    const rows = eventsQuery.data ?? []
-    const blob = new Blob([toCsv(rows, cameraName)], { type: 'text/csv' })
-    const a = document.createElement('a')
-    a.href = URL.createObjectURL(blob)
-    a.download = `plate-reads-${new Date().toISOString().slice(0, 10)}.csv`
-    a.click()
-    URL.revokeObjectURL(a.href)
+  // Fetches its own rows rather than exporting what is on screen. The
+  // table now holds ONE PAGE, and an export that quietly contained 25 of
+  // 312 reads would be worse than no export at all — this file is the
+  // evidence trail an operator hands to someone else.
+  const [exporting, setExporting] = useState(false)
+  const exportCsv = async () => {
+    setExporting(true)
+    try {
+      const { data } = await apiService.getPlateEvents({
+        ...readFilters, limit: EXPORT_MAX,
+      })
+      const rows = ((data as any)?.events ?? []) as PlateEvent[]
+      const total = (data as any)?.total as number | undefined
+      const blob = new Blob([toCsv(rows, cameraName)], { type: 'text/csv' })
+      const a = document.createElement('a')
+      a.href = URL.createObjectURL(blob)
+      a.download = `plate-reads-${new Date().toISOString().slice(0, 10)}.csv`
+      a.click()
+      URL.revokeObjectURL(a.href)
+      // Say so rather than truncating in silence.
+      if (typeof total === 'number' && total > rows.length) {
+        showError(`Exported the newest ${rows.length} of ${total} reads — narrow the window for the rest.`)
+      } else {
+        showSuccess(`Exported ${rows.length} read${rows.length === 1 ? '' : 's'}.`)
+      }
+    } catch (e) {
+      showError(extractApiError(e, 'Could not export the reads.'))
+    } finally {
+      setExporting(false)
+    }
   }
 
   const stats = statsQuery.data
-  const events = eventsQuery.data ?? []
+  const events = eventsQuery.data?.rows ?? []
+  const eventsTotal = eventsQuery.data?.total
+
+  const readColumns: Column<PlateEvent>[] = ([
+    {
+      // FIRST column: the row's controls live in a left gutter, always
+      // visible. They are dim icons that brighten on approach — quiet
+      // enough not to crowd the data, present enough that nobody has to
+      // discover them by hovering.
+      key: 'watchlist', header: '', srHeader: 'Watchlist actions',
+      width: 'w-[72px]', className: 'whitespace-nowrap',
+      isAction: true,
+      cell: (e) => {
+        const p = (e.plate_text ?? '').toUpperCase()
+        if (!lprApp || !canConfigure) return null
+        const registered = registryPlates.has(p)
+        const monitored = monitoredPlates.has(p)
+        const entry = registry.find((r) => r.plate === p)
+        const hasDetails = !!(entry?.owner || entry?.unit || entry?.expires
+          || entry?.model || entry?.note)
+
+        // BOTH icons on every row, always. They used to appear only when
+        // the plate was NOT on that list, so a row's gutter changed shape
+        // depending on state — the control you wanted was missing exactly
+        // when you wanted to undo something. Now the icon is the state:
+        // lit means on, dim means off, and clicking it flips that.
+        const toggle = (list: 'registry' | 'monitor', on: boolean) => {
+          if (list === 'registry' && !on && hasDetails
+            && !window.confirm(
+              `${p} has owner or unit details in the vehicle register.
+
+`
+              + 'Removing it discards that entry and those details.')) {
+            return
+          }
+          if (list === 'registry' && on) setRegisterPrefill(p)
+          toggleList.mutate({ plateText: p, list, on })
+        }
+
+        return (
+          <>
+            <button
+              aria-pressed={registered}
+              disabled={toggleList.isPending}
+              title={registered
+                ? `${p} is in the vehicle register — click to remove`
+                : 'Register this vehicle — add owner details in the Vehicle register tab'}
+              aria-label={registered ? `Remove ${p} from the register` : `Register ${p}`}
+              className={`mr-2 rounded p-0.5 ${registered
+                ? 'text-[var(--badge-success-text)]'
+                : 'text-[var(--text-dim)] hover:text-[var(--text)]'}`}
+              onClick={() => toggle('registry', !registered)}
+            >
+              <BookUser size={15} />
+            </button>
+            <button
+              aria-pressed={monitored}
+              disabled={toggleList.isPending}
+              title={monitored
+                ? `${p} is monitored — click to stop alerting on it`
+                : 'Monitor this plate — alert whenever it is seen'}
+              aria-label={monitored ? `Stop monitoring ${p}` : `Monitor ${p}`}
+              className={`rounded p-0.5 ${monitored
+                ? 'text-[var(--badge-destructive-text)]'
+                : 'text-[var(--text-dim)] hover:text-[var(--text)]'}`}
+              onClick={() => toggle('monitor', !monitored)}
+            >
+              <ShieldAlert size={15} />
+            </button>
+          </>
+        )
+      },
+    },
+    {
+      key: 'photo', header: 'Photo', width: 'w-20',
+      cell: (e) => (e.has_plate_evidence || e.has_evidence)
+        ? <RowThumb e={e} plate={(e.plate_text ?? '').toUpperCase()} onOpen={() => setPreview(e)} />
+        : <div className="h-8 w-14 grid place-items-center text-[10px] text-[var(--text-dim)] bg-[var(--bg-2)] rounded">—</div>,
+    },
+    {
+      key: 'plate', header: 'Plate', width: 'w-[148px]',
+      cellClassName: 'font-mono font-semibold',
+      cell: (e) => {
+        const p = (e.plate_text ?? '').toUpperCase()
+        return (
+          <button
+            className="hover:underline inline-flex items-center gap-1"
+            title="Vehicle history — every time this plate was seen"
+            onClick={() => setHistoryPlate(p)}
+          >
+            {p} <History size={12} className="text-[var(--text-dim)]" />
+          </button>
+        )
+      },
+    },
+    {
+      key: 'camera', header: 'Camera',
+      // The one column with no width — it absorbs the slack. Under
+      // table-fixed an over-long name WRAPS rather than widening, and an
+      // uneven row height is exactly what the thumbnail rules exist to
+      // prevent, so it truncates with the full name on hover.
+      cellClassName: 'truncate',
+      cell: (e) => {
+        const r = cameraRoles[String(e.camera_id)]
+        // roleLabel falls back to "Other" for any role that is not a
+        // gate or parking, so every ordinary camera wore a grey badge
+        // saying nothing. Badge only what an operator can act on: a
+        // gate direction, parking, or a label someone actually chose.
+        const named = !!r && (r.role === 'gate_in' || r.role === 'gate_out'
+          || r.role === 'parking' || !!r.label)
+        const label = named ? roleLabel(r) : null
+        const name = cameraName(e.camera_id)
+        return (
+          <span className="flex items-center gap-1.5 min-w-0" title={name}>
+            <span className="truncate">{name}</span>
+            {label && (
+              <Badge variant={r!.role === 'gate_in' ? 'success' : 'neutral'} className="shrink-0">
+                {label}
+              </Badge>
+            )}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'seen', header: 'Date & time', width: 'w-[164px]',
+      className: 'whitespace-nowrap',
+      // Colour and numerals belong to the DATA, not the header — putting
+      // them on `className` dimmed this column's header and made it the
+      // odd one out.
+      cellClassName: 'text-[var(--text-dim)] tabular-nums',
+      cell: (e) => {
+        const iso = plateSeenIso(e)
+        return <span title={seenAtTitle(iso)}>{formatSeenAt(iso) || '—'}</span>
+      },
+    },
+    {
+      key: 'status', header: 'Status', width: 'w-[120px]',
+      // Read-only again. A <select> in a data row was heavier than the
+      // thing it described and put a second, differently-shaped control
+      // next to the gutter toggles that already do this. The badge
+      // reports; the icons act.
+      cell: (e) => {
+        const p = (e.plate_text ?? '').toUpperCase()
+        if (monitoredPlates.has(p)) {
+          return (
+            <Badge variant="destructive" title={monitors.find((m) => m.plate === p)?.note}>
+              monitored
+            </Badge>
+          )
+        }
+        if (registryPlates.has(p)) return <Badge variant="success">registered</Badge>
+        if (expiredPlates.has(p)) return <Badge variant="warning">pass expired</Badge>
+        if (allow.includes(p)) return <Badge variant="success">expected</Badge>
+        if (alarmOnUnknown) return <Badge variant="warning">unknown</Badge>
+        return <span className="text-[var(--text-dim)]">—</span>
+      },
+    },
+  ] as Column<PlateEvent>[])
 
   return (
     <section className="space-y-4">
-      <PageHeader
-        title="Vehicles (ANPR)"
-        description="License plate reads across your cameras — searched from the evidence store, whichever part of the platform ran the OCR. Watchlists apply live."
-        actions={
-          <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={() => setReportOpen(true)}>
-              <FileText size={14} /> Monthly report
+      <div>
+        {/* The description dropped "searched from the evidence store,
+            whichever part of the platform ran the OCR" — an implementation
+            note, not something an operator needs on every visit, and it
+            cost a second line. */}
+        <PageHeader
+          title="Vehicles (ANPR)"
+          description="License plate reads across your cameras. Watchlists apply live."
+          actions={
+            <>
+              {/* A settings destination, not a filter — it belongs with
+                  the other page-level actions rather than wedged between
+                  the severity chips and the pager. Only on the tab it
+                  applies to; this header is shared by all four. */}
+              {/* Every tab, not just Alarms: how the site SOUNDS is
+                  something you go and set, not something you only think
+                  about while already looking at a list of alarms. */}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate('/alerts-incidents')}
+                title="Sound, phone-call and hooter settings apply site-wide, across every app's alarms"
+              >
+                <Volume2 size={13} /> Sound &amp; hooter
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => setReportOpen(true)}>
+                <FileText size={13} /> Monthly report
+              </Button>
+              {/* An empty PAGE is not an empty result set, so the guard is
+                  the export's own state, not the row count. */}
+              <Button variant="outline" size="sm" onClick={exportCsv} disabled={exporting}>
+                <Download size={13} className={exporting ? 'animate-pulse' : ''} />
+                {exporting ? 'Exporting…' : 'Export CSV'}
+              </Button>
+              <Button size="sm" onClick={() => eventsQuery.refetch()} disabled={eventsQuery.isFetching}>
+                <RefreshCw size={13} className={eventsQuery.isFetching ? 'animate-spin' : ''} /> Refresh
+              </Button>
+            </>
+          }
+        />
+
+        {/* Sits directly under the product description, where it reads as
+            part of what this page IS rather than an interruption in the
+            middle of the work. Deliberately NOT below the table: the
+            fill-height calculation reserves for anything under there, so
+            it would cost table rows on every visit. */}
+        <div className="mb-3 flex items-start gap-2.5 rounded border border-[var(--border)] bg-[var(--bg-2)] px-3 py-2">
+            <PhoneCall size={15} className="mt-0.5 shrink-0 text-[var(--text-dim)]" />
+            <p className="min-w-0 flex-1 text-xs leading-snug">
+              <span className="font-medium text-[var(--text)]">Need more for your site?</span>{' '}
+              <span className="text-[var(--text-dim)]">
+                Housing societies, industrial estates, factories, company campuses,
+                warehouses and logistics yards — phone-number &amp; SMS alerts,
+                WhatsApp notifications, complete gate &amp; process automation
+                (barrier lift for registered vehicles, truck-bay logging),
+                scheduled reports, or any custom feature. We build per-site
+                solutions.
+              </span>
+            </p>
+            {/* The one accent-filled control on the page. Everything
+                around it is outline or ghost, so primary is the loudest
+                thing available without inventing a colour outside the
+                token set — and the arrow says it leaves the app. */}
+            <Button
+              variant="primary"
+              size="sm"
+              className="shrink-0 self-center font-medium"
+              onClick={() => window.open(CONTACT_URL, '_blank', 'noopener,noreferrer')}
+            >
+              Contact us <ArrowRight size={13} />
             </Button>
-            <Button variant="outline" onClick={exportCsv} disabled={!events.length}>
-              <Download size={14} /> Export CSV
-            </Button>
-            <Button onClick={() => eventsQuery.refetch()} disabled={eventsQuery.isFetching}>
-              <RefreshCw size={14} className={eventsQuery.isFetching ? 'animate-spin' : ''} /> Refresh
-            </Button>
+        </div>
+
+        {lprApp && (
+          // flex-1 on each chip so the row spans the page instead of
+          // trailing off mid-width. min-w keeps them from crushing
+          // together before they wrap.
+          <div className="mb-3 flex flex-wrap items-stretch gap-2">
+            <StatChip
+              icon={ScanLine} value={stats?.total_reads} label="reads"
+              onClick={() => setTab('reads')} title="Show the plate reads"
+            />
+            <StatChip
+              icon={Fingerprint} value={stats?.unique_plates} label="unique plates"
+            />
+            {gatesConfigured && (
+              <StatChip icon={Car} value={occupancyQuery.data?.inside} label="inside now" />
+            )}
+            {/* The registry and monitoring tabs are superuser-only, so a
+                chip that navigates to one is too. "Busiest camera" used
+                to sit here: on a single-camera site it names the only
+                camera there is, and on any site it repeats what the
+                monthly report breaks down properly. */}
+            {canConfigure && (
+              <StatChip
+                icon={BookUser} value={registry.length} label="registered"
+                onClick={() => setTab('registry')} title="Open the vehicle register"
+              />
+            )}
+            {canConfigure && (
+              <StatChip
+                icon={ShieldAlert} value={monitors.length} label="monitored"
+                onClick={() => setTab('monitoring')} title="Open the monitoring list"
+              />
+            )}
           </div>
-        }
-      />
-
-      {/* ── Stat tiles (follow the selected range) ────────────────── */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        {[
-          { label: `Reads (${range.label})`, value: stats?.total_reads },
-          { label: `Unique plates (${range.label})`, value: stats?.unique_plates },
-          gatesConfigured
-            ? { label: 'Inside now', value: occupancyQuery.data?.inside }
-            : { label: `Busiest camera (${range.label})`, value: stats?.per_camera?.length
-                ? cameraName([...stats.per_camera].sort((a, b) => b.reads - a.reads)[0].camera_id)
-                : '—' },
-          { label: 'Registered vehicles', value: lprApp ? registry.length : '—' },
-        ].map((t) => (
-          <Card key={t.label}>
-            <CardContent className="py-3">
-              <div className="text-2xl font-semibold">{t.value ?? '…'}</div>
-              <div className="text-xs text-[var(--text-dim)]">{t.label}</div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {/* ── Tabs: live reads vs the vehicle register ─────────────── */}
-      <div className="flex items-center gap-1 border-b border-[var(--border)]">
-        {([
-          { key: 'reads', label: 'Plate reads' },
-          { key: 'registry', label: `Vehicle register (${registry.length})` },
-          { key: 'monitoring', label: `Monitoring (${monitors.length})` },
-          { key: 'alarms', label: 'Alarms' },
-        ] as const).filter((t) => canConfigure || t.key === 'reads' || t.key === 'alarms').map((t) => (
-          <button
-            key={t.key}
-            onClick={() => setTab(t.key)}
-            className={`px-3 py-2 text-sm -mb-px border-b-2 ${tab === t.key
-              ? 'border-[var(--accent,var(--text))] text-[var(--text)] font-medium'
-              : 'border-transparent text-[var(--text-dim)] hover:text-[var(--text)]'}`}
-          >
-            {t.label}
-          </button>
-        ))}
-        {alarmOnUnknown && (
-          <span className="ml-auto inline-flex items-center gap-1 text-xs text-[var(--warning,#b7791f)]">
-            <BellRing size={13} /> Unknown-vehicle alarm is ON
-          </span>
         )}
+
+        {/* Header and tabs are ONE block. PageHeader carries its own mb-4
+            and the section's space-y-4 was stacking a second 16px on top,
+            so the tab bar floated 32px under the title looking unrelated to
+            it. Wrapped together, the tab rule reads as the bottom edge of
+            the page header — which is what a tab bar is.
+            Tabs scope the CONTENT; the filter bar below scopes the rows.
+            They stayed separate rows on purpose — hanging the reads
+            filters off the tab rule would leave them sitting live above the
+            Vehicle register, where they do nothing. */}
+        <Tabs
+          tabs={([
+            { key: 'reads', label: 'Plate reads' },
+            { key: 'registry', label: `Vehicle register (${registry.length})` },
+            { key: 'monitoring', label: `Monitoring (${monitors.length})` },
+            {
+            key: 'alarms',
+            // "(119/1358)" — unacknowledged over total, in the same
+            // parenthesised shape the other tabs use, so the row of tabs
+            // still scans as one thing. Only the unacknowledged half
+            // takes colour: it is the number you act on, and a badge
+            // around it made the tab shout louder than the tab you were
+            // actually on. At zero it stays dim — nothing to act on,
+            // nothing to highlight.
+            label: (
+              <span className="inline-flex items-center gap-1.5">
+                Alarms
+                {typeof alarmCounts.data?.total === 'number' && (
+                  <span className="text-[var(--text-dim)]">
+                    (
+                    <span className={alarmCounts.data.unacked
+                      ? 'font-semibold text-[var(--badge-warning-text)]'
+                      : undefined}
+                    >
+                      {alarmCounts.data.unacked ?? 0}
+                    </span>
+                    /{alarmCounts.data.total})
+                  </span>
+                )}
+              </span>
+            ),
+          },
+          ] as const)
+            .filter((t) => canConfigure || t.key === 'reads' || t.key === 'alarms')
+            .map((t) => ({ key: t.key, label: t.label }))}
+          active={tab}
+          onChange={(k: string) => setTab(k as typeof tab)}
+        />
       </div>
 
       {tab === 'alarms' ? (
-        <VehicleAlarmsTab />
+        <VehicleAlarmsTab cameraName={cameraName} />
       ) : tab === 'monitoring' ? (
         <MonitoringTab
           monitors={monitors}
@@ -980,202 +1399,136 @@ export function Vehicles() {
         </Card>
       )}
 
-      {/* ── Filters ───────────────────────────────────────────────── */}
-      <Card>
-        <CardContent className="py-3 flex flex-wrap items-center gap-2">
-          <div className="relative">
-            <Search size={14} className="absolute left-2 top-1/2 -translate-y-1/2 text-[var(--text-dim)]" />
-            <input
-              value={plate}
-              onChange={(e) => setPlate(e.target.value)}
-              placeholder="Plate contains… (e.g. 1234)"
-              className="pl-7 pr-2 py-1.5 rounded border border-[var(--border)] bg-[var(--bg-2)] text-sm w-56"
-            />
-          </div>
-          <select
-            value={cameraId}
-            onChange={(e) => setCameraId(e.target.value === '' ? '' : Number(e.target.value))}
-            className="py-1.5 px-2 rounded border border-[var(--border)] bg-[var(--bg-2)] text-sm"
-          >
-            <option value="">All cameras</option>
-            {(camerasQuery.data ?? []).map((c) => (
-              <option key={c.id} value={c.id}>{c.name}</option>
-            ))}
-          </select>
-          <div className="flex rounded border border-[var(--border)] overflow-hidden">
-            {RANGE_PRESETS.map((r) => (
-              <button
-                key={r.key}
-                onClick={() => setRange(r)}
-                className={`px-3 py-1.5 text-sm ${range.key === r.key
-                  ? 'bg-[var(--accent,var(--bg-2))] text-white'
-                  : 'bg-[var(--bg-2)] text-[var(--text-dim)]'}`}
-              >
-                {r.label}
-              </button>
-            ))}
-          </div>
-          {!lprApp && (
-            <span className="text-xs text-[var(--text-dim)] ml-auto">
-              No enabled LPR app — reads still collect; watchlists need the app.
-            </span>
-          )}
-        </CardContent>
-      </Card>
-
       {/* ── Reads table ───────────────────────────────────────────── */}
-      {eventsQuery.isPending ? (
-        <Skeleton className="h-64" />
-      ) : eventsQuery.isError ? (
-        <ErrorCard
-          title="Could not load plate reads"
-          message={extractApiError(eventsQuery.error, 'The events store is unreachable.')}
-          onRetry={() => eventsQuery.refetch()}
-        />
-      ) : events.length === 0 ? (
-        <EmptyState
-          icon={<Car size={28} />}
-          title="No plate reads in this window"
-          description="Assign cameras the License Plate Recognition skill (Cameras → edit → Assignments) and vehicle visits will appear here with their evidence photos."
-        />
-      ) : (
-        <Card>
-          <CardContent className="p-0 overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-xs text-[var(--text-dim)] border-b border-[var(--border)]">
-                  <th className="px-3 py-2">Photo</th>
-                  <th className="px-3 py-2">Plate</th>
-                  <th className="px-3 py-2">Camera</th>
-                  <th className="px-3 py-2">Seen</th>
-                  <th className="px-3 py-2">Status</th>
-                  <th className="px-3 py-2 text-right pr-4">Watchlist</th>
-                </tr>
-              </thead>
-              <tbody>
-                {events.map((e) => {
-                  const p = (e.plate_text ?? '').toUpperCase()
-                  const inDeny = monitoredPlates.has(p)
-                  const inAllow = allow.includes(p)
-                  const registered = registryPlates.has(p)
-                  return (
-                    <tr key={e.id} className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-2)]">
-                      <td className="px-3 py-1.5">
-                        {(e.has_plate_evidence || e.has_evidence) ? (
-                          <RowThumb e={e} plate={p} onOpen={() => setPreview(e)} />
-                        ) : (
-                          <div className="h-10 w-16 grid place-items-center text-[10px] text-[var(--text-dim)] bg-[var(--bg-2)] rounded">—</div>
-                        )}
-                      </td>
-                      <td className="px-3 py-1.5 font-mono font-semibold">
-                        <button
-                          className="hover:underline inline-flex items-center gap-1"
-                          title="Vehicle history — every time this plate was seen"
-                          onClick={() => setHistoryPlate(p)}
-                        >
-                          {p} <History size={12} className="text-[var(--text-dim)]" />
-                        </button>
-                      </td>
-                      <td className="px-3 py-1.5">
-                        {cameraName(e.camera_id)}
-                        {(() => {
-                          const r = cameraRoles[String(e.camera_id)]
-                          const label = roleLabel(r)
-                          if (!label) return null
-                          return (
-                            <Badge
-                              variant={r!.role === 'gate_in' ? 'success' : 'neutral'}
-                              className="ml-1.5"
-                            >
-                              {label}
-                            </Badge>
-                          )
-                        })()}
-                      </td>
-                      <td className="px-3 py-1.5 text-[var(--text-dim)]">
-                        {plateSeenAt(e) ?? '—'}
-                      </td>
-                      <td className="px-3 py-1.5">
-                        {inDeny ? <Badge variant="destructive" title={monitors.find((m) => m.plate === p)?.note}>monitored</Badge>
-                          : registered ? <Badge variant="success">registered</Badge>
-                          : expiredPlates.has(p) ? <Badge variant="warning">pass expired</Badge>
-                          : inAllow ? <Badge variant="success">expected</Badge>
-                          : alarmOnUnknown ? <Badge variant="warning">unknown</Badge>
-                          : <Badge variant="neutral">{e.label || 'vehicle'}</Badge>}
-                      </td>
-                      <td className="px-3 py-1.5 text-right pr-4 whitespace-nowrap">
-                        {lprApp && canConfigure && !registered && (
-                          <button
-                            title="Register this vehicle — one click adds the plate to the Vehicle register; add owner details there any time"
-                            className="text-[var(--text-dim)] hover:text-[var(--text)] mr-2"
-                            onClick={() => {
-                              // One click = registered (the ask); details
-                              // are optional and live in the register tab,
-                              // pre-filtered to this plate via prefill.
-                              setRegisterPrefill(p)
-                              saveConfig.mutate(
-                                { registry: [...registry, { plate: p }] },
-                                {
-                                  onSuccess: () => showSuccess(
-                                    `${p} registered — add owner details in the Vehicle register tab`),
-                                },
-                              )
-                            }}
-                          >
-                            <BookUser size={15} />
-                          </button>
-                        )}
-                        {lprApp && canConfigure && !inDeny && (
-                          <button
-                            title="Monitor this plate — alert whenever it is seen (configure in the Monitoring tab)"
-                            className="text-[var(--text-dim)] hover:text-[var(--text)] mr-2"
-                            onClick={() => watchlist.mutate({ plateText: p, list: 'monitor' })}
-                          >
-                            <ShieldAlert size={15} />
-                          </button>
-                        )}
-
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </CardContent>
-        </Card>
-      )}
+      <DataTable<PlateEvent>
+        caption="Plate reads"
+        columns={readColumns}
+        rows={events}
+        rowKey={(e) => e.id}
+        isPending={eventsQuery.isPending}
+        isFetching={eventsQuery.isFetching}
+        isError={eventsQuery.isError}
+        error={eventsQuery.error}
+        errorTitle="Could not load plate reads"
+        onRetry={() => eventsQuery.refetch()}
+        fillHeight
+        fixed
+        dense
+        minWidth="min-w-[720px]"
+        // The row IS the record: clicking anywhere on it opens the
+        // evidence, the way a mail row opens the mail. The photo keeps
+        // its own handler for the zoom affordance.
+        onRowClick={(e) => setPreview(e)}
+        // No zebra. Striping earns its place on a wide numeric grid; on
+        // a short row with a photo it is visual noise, and a plain hover
+        // reads cleaner and makes the hovered row unmistakable.
+        striped={false}
+        empty={
+          <EmptyState
+            icon={<Car size={28} />}
+            title={debouncedPlate || cameraId !== ''
+              ? 'No plate reads match these filters'
+              : 'No plate reads in this window'}
+            description="Assign cameras the License Plate Recognition skill (Cameras → edit → Assignments) and vehicle visits will appear here with their evidence photos."
+            action={(debouncedPlate || cameraId !== '') ? (
+              <Button variant="outline" onClick={() => {
+                setPlate(''); setCameraId(''); reads.setPage(1)
+              }}>Clear filters</Button>
+            ) : undefined}
+          />
+        }
+        // Filters and paging share ONE bar inside the table's own border.
+        // They used to be three separately-bordered controls floating
+        // above a separately-bordered table, so the eye counted four
+        // rectangles before reaching a row of data. Controls belong to
+        // the thing they control.
+        toolbar={
+          <div className="flex flex-wrap items-center gap-2 py-1.5 pl-3">
+            <div className="relative">
+              <Search size={14} className="absolute left-2 top-1/2 -translate-y-1/2 text-[var(--text-dim)]" />
+              <input
+                value={plate}
+                onChange={(e) => { setPlate(e.target.value); reads.setPage(1) }}
+                placeholder="Plate contains… (e.g. 1234)"
+                aria-label="Filter by plate"
+                className="w-48 rounded border border-[var(--border)] bg-[var(--bg-2)] py-1 pl-7 pr-2 text-xs"
+              />
+            </div>
+            <select
+              value={cameraId}
+              onChange={(e) => {
+                setCameraId(e.target.value === '' ? '' : Number(e.target.value))
+                reads.setPage(1)
+              }}
+              aria-label="Filter by camera"
+              className="rounded border border-[var(--border)] bg-[var(--bg-2)] px-2 py-1 text-xs"
+            >
+              <option value="">All cameras</option>
+              {(camerasQuery.data ?? []).map((c) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+            {/* The selected range reads as a state, not a call to action:
+                a filled accent segment competed with the one primary
+                button on the page. Weight and a tint carry it instead. */}
+            <div className="flex overflow-hidden rounded border border-[var(--border)]"
+                 role="group" aria-label="Time range">
+              {RANGE_PRESETS.map((r) => (
+                <button
+                  key={r.key}
+                  type="button"
+                  aria-pressed={range.key === r.key}
+                  onClick={() => { setRange(r); reads.setPage(1) }}
+                  className={`px-2.5 py-1 text-xs ${range.key === r.key
+                    ? 'bg-[var(--panel-2)] font-semibold text-[var(--text)]'
+                    : 'text-[var(--text-dim)] hover:text-[var(--text)]'}`}
+                >
+                  {r.label}
+                </button>
+              ))}
+            </div>
+            {alarmOnUnknown && (
+              <Badge variant="warning" title="Any plate not in the vehicle register raises a high-severity alert">
+                <BellRing size={12} /> Unknown-vehicle alarm ON
+              </Badge>
+            )}
+            {!lprApp && (
+              <span className="text-xs text-[var(--text-dim)]">
+                No enabled LPR app — reads still collect; watchlists need the app.
+              </span>
+            )}
+            <div className="ml-auto">
+              <Pagination
+                page={reads.page}
+                pageSize={reads.pageSize}
+                total={eventsTotal}
+                rowCount={events.length}
+                hasNext={events.length === reads.pageSize}
+                isFetching={eventsQuery.isFetching}
+                label="reads"
+                onPageChange={reads.setPage}
+                onPageSizeChange={reads.setPageSize}
+                announce={false}
+              />
+            </div>
+          </div>
+        }
+        footer={
+          <Pagination
+            page={reads.page}
+            pageSize={reads.pageSize}
+            total={eventsTotal}
+            rowCount={events.length}
+            hasNext={events.length === reads.pageSize}
+            isFetching={eventsQuery.isFetching}
+            label="reads"
+            onPageChange={reads.setPage}
+            onPageSizeChange={reads.setPageSize}
+          />
+        }
+      />
       </>
       )}
-
-      {/* ── Custom solutions (the providing app's contact) ────────── */}
-      {(() => {
-        const contact =
-          (lprApp?.manifest as any)?.contact || (lprApp?.manifest as any)?.website
-        if (!contact) return null
-        return (
-          <Card>
-            <CardContent className="py-3 flex flex-wrap items-center gap-3">
-              <PhoneCall size={18} className="text-[var(--text-dim)] shrink-0" />
-              <div className="min-w-0 flex-1 text-sm">
-                <span className="font-medium">Need more for your site?</span>{' '}
-                <span className="text-[var(--text-dim)]">
-                  Housing societies, industrial estates, factories, company campuses,
-                  warehouses and logistics yards — phone-number &amp; SMS alerts, WhatsApp
-                  notifications, complete gate &amp; process automation (barrier lift for
-                  registered vehicles, truck-bay logging), scheduled reports, or any
-                  custom feature. We build per-site solutions.
-                </span>
-              </div>
-              <Button
-                variant="outline"
-                onClick={() => window.open(contact, '_blank', 'noopener,noreferrer')}
-              >
-                Contact us
-              </Button>
-            </CardContent>
-          </Card>
-        )
-      })()}
 
       {/* ── Printable monthly report ──────────────────────────────── */}
       {reportOpen && (
@@ -1326,7 +1679,7 @@ export function Vehicles() {
  *  that is ~200 at once, each holding a server-side DB connection while it
  *  runs, which is precisely what exhausted core's pool.
  *
- *  The placeholder is the SAME h-10 w-16 box as the image: anything else
+ *  The placeholder is the SAME h-8 w-14 box as the image: anything else
  *  and rows resize as they scroll in, which moves the very elements the
  *  observer is measuring.
  */
@@ -1345,7 +1698,7 @@ function RowThumb({ e, plate, onOpen }: {
         type="button"
         onClick={onOpen}
         title="The frame this plate was read from was not stored"
-        className="h-10 w-16 rounded bg-[var(--bg-2)] grid place-items-center text-[9px] leading-tight text-[var(--text-dim)] cursor-zoom-in"
+        className="h-8 w-14 rounded bg-[var(--bg-2)] grid place-items-center text-[9px] leading-tight text-[var(--text-dim)] cursor-zoom-in"
       >
         no read
         <br />frame
@@ -1353,7 +1706,7 @@ function RowThumb({ e, plate, onOpen }: {
     )
   }
   return (
-    <div ref={ref} className="h-10 w-16">
+    <div ref={ref} className="h-8 w-14">
       {seen ? (
         <AuthedImage
           {...rowThumbImage(e)}
@@ -1363,11 +1716,11 @@ function RowThumb({ e, plate, onOpen }: {
           // already-small picture. Nothing here has to stay legible the
           // way the plate crop did (#385); it is a "which car" glance,
           // and the dialog is one click away.
-          className="h-10 w-16 rounded cursor-zoom-in object-cover"
+          className="h-8 w-14 rounded cursor-zoom-in object-cover"
           onClick={onOpen}
         />
       ) : (
-        <div className="h-10 w-16 rounded bg-[var(--bg-2)]" />
+        <div className="h-8 w-14 rounded bg-[var(--bg-2)]" />
       )}
     </div>
   )
@@ -2386,123 +2739,110 @@ function ReportOverlay({
 // hooter configuration stay site-wide (one guard phone for every app's
 // alarms), linked below.
 
-const VEHICLE_ALARM_SEVERITY: Record<string, string> = {
-  critical: 'bg-red-600 text-white',
-  high: 'bg-orange-600 text-white',
-  medium: 'bg-yellow-600 text-black',
-  low: 'bg-neutral-600 text-white',
-}
-
-function VehicleAlarmsTab() {
-  const queryClient = useQueryClient()
+function VehicleAlarmsTab({ cameraName }: { cameraName: (id: number) => string }) {
   const [onlyUnacked, setOnlyUnacked] = useState(false)
-  const list = useQuery({
-    queryKey: ['vehicle-alarms', onlyUnacked],
-    queryFn: async () => {
-      const { data } = await alertsInboxService.listInboxAlerts({
-        source_name: 'license-plate-recognition',
-        unacked: onlyUnacked || undefined,
-        limit: 100,
-      })
-      return data as { alerts: InboxAlert[]; unacked_count: number }
-    },
-    refetchInterval: 10_000,
+  const [severityFilter, setSeverityFilter] = useState<string | null>(null)
+  const pager = usePagination(25, 'vehicle-alarms')
+
+  const list = useAlarmsList({
+    queryKeyPrefix: 'vehicle-alarms',
+    sourceName: LPR_SOURCE,
+    unacked: onlyUnacked,
+    severity: severityFilter,
+    page: pager.page,
+    pageSize: pager.pageSize,
+    skip: pager.skip,
   })
-  const ack = useMutation({
-    mutationFn: (ids?: number[]) => alertsInboxService.ackInboxAlerts(ids),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vehicle-alarms'] })
-      queryClient.invalidateQueries({ queryKey: ['alerts-inbox-unacked'] })
-      queryClient.invalidateQueries({ queryKey: ['alarms-page'] })
-    },
+  const sel = useRowSelection<number>({
+    unacked: onlyUnacked, severity: severityFilter,
+    page: pager.page, size: pager.pageSize,
   })
-  const rows = (list.data?.alerts ?? []).filter(
-    (a) => a.source_name === 'license-plate-recognition')
-  const unackedHere = rows.filter((a) => !a.acknowledged_at)
+  const ack = useAckAlarms(() => {
+    sel.clear()
+    if (list.rows.length <= 1 && pager.page > 1) pager.setPage(pager.page - 1)
+  })
+
+  // Belt and braces: the server already filters by source_name. Note
+  // this now runs AFTER paging, so a server that ignored the parameter
+  // would show short pages rather than other apps' alarms — a visible
+  // symptom instead of silently wrong data.
+  const rows = list.rows.filter((a) => a.source_name === LPR_SOURCE)
+
   return (
-    <Card>
-      <CardContent className="p-3 space-y-3">
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <button
-            className={`px-2 py-1 rounded border ${onlyUnacked ? 'bg-[var(--panel-2)] border-[var(--border)]' : 'border-neutral-700'}`}
-            onClick={() => setOnlyUnacked((s) => !s)}
-          >
-            Unacknowledged only
-          </button>
-          {unackedHere.length > 0 && (
-            <button
-              className="px-2 py-1 rounded border border-neutral-700 hover:bg-[var(--panel-2)]"
-              onClick={() => ack.mutate(unackedHere.map((a) => a.id))}
-            >
-              Acknowledge all ({unackedHere.length})
-            </button>
-          )}
-          <Link
-            to="/alerts-incidents"
-            className="ml-auto text-[var(--text-dim)] hover:text-[var(--text)] underline"
-          >
-            Sound, phone-call &amp; hooter settings (site-wide) →
-          </Link>
-        </div>
-        <table className="w-full text-sm">
-          <thead className="text-left text-[var(--text-dim)]">
-            <tr>
-              <th className="px-2 py-1.5">Severity</th>
-              <th className="px-2 py-1.5">Alarm</th>
-              <th className="px-2 py-1.5">Camera</th>
-              <th className="px-2 py-1.5">Seen</th>
-              <th className="px-2 py-1.5">Status</th>
-              <th className="px-2 py-1.5" />
-            </tr>
-          </thead>
-          <tbody>
-            {rows.length === 0 && (
-              <tr>
-                <td colSpan={6} className="px-2 py-6 text-center text-[var(--text-dim)]">
-                  {list.isLoading
-                    ? 'Loading…'
-                    : 'No vehicle alarms yet — arm the unknown-vehicle alarm in the Vehicle register tab, or monitor a plate'}
-                </td>
-              </tr>
-            )}
-            {rows.map((a) => (
-              <tr key={a.id} className="border-t border-[var(--border)]">
-                <td className="px-2 py-1.5">
-                  <span className={`px-1.5 py-0.5 rounded text-[10px] uppercase ${VEHICLE_ALARM_SEVERITY[a.severity] ?? VEHICLE_ALARM_SEVERITY.low}`}>
-                    {a.severity}
-                  </span>
-                </td>
-                <td className="px-2 py-1.5">
-                  <div className="font-medium">{a.title}</div>
-                  {a.description && (
-                    <div className="text-[11px] text-[var(--text-dim)]">{a.description}</div>
+    // No Card. This tab used to sit on a panel ground while the
+    // site-wide alarms page rendered bare, so the same table looked like
+    // two different components depending on where you opened it.
+    <>
+      <AlarmsTable
+          caption="Vehicle alarms"
+          rows={rows}
+          selected={sel.selected}
+          onToggle={sel.toggle}
+          onToggleAll={(on) => sel.toggleMany(rows.map((a) => a.id), on)}
+          cameraLabel={(handle) => {
+            const id = cameraIdFromHandle(handle)
+            return id === null ? (handle || '—') : cameraName(id)
+          }}
+          onAck={(ids) => ack.mutate(ids)}
+          isPending={list.isPending}
+          isFetching={list.isFetching}
+          isError={list.isError}
+          error={list.error}
+          onRetry={() => list.refetch()}
+          emptyTitle={onlyUnacked ? 'No unacknowledged vehicle alarms' : 'No vehicle alarms yet'}
+          emptyDescription="Arm the unknown-vehicle alarm in the Vehicle register tab, or monitor a plate."
+          toolbar={
+            <>
+              <div className="flex flex-wrap items-center gap-2 py-1.5 pl-3">
+                <AlarmsFilters
+                  onlyUnacked={onlyUnacked}
+                  onToggleUnacked={() => { setOnlyUnacked((v) => !v); pager.setPage(1) }}
+                  severity={severityFilter}
+                  onSeverity={(sev) => { setSeverityFilter(sev); pager.setPage(1) }}
+                />
+                <AlarmsSelectionBar
+                  count={sel.count}
+                  allOnPage={rows.length > 0 && rows.every((a) => sel.has(a.id))}
+                  allMatching={sel.allMatching}
+                  matchingTotal={list.total}
+                  label="vehicle alarms"
+                  onSelectAllMatching={sel.selectAllMatching}
+                  onClear={sel.clear}
+                  onAck={() => ack.mutate(
+                    sel.allMatching ? { source_name: LPR_SOURCE } : [...sel.selected],
                   )}
-                </td>
-                <td className="px-2 py-1.5 text-[var(--text-dim)]">{a.camera_id || '—'}</td>
-                <td className="px-2 py-1.5 text-[var(--text-dim)]"
-                    title={alarmSeenTitle(a)}>
-                  {alarmSeenAt(a)}
-                </td>
-                <td className="px-2 py-1.5">
-                  {a.acknowledged_at
-                    ? <span className="text-[var(--text-dim)]">acked</span>
-                    : <span className="text-red-400">unacked</span>}
-                </td>
-                <td className="px-2 py-1.5 text-right">
-                  {!a.acknowledged_at && (
-                    <button
-                      className="px-2 py-0.5 rounded border border-neutral-700 hover:bg-[var(--panel-2)]"
-                      onClick={() => ack.mutate([a.id])}
-                    >
-                      Ack
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </CardContent>
-    </Card>
+                />
+                <div className="ml-auto">
+                  <Pagination
+                    page={pager.page}
+                    pageSize={pager.pageSize}
+                    total={list.total}
+                    rowCount={rows.length}
+                    hasNext={rows.length === pager.pageSize}
+                    isFetching={list.isFetching}
+                    label="alarms"
+                    onPageChange={pager.setPage}
+                    onPageSizeChange={pager.setPageSize}
+                    announce={false}
+                  />
+                </div>
+              </div>
+            </>
+          }
+          footer={
+            <Pagination
+              page={pager.page}
+              pageSize={pager.pageSize}
+              total={list.total}
+              rowCount={rows.length}
+              hasNext={rows.length === pager.pageSize}
+              isFetching={list.isFetching}
+              label="alarms"
+              onPageChange={pager.setPage}
+              onPageSizeChange={pager.setPageSize}
+            />
+          }
+      />
+    </>
   )
 }

--- a/bench/event_memory_dividend.py
+++ b/bench/event_memory_dividend.py
@@ -70,14 +70,30 @@ def summarize_events(events: list[dict], attended: tuple[int, int] = (8, 18)) ->
 
 # ── Fetch (needs a running backend) ────────────────────────────────
 
+#: /events caps `limit` at 500 (it always clamped there; since the paging
+#: work it says so with a 422 instead of silently trimming). This bench
+#: wants the whole window, so it pages.
+_PAGE = 500
+
+
 def fetch_events(url: str, token: str | None, days: int, timeout: float = 30.0) -> list[dict]:
     frm = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-    q = f"{url.rstrip('/')}/api/v1/events?from={frm}&limit=100000"
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    req = urllib.request.Request(q, headers=headers)
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        payload = json.loads(resp.read().decode())
-    return payload.get("events") or []
+    out: list[dict] = []
+    skip = 0
+    while True:
+        q = (f"{url.rstrip('/')}/api/v1/events?from={frm}"
+             f"&limit={_PAGE}&skip={skip}")
+        req = urllib.request.Request(q, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+        page = payload.get("events") or []
+        out += page
+        # A short page is the end of the set — the same rule the server
+        # uses to answer `total` without a COUNT.
+        if len(page) < _PAGE:
+            return out
+        skip += _PAGE
 
 
 def _report(summary: dict, days: int) -> None:

--- a/server/core/pagination.py
+++ b/server/core/pagination.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Offset paging helpers shared by the paginated read endpoints.
+
+One function, because one rule is easy to get subtly wrong and it is
+worth having in a single tested place rather than inlined per router.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+
+def resolve_total(page_len: int, skip: int, limit: int,
+                  count_fn: Callable[[], int]) -> int:
+    """How many rows match — without a COUNT when the page proves it.
+
+    A page SHORTER than the limit means the result set ended inside it,
+    so the total is arithmetic: ``skip + page_len``. That short-circuit
+    is what keeps a filtered total affordable on an endpoint the UI
+    polls every ten seconds — the common request (a list smaller than
+    one page) pays nothing at all.
+
+    The trap, and the reason this is a function rather than an inline
+    conditional: an EMPTY page at ``skip > 0`` proves only that the
+    total is <= skip, NOT that it IS skip. A client that jumped past
+    the end would otherwise be told "of 500" for a twelve-row table —
+    a wrong number that looks entirely plausible. That case must fall
+    through to the real count.
+    """
+    if page_len < limit and (skip == 0 or page_len > 0):
+        return skip + page_len
+    return count_fn()

--- a/server/routers/alerts_inbox.py
+++ b/server/routers/alerts_inbox.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import Session
 from core.auth import get_current_active_user, get_current_superuser
 from core.database import get_db
 from models import AppAlert, SecuritySetting, User
+from core.pagination import resolve_total
 from services.alerts_inbox import (
     DEFAULT_RING_CONFIG,
     RING_CONFIG_KEY,
@@ -119,12 +120,29 @@ async def list_alerts(
     after_id: int | None = Query(
         None, description="Only rows with id > after_id — lets the bell "
         "poll for 'anything new since my last look' cheaply"),
+    before_id: int | None = Query(
+        None, description="Only rows with id <= before_id — pins a paged "
+        "table to the set it first saw, so arrivals cannot shuffle it"),
+    skip: int = Query(0, ge=0, le=100_000),
     limit: int = Query(50, ge=1, le=_MAX_LIMIT),
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ):
     """Inbox listing, newest first. ``unacked=true`` is what the bell
-    polls; the full list backs the Alerts & Incidents page."""
+    polls; the full list backs the Alerts & Incidents page.
+
+    TWO counts come back, and they answer different questions. Reading
+    one as the other is the mistake this docstring exists to prevent:
+
+    ``unacked_count`` is the BELL BADGE — how many unacknowledged alerts
+    exist in the caller's scope, ignoring every filter on this request
+    (including ``unacked`` itself). It is why the bell can show "12"
+    while the page below it shows three rows.
+
+    ``total`` is how many rows THIS request's filters match, for the
+    pager's "1-25 of 312". So ``?severity=critical`` can legitimately
+    return ``unacked_count: 40`` beside ``total: 3``.
+    """
     from services.camera_scope import visible_camera_ids
 
     scope = visible_camera_ids(db, current_user)
@@ -137,20 +155,70 @@ async def list_alerts(
         q = q.filter(AppAlert.source_name == source_name)
     if after_id is not None:
         q = q.filter(AppAlert.id > after_id)
-    rows = q.order_by(AppAlert.id.desc()).limit(limit).all()
-    unacked_count = (
+    if before_id is not None:
+        q = q.filter(AppAlert.id <= before_id)
+    # id is unique, so id DESC is already a total order — unlike /events,
+    # this endpoint needs no tiebreaker. Ordering is applied HERE and not
+    # to `q`, so the counts below do not drag it into their subquery.
+    rows = q.order_by(AppAlert.id.desc()).offset(skip).limit(limit).all()
+    # Same `q` — same scope, same filters. A total assembled from a
+    # separately-written query is how a count for someone else's camera
+    # leaks; reusing the object makes that impossible rather than
+    # merely unlikely.
+    total = resolve_total(len(rows), skip, limit, q.count)
+    unacked_count = _unacked_count(
+        db, scope,
+        # The bell's own request shape answers its badge for free: an
+        # unfiltered first page of unacked rows that came back SHORT is
+        # already the whole unacked set. That deletes a COUNT this
+        # endpoint pays today, on every poll, in every open tab.
+        rows if (unacked and skip == 0 and not severity and not source_name
+                 and after_id is None and before_id is None
+                 and len(rows) < limit) else None,
+    )
+    return {"alerts": [_row_out(a) for a in rows],
+            "unacked_count": unacked_count,
+            "total": total}
+
+
+def _unacked_count(db, scope, proven_rows) -> int:
+    """The bell badge: unacknowledged alerts in scope, filter-blind.
+
+    ``proven_rows`` short-circuits the query when the caller already
+    holds the complete unacked set (see the call site); None means
+    count.
+    """
+    if proven_rows is not None:
+        return len(proven_rows)
+    return (
         _scope_alerts(db.query(AppAlert.id), scope)
         .filter(AppAlert.acknowledged_at.is_(None))
         .count()
     )
-    return {"alerts": [_row_out(a) for a in rows],
-            "unacked_count": unacked_count}
 
 
 class AckIn(BaseModel):
-    """Empty body acks ALL unacknowledged alerts; ``ids`` acks a set."""
+    """What to silence. Three shapes, and the caller must pick one:
+
+    * ``ids`` — exactly these alerts ("acknowledge these 25").
+    * ``source_name`` and/or ``severity`` — every unacknowledged alert in
+      the caller's scope matching them ("acknowledge all 39 vehicle
+      alarms"). Added so a paged table's "all" button can mean the whole
+      filtered set rather than whichever page happens to be loaded.
+    * empty — every unacknowledged alert in scope. Unchanged.
+
+    ``ids`` and the filters are mutually exclusive: a body carrying both
+    reads as two different intentions, and guessing which one an operator
+    meant is not a thing to do with a control that silences alarms.
+    """
 
     ids: list[int] | None = None
+    source_name: str | None = None
+    severity: str | None = None
+
+    def filters(self) -> dict[str, str]:
+        return {k: v for k, v in (("source_name", self.source_name),
+                                  ("severity", self.severity)) if v}
 
 
 @router.post("/ack")
@@ -165,6 +233,13 @@ async def acknowledge(
     inbox, and an id on someone else's camera is simply not found."""
     from services.camera_scope import visible_camera_ids
 
+    filters = payload.filters()
+    if payload.ids is not None and filters:
+        raise HTTPException(
+            status_code=400,
+            detail="Send ids OR a filter, not both — they are two "
+                   "different intentions.",
+        )
     q = _scope_alerts(db.query(AppAlert),
                       visible_camera_ids(db, current_user)).filter(
         AppAlert.acknowledged_at.is_(None))
@@ -172,6 +247,14 @@ async def acknowledge(
         if not payload.ids:
             return {"acknowledged": 0}
         q = q.filter(AppAlert.id.in_(payload.ids))
+    else:
+        # Scope is applied above and is NOT negotiable here: a filtered
+        # "acknowledge all" must still be unable to touch a camera the
+        # caller cannot open.
+        if filters.get("source_name"):
+            q = q.filter(AppAlert.source_name == filters["source_name"])
+        if filters.get("severity"):
+            q = q.filter(AppAlert.severity == filters["severity"])
     now = datetime.now(UTC)
     count = 0
     for row in q.all():

--- a/server/routers/timeline_events.py
+++ b/server/routers/timeline_events.py
@@ -35,6 +35,7 @@ from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from core.auth import get_current_active_user
+from core.pagination import resolve_total
 from core.database import get_db, release
 from models import TimelineEvent, User
 from services.camera_scope import visible_camera_ids
@@ -119,7 +120,8 @@ async def list_events(
     has_plate: bool = False,
     from_: datetime | None = Query(default=None, alias="from"),
     to: datetime | None = None,
-    limit: int = 100,
+    skip: int = Query(0, ge=0, le=100_000),
+    limit: int = Query(100, ge=1, le=500),
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ):
@@ -128,19 +130,47 @@ async def list_events(
     Time filters use the OVERLAP rule — an event counts if any part of it
     intersects [from, to) — because "who was here 3-4pm" must include the
     visit that started 14:58 and left 15:03.
-    """
-    from services.timeline_service import query_events
 
-    rows = query_events(
-        db, camera_id=camera_id, label=label, source=source, plate=plate,
-        has_plate=has_plate, from_=from_, to=to, limit=limit,
+    Paging is ``skip``/``limit`` (the house shape — audit-logs, cameras,
+    users). ``limit`` is now VALIDATED at the 500 the service always
+    clamped to: silently trimming a larger request was harmless while
+    nothing paged, but a client that believes it asked for 1000 and then
+    asks for skip=1000 would step clean over rows 500-999. A 422 is the
+    honest answer.
+
+    ``skip`` is capped because page numbers invite a "last page" jump,
+    and the last page of a large scoped set is the single most expensive
+    query this endpoint can be asked for.
+
+    Two counts, deliberately different:
+      count  — rows in THIS page (unchanged; every existing client
+               ignores it, which is why it stays rather than moving).
+      total  — rows matching these filters and this caller's scope, for
+               the pager's "1-25 of 312".
+    """
+    from services.timeline_service import count_events, query_events
+
+    # ONE filter dict for the page and the total. That shared dict is the
+    # structural guarantee they cannot drift apart — a total built from a
+    # separately-written query is how a row count for a camera the caller
+    # cannot see leaks out.
+    filters = dict(
+        camera_id=camera_id, label=label, source=source, plate=plate,
+        has_plate=has_plate, from_=from_, to=to,
         # Camera data is scoped to the caller's cameras (owned + can_view
         # grants) everywhere in OpenNVR; history and evidence photos are
         # the MOST sensitive camera data, so the same rule applies here.
         # Superusers see the fleet.
         scope=visible_camera_ids(db, current_user),
     )
-    return {"events": [_serialize(e) for e in rows], "count": len(rows)}
+    rows = query_events(db, limit=limit, skip=skip, **filters)
+    total = resolve_total(len(rows), skip, limit,
+                          lambda: count_events(db, **filters))
+    return {
+        "events": [_serialize(e) for e in rows],
+        "count": len(rows),
+        "total": total,
+    }
 
 
 @router.get("/events/{event_id}/evidence")

--- a/server/services/timeline_service.py
+++ b/server/services/timeline_service.py
@@ -90,7 +90,7 @@ def record_track_visit(
     return row
 
 
-def query_events(
+def _events_query(
     db: Session,
     *,
     camera_id: int | None = None,
@@ -98,18 +98,23 @@ def query_events(
     source: str | None = None,
     from_: datetime | None = None,
     to: datetime | None = None,
-    limit: int = 100,
     scope: set[int] | None = None,
     plate: str | None = None,
     has_plate: bool = False,
-) -> list[TimelineEvent]:
-    """Newest-first visits/alarms/alerts intersecting [from, to).
+):
+    """Scope + filters, with NO ordering, offset or limit.
 
-    ``scope`` is the caller's visible camera set from
-    ``camera_scope.visible_camera_ids`` — own cameras plus can_view
-    grants. Pass None ONLY for superusers (unrestricted).
+    The one place the /events predicate lives, so a page and its total
+    can never disagree. A total built from a SECOND, similar query is
+    how a row count for a camera the caller cannot see leaks out — the
+    two must be the same query object or the scoping is decorative.
+
+    Deliberately unordered: ``.count()`` wraps this in
+    ``SELECT count(*) FROM (...)``, and an ORDER BY riding along into
+    that subquery makes the database sort rows it is only going to
+    count. Ordering belongs to :func:`query_events`, which is the only
+    caller that returns rows.
     """
-    limit = max(1, min(500, limit))
     q = db.query(TimelineEvent)
     q = scope_query(q, TimelineEvent.camera_id, scope)
     if camera_id is not None:
@@ -136,7 +141,46 @@ def query_events(
             ((TimelineEvent.ended_at.isnot(None)) & (TimelineEvent.ended_at >= from_))
             | ((TimelineEvent.ended_at.is_(None)) & (TimelineEvent.started_at >= from_))
         )
-    return q.order_by(TimelineEvent.started_at.desc()).limit(limit).all()
+    return q
+
+
+def query_events(
+    db: Session,
+    *,
+    limit: int = 100,
+    skip: int = 0,
+    **filters,
+) -> list[TimelineEvent]:
+    """Newest-first visits/alarms/alerts intersecting [from, to).
+
+    ``scope`` (in ``filters``) is the caller's visible camera set from
+    ``camera_scope.visible_camera_ids`` — own cameras plus can_view
+    grants. Pass None ONLY for superusers (unrestricted).
+
+    The ordering carries an ``id`` tiebreaker because ``started_at`` is
+    NOT unique: ``uq_events_visit`` is on the triple (camera, track,
+    start), and Tier-0 emits visits in bursts, so ties cluster exactly
+    when a page boundary is most likely to land in one. Without a total
+    order, paging across a tie set silently repeats or drops rows.
+
+    The clamp stays here even though the router validates: this is a
+    public surface (``internal_camera_agent`` calls it with an
+    unvalidated int), and one line of defence in depth is cheap.
+    """
+    limit = max(1, min(500, limit))
+    skip = max(0, int(skip))
+    return (
+        _events_query(db, **filters)
+        .order_by(TimelineEvent.started_at.desc(), TimelineEvent.id.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def count_events(db: Session, **filters) -> int:
+    """How many rows the SAME filters and scope match, ignoring paging."""
+    return _events_query(db, **filters).count()
 
 
 def can_access_event(db: Session, event: TimelineEvent, *, user) -> bool:

--- a/server/tests/test_alerts_inbox.py
+++ b/server/tests/test_alerts_inbox.py
@@ -597,3 +597,148 @@ def test_alarm_policy_is_superuser_only(scoped_client):
     assert tc.put("/alerts-inbox/ring-config",
                   json={"ring": {"low": "ping"}}).status_code == 200
     assert tc.get("/alerts-inbox/actions").status_code == 200
+
+
+# ── paging (#451 follow-up) ─────────────────────────────────────────
+
+
+def _src(name):
+    """An envelope from a named app — `source` is a nested dict, so
+    source_name cannot be passed as a flat **extra."""
+    return {"source": {"kind": "app", "name": name, "version": "1.0.0"}}
+
+
+def test_pages_do_not_repeat_or_drop_rows(client):
+    tc, *_ = client
+    for i in range(7):
+        apply_alert(_envelope(f"pg{i}"))
+    whole = [a["alert_id"]
+             for a in tc.get("/alerts-inbox", params={"limit": 50}).json()["alerts"]]
+    paged = []
+    for skip in (0, 3, 6):
+        paged += [a["alert_id"] for a in tc.get(
+            "/alerts-inbox", params={"skip": skip, "limit": 3}).json()["alerts"]]
+    assert paged == whole
+
+
+def test_total_respects_filters_while_unacked_count_does_not(client):
+    """The two numbers answer different questions and sit side by side in
+    one response, so pin the difference — names alone will not stop it."""
+    tc, *_ = client
+    for i in range(3):
+        apply_alert(_envelope(f"crit{i}", severity="critical"))
+    for i in range(5):
+        apply_alert(_envelope(f"low{i}", severity="low"))
+    body = tc.get("/alerts-inbox",
+                  params={"severity": "critical", "limit": 2}).json()
+    assert len(body["alerts"]) == 2      # one page
+    assert body["total"] == 3            # matching THIS filter
+    assert body["unacked_count"] == 8    # the badge, filter-blind
+
+
+def test_a_page_past_the_end_reports_the_true_total(client):
+    """resolve_total's trap through the route: an empty page at skip=100
+    proves total <= 100, never that it IS 100."""
+    tc, *_ = client
+    for i in range(5):
+        apply_alert(_envelope(f"end{i}"))
+    body = tc.get("/alerts-inbox", params={"skip": 100, "limit": 25}).json()
+    assert body["alerts"] == []
+    assert body["total"] == 5
+
+
+def test_before_id_pins_a_page_against_new_arrivals(client):
+    tc, *_ = client
+    for i in range(4):
+        apply_alert(_envelope(f"anchor{i}"))
+    anchor = tc.get("/alerts-inbox",
+                    params={"limit": 50}).json()["alerts"][0]["id"]
+    for i in range(2):
+        apply_alert(_envelope(f"late{i}"))        # arrive mid-read
+    body = tc.get("/alerts-inbox",
+                  params={"before_id": anchor, "limit": 50}).json()
+    assert body["total"] == 4
+    assert all(not a["alert_id"].startswith("late") for a in body["alerts"])
+
+
+@pytest.mark.parametrize("params", [
+    {"limit": 0}, {"limit": 201}, {"skip": -1},
+])
+def test_out_of_range_paging_is_rejected(client, params):
+    tc, *_ = client
+    assert tc.get("/alerts-inbox", params=params).status_code == 422
+
+
+# ── acknowledge by filter ("acknowledge all N", not "this page") ────
+
+
+def test_ack_by_source_leaves_other_sources_alone(client):
+    tc, *_ = client
+    apply_alert(_envelope("lpr1", **_src("license-plate-recognition")))
+    apply_alert(_envelope("lpr2", **_src("license-plate-recognition")))
+    apply_alert(_envelope("other", **_src("intrusion-detection")))
+    r = tc.post("/alerts-inbox/ack",
+                json={"source_name": "license-plate-recognition"})
+    assert r.json()["acknowledged"] == 2
+    left = tc.get("/alerts-inbox",
+                  params={"unacked": True, "limit": 50}).json()
+    assert [a["alert_id"] for a in left["alerts"]] == ["other"]
+
+
+def test_ack_by_severity_matches_what_the_label_would_claim(client):
+    """The point of the filtered ack: the number the button shows and the
+    number it silences must be the same number."""
+    tc, *_ = client
+    for i in range(3):
+        apply_alert(_envelope(f"c{i}", severity="critical"))
+    apply_alert(_envelope("l", severity="low"))
+    shown = tc.get("/alerts-inbox",
+                   params={"severity": "critical", "limit": 50}).json()["total"]
+    acked = tc.post("/alerts-inbox/ack",
+                    json={"severity": "critical"}).json()["acknowledged"]
+    assert acked == shown == 3
+
+
+def test_ack_refuses_ids_and_filters_together(client):
+    tc, *_ = client
+    apply_alert(_envelope("both"))
+    r = tc.post("/alerts-inbox/ack", json={"ids": [1], "source_name": "x"})
+    assert r.status_code == 400
+
+
+def test_total_never_counts_alerts_on_invisible_cameras(scoped_client):
+    """The leak case. A pager total that ignores scope tells an operator
+    exactly how many alarms exist on cameras they cannot open."""
+    tc, current, op, admin, gate_id, yard_id = scoped_client
+    for i in range(2):
+        apply_alert(_envelope(f"gate{i}", camera_id=f"cam{gate_id}"))
+    for i in range(5):
+        apply_alert(_envelope(f"yard{i}", camera_id=f"cam{yard_id}"))
+    apply_alert(_envelope("site-wide", camera_id=None))
+
+    # op sees the gate pair and the camera-less notice — and the total
+    # must agree with the rows, not with the table.
+    body = tc.get("/alerts-inbox", params={"limit": 50}).json()
+    assert body["total"] == len(body["alerts"]) == 3
+
+    current["user"] = admin
+    body = tc.get("/alerts-inbox", params={"limit": 50}).json()
+    assert body["total"] == 8
+
+
+def test_a_filtered_ack_cannot_reach_another_operators_camera(scoped_client):
+    """"Acknowledge all" widened what one click does, so pin the limit:
+    a filter still cannot silence an alarm outside the caller's scope."""
+    tc, current, op, admin, gate_id, yard_id = scoped_client
+    apply_alert(_envelope("gate-lpr", camera_id=f"cam{gate_id}",
+                          **_src("license-plate-recognition")))
+    apply_alert(_envelope("yard-lpr", camera_id=f"cam{yard_id}",
+                          **_src("license-plate-recognition")))
+
+    acked = tc.post("/alerts-inbox/ack",
+                    json={"source_name": "license-plate-recognition"}).json()
+    assert acked == {"acknowledged": 1}          # the gate one only
+
+    current["user"] = admin
+    left = tc.get("/alerts-inbox", params={"unacked": True}).json()
+    assert [a["alert_id"] for a in left["alerts"]] == ["yard-lpr"]

--- a/server/tests/test_pagination_total.py
+++ b/server/tests/test_pagination_total.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""resolve_total: exact totals, and the one case that must not guess."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.pagination import resolve_total  # noqa: E402
+
+
+def _counter(value):
+    """A count_fn that records whether it was called."""
+    calls = []
+
+    def fn():
+        calls.append(1)
+        return value
+
+    fn.calls = calls
+    return fn
+
+
+def test_a_short_first_page_is_the_whole_answer():
+    c = _counter(999)
+    assert resolve_total(page_len=7, skip=0, limit=25, count_fn=c) == 7
+    assert c.calls == [], "a short page already proves the total; do not count"
+
+
+def test_a_short_later_page_adds_the_offset():
+    c = _counter(999)
+    assert resolve_total(page_len=5, skip=50, limit=25, count_fn=c) == 55
+    assert c.calls == []
+
+
+def test_a_full_page_must_count():
+    c = _counter(312)
+    assert resolve_total(page_len=25, skip=0, limit=25, count_fn=c) == 312
+    assert c.calls == [1], "a full page proves nothing about what follows"
+
+
+def test_an_empty_page_past_the_end_counts_rather_than_guessing():
+    """The trap. skip=100 with no rows proves total <= 100, not == 100 —
+    guessing would report 'of 100' for a five-row table."""
+    c = _counter(5)
+    assert resolve_total(page_len=0, skip=100, limit=25, count_fn=c) == 5
+    assert c.calls == [1]
+
+
+def test_an_empty_first_page_is_genuinely_empty():
+    c = _counter(0)
+    assert resolve_total(page_len=0, skip=0, limit=25, count_fn=c) == 0
+    assert c.calls == []
+
+
+@pytest.mark.parametrize("limit", [1, 25, 200, 500])
+def test_a_full_page_always_counts_whatever_the_limit(limit):
+    c = _counter(1000)
+    assert resolve_total(limit, 0, limit, c) == 1000
+    assert c.calls == [1]

--- a/server/tests/test_timeline_events.py
+++ b/server/tests/test_timeline_events.py
@@ -40,7 +40,9 @@ from sqlalchemy.orm import sessionmaker  # noqa: E402
 from core.database import Base  # noqa: E402
 from models import Camera, Role, User  # noqa: E402
 from services import evidence_store  # noqa: E402
-from services.timeline_service import query_events, record_track_visit  # noqa: E402
+from services.timeline_service import (  # noqa: E402
+    count_events, query_events, record_track_visit,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -81,6 +83,16 @@ def db():
         yield s
     finally:
         s.close()
+
+
+def _camera(db, name):
+    """A second camera, for the scope and tie-ordering cases."""
+    cam = Camera(name=name, ip_address="10.0.0.10", port=80,
+                 owner_id=db.query(User).first().id)
+    db.add(cam)
+    db.commit()
+    db.refresh(cam)
+    return cam.id
 
 
 def _visit(db, *, start_min, end_min=None, label="person", cam=None, **kw):
@@ -330,3 +342,168 @@ def test_extract_plate_keeps_a_whole_read():
         {"result": {"plate_text": "66HH07", "accepted": True}},
         image_size=(1035, 720),
     ) == "66HH07"
+
+
+# ── paging (#451 follow-up) ─────────────────────────────────────────
+#
+# The rule these pin: walking `skip` through a result set must visit
+# every row exactly once. That is only true if the ordering is a TOTAL
+# order, which is why the `id` tiebreaker exists.
+
+
+def test_skip_walks_pages_without_gaps_or_repeats(db):
+    for m in range(10):
+        _visit(db, start_min=m)
+    whole = [r.id for r in query_events(db, limit=100)]
+    paged = []
+    for skip in (0, 4, 8):
+        paged += [r.id for r in query_events(db, limit=4, skip=skip)]
+    # List equality, not set equality: this catches a page boundary that
+    # repeats a row as well as one that drops it.
+    assert paged == whole
+
+
+def test_ties_on_started_at_page_stably(db):
+    """Six visits sharing ONE timestamp across two cameras and three
+    tracks — permitted by uq_events_visit (camera, track, start).
+
+    Without the id tiebreaker the database is free to return these in a
+    different order per query, so paging would repeat and drop rows at
+    random. This test is flaky by construction against the old ordering,
+    which is exactly the bug it guards.
+    """
+    other = _camera(db, "second")
+    for i in range(3):
+        _visit(db, start_min=0, track_id=f"a{i}")
+        _visit(db, start_min=0, cam=other, track_id=f"b{i}")
+    whole = [r.id for r in query_events(db, limit=100)]
+    assert len(whole) == 6
+    paged = []
+    for skip in (0, 2, 4):
+        paged += [r.id for r in query_events(db, limit=2, skip=skip)]
+    assert paged == whole
+    assert whole == sorted(whole, reverse=True)   # id DESC within the tie
+
+
+def test_skip_past_the_end_is_empty(db):
+    _visit(db, start_min=1)
+    assert query_events(db, skip=999) == []
+
+
+def test_count_matches_the_rows_it_pages(db):
+    for m in range(6):
+        _visit(db, start_min=m, label="car" if m % 2 else "person")
+    for filters in ({}, {"label": "car"}, {"label": "person"}):
+        assert count_events(db, **filters) == len(
+            query_events(db, limit=500, **filters))
+
+
+def test_count_is_scoped_and_does_not_leak_other_cameras(db):
+    """The security case: a total that ignores scope tells an operator
+    how many rows exist on cameras they cannot open."""
+    other = _camera(db, "not-mine")
+    for m in range(3):
+        _visit(db, start_min=m)
+    for m in range(7):
+        _visit(db, start_min=m, cam=other)
+    assert count_events(db, scope={db.cam_id}) == 3
+    assert count_events(db) == 10                 # superuser: unrestricted
+    assert count_events(db, scope=set()) == 0     # granted nothing: nothing
+
+
+# ── the HTTP envelope (nothing pinned it before) ────────────────────
+
+
+@pytest.fixture
+def api():
+    """Just the timeline router on a bare app — enough to pin the
+    response envelope, which nothing did before.
+
+    Its own engine rather than the `db` fixture's: TestClient serves the
+    request on another thread, and a plain sqlite :memory: connection
+    refuses to cross one. StaticPool keeps every thread on the ONE
+    connection, which is also what keeps the in-memory schema alive.
+
+    Yields (client, session) so a test can seed rows the route will see.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from sqlalchemy.pool import StaticPool
+
+    import core.auth as auth_mod
+    from core.database import get_db
+    from routers.timeline_events import router
+
+    eng = create_engine("sqlite://", connect_args={"check_same_thread": False},
+                        poolclass=StaticPool)
+    Base.metadata.create_all(eng)
+    s = sessionmaker(bind=eng)()
+    role = Role(name="admin")
+    s.add(role)
+    s.commit()
+    owner = User(username="t", email="t@t.io", hashed_password="x",
+                 role_id=role.id)
+    s.add(owner)
+    s.commit()
+    cam = Camera(name="gate", ip_address="10.0.0.9", port=80,
+                 owner_id=owner.id)
+    s.add(cam)
+    s.commit()
+    s.refresh(cam)
+    s.cam_id = cam.id
+
+    def _fake_db():
+        # A generator FUNCTION, not a lambda returning an iterator —
+        # FastAPI only unwraps the former as a dependency.
+        yield s
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = _fake_db
+    app.dependency_overrides[auth_mod.get_current_active_user] = lambda: owner
+    try:
+        yield TestClient(app), s
+    finally:
+        s.close()
+
+
+def test_response_carries_page_length_and_total_separately(api):
+    client, db = api
+    for m in range(7):
+        _visit(db, start_min=m)
+    r = client.get("/events", params={"limit": 3})
+    assert r.status_code == 200
+    body = r.json()
+    # `count` is the PAGE length and `total` the whole set. Existing
+    # clients read neither, but `count` predates this work and stays.
+    assert body["count"] == len(body["events"]) == 3
+    assert body["total"] == 7
+
+
+def test_a_short_page_reports_an_exact_total(api):
+    client, db = api
+    for m in range(3):
+        _visit(db, start_min=m)
+    body = client.get("/events", params={"limit": 25}).json()
+    assert body["count"] == 3 and body["total"] == 3
+
+
+def test_paging_past_the_end_reports_the_true_total(api):
+    """The resolve_total trap, through the route: an empty page at a big
+    skip must not report the skip as the total."""
+    client, db = api
+    for m in range(4):
+        _visit(db, start_min=m)
+    body = client.get("/events", params={"skip": 100, "limit": 25}).json()
+    assert body["events"] == [] and body["count"] == 0
+    assert body["total"] == 4
+
+
+@pytest.mark.parametrize("params", [
+    {"limit": 0}, {"limit": 501}, {"skip": -1},
+])
+def test_out_of_range_paging_is_rejected(api, params):
+    """Previously `limit=1000` was silently trimmed to 500 — harmless
+    until skip existed, then it steps over rows 500-999 in silence."""
+    client, _db = api
+    assert client.get("/events", params=params).status_code == 422


### PR DESCRIPTION
Closes #453.

Three operator tables rendered every row the API returned, capped at 200/100/200 by inline literals, past which older data was simply unreachable — no "older" affordance existed at all. They were also three separately-written tables that had drifted apart in padding, header treatment, empty states and overflow behaviour.

Server-side paging, because the alternative does not address the complaint: client-side paging would still download every row and every thumbnail up front. Measured on a live stack, the reads request returned 113 KB for 109 rows (~1 KB/row), against 16 KB for 25. Worth being honest about the size of that win — useInView already defers off-screen thumbnails, so first paint does not get eight times faster; what improves is the payload and the number of image requests a scroll can fire, which is the thing that once exhausted core's DB pool.

── API ────────────────────────────────────────────────────────────────

/events and /alerts-inbox take `skip` and return a filtered `total`. Verified live: consecutive pages return disjoint ids against a stable total, and ?severity=high returns total 5 beside a badge of 29.

The /events ORDERING had to be fixed first, and it was a latent bug on its own. It sorted by started_at alone, but that column is not unique — uq_events_visit is on the TRIPLE (camera, track, start), and Tier-0 emits visits in bursts, so ties cluster exactly where a page boundary is most likely to land in one. Paging across a tie set silently repeats and drops rows. The ordering is now total, and the test for it fails against the old one, which is the point of having it.

query_events splits into _events_query (scope + filters, unordered) plus query_events and count_events over it, and the router hands ONE filters dict to both — so a page and its total are structurally incapable of disagreeing. A total written as a second, similar query is how a row count for a camera the caller cannot open leaks out; there are tests for that on both endpoints.

resolve_total answers the total without a COUNT whenever a short page already proves it. The trap it exists to hold is the empty page past the end: skip=100 with no rows proves total <= 100, not == 100, and guessing there reports "of 100" for a five-row table. It pays off backwards too — the bell's own request shape proves its own badge, so the COUNT this endpoint ran on every poll in every open tab usually disappears.

`limit` is now validated at the 500 the service always clamped to. Silent trimming was harmless while nothing paged; with skip, a client that believes it asked for 1000 steps clean over rows 500-999. bench/event_memory_dividend.py was the one in-repo caller relying on the old behaviour and now pages.

ACK BY FILTER is new, for "these 25 or all N". AckIn also takes source_name/severity, meaning every unacknowledged alert in the caller's scope matching them. ids and filters are mutually exclusive — two different intentions, and guessing between them is not a thing to do with a control that silences alarms. Scope is applied first and is not negotiable. Behaviour change to note: on Alerts & Incidents with a severity filter active, "acknowledge all" now acks that severity rather than everything.

── UI ─────────────────────────────────────────────────────────────────

One DataTable behind all three, built on the existing ui primitives. Its state machine is the actual point: isError is part of the props type and takes precedence over empty, because two of the three tables never read their query's error flag — a failed fetch rendered as "No alarms yet", so a dead backend and a quiet night looked identical.

The two alarm tables shared their data layer and duplicated their entire presentation layer, which is how they came to disagree about WHICH timestamp to show until #451 fixed both by hand. They now render through one AlarmsTable, so the next divergence has nowhere to start.

THE ROWS SCROLL, not the page. The table takes the height left below it and scrolls inside that, with a sticky header. Sticky positions against the nearest SCROLLING ancestor, so an earlier attempt that added the class to a horizontal-only scroller did nothing at all — the header had nothing to stick to. Both halves have to arrive together. The height is measured rather than a calc(100vh - 420px) that would be wrong the first time the filter bar wrapped, and it is measured DOCUMENT-absolute so the table does not grow and shrink as the outer page scrolls. It also reserves for whatever follows it in the page, or that content would push the page taller and put back the outer scrollbar this removes. The scroller uses the app's existing .thin-scroll panel scrollbar; the default chrome looked bolted on beside it.

THE CSV EXPORT had to change with the reads table. It exported eventsQuery.data, which is now one page — "Export CSV" would have quietly produced 25 of 312 reads, and the code calls that file evidence two hundred lines further up. It fetches its own rows and says so in a snackbar when it hits the ceiling rather than truncating in silence.

Smaller things, all fallout from the duplication:
* The Status column no longer prints the vehicle TYPE. With no watchlist match and the unknown-vehicle alarm off, every row fell through to a neutral badge holding e.label, so the column read "truck / car / truck". A badge there should mean "this plate is on a list".
* Timestamps use tabular figures and drop the repeated date: every row printed 09/09/2026, 17:06:48, so the identical date ran down the whole column and the part that differs sat furthest right.
* Alerts & Incidents wrapped its table in overflow-hidden, which CLIPS; the Vehicles alarms tab had no overflow container at all.
* The Vehicles tab printed the raw camera handle, so one screen called the same camera "Demo IN" and "cam1".
* Ack invalidation was asymmetric — acking on one page left the other showing the alarm as live until its own poll.
* Severity pills come from tokens now; the duplicated raw-palette maps washed out on the light theme. The "Test {severity}" buttons were converted before their map was deleted.
* keepPreviousData everywhere, and polling stops past page 1: the lists are newest-first, so arrivals shift every row down under the cursor of someone reading history.

server 1363 passed, same 4 pre-existing failures (mediamtx+TLS, local cert env, identical on main). typecheck, lint and the production build clean. Note app/ has no test runner, so the UI half is verified by typecheck, lint and looking at it.

── The design pass ────────────────────────────────────────────────────

Shipping the mechanics was not the same as the page looking finished, and it did not. Chrome above the first row measured ~431px against ~211px of rows — two parts furniture to one part data, or 3.8 of a 25-row page. Most of it came from the page quietly breaking the app's own rules: rounded-full chips in a product whose radius token is 0 and whose stat values are text-lg or larger everywhere else; a hand-rolled tab bar with no ARIA beside a shared Tabs component that has it; a filter row in a Card where every other view leaves it bare; and eight uses of var(--warning|--danger|--success), none of which exist, so each was permanently its fallback hex and never flipped with the light theme.

Four of the defects were bugs rather than taste:

* PageHeader's text column had no min-w-0, so its hypothetical size was max-content — a whole description on one unbroken line. Flexbox wraps before it shrinks, so the actions were pushed to a second flex row, where justify-between parks a lone item at the START. That is why several pages rendered their buttons bottom-left under the description. AIAdapters and AppCatalog were doing it too, and are fixed by the same change.
* The pagination footer was counted TWICE in the fill-height reservation: measured via footerRef, and walked again as the scroller's first following sibling. ~100px of dead page under the table while the rows starved. Walk from the shell, not the scroller.
* Column `width` reached the TH and never the TD, so nothing constrained the body and table-layout:auto sprayed the surplus into whichever columns had the longest content.
* Tabs' overflow-x-auto makes the computed overflow-y `auto` as well (the spec: a non-visible value on one axis forces the other off `visible`), and the tabs' -mb-px then overflowed by 1px. The browser drew a scrollbar for it, floating in the tab strip.

What the page is now, and why:

  header   Title, one-line description, sm actions. The description
           dropped an implementation note no operator needs daily.
  banner   The per-site pitch, full copy, directly under the
           description — NOT under the table, where the fill-height
           reservation makes it cost rows on every visit. Its CTA is
           the one accent-filled control on the page.
  stats    Chips that are also navigation: reads, unique plates,
           registered, monitored, each flex-1 so the row spans the
           page. Real buttons, so they are keyboard reachable. Dropped
           "busiest camera" — on a one-camera site it names the only
           camera there is, and it was the one chip whose value was a
           string, so it swung the row width on every poll.
  tabs     The shared component, bound into the header block: it
           carried its own mb-4 and the section's space-y-4 stacked a
           second 16px, so the bar floated 32px under the title
           attached to nothing.
  table    Filters and paging share ONE bar inside the table's border.
           Three separately-bordered controls above a separately-
           bordered table meant four rectangles before a row of data.

Rows follow a mail client: actions hidden until the row is hovered, the whole row opens the evidence (with a focus ring and Enter/Space, not a bare onClick), no zebra, a smaller thumbnail. Pagination is borderless — first/prev/next/last chevrons, no number strip, top and bottom, and only the bottom instance is a live region so a screen reader does not hear the range twice per page change.

Two smaller fixes worth naming. Column `className` was applied to header AND cells, so a column dimming its own DATA also dimmed its header and made it the odd one out — body-only styling moved to `cellClassName`. And timestamps are always dated: dropping the date for today's rows read fine at a glance and badly in practice, since a bare 06:50:23 says nothing about which day once the range is 7 or 30 days, and this column is exported as evidence.

The Status column renders only when something can populate it (a register, monitors, an allowlist, or the unknown-vehicle alarm). On a fresh install every cell was a muted em-dash under a header promising information the install cannot produce.

── Acting on rows, not just reading them ──────────────────────────────

The tables could be read but barely used: acknowledging meant one button per row, and putting a plate on a watchlist meant leaving for another tab. Both now work where the operator already is.

ALARMS gain mail-client selection: a checkbox per row, a header checkbox that goes indeterminate on a partial page (set through a ref — that is a DOM property, there is no HTML attribute for it), and a bar that appears when anything is ticked. Selecting every row on the page offers to extend to everything the filter matches, which cannot be a longer list of ids because those rows are not in the browser — it sends the FILTER, which is what the ack endpoint's source_name/severity form was built for earlier in this commit. The two halves met up.

Ticks clear on any change of page, filter or tab. Carrying them across a filter change would let a bulk acknowledge reach rows the operator can no longer see, which is the wrong surprise for a control that silences alarms.

The Status column stopped being a label and became a pair of toggles in the row's left gutter. Both icons now render on EVERY row and the icon is the state — lit means on, dim means off, clicking flips it. They used to appear only when the plate was NOT on that list, so the control you wanted was missing exactly when you wanted to undo something. Register and monitor are separate lists on the app config, so they are separate toggles: a resident's car can be registered and also worth alerting on. An exclusive <select> was tried first and rejected — it was heavier than the data it described, and setting one state silently cleared the other. Leaving the register asks first when the entry carries owner/unit/model details, because nothing else on the platform holds them.

── The two alarm views are one view ───────────────────────────────────

They are not duplicates — /vehicles needs live.view while /alerts-incidents needs alerts.view, so a gate operator without the latter has the Vehicles tab as their only route to their own alarms, and the scopes differ (one app's alarms versus every source). But they had drifted into looking like different components: one sat on a Card ground while the other rendered bare, and only one had a severity filter. Both now render through the same shell with the same filter set, so neither can grow a control the other lacks.

── Density and legibility ─────────────────────────────────────────────

* Acknowledged state moved from a column of words to the ROW, and then from background to TEXT. Background could not carry it: three rules were already competing there — the zebra stripe, the hover, and the state tint — and zebra versus tint is decided by stylesheet order, not intent, so the cue appeared on some rows and not others. Now text is state and background is interaction, one channel each. Text also survives both themes, which a tint did not: --bg-2 is a hair off --panel in dark, and in light a grey wash would darken the row needing the MOST attention.
* Alarm rows are one line: the description sits inline and dim in brackets instead of a second 11px row under every title. Roughly twice as many alarms fit.
* A `dense` prop trims cell padding on these three tables only, through the table element, so the app's default density is untouched elsewhere.
* Row actions are always visible rather than revealed on hover — an action performed on most rows should not have to be discovered.
* The Alarms tab reads "(6/1374)": unacknowledged over total, in the same parenthesised shape the other tabs use, with colour on the actionable half only. It needs two limit=1 requests because the response's unacked_count is deliberately filter-blind (it is the bell's badge, every source) and cannot answer "unacknowledged VEHICLE alarms".
* Pagination is first/prev/next/last chevrons, borderless, at both ends of the table. Numbered pages grew wider with the result set and were mostly used to reach the ends.
* Filters moved inside the table's own border beside the pager. Three separately-bordered controls above a separately-bordered table meant four rectangles before a row of data.

One CSS trap worth recording: a literal color-mix() arbitrary value generates NO class in this build. The build stays green and typecheck passes, and the style simply never renders. Tailwind's opacity modifier (`/10`) compiles correctly. Every rule added here was checked in the emitted stylesheet rather than assumed from a clean build.