### PR TITLE
feat(cameras): a camera is used by the apps it is assigned to, and no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,42 @@ Reporters are credited in [SECURITY.md](SECURITY.md#reporters).
 
 ### Changed
 
+- **BREAKING — a camera is now used by the apps it is assigned to, and
+  no others.** Assignment used to be advisory: "nothing assigned" meant
+  "no restriction declared", so an app nobody had pointed at a camera
+  watched the entire fleet, and plate OCR ran on every vehicle on every
+  camera whether or not that camera was for LPR — `wants_plate` took no
+  camera argument, so it could not consult an assignment even in
+  principle. The least-configured install was the most expensive one.
+
+  Closed by default now. A camera with no assignments is *eligible*
+  everywhere — it appears in every app's picker — and *adopted* nowhere,
+  so no app inference runs on it and it costs nothing. Streaming,
+  recording and the always-on Tier-0 detection behind the timeline are
+  unchanged on every camera, assigned or not; history and recordings
+  already captured stay exactly where they are.
+
+  **After upgrading, assign your cameras.** Apps that were watching the
+  whole fleet by default now watch nothing until an operator points them
+  somewhere, and plate reads stop on unassigned cameras. The Vehicles
+  page says so in place of an empty table, and giving a camera a gate
+  role there assigns it to LPR as part of the same action. See
+  [CAMERA_ASSIGNMENTS.md](docs/CAMERA_ASSIGNMENTS.md).
+
+  For app authors: `filter_cameras_for_skill()` now returns `[]`, not
+  `None`, when no camera carries the skill — an empty roster means watch
+  nothing. `cameras_for_skill()` still returns `None`, but only when
+  core could not be *asked*: unknown, so keep the roster you had rather
+  than acting on a network blip in either direction.
+
+- **Changing a camera's skill assignment now needs permission to
+  configure that camera.** `PUT`/`DELETE /api/v1/skills/{skill}/cameras/
+  {camera_id}` accepted any active user's JWT while the camera editor
+  they duplicate went through camera-update checks. Since assignment is
+  what turns an app's inference on or off, a viewer could start or stop
+  compute on any camera in the site. `GET .../cameras` is scoped to the
+  caller's visible cameras for the same reason.
+
 - **camera-agent: installed apps no longer speak unless asked.**
   `announce_app_alerts` defaulted to `important`, which speaks
   high/critical — and app alerts are mostly exactly that, so ANPR read

--- a/app/src/lib/cameraAssignments.ts
+++ b/app/src/lib/cameraAssignments.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 OpenNVR
+ * This file is part of OpenNVR.
+ *
+ * OpenNVR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenNVR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNVR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Which cameras an app may be offered, and which it actually runs on.
+ *
+ * The browser mirror of `server/services/skill_assignments.py`. Keep the
+ * two in step: this decides what a picker shows, the server decides what
+ * computes, and a picker that offers a camera the server will refuse is
+ * worse than no picker at all.
+ *
+ *   eligible — no camera is claimed by anyone, or this skill is among
+ *              its claims. What a picker may OFFER.
+ *   adopted  — this skill is among the camera's claims. What COSTS
+ *              money: skill inference runs only on adopted cameras.
+ *
+ * An unassigned camera is eligible everywhere and adopted nowhere, so a
+ * fresh install shows a full picker and pays for nothing until an
+ * operator points a skill at something.
+ */
+
+export const LPR_SKILL = 'license_plate_recognition'
+
+export type CameraAssignment = { skill?: string | null; label?: string | null }
+
+/** The skills a camera carries, lower-cased and trimmed. */
+export function cameraSkills(camera: { assignments?: CameraAssignment[] | null }): string[] {
+  const entries = camera?.assignments
+  if (!Array.isArray(entries)) return []
+  const out: string[] = []
+  for (const entry of entries) {
+    const skill = typeof entry?.skill === 'string' ? entry.skill.trim().toLowerCase() : ''
+    if (skill && !out.includes(skill)) out.push(skill)
+  }
+  return out
+}
+
+/** Does this camera carry the skill — i.e. does its inference run? */
+export function cameraAdopted(
+  camera: { assignments?: CameraAssignment[] | null },
+  skill: string
+): boolean {
+  return cameraSkills(camera).includes(skill.trim().toLowerCase())
+}
+
+/** May this skill be offered this camera? Unclaimed cameras are open. */
+export function cameraEligible(
+  camera: { assignments?: CameraAssignment[] | null },
+  skill: string
+): boolean {
+  const claimed = cameraSkills(camera)
+  return claimed.length === 0 || claimed.includes(skill.trim().toLowerCase())
+}
+
+/**
+ * Why a camera is not on offer, phrased for an operator who is looking
+ * for it and cannot find it. Null when it is eligible.
+ */
+export function ineligibleReason(
+  camera: { assignments?: CameraAssignment[] | null },
+  skill: string
+): string | null {
+  if (cameraEligible(camera, skill)) return null
+  const other = cameraSkills(camera).map(prettySkill).join(', ')
+  return `assigned to ${other}`
+}
+
+export function prettySkill(skill: string): string {
+  return skill.replace(/[_-]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}

--- a/app/src/services/cameraService.ts
+++ b/app/src/services/cameraService.ts
@@ -49,6 +49,17 @@ export const cameraService = {
   updateCamera: (cameraId: number, payload: any) => api.put(`/api/v1/cameras/${cameraId}`, payload),
   // Suggestions + live availability for the camera Assignments editor.
   getAssignableSkills: () => api.get('/api/v1/cameras/assignable-skills'),
+  // Claims: which cameras a skill is pointed at. Assignment is what
+  // turns an app's inference ON for a camera, so these need the same
+  // permission as editing the camera — the server enforces that.
+  getSkillCameras: (skill: string) =>
+    api.get(`/api/v1/skills/${encodeURIComponent(skill)}/cameras`),
+  declareSkillCamera: (skill: string, cameraId: number, consumer: string) =>
+    api.put(`/api/v1/skills/${encodeURIComponent(skill)}/cameras/${cameraId}`, { consumer }),
+  releaseSkillCamera: (skill: string, cameraId: number, consumer: string) =>
+    api.delete(`/api/v1/skills/${encodeURIComponent(skill)}/cameras/${cameraId}`, {
+      params: { consumer },
+    }),
   deleteCamera: (cameraId: number) => api.delete(`/api/v1/cameras/${cameraId}`),
   // Bin (irreversibly soft-deleted cameras)
   getDeletedCameras: () => api.get('/api/v1/cameras/deleted'),

--- a/app/src/views/Vehicles.tsx
+++ b/app/src/views/Vehicles.tsx
@@ -58,6 +58,13 @@ import { DataTable, type Column } from '../components/ui/DataTable'
 import { Pagination } from '../components/ui/Pagination'
 import { formatSeenAt, seenAtTitle } from '../lib/time'
 import {
+  LPR_SKILL,
+  cameraAdopted,
+  ineligibleReason,
+  type CameraAssignment,
+} from '../lib/cameraAssignments'
+import { cameraService } from '../services/cameraService'
+import {
   Badge, Button, Card, CardContent,
   EmptyState, PageHeader, Skeleton,
 } from '../components/ui'
@@ -180,7 +187,13 @@ type PlateStats = {
   per_day: { day: string; reads: number }[]
 }
 
-type CameraRow = { id: number; name: string }
+type CameraRow = {
+  id: number
+  name: string
+  // Which skills the camera is pointed at. [] / absent = unassigned:
+  // eligible for every picker, adopted by none, computing nothing.
+  assignments?: CameraAssignment[] | null
+}
 
 type PlateSummary = {
   plate: string
@@ -675,6 +688,32 @@ export function Vehicles() {
 
   const lprApp = findLprApp(appsQuery.data)
   const allow: string[] = (lprApp?.config as any)?.allowlist ?? []
+
+  // Giving a camera a gate role is the operator saying "read plates
+  // here", so it is also the moment the camera is CLAIMED for LPR —
+  // one action, not a role here and an assignment on another page.
+  // Without the claim the server reads no plates on that camera at all,
+  // and the role would quietly do nothing.
+  const claimCamera = useMutation({
+    mutationFn: async ({ cameraId, adopt }: { cameraId: number; adopt: boolean }) => {
+      // The installed app's own id when we have it — the claim should
+      // name the thing that holds it, not a constant that happens to
+      // match today.
+      const consumer = `app:${lprApp?.id ?? LPR_SOURCE}`
+      if (adopt) await cameraService.declareSkillCamera(LPR_SKILL, cameraId, consumer)
+      else await cameraService.releaseSkillCamera(LPR_SKILL, cameraId, consumer)
+    },
+    // The picker reads eligibility off `assignments`, so it has to see
+    // the write it just made.
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['cameras'] }),
+    onError: (e) => showError(extractApiError(e, 'Could not assign the camera.')),
+  })
+  // Cameras actually reading plates. Empty means the skill is dormant:
+  // reads stop, and the page has to say so rather than look broken.
+  const lprCameras = useMemo(
+    () => (camerasQuery.data ?? []).filter((c) => cameraAdopted(c, LPR_SKILL)),
+    [camerasQuery.data]
+  )
 
   // The society register + alarm mode live in the providing app's
   // config, exactly like the watchlists (live-applied by the app).
@@ -1326,6 +1365,14 @@ export function Vehicles() {
             const next = { ...cameraRoles }
             if (!role) delete next[String(cameraId)]
             else next[String(cameraId)] = label ? { role, label } : { role }
+            // Adopt on set, release on clear. Releasing drops only this
+            // app's claim — an operator who assigned LPR on the Cameras
+            // page keeps their assignment, and the camera keeps reading.
+            const camera = (camerasQuery.data ?? []).find((c) => c.id === cameraId)
+            const adopt = Boolean(role)
+            if (camera && adopt !== cameraAdopted(camera, LPR_SKILL)) {
+              claimCamera.mutate({ cameraId, adopt })
+            }
             // Only declared manifest params may be written — the server
             // rejects unknown config keys. camera_roles is declared;
             // the legacy gate_directions map is read-only fallback.
@@ -1429,7 +1476,9 @@ export function Vehicles() {
             title={debouncedPlate || cameraId !== ''
               ? 'No plate reads match these filters'
               : 'No plate reads in this window'}
-            description="Assign cameras the License Plate Recognition skill (Cameras → edit → Assignments) and vehicle visits will appear here with their evidence photos."
+            description={lprCameras.length === 0
+              ? 'No camera is reading plates yet. Give a camera a role under Vehicle register → Camera roles (or assign it the License Plate Recognition skill under Cameras → edit → Assignments) and visits will appear here with their evidence photos.'
+              : 'Vehicle visits appear here with their evidence photos.'}
             action={(debouncedPlate || cameraId !== '') ? (
               <Button variant="outline" onClick={() => {
                 setPlate(''); setCameraId(''); reads.setPage(1)
@@ -2109,6 +2158,19 @@ function RegistryTab({
           {(() => {
             const hasIn = Object.values(cameraRoles).some((r) => r.role === 'gate_in')
             const hasOut = Object.values(cameraRoles).some((r) => r.role === 'gate_out')
+            // Adoption is the switch that costs money, so its absence is
+            // the loudest thing on the card: no camera claimed, no plate
+            // is read anywhere, and nothing else here matters yet.
+            const reading = cameras.filter((c) => cameraAdopted(c, LPR_SKILL))
+            if (reading.length === 0) {
+              return (
+                <div className="text-xs rounded border border-[var(--warning,#b7791f)] text-[var(--warning,#b7791f)] px-3 py-2 mb-2">
+                  No camera is reading plates. Give a camera a role below and this app
+                  starts reading it — until then plate recognition runs nowhere, which
+                  is also why it costs nothing.
+                </div>
+              )
+            }
             if (!hasIn) {
               return (
                 <div className="text-xs rounded border border-[var(--warning,#b7791f)] text-[var(--warning,#b7791f)] px-3 py-2 mb-2">
@@ -2130,8 +2192,17 @@ function RegistryTab({
           <div className="flex flex-wrap gap-3">
             {cameras.map((c) => {
               const entry = cameraRoles[String(c.id)]
+              // Ineligible cameras stay on screen, greyed, with the
+              // reason. Hiding them makes an operator hunt for a camera
+              // that is right there — the question is always "why is it
+              // not in the list", so answer it in the list.
+              const blocked = ineligibleReason(c, LPR_SKILL)
               return (
-                <label key={c.id} className="inline-flex items-center gap-2 text-sm">
+                <label
+                  key={c.id}
+                  className={`inline-flex items-center gap-2 text-sm${blocked ? ' opacity-60' : ''}`}
+                  title={blocked ? `${c.name} is ${blocked} — release it there to use it here` : undefined}
+                >
                   <span>{c.name}</span>
                   <select
                     value={entry?.role ?? ''}
@@ -2139,7 +2210,7 @@ function RegistryTab({
                       const role = e.target.value as CameraRole | ''
                       onSetRole(c.id, role, role === 'other' ? (entry?.label ?? '') : undefined)
                     }}
-                    disabled={saving}
+                    disabled={saving || Boolean(blocked)}
                     className="py-1 px-2 rounded border border-[var(--border)] bg-[var(--bg-2)] text-sm"
                   >
                     <option value="">no role</option>
@@ -2159,6 +2230,9 @@ function RegistryTab({
                       disabled={saving}
                       className="py-1 px-2 rounded border border-[var(--border)] bg-[var(--bg-2)] text-sm w-36"
                     />
+                  )}
+                  {blocked && (
+                    <span className="text-xs text-[var(--text-dim)]">{blocked}</span>
                   )}
                 </label>
               )

--- a/docs/APP_CREDENTIALS.md
+++ b/docs/APP_CREDENTIALS.md
@@ -19,11 +19,13 @@ a catalog of third-party apps.
 
 An app's **roster** is the cameras the operator assigned to it on the
 camera settings page (`Camera.assignments[].skill` naming one of the
-app's manifest `provides`, or the app id). When no camera names the app,
-it sees every camera — the additive rule of
-[CAMERA_ASSIGNMENTS.md](CAMERA_ASSIGNMENTS.md), the same rule the SDK's
-`cameras_for_skill` applies client-side, now enforced where the frames are
-handed out.
+app's manifest `provides`, or the app id). It is **closed by default**:
+an app sees the cameras it was pointed at and no others, and an app
+nobody has assigned a camera sees nothing
+([CAMERA_ASSIGNMENTS.md](CAMERA_ASSIGNMENTS.md)) — the same rule the
+SDK's `cameras_for_skill` applies client-side, enforced here where the
+frames are actually handed out. This reverses the earlier additive rule,
+under which an unassigned app got the whole fleet.
 
 ## The handshake
 

--- a/docs/CAMERA_ASSIGNMENTS.md
+++ b/docs/CAMERA_ASSIGNMENTS.md
@@ -17,26 +17,38 @@ An **assignment** is *additional, specialized attention* layered on top:
 it declares what a camera is *for*, so the capabilities ("skills") that
 can serve that purpose point themselves at the right cameras. Assigning
 camera 1 to `license_plate_recognition` doesn't change what camera 1
-records — it tells the LPR capability *this is your camera*. Assigning
-cameras 2–3 to `occupancy_counting` tells the counting app to watch
-exactly those two and ignore the rest.
+records — it tells the LPR capability *this is your camera*, and it is
+what turns plate reading ON for that camera. Assigning cameras 2–3 to
+`occupancy_counting` tells the counting app to watch exactly those two
+and ignore the rest.
 
 Think of skills as what the system **can do** (detect objects, read
 plates, count occupancy, recognise faces) and an assignment as **where
 each of those abilities should look**.
 
-## The one rule that keeps old setups working
+## The one rule: eligible everywhere, computing nowhere
 
-**Nothing assigned means nothing restricted.** A skill with no camera
-assigned to it behaves exactly as before assignments existed: the
-occupancy app watches every camera, the indexer indexes everything.
-Restriction begins only when the *first* camera is assigned a given
-skill — from that moment, the assignment list for that skill is the
-whole truth. Un-assign the last camera and the restriction lifts again.
+An unassigned camera is **offered to every skill and used by none.**
 
-This is why upgrading changes nothing until you choose to use the
-feature, and why an app never goes silently blind: "no assignment" can
-never be misread as "watch nothing".
+* **Eligible** — it appears in every app's camera picker, so a fresh
+  install shows you your whole fleet and you choose where each skill
+  looks. Assign a camera to one skill and it stops being offered to the
+  others: a camera has a job, not five.
+* **Adopted** — a skill's inference runs on a camera *only* once that
+  camera carries the skill. Until then it costs nothing.
+
+> **This reverses the earlier rule, and it matters on upgrade.** "No
+> camera assigned" used to mean "no restriction declared", so an app
+> with no assignments watched the entire fleet. That made the
+> least-configured install the most expensive one, and let a newly
+> installed app read every camera nobody had offered it. **After
+> upgrading, assign your cameras.** An app pointed at nothing now
+> watches nothing — plate reads stop on unassigned cameras until you
+> assign them.
+
+What never depends on assignments: streaming, recording, and the
+always-on Tier-0 detection behind the event timeline. Un-assigning a
+camera turns a skill off; it never turns the camera off.
 
 ## How to assign
 
@@ -58,17 +70,24 @@ what's actually installed arrives with the catalog-UI integration.
 
 ## What honours assignments today
 
-* **occupancy-counting** (on by default): when at least one camera is
-  assigned `occupancy_counting`, the app scopes to exactly those
-  cameras — picked up at boot *and* on its 5-minute discovery refresh,
-  so assigning or un-assigning on the settings page takes effect within
-  minutes, no restart. An explicit `cameras:` list in the app's own
-  config always wins over assignments (the operator's written word is
-  never second-guessed).
+* **occupancy-counting** (on by default): the app scopes to exactly the
+  cameras assigned `occupancy_counting` — picked up at boot *and* on its
+  5-minute discovery refresh, so assigning or un-assigning on the
+  settings page takes effect within minutes, no restart. Assign none and
+  it counts nowhere. An explicit `cameras:` list in the app's own config
+  always wins over assignments (the operator's written word is never
+  second-guessed).
+* **License Plate Recognition**: plate OCR runs **only** on cameras
+  carrying `license_plate_recognition`. This is the expensive one — one
+  full OCR call per vehicle visit — and it is now the operator's switch,
+  per camera. Giving a camera a gate role on the Vehicles page assigns
+  the skill as part of the same action; clearing the role releases it.
 * **Any app built on the App SDK** can adopt the same behaviour with
   one call — `filter_cameras_for_skill(discovered, "my_skill")` /
-  `cameras_for_skill(url, "my_skill")` — following the same
-  `None` = "no restriction declared" contract.
+  `cameras_for_skill(url, "my_skill")`. Both return `[]` when nothing
+  carries the skill: **watch nothing**. `cameras_for_skill` returns
+  `None` only when core could not be asked at all — unknown, so keep
+  whatever roster you already had rather than acting on a blip.
 * **Tier-0 (the always-on detector)**: an `object_detection` assignment
   with labels narrows that camera's detected classes ("camera 4 wants
   person + truck") — the global `DETECT_LABELS` still applies to every

--- a/examples/license-plate-recognition/license_plate_recognition.py
+++ b/examples/license-plate-recognition/license_plate_recognition.py
@@ -746,9 +746,11 @@ class PlateAlerter(Detector):
                 )
             except Exception:  # noqa: BLE001 — scope is advisory, never fatal
                 assigned = None
-            # None = "no restriction declared / couldn't tell" — the SDK
-            # helper's contract. On failure keep the previous answer
-            # (advisory scope must never turn a hiccup into a policy).
+            # None means core could not be ASKED — the SDK helper's
+            # contract. Keep the previous answer: an outage must never
+            # turn into a policy. An empty LIST is core answering "no
+            # camera is assigned this skill", which is a real scope of
+            # nothing and is applied.
             if assigned is not None:
                 self._assigned_scope = frozenset(assigned)
         return self._assigned_scope

--- a/examples/license-plate-recognition/tests/test_license_plate_recognition.py
+++ b/examples/license-plate-recognition/tests/test_license_plate_recognition.py
@@ -151,12 +151,26 @@ def test_assignment_scope_via_sdk(monkeypatch):
     assert len(alerter.handle_event(_envelope(camera="cam-7"))) == 1
 
 
+def test_no_assigned_camera_means_no_alert_anywhere(monkeypatch):
+    """Closed by default: core answering "nobody carries this skill" is a
+    real scope of nothing, not "no restriction declared". An app nobody
+    pointed at a camera must not alert on the whole fleet."""
+    alerter, _ = _alerter(opennvr_url="http://core:8000")
+    monkeypatch.setattr(lpr, "cameras_for_skill",
+                        lambda url, skill, api_key=None: [])
+    assert alerter.handle_event(_envelope(camera="cam-1")) == []
+    assert alerter.handle_event(_envelope(camera="cam-7")) == []
+
+
 def test_scope_fetch_failure_means_no_restriction(monkeypatch):
     alerter, _ = _alerter(opennvr_url="http://core:8000")
 
     def boom(url, skill, api_key=None):
         raise RuntimeError("core down")
     monkeypatch.setattr(lpr, "cameras_for_skill", boom)
+    # Unknown, not empty: core could not be asked, so the previous
+    # answer stands. There is none yet at boot, so nothing is narrowed —
+    # an outage must not silently mute every alert either.
     assert len(alerter.handle_event(_envelope(camera="anything"))) == 1
 
 

--- a/examples/occupancy-counting/occupancy_counting.py
+++ b/examples/occupancy-counting/occupancy_counting.py
@@ -121,9 +121,11 @@ ALERT_COOLDOWN_SECONDS_DEFAULT: int = 120
 def _scope_to_assignment(discovered: list[dict]) -> list[dict]:
     """Narrow a discover_cameras() payload to this app's assigned cameras.
 
-    No camera assigned SKILL -> no restriction declared -> unchanged.
-    Assignments are additive intent: they point THIS app's attention;
-    streaming/recording/Tier-0 on the other cameras are unaffected.
+    Closed by default: no camera assigned SKILL -> this app counts
+    NOWHERE. It used to mean "no restriction declared -> count
+    everywhere", which handed an unconfigured app the whole fleet.
+    Assignment only points THIS app's attention; streaming, recording
+    and Tier-0 on every camera are unaffected either way.
     """
     assigned = filter_cameras_for_skill(discovered, SKILL)
     if assigned is None:
@@ -684,16 +686,20 @@ class OccupancyCounter(Detector):
                 self._config.opennvr_url_for_discovery,
                 api_key=self._config.internal_api_key,
             )
-        # Assignment scoping runs on every refresh, so assigning or
-        # un-assigning a camera on the settings page takes effect within
-        # one refresh interval — no app restart.
-        discovered = _scope_to_assignment(discovered)
-        ids = {c["camera_id"] for c in discovered}
-        if not ids:
-            # Treat "core answered with nothing" as no news rather than
+        if not discovered:
+            # Core answered with NO CAMERAS AT ALL — no news rather than
             # "delete every camera": a transient blip mid-poll must not
             # silently stop the app watching everything it was watching.
+            # This has to be tested BEFORE scoping, or it would swallow
+            # the un-assignment below, which is a real empty answer.
             return [], []
+        # Assignment scoping runs on every refresh, so assigning or
+        # un-assigning a camera on the settings page takes effect within
+        # one refresh interval — no app restart. An empty result here is
+        # the operator saying "count nowhere", and is applied: cameras
+        # this app was watching are dropped.
+        discovered = _scope_to_assignment(discovered)
+        ids = {c["camera_id"] for c in discovered}
         current = set(self._config.cameras)
         added = sorted(ids - current)
         removed = sorted(current - ids)

--- a/examples/occupancy-counting/tests/test_occupancy_counting.py
+++ b/examples/occupancy-counting/tests/test_occupancy_counting.py
@@ -214,9 +214,13 @@ def _write_config(tmp_path, body: str) -> str:
 def test_cameras_are_derived_from_opennvr_when_unlisted(tmp_path, monkeypatch):
     import opennvr_app_sdk.cameras as sdk_cameras
 
+    # Assigned, because assignment is what puts a camera in this app's
+    # scope at all — the mechanics under test here are discovery and the
+    # auto zone, not the scoping rule (that is its own test below).
     monkeypatch.setattr(
         oc, "discover_cameras",
-        lambda url, api_key=None: [{"camera_id": "cam1"}, {"camera_id": "cam2"}],
+        lambda url, api_key=None: _discovered("cam1:occupancy_counting",
+                                              "cam2:occupancy_counting"),
     )
     cfg = oc.load_config(_write_config(tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
     assert sorted(cfg.cameras) == ["cam1", "cam2"]
@@ -271,21 +275,22 @@ def test_core_reachable_but_no_cameras_yet_boots_empty(tmp_path, monkeypatch):
 def test_cameras_added_after_boot_are_picked_up(tmp_path, monkeypatch):
     """A set captured once at boot would silently never watch a camera
     added tomorrow."""
-    live = [{"camera_id": "cam1"}]
-    monkeypatch.setattr(oc, "discover_cameras", lambda url, api_key=None: list(live))
+    live = _discovered("cam1:occupancy_counting")
+    monkeypatch.setattr(oc, "discover_cameras",
+                        lambda url, api_key=None: [dict(c) for c in live])
     cfg = oc.load_config(_write_config(
         tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
     counter = oc.OccupancyCounter(cfg, _NullDispatcher())
     assert sorted(cfg.cameras) == ["cam1"]
 
-    live.append({"camera_id": "cam2"})                 # operator adds a camera
+    live.extend(_discovered("cam2:occupancy_counting"))  # operator adds one
     added, removed = counter.refresh_cameras()
     assert added == ["cam2"] and removed == []
     # ...and it is counted immediately, with the app-level threshold.
     fired = counter.handle_event(_tier0_event(6, camera_id="cam2"))
     assert len(fired) == 1 and fired[0].evidence["count"] == 6
 
-    live.remove({"camera_id": "cam1"})                 # ...and removes one
+    live[:] = _discovered("cam2:occupancy_counting")    # ...and removes one
     added, removed = counter.refresh_cameras()
     assert added == [] and removed == ["cam1"]
     assert "cam1" not in cfg.cameras
@@ -293,8 +298,9 @@ def test_cameras_added_after_boot_are_picked_up(tmp_path, monkeypatch):
 
 def test_refresh_ignores_an_empty_discovery_blip(tmp_path, monkeypatch):
     """Core answering with nothing mid-poll must not delete every camera."""
-    live = [{"camera_id": "cam1"}]
-    monkeypatch.setattr(oc, "discover_cameras", lambda url, api_key=None: list(live))
+    live = _discovered("cam1:occupancy_counting")
+    monkeypatch.setattr(oc, "discover_cameras",
+                        lambda url, api_key=None: [dict(c) for c in live])
     cfg = oc.load_config(_write_config(
         tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
     counter = oc.OccupancyCounter(cfg, _NullDispatcher())
@@ -378,7 +384,7 @@ def test_refresh_accepts_a_prefetched_camera_list(tmp_path, monkeypatch):
 
     def _boot_only(url, api_key=None):
         calls["n"] += 1
-        return [{"camera_id": "cam1"}]
+        return _discovered("cam1:occupancy_counting")
 
     monkeypatch.setattr(oc, "discover_cameras", _boot_only)
     cfg = oc.load_config(_write_config(
@@ -387,7 +393,8 @@ def test_refresh_accepts_a_prefetched_camera_list(tmp_path, monkeypatch):
     assert calls["n"] == 1                              # boot discovery only
 
     added, removed = counter.refresh_cameras(
-        discovered=[{"camera_id": "cam1"}, {"camera_id": "cam2"}]
+        discovered=_discovered("cam1:occupancy_counting",
+                               "cam2:occupancy_counting")
     )
     assert added == ["cam2"] and removed == []
     assert calls["n"] == 1, "a supplied list must not trigger a fetch"
@@ -454,39 +461,45 @@ def test_boot_scopes_to_assigned_cameras(tmp_path, monkeypatch):
     assert len(fired) == 1
 
 
-def test_no_assignments_anywhere_means_watch_everything(tmp_path, monkeypatch):
-    """Back-compat: assignments that exist for OTHER skills only do not
-    restrict this app either way — restriction starts with OUR skill."""
+def test_no_assignments_anywhere_means_count_nowhere(tmp_path, monkeypatch):
+    """Closed by default. Cameras nobody assigned this app are not its
+    cameras — it counts nowhere until an operator points it somewhere.
+
+    This used to assert the opposite ("restriction starts with OUR
+    skill", so an unassigned fleet was watched entirely), which made a
+    fresh install the most expensive configuration there is."""
     monkeypatch.setattr(oc, "discover_cameras", lambda url, api_key=None: _discovered(
-        "cam1:", "cam2:",
+        "cam1:", "cam2:license_plate_recognition",
     ))
     cfg = oc.load_config(_write_config(
         tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
-    assert sorted(cfg.cameras) == ["cam1", "cam2"]
+    assert sorted(cfg.cameras) == []
 
 
 def test_refresh_follows_assignment_changes(tmp_path, monkeypatch):
     """Assigning / un-assigning on the settings page takes effect within
-    one refresh — including un-assigning the LAST camera, which lifts the
-    restriction entirely (back to watch-everything, by the rule)."""
-    live = _discovered("cam1:", "cam2:")
+    one refresh — including un-assigning the LAST camera, which stops the
+    app counting anywhere rather than handing it the fleet."""
+    live = _discovered("cam1:occupancy_counting", "cam2:occupancy_counting")
     monkeypatch.setattr(oc, "discover_cameras", lambda url, api_key=None: [dict(c) for c in live])
     cfg = oc.load_config(_write_config(
         tmp_path, 'opennvr_url: "http://core:8000"\ncameras: []\n'))
     counter = oc.OccupancyCounter(cfg, _NullDispatcher())
     assert sorted(cfg.cameras) == ["cam1", "cam2"]
 
-    # Operator assigns occupancy to cam2 only → scope narrows.
+    # Operator un-assigns cam1 → scope narrows.
     live[:] = _discovered("cam1:", "cam2:occupancy_counting")
     added, removed = counter.refresh_cameras()
     assert removed == ["cam1"] and added == []
     assert sorted(cfg.cameras) == ["cam2"]
 
-    # Operator removes the assignment again → restriction lifts.
+    # Operator un-assigns the LAST one → the app counts nowhere. The
+    # empty answer is applied, not mistaken for a discovery blip: core
+    # returned two cameras, it just assigned this app neither.
     live[:] = _discovered("cam1:", "cam2:")
     added, removed = counter.refresh_cameras()
-    assert added == ["cam1"] and removed == []
-    assert sorted(cfg.cameras) == ["cam1", "cam2"]
+    assert added == [] and removed == ["cam2"]
+    assert sorted(cfg.cameras) == []
 
 
 def test_explicit_camera_list_ignores_assignments(tmp_path, monkeypatch):

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2026 OpenNVR
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Single source of the SDK version (pyproject mirrors it)."""
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/cameras.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/cameras.py
@@ -64,10 +64,26 @@ def discover_cameras(
     Never raises: discovery runs at app startup, and an app that refuses
     to boot because core was still starting is worse than one that boots
     with no cameras and says so. Callers should log the empty result.
+
+    ``[]`` deliberately conflates "core said zero cameras" with "core
+    could not be reached" — for a boot-time listing they are the same
+    non-answer. Callers that must tell them apart (assignment, where
+    the two mean opposite things) use :func:`_fetch_cameras`.
     """
+    return _fetch_cameras(opennvr_url, api_key=api_key, timeout=timeout) or []
+
+
+def _fetch_cameras(
+    opennvr_url: str,
+    *,
+    api_key: str | None = None,
+    timeout: float = 5.0,
+) -> list[dict[str, Any]] | None:
+    """As :func:`discover_cameras`, but ``None`` when core could not be
+    asked at all — as opposed to ``[]``, core answering "no cameras"."""
     base = (opennvr_url or "").rstrip("/")
     if not base:
-        return []
+        return None
     key = internal_api_key(api_key)
     headers = {"X-Internal-Api-Key": key} if key else {}
     try:
@@ -80,14 +96,14 @@ def discover_cameras(
                 response.status_code,
                 " (is OPENNVR_INTERNAL_API_KEY set?)" if response.status_code in (401, 403) else "",
             )
-            return []
+            return None
         payload = response.json()
     except Exception as exc:                      # network, JSON, import
         logger.warning("camera discovery failed against %s: %s", base, exc)
-        return []
+        return None
     cameras = payload.get("cameras") if isinstance(payload, dict) else None
     if not isinstance(cameras, list):
-        return []
+        return None
     return [c for c in cameras if isinstance(c, dict) and c.get("camera_id")]
 
 
@@ -98,17 +114,19 @@ def full_frame_polygon(size: int = UNIT_FRAME) -> list[list[int]]:
 
 # ── Per-camera capability assignment (slice 2) ─────────────────────
 #
-# Operators can declare "camera 1 does LPR, cameras 2-3 count people" on
-# the camera settings page; the internal endpoint serves it as an
-# ``assignments`` list on each camera. An assignment is ADDITIVE intent:
-# the camera keeps streaming, recording, and Tier-0 detection regardless
-# — it only tells interested apps WHERE to point their attention.
+# Operators declare "camera 1 does LPR, cameras 2-3 count people" on the
+# camera settings page; the internal endpoint serves it as an
+# ``assignments`` list on each camera. The camera keeps streaming,
+# recording and Tier-0 detection regardless — assignment governs which
+# apps may use it and which SKILL INFERENCE runs on it.
 #
-# The back-compat rule every consumer must honour: restriction exists
-# only once at least one camera carries THIS skill. No camera assigned
-# the skill (or no assignments feature at all — an older core) means
-# "no restriction declared", and the app behaves exactly as before
-# assignments existed: watch everything.
+# CLOSED BY DEFAULT. An app watches the cameras it was pointed at, and
+# no more. This reverses the original additive rule, under which "no
+# camera carries this skill" meant "watch everything": that made the
+# least-configured install the most expensive one, and let an app read
+# cameras nobody had offered it. An app with no assigned cameras now
+# watches nothing — visibly, so an operator fixes it, rather than
+# silently getting the fleet.
 
 
 def filter_cameras_for_skill(
@@ -117,11 +135,14 @@ def filter_cameras_for_skill(
     """Which of ``cameras`` (a :func:`discover_cameras` payload) are
     assigned ``skill``.
 
-    Returns ``None`` when NO camera carries the skill — "no restriction
-    declared": the caller must fall back to watching everything, exactly
-    as before assignments existed. Returns the (possibly empty-labelled)
-    camera-id list once at least one camera is assigned the skill —
-    from then on the operator's declaration is the whole truth.
+    Returns the camera-id list, EMPTY when no camera carries the skill.
+    An empty list means watch nothing: the operator has not pointed this
+    skill at anything yet. It used to return ``None`` there, meaning
+    "watch everything", which is why an unconfigured app saw the fleet.
+
+    The return type stays ``| None`` for callers that still branch on
+    it; ``None`` now only means "could not ask" (an empty skill name),
+    never "no restriction".
 
     Pure — feed it the list you already fetched instead of fetching
     twice (the occupancy example's refresh loop does exactly this).
@@ -137,7 +158,7 @@ def filter_cameras_for_skill(
             if isinstance(a, dict) and str(a.get("skill", "")).lower() == want:
                 out.append(str(cam["camera_id"]))
                 break
-    return out or None
+    return out
 
 
 def cameras_for_skill(
@@ -149,11 +170,16 @@ def cameras_for_skill(
 ) -> list[str] | None:
     """Fetch-and-filter convenience: the camera ids assigned ``skill``.
 
-    ``None`` means "no restriction declared" — either no camera carries
-    the skill, or discovery failed (both cases mean: keep current
-    behaviour, don't narrow). Use :func:`filter_cameras_for_skill` when
-    you already hold a :func:`discover_cameras` result.
+    ``[]`` means core answered and no camera carries the skill: watch
+    nothing. ``None`` means core could not be ASKED — unknown, and
+    unknown must not be acted on in either direction: keep whatever
+    roster you already had rather than dropping to nothing on a restart
+    that raced core, or widening to everything on a network blip.
+
+    Use :func:`filter_cameras_for_skill` when you already hold a
+    :func:`discover_cameras` result.
     """
-    return filter_cameras_for_skill(
-        discover_cameras(opennvr_url, api_key=api_key, timeout=timeout), skill
-    )
+    cameras = _fetch_cameras(opennvr_url, api_key=api_key, timeout=timeout)
+    if cameras is None:
+        return None
+    return filter_cameras_for_skill(cameras, skill)

--- a/sdk/opennvr-app-sdk/pyproject.toml
+++ b/sdk/opennvr-app-sdk/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "opennvr-app-sdk"
-version = "0.6.0"
+version = "0.7.0"
 description = "Shared SDK for OpenNVR monitoring apps: §11.5 alert dispatch, zone geometry, keyed TTL state, app manifests, and the Detector / FrameApp base loops."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/opennvr-app-sdk/tests/test_cameras.py
+++ b/sdk/opennvr-app-sdk/tests/test_cameras.py
@@ -76,12 +76,12 @@ def test_full_frame_polygon_covers_the_unit_space():
     assert poly == [[0, 0], [UNIT_FRAME, 0], [UNIT_FRAME, UNIT_FRAME], [0, UNIT_FRAME]]
 
 
-# ── Per-camera assignment (slice 2) ────────────────────────────────
+# ── Per-camera assignment ──────────────────────────────────────────
 #
-# "Camera 1 does LPR, cameras 2-3 count people." The back-compat rule:
-# restriction exists only once at least one camera carries the skill —
-# no camera assigned (or an older core with no assignments field) means
-# "no restriction declared", and the caller keeps watching everything.
+# "Camera 1 does LPR, cameras 2-3 count people." Closed by default: an
+# app watches the cameras it was pointed at and no more. Nothing
+# assigned means an EMPTY list — watch nothing — not the old additive
+# rule where it meant watch everything.
 
 
 _ASSIGNED = [
@@ -102,14 +102,17 @@ def test_filter_returns_only_cameras_assigned_the_skill():
     assert filter_cameras_for_skill(_ASSIGNED, "license_plate_recognition") == ["cam1"]
 
 
-def test_filter_none_means_no_restriction_declared():
-    # Nobody carries the skill → None, NOT [] — the caller must fall back
-    # to watching everything, exactly as before assignments existed.
-    assert filter_cameras_for_skill(_ASSIGNED, "face_recognition") is None
-    # Older core: cameras with no assignments field at all.
+def test_filter_is_empty_when_nothing_carries_the_skill():
+    # Nobody carries the skill → [], meaning watch NOTHING. It used to
+    # be None ("no restriction declared"), which handed an unconfigured
+    # app the whole fleet.
+    assert filter_cameras_for_skill(_ASSIGNED, "face_recognition") == []
+    # An older core with no assignments field at all is the same case:
+    # nobody pointed this app at anything.
     legacy = [{"camera_id": "cam1"}, {"camera_id": "cam2"}]
-    assert filter_cameras_for_skill(legacy, "occupancy_counting") is None
-    assert filter_cameras_for_skill([], "occupancy_counting") is None
+    assert filter_cameras_for_skill(legacy, "occupancy_counting") == []
+    assert filter_cameras_for_skill([], "occupancy_counting") == []
+    # None survives for one case only: we could not even ask.
     assert filter_cameras_for_skill(_ASSIGNED, "") is None
 
 

--- a/server/models.py
+++ b/server/models.py
@@ -253,11 +253,13 @@ class Camera(Base):
     # A list of {"skill": "<capability>", "labels": [..]?} entries, e.g.
     # [{"skill": "license_plate_recognition"},
     #  {"skill": "object_detection", "labels": ["person", "truck"]}].
-    # Written ONLY by the camera settings surface; served additively on the
-    # internal camera-agent endpoint so consumers (Tier-0 reconcile, the
-    # App SDK's cameras_for_skill, the catalog UI) can opt in one by one.
-    # NULL/[] = nothing assigned — every consumer must treat that as
-    # "no restriction declared", never as "do nothing" (back-compat).
+    # Written by the camera settings surface and by an app adopting a
+    # camera in its own config; served on the internal camera-agent
+    # endpoint to Tier-0 reconcile, the App SDK's cameras_for_skill and
+    # the catalog UI.
+    # NULL/[] = nothing assigned. That camera is ELIGIBLE for every
+    # skill's picker and ADOPTED by none: it keeps streaming, recording
+    # and Tier-0 detection, and no app inference runs on it.
     # Nullable so the additive column self-heal can add it to old
     # create_all databases.
     assignments = Column(JSON, nullable=True)

--- a/server/routers/internal_camera_agent.py
+++ b/server/routers/internal_camera_agent.py
@@ -27,6 +27,7 @@ from models import Camera, SecuritySetting
 from services.app_keys import (
     AppPrincipal, app_camera_ids, looks_like_app_key, resolve_app_key,
 )
+from services.skill_assignments import camera_adopted, camera_skills
 from services.stream_service import _build_stream_name
 
 logger = logging.getLogger(__name__)
@@ -336,6 +337,11 @@ async def ingest_track_event(
             and wants_plate(
         row.label, evidence_rel or (candidates and "candidates"),
         settings.events_plate_enrichment,
+        # The assignment gate. `camera` is already in hand from the
+        # existence check above, so this costs no extra query on the
+        # hot path — and without it every vehicle on every camera
+        # bought an OCR inference.
+        camera_skills(camera),
     ):
         # Registered BEFORE the task is queued: KAI-C republishes every
         # accepted read this sweep makes as plate.recognized.v1, and the
@@ -479,6 +485,14 @@ async def ingest_plate_attempt(
         raise HTTPException(status_code=404, detail="unknown camera_id")
     if not settings.events_plate_enrichment:
         return {"status": "disabled"}
+    # The same assignment gate the ingest sweep applies. Tier-0 already
+    # declines to POST here for an unassigned camera, so today this is
+    # belt and braces — but the endpoint is reachable by any platform
+    # key, and "no producer currently misuses it" is not a gate.
+    from services.plate_enrichment import PLATE_SKILL
+
+    if not camera_adopted(camera, PLATE_SKILL):
+        return {"status": "unassigned"}
 
     from services.evidence_store import MAX_EVIDENCE_BYTES
 
@@ -703,10 +717,11 @@ def list_camera_agent_sources(
         .order_by(Camera.id.asc())
         .all()
     )
-    # An app key gets the cameras the operator assigned to it (every
-    # camera when none is assigned — the additive rule); the site key
-    # gets the fleet. Same rule the SDK's cameras_for_skill applies
-    # client-side, now enforced where the frames are handed out.
+    # An app key gets the cameras the operator assigned to it, and only
+    # those — an app assigned nothing gets an empty roster rather than
+    # the fleet. The site key (detect-pipeline, KAI-C) still gets every
+    # camera. Same rule the SDK's cameras_for_skill applies client-side,
+    # enforced here where the frames are actually handed out.
     roster = _app_roster(db, principal)
     if roster is not None:
         cameras = [c for c in cameras if int(c.id) in roster]
@@ -791,10 +806,9 @@ def list_camera_agent_sources(
                 "frame_url": frame_url,
                 "role": role,
                 "source": source,
-                # Per-camera capability assignment (slice 1 of
-                # docs/design/per-camera-assignment.md). Additive: existing
-                # consumers ignore it. [] = nothing assigned — consumers must
-                # read that as "no restriction declared", never "do nothing".
+                # Per-camera capability assignment. [] = nothing
+                # assigned: the camera is eligible for any skill's picker
+                # but adopted by none, so no app inference runs on it.
                 "assignments": list(cam.assignments or []),
             }
         )

--- a/server/routers/skills.py
+++ b/server/routers/skills.py
@@ -30,6 +30,7 @@ from core.logging_config import main_logger
 from models import InstalledApp, User
 from routers.ai_models import _load_tasks_registry
 from services import skill_assignments
+from services.camera_scope import can_manage_camera, in_scope, visible_camera_ids
 from services.kai_c_service import get_kai_c_service
 from services.skills_registry import derive_skills
 
@@ -100,7 +101,33 @@ async def get_skill_cameras(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ) -> dict[str, Any]:
-    return skill_assignments.skill_view(db, skill_id)
+    # A claim names a camera, so the view is camera data and obeys the
+    # same grants every other camera read does. Superusers scope to None.
+    view = skill_assignments.skill_view(db, skill_id)
+    scope = visible_camera_ids(db, current_user)
+    if scope is not None:
+        view = dict(view)
+        view["cameras"] = [
+            c for c in (view.get("cameras") or [])
+            if in_scope(scope, (c or {}).get("camera_id"))
+        ]
+    return view
+
+
+def _require_camera_manage(db: Session, user: User, camera_id: int) -> None:
+    """A claim changes what a camera is used for, so it needs the same
+    permission editing that camera does.
+
+    These two routes took any active user's JWT while the camera editor
+    they duplicate went through camera-update checks — a viewer could
+    point any camera at any skill (and, since assignment now gates
+    inference, turn its compute on or off).
+    """
+    if not can_manage_camera(db, user, camera_id):
+        raise HTTPException(
+            status_code=403,
+            detail="you do not have permission to configure this camera",
+        )
 
 
 @router.put("/{skill_id}/cameras/{camera_id}")
@@ -119,6 +146,7 @@ async def declare_skill_camera(
     per-camera-assignment design rule); GET /skills is where its status
     shows as missing-dependency.
     """
+    _require_camera_manage(db, current_user, camera_id)
     try:
         skill_assignments.declare(
             db, skill=skill_id, camera_id=camera_id,
@@ -142,6 +170,7 @@ async def release_skill_camera(
 ) -> dict[str, Any]:
     """Release one consumer's claim. The union shrinks by exactly this
     claim; other consumers' assignments survive (decision 8)."""
+    _require_camera_manage(db, current_user, camera_id)
     if not skill_assignments.release(
             db, skill=skill_id, camera_id=camera_id, consumer=consumer):
         raise HTTPException(

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -683,8 +683,9 @@ class CameraResponse(CameraBase):
     id: int
     owner_id: int
     is_active: bool
-    # Per-camera capability assignment; None and [] both mean "nothing
-    # assigned" (read as: no restriction declared).
+    # Per-camera capability assignment. None and [] both mean "nothing
+    # assigned": eligible for any skill's picker, adopted by none, so no
+    # app inference runs on it. The UI reads eligibility off this.
     assignments: list[CameraAssignment] | None = None
     deleted_at: datetime | None = None
     created_at: datetime

--- a/server/services/app_keys.py
+++ b/server/services/app_keys.py
@@ -17,10 +17,10 @@ The model here:
   the secret half is what is hashed (SHA-256) and stored.
 * Presenting an app key authenticates AS THAT APP: it may read its own
   config and status, register itself again, and read the platform's
-  internal camera/event routes **for its own roster** (the cameras the
-  operator assigned it — ``Camera.assignments[].skill == app id`` —
-  or every camera when no assignment names it, the additive rule of
-  docs/CAMERA_ASSIGNMENTS.md). Never another app's config, never the
+  internal camera/event routes **for its own roster** — the cameras the
+  operator assigned it (``Camera.assignments[].skill == app id``), and
+  only those: an app pointed at nothing sees nothing
+  (docs/CAMERA_ASSIGNMENTS.md). Never another app's config, never the
   detect-pipeline's write routes.
 * A superuser can rotate or revoke a key from the registry; the site
   key keeps working for platform components and for onboarding.
@@ -117,9 +117,22 @@ def app_skills(row) -> set[str]:
 
 def app_camera_ids(db: Session, row) -> set[int] | None:
     """Cameras the operator assigned to this app (``assignments[].skill``
-    in :func:`app_skills`), or ``None`` = every camera when no assignment
-    names it — the additive rule of docs/CAMERA_ASSIGNMENTS.md, exactly
-    as ``cameras_for_skill`` in the SDK reads it."""
+    in :func:`app_skills`).
+
+    Returns a SET — empty when nothing names this app, which scopes the
+    app to nothing. It used to return ``None`` there, meaning "every
+    camera", on the reasoning that an undeclared restriction is not a
+    restriction. That inverted the incentive: the less an operator
+    configured, the more each app could see and compute on, and a fresh
+    install handed every app the whole fleet.
+
+    Closed by default now. An app sees the cameras it was pointed at,
+    and an operator who has pointed it at nothing gets nothing —
+    visibly, rather than silently getting everything.
+
+    Callers test ``roster is not None``, which still holds: an empty set
+    is not None and correctly filters to zero cameras.
+    """
     from models import Camera
 
     skills = app_skills(row)
@@ -134,4 +147,4 @@ def app_camera_ids(db: Session, row) -> set[int] | None:
             if isinstance(entry, dict) and entry.get("skill") in skills:
                 named.add(int(cam_id))
                 break
-    return named or None
+    return named

--- a/server/services/plate_enrichment.py
+++ b/server/services/plate_enrichment.py
@@ -1394,7 +1394,31 @@ async def enrich_event_plate(
         clear_sweep_pending(event_id)
 
 
+#: The skill a camera must carry before its vehicles are read.
+PLATE_SKILL = "license_plate_recognition"
+
+
 def wants_plate(label: str | None, evidence_path: str | None,
-                enabled: bool = True) -> bool:
-    """Should this freshly-ingested visit be queued for OCR? Pure, tested."""
-    return bool(enabled and evidence_path and (label or "") in VEHICLE_LABELS)
+                enabled: bool = True,
+                camera_skills: set[str] | None = None) -> bool:
+    """Should this freshly-ingested visit be queued for OCR? Pure, tested.
+
+    ``camera_skills`` is the ASSIGNMENT gate, and it is the reason this
+    function grew a fourth argument. Without it there was no camera in
+    scope at all, so every vehicle visit on every camera bought a full
+    OCR inference — a thirty-camera site paid plate recognition thirty
+    times over to watch one gate. Tier-0 has always declined to send
+    plate CANDIDATES for an unassigned camera; core then read the
+    visit's evidence frame instead and OCR'd that, which put the cost
+    straight back.
+
+    ``None`` means "caller could not resolve the camera" and is treated
+    as NOT assigned. Failing closed is right for a privacy-sensitive
+    inference: the cost of a wrong False is a missed read on a
+    misconfigured camera, which the Vehicles page can say out loud; the
+    cost of a wrong True is silently reading plates on cameras nobody
+    asked to have read.
+    """
+    if not (enabled and evidence_path and (label or "") in VEHICLE_LABELS):
+        return False
+    return PLATE_SKILL in (camera_skills or set())

--- a/server/services/skill_assignments.py
+++ b/server/services/skill_assignments.py
@@ -270,3 +270,64 @@ def assignments_by_skill(db: Session) -> dict[str, list[int]]:
     for row in rows:
         out.setdefault(row.skill, set()).add(row.camera_id)
     return {k: sorted(v) for k, v in out.items()}
+
+
+# ── The eligibility rule, in one place ──────────────────────────────
+#
+# Two different questions get asked about a camera and a skill, and
+# conflating them is what made assignments advisory:
+#
+#   ELIGIBLE — may this skill be offered this camera? Open by default:
+#     a camera nobody has claimed can be picked by anyone. This is what
+#     a configuration picker asks.
+#   ADOPTED  — is this camera actually claimed by that skill? This is
+#     what COMPUTE asks, and it is never true by default. An unassigned
+#     camera is eligible everywhere and computes nowhere.
+#
+# Both read the denormalised ``Camera.assignments`` projection rather
+# than the claim table, because the hot path (plate ingest) already has
+# the camera row in hand and must not pay a second query per visit.
+
+
+def camera_skills(camera) -> set[str]:
+    """Skills claimed on a camera, from the JSON projection.
+
+    The projection is NULL when nothing is claimed and a list of
+    ``{"skill": ..., "labels"?: [...]}`` otherwise (see
+    :func:`project_camera`). Malformed entries are ignored rather than
+    raised on: this is read on the ingest path, and a bad row in the
+    column must not cost a visit.
+    """
+    entries = getattr(camera, "assignments", None)
+    if not isinstance(entries, list):
+        return set()
+    out: set[str] = set()
+    for entry in entries:
+        if isinstance(entry, dict):
+            skill = entry.get("skill")
+            if isinstance(skill, str) and skill.strip():
+                out.add(skill.strip().lower())
+    return out
+
+
+def camera_adopted(camera, skill: str) -> bool:
+    """Does this camera actually carry that skill? The COMPUTE gate.
+
+    False for an unassigned camera — that is the point. Inference for a
+    skill runs on the cameras an operator pointed it at, not on every
+    camera that happens to exist.
+    """
+    return skill.strip().lower() in camera_skills(camera)
+
+
+def camera_eligible(camera, skill: str) -> bool:
+    """May this skill be OFFERED this camera? The picker gate.
+
+    Open by default: a camera with no claims at all is fair game for
+    every skill, which is what "nothing assigned = no restriction
+    declared" has always meant in the editor. Once a camera declares
+    anything, that declaration is exhaustive — a camera assigned to
+    object detection stops appearing in the LPR picker.
+    """
+    claimed = camera_skills(camera)
+    return not claimed or skill.strip().lower() in claimed

--- a/server/tests/test_app_credentials.py
+++ b/server/tests/test_app_credentials.py
@@ -234,13 +234,27 @@ def test_internal_cameras_and_events_follow_the_apps_assignments(env):
     assert {e["camera_id"] for e in ev} == {ids["gate"], ids["yard"]}
 
 
-def test_unassigned_app_sees_the_fleet_additive_rule(env):
-    """No camera names this app → no restriction declared → everything
+def test_unassigned_app_sees_nothing(env):
+    """No camera names this app → it gets NONE of them.
+
+    This used to be the additive rule: an unnamed app saw the whole
+    fleet, so the least-configured install was the most expensive one
+    and a freshly installed app could read every camera nobody had
+    offered it. Closed by default now — the roster is what an operator
+    pointed at the app, and an app pointed at nothing watches nothing
     (docs/CAMERA_ASSIGNMENTS.md, same as the SDK's cameras_for_skill)."""
     tc, ids, _ = env
     body = {"url": "http://occ:9200", "manifest": _manifest("occupancy-counting", ("occupancy",))}
     key = tc.post("/apps/register", json=body, headers=_site()).json()["api_key"]
     cams = tc.get("/internal/camera-agent/cameras", headers=_app(key)).json()["cameras"]
+    assert cams == []
+    # And the same for events: no roster, no stream of other people's
+    # cameras leaking through the event route.
+    ev = tc.get("/internal/camera-agent/events", headers=_app(key)).json()["events"]
+    assert ev == []
+    # The site key is unaffected — platform components still see the
+    # fleet, or the detect-pipeline would stop feeding every camera.
+    cams = tc.get("/internal/camera-agent/cameras", headers=_site()).json()["cameras"]
     assert sorted(int(c["open_nvr_camera_id"]) for c in cams) == sorted(ids.values())
 
 

--- a/server/tests/test_camera_assignment_gate.py
+++ b/server/tests/test_camera_assignment_gate.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Assignment decides where a skill's inference RUNS — and who may say so.
+
+A camera used to be advisory about what it was for: the editor said
+"nothing assigned = no restriction declared", and that was honoured in
+the cheap places and ignored in the expensive one. Plate OCR ran on
+every vehicle on every camera, assigned or not, because ``wants_plate``
+took no camera argument and so could not consult an assignment even in
+principle.
+
+Three rules are pinned here, and they are the whole change:
+
+* **eligible** — what a picker may OFFER. An unassigned camera is open
+  to every skill, so a fresh install shows a full picker.
+* **adopted** — what COSTS money. Inference runs only on a camera that
+  carries the skill; an unassigned camera computes nothing.
+* **who may assign** — changing a claim turns a camera's compute on or
+  off, so it needs the same permission as editing that camera. The two
+  claim routes took any active user's JWT.
+
+Run with:
+    cd server && pytest tests/test_camera_assignment_gate.py -v
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017
+
+import os
+import secrets
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "server"))
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("SECRET_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("MEDIAMTX_SECRET", secrets.token_hex(32))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_urlsafe(48))
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+_lm = _types.ModuleType("core.logging_config")
+
+
+class _L:
+    def __getattr__(self, _n):
+        return lambda *a, **k: None
+
+
+_lm.__getattr__ = lambda _n: _L()
+_lm.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("core.logging_config", _lm)
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.auth as auth_mod  # noqa: E402
+from core.database import Base, get_db  # noqa: E402
+from models import Camera, CameraPermission, Role, User  # noqa: E402
+from routers import skills as skills_router  # noqa: E402
+from services.plate_enrichment import PLATE_SKILL, wants_plate  # noqa: E402
+from services.skill_assignments import (  # noqa: E402
+    camera_adopted,
+    camera_eligible,
+    camera_skills,
+)
+
+_SERVER = REPO_ROOT / "server"
+
+
+def _cam(*skills):
+    """A stand-in camera carrying exactly these skills."""
+    return _types.SimpleNamespace(assignments=[{"skill": s} for s in skills])
+
+
+# ── the rule itself ────────────────────────────────────────────────
+
+
+def test_unassigned_camera_is_eligible_everywhere_and_adopted_nowhere():
+    """The two halves must disagree about an unassigned camera — that
+    disagreement IS the design. Offer it in every picker; compute on it
+    for nobody until someone points a skill at it."""
+    blank = _cam()
+    assert camera_skills(blank) == set()
+    for skill in (PLATE_SKILL, "occupancy_counting", "face_recognition"):
+        assert camera_eligible(blank, skill) is True
+        assert camera_adopted(blank, skill) is False
+    # A camera with no assignments attribute at all (an older row, or a
+    # projection that has not been recomputed) is the same case.
+    assert camera_eligible(_types.SimpleNamespace(), PLATE_SKILL) is True
+    assert camera_adopted(_types.SimpleNamespace(), PLATE_SKILL) is False
+
+
+def test_a_claimed_camera_is_closed_to_every_other_skill():
+    lpr = _cam(PLATE_SKILL)
+    assert camera_adopted(lpr, PLATE_SKILL) is True
+    assert camera_eligible(lpr, PLATE_SKILL) is True
+    # Claimed by LPR — occupancy may not even be offered it, so an
+    # operator cannot accidentally spend that camera twice.
+    assert camera_eligible(lpr, "occupancy_counting") is False
+    assert camera_adopted(lpr, "occupancy_counting") is False
+    # Multiple claims: each is open, everything else is closed.
+    both = _cam(PLATE_SKILL, "occupancy_counting")
+    assert camera_eligible(both, "occupancy_counting") is True
+    assert camera_eligible(both, "face_recognition") is False
+
+
+def test_skill_names_compare_case_and_space_insensitively():
+    messy = _types.SimpleNamespace(assignments=[
+        {"skill": "  License_Plate_Recognition "}, {"skill": ""},
+        {"nothing": "here"}, "junk", 42,
+    ])
+    assert camera_skills(messy) == {PLATE_SKILL}
+    assert camera_adopted(messy, " LICENSE_PLATE_RECOGNITION ") is True
+
+
+def test_junk_assignments_never_widen_what_a_camera_carries():
+    """A malformed projection must read as "carries nothing" — open to
+    pickers and closed to compute — never as "carries this"."""
+    for junk in (None, "not-a-list", 7, {"skill": PLATE_SKILL}):
+        cam = _types.SimpleNamespace(assignments=junk)
+        assert camera_skills(cam) == set()
+        assert camera_adopted(cam, PLATE_SKILL) is False
+
+
+# ── the expensive path: no claim, no OCR ───────────────────────────
+
+
+def test_wants_plate_needs_the_claim_not_just_a_vehicle():
+    """The gate that used to be missing. A car in front of an
+    unassigned camera is still a car — and still must not be read."""
+    evidence = "cam1/2026/09/10/frame.jpg"
+    assert wants_plate("car", evidence, True, {PLATE_SKILL}) is True
+    assert wants_plate("car", evidence, True, set()) is False
+    assert wants_plate("car", evidence, True, {"occupancy_counting"}) is False
+    # None is not "unknown, allow it" — a caller that cannot say which
+    # skills a camera carries gets no OCR. Fail closed, deliberately.
+    assert wants_plate("car", evidence, True, None) is False
+    # The pre-existing gates still hold on an assigned camera.
+    assert wants_plate("person", evidence, True, {PLATE_SKILL}) is False
+    assert wants_plate("car", None, True, {PLATE_SKILL}) is False
+    assert wants_plate("car", evidence, False, {PLATE_SKILL}) is False
+
+
+def test_both_ocr_entry_points_are_gated_in_lockstep():
+    """Two doors lead to KAI-C: the ingest sweep and the early-attempt
+    endpoint. Gating one and not the other buys nothing — anything that
+    can POST /plates/attempt would still get free OCR on any camera."""
+    src = (_SERVER / "routers" / "internal_camera_agent.py").read_text()
+    assert "camera_skills(camera)" in src, (
+        "ingest no longer passes the camera's skills to wants_plate — "
+        "plate OCR is running on every camera again")
+    assert "camera_adopted(camera, PLATE_SKILL)" in src, (
+        "/plates/attempt no longer checks adoption — any producer can "
+        "spend OCR on a camera nobody assigned to LPR")
+
+
+# ── who may change a claim ─────────────────────────────────────────
+
+
+@pytest.fixture()
+def env():
+    """Two cameras owned by an admin; a guard who may VIEW the gate and
+    MANAGE the yard. The caller is switchable so one client speaks as
+    either user."""
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    s = SessionLocal()
+    role = Role(name="admin")
+    s.add(role)
+    s.flush()
+    admin = User(username="admin", email="a@x", hashed_password="x",
+                 role_id=role.id, is_superuser=True)
+    guard = User(username="guard", email="g@x", hashed_password="x",
+                 role_id=role.id)
+    s.add_all([admin, guard])
+    s.flush()
+    gate = Camera(name="Gate", ip_address="10.0.0.1", owner_id=admin.id)
+    yard = Camera(name="Yard", ip_address="10.0.0.2", owner_id=admin.id)
+    s.add_all([gate, yard])
+    s.flush()
+    s.add_all([
+        CameraPermission(user_id=guard.id, camera_id=gate.id,
+                         can_view=True, can_manage=False),
+        CameraPermission(user_id=guard.id, camera_id=yard.id,
+                         can_view=True, can_manage=True),
+    ])
+    s.commit()
+    ids = {"gate": gate.id, "yard": yard.id}
+    s.close()
+
+    app = FastAPI()
+    app.include_router(skills_router.router, prefix="/api/v1")
+
+    def _db():
+        sess = SessionLocal()
+        try:
+            yield sess
+        finally:
+            sess.close()
+
+    current = {"user": guard}
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[auth_mod.get_current_active_user] = (
+        lambda: current["user"])
+    with TestClient(app) as tc:
+        yield tc, current, admin, guard, ids
+    engine.dispose()
+
+
+def _claim_url(cam_id):
+    return f"/api/v1/skills/{PLATE_SKILL}/cameras/{cam_id}"
+
+
+CONSUMER = "app:license-plate-recognition"
+
+
+def test_a_viewer_cannot_turn_a_cameras_compute_on(env):
+    tc, current, admin, guard, ids = env
+    # can_view only — declaring here would start paying for OCR on a
+    # camera this user may not configure.
+    assert tc.put(_claim_url(ids["gate"]),
+                  json={"consumer": CONSUMER}).status_code == 403
+    # can_manage — their own camera, their own call.
+    r = tc.put(_claim_url(ids["yard"]), json={"consumer": CONSUMER})
+    assert r.status_code == 200
+    assert [c["camera_id"] for c in r.json()["cameras"]] == [ids["yard"]]
+
+
+def test_a_viewer_cannot_turn_someone_elses_compute_off(env):
+    tc, current, admin, guard, ids = env
+    current["user"] = admin
+    assert tc.put(_claim_url(ids["gate"]),
+                  json={"consumer": CONSUMER}).status_code == 200
+    current["user"] = guard
+    # Release is the same authority as declare: a viewer silencing a
+    # gate camera's plate reads is the outage, not the safe direction.
+    r = tc.delete(_claim_url(ids["gate"]), params={"consumer": CONSUMER})
+    assert r.status_code == 403
+    current["user"] = admin
+    assert tc.get(f"/api/v1/skills/{PLATE_SKILL}/cameras").json()["cameras"]
+
+
+def test_the_claim_view_shows_only_the_callers_cameras(env):
+    """A claim names a camera, so the view is camera data and obeys the
+    same grants every other camera read does."""
+    tc, current, admin, guard, ids = env
+    current["user"] = admin
+    for cam in ids.values():
+        assert tc.put(_claim_url(cam),
+                      json={"consumer": "operator"}).status_code == 200
+    seen = {c["camera_id"]
+            for c in tc.get(f"/api/v1/skills/{PLATE_SKILL}/cameras")
+            .json()["cameras"]}
+    assert seen == set(ids.values())
+    # The guard may VIEW both, so both stay — the filter is on view
+    # grants, not on the manage grant that gates the writes above.
+    current["user"] = guard
+    seen = {c["camera_id"]
+            for c in tc.get(f"/api/v1/skills/{PLATE_SKILL}/cameras")
+            .json()["cameras"]}
+    assert seen == set(ids.values())

--- a/server/tests/test_timeline_events.py
+++ b/server/tests/test_timeline_events.py
@@ -262,10 +262,22 @@ def test_extract_plate_and_wants_plate():
     assert extract_plate({"result": {}}) is None
     assert extract_plate(None) is None
 
-    assert wants_plate("car", "ab/x.jpg") is True
-    assert wants_plate("person", "ab/x.jpg") is False
-    assert wants_plate("car", None) is False
-    assert wants_plate("car", "ab/x.jpg", enabled=False) is False
+    # The assignment gate. A vehicle with evidence is NOT enough — the
+    # camera has to carry the plate skill, or a thirty-camera site pays
+    # OCR thirty times over to watch one gate.
+    lpr = {"license_plate_recognition"}
+    assert wants_plate("car", "ab/x.jpg", True, lpr) is True
+    assert wants_plate("person", "ab/x.jpg", True, lpr) is False
+    assert wants_plate("car", None, True, lpr) is False
+    assert wants_plate("car", "ab/x.jpg", False, lpr) is False
+
+    # Unassigned, or assigned to something else, or the caller could not
+    # resolve the camera at all: no read. Failing CLOSED is deliberate —
+    # a missed read on a misconfigured camera is visible and fixable,
+    # silently reading plates nobody asked for is neither.
+    assert wants_plate("car", "ab/x.jpg", True, set()) is False
+    assert wants_plate("car", "ab/x.jpg", True, {"object_detection"}) is False
+    assert wants_plate("car", "ab/x.jpg", True, None) is False
 
 
 # ── Partial plate reads (fragments) ────────────────────────────────


### PR DESCRIPTION
… others

Assignment was advisory. The editor said "nothing assigned = no restriction declared", and that phrase was honoured in the cheap places and ignored in the expensive one: plate OCR ran on every vehicle on every camera, assigned or not, because `wants_plate` took no camera argument and so could not consult an assignment even in principle. A thirty-camera site paid plate recognition thirty times over to watch one gate. The same rule made `app_camera_ids` return "every camera" when nothing named an app, so the less an operator configured, the more each app could see — a fresh install handed every app the whole fleet.

Two questions were being conflated, and separating them is the change:

  eligible  — may this skill be OFFERED this camera? Open by default,
              so a fresh install shows a full picker.
  adopted   — is this camera actually claimed by that skill? Never true
              by default. This is the one that costs money.

An unassigned camera is now eligible everywhere and adopted nowhere. Both live in `services/skill_assignments.py`, read off the denormalised `Camera.assignments` projection so the ingest path pays no extra query, and are mirrored for the browser in `lib/cameraAssignments.ts`.

Gated at both doors into KAI-C: the ingest sweep (`camera` is already in hand from the existence check) and `POST /plates/attempt`, which is reachable by any platform key — Tier-0 declining to send is not a gate. `wants_plate(..., camera_skills)` treats `None` as not assigned: a wrong False is a missed read the UI can say out loud, a wrong True is reading plates nobody asked to have read.

Flipped the inverted default in `app_camera_ids` and mirrored it in the SDK, where `filter_cameras_for_skill` now returns `[]` — watch nothing — instead of `None`. `cameras_for_skill` keeps `None` for the one case it should ever have meant: core could not be ASKED. That needed a real fix, not a test edit: `discover_cameras` flattened "core is down" and "core says zero cameras" into `[]`, and under the new rule those are opposite answers. Occupancy's blip guard moved ahead of scoping for the same reason — after it, un-assigning the last camera looked like an outage.

Adoption is now one operator action: giving a camera a gate role on the Vehicles page declares the LPR claim (`consumer=app:<id>`, so an operator's own assignment on the Cameras page survives a release), and clearing the role releases it. Ineligible cameras stay in the picker, greyed, with the reason — the question is always "why is my camera not in this list", so it is answered in the list. When no camera is adopted the page says plate recognition is running nowhere instead of showing an empty table.

Closed the RBAC gap this reaches: `PUT`/`DELETE /skills/{id}/cameras/{id}` took any active user's JWT while the camera editor they duplicate went through camera-update checks, so a viewer could turn any camera's compute on or off. `GET` is scoped to the caller's visible cameras.

BREAKING for existing installs, deliberately and without a migration: an app pointed at nothing now watches nothing, and plate reads stop on unassigned cameras until an operator assigns them. Streaming, recording, Tier-0 detection, history and captured events are untouched on every camera. CHANGELOG leads with it; SDK 0.6.0 → 0.7.0.

Closes #455