### PR TITLE
fix(launcher): keep a single detected LAN IP whole (#458)

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -641,6 +641,9 @@ function Get-LanIPs {
             }
         } catch {}
     }
+    # Callers MUST wrap this in @(): PowerShell unrolls the returned list, so
+    # on a single-IP host the caller otherwise gets a bare [string] and
+    # $lanIps[0] is the character "1" of "192.168.1.5".
     return $found
 }
 
@@ -650,7 +653,8 @@ function Set-HostIpEnv {
     $lanIpsSet = -not [string]::IsNullOrWhiteSpace($env:OPENNVR_LAN_IPS) -or
                  -not [string]::IsNullOrWhiteSpace((Get-EnvVar "OPENNVR_LAN_IPS"))
     if ($hostIpSet -and $lanIpsSet) { return }
-    $lanIps = Get-LanIPs
+    # @() so a single detected IP stays an array (see Get-LanIPs).
+    $lanIps = @(Get-LanIPs)
     if ($lanIps.Count -eq 0) { return }
     # Process env feeds compose ${VAR:-} interpolation; operator .env wins.
     if (-not $hostIpSet) {


### PR DESCRIPTION
Get-LanIPs returns a List[string], and PowerShell unrolls a returned collection into the pipeline. With exactly one physical, connected adapter the caller got back a bare [string] — which still reports .Count = 1, so the empty check passed and $lanIps[0] indexed the string: OPENNVR_HOST_IP became "1" instead of "192.168.1.5".

That value reaches two places. Both cert-init containers append IP:${OPENNVR_HOST_IP} to the SAN, and openssl rejects "IP:1" with "bad ip address", so on a fresh install neither nginx nor mediamtx starts (each depends on its init with service_completed_successfully). And Write-NetHints writes "1" to data/net-hints/host-ips; detect_local_subnets() trusts that file over the env vars, drops the token as not-an-IP, and is left with only the excluded Docker bridge — ONVIF discovery finds no LAN.

Wrap the call in @() so one IP stays a one-element array, and note on Get-LanIPs that callers must do the same. Set-HostIpEnv is the only caller. Multi-NIC hosts and start.sh were never affected.

Regressed in 1cf18d5 (#257).

Closes #458