### PR TITLE
release: 0.1.5 — the app platform grows up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -448,7 +448,7 @@ INFERENCE_USE_MEDIAMTX_TAP=true
 # Image tag for ghcr.io/open-nvr/core. Pinned to the current release so a
 # fresh install gets the tested core↔adapter pairing. Set "latest" or "main"
 # for bleeding-edge main builds.
-CORE_TAG=0.1.4
+CORE_TAG=0.1.5
 
 # Camera-agent LLM runtime. EMPTY (default) = the bundled ollama
 # container — fine on Linux hosts, but on macOS / Windows the container
@@ -488,7 +488,7 @@ OLLAMA_VLM_MODEL=moondream
 
 # Image tag for all GHCR adapter images (whisper, piper, yolov8, blip,
 # moondream, …). Pinned to the current release; set "latest" for bleeding edge.
-ADAPTER_TAG=0.1.4
+ADAPTER_TAG=0.1.5
 
 # Tag for the CAPTION_ADAPTER image only (falls back to ADAPTER_TAG when
 # empty/unset). Adapter releases from 0.1.4 on publish the ollamavlm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.5] — 2026-09-10
+
+The largest release since 0.1.0, and the one where the app platform grew
+up: apps stop sharing the deployment's site key, the App Catalog becomes
+a product surface rather than a list, and the camera-agent moves to
+Pipecat 1.8 with a real end-of-turn model.
+
+Each component keeps its own version line, because each is versioned by
+what consumes it: the platform and the adapter images at 0.1.5,
+`opennvr-app-sdk` at **0.5.0** (its first publish since 0.4.0 — see
+below), `opennvr-adapter-sdk` unchanged at 1.2.0, and the app contract's
+own `api_version`.
+
+Upgrading: `.env.example` now pins `CORE_TAG=0.1.5` and
+`ADAPTER_TAG=0.1.5`. There is no migration beyond the usual `docker
+compose pull && docker compose up -d`; the apps-bus and per-app
+credential work below converges on its own at start-up.
+
+The headline work in this release, at a glance — every entry is below:
+
+- **Apps stopped sharing the site key.** Each installed app now holds its
+  own credential, joins its own NATS server with permissions derived
+  from its manifest, and reaches the network only through an enforced
+  egress proxy. Catalog images are signed and verified at install.
+- **The App Catalog became a product surface** — search, category
+  filters, its own `apps.view` permission, detail pages for apps you
+  have not installed, screenshots and editorial rank.
+- **The camera-agent moved to Pipecat 1.8 with Smart Turn v3** —
+  semantic end-of-turn instead of a silence timer, turn-taking sized to
+  the hardware it runs on, interruptions that ignore a cough or a remark
+  to someone else, and it says what it is checking while it checks.
+- **A security sweep** closed cross-camera event disclosure, a blind
+  SSRF on camera create, cloud-metadata access, an anonymous MediaMTX
+  health route and unrestricted integration webhooks.
+
+
 ### Security
 
 Five findings from a coordinated disclosure by Kamal Sentassi (S9S
@@ -542,7 +578,7 @@ Reporters are credited in [SECURITY.md](SECURITY.md#reporters).
   `manifest.json` of SHA-256 hashes. Stream URLs and secrets are
   redacted; missing routes are recorded, never fatal.
 
-- **SDK toward 1.0 (on main; no tag until QA signs off 0.5.0).**
+- **SDK toward 1.0.**
   `opennvr_app_sdk.testing` — `RecorderChannel`, `app_config`,
   `detection` / `inference_event` / `tier0_event` / `domain_event`
   builders, `feed(app, *events)` through the real decode → rule →
@@ -666,7 +702,7 @@ Reporters are credited in [SECURITY.md](SECURITY.md#reporters).
   must name an `author`) and `featured` (a row at the top of the
   catalog), with validator rules and the review policy in
   CONTRIBUTING_APPS.md. `GET /apps/index` returns both.
-- **SDK 0.5.0 (unreleased): less boilerplate for every app.** The three
+- **Less boilerplate for every app.** The three
   on-ramp gaps the outside-the-repo walk left open, closed:
   `BaseAppConfig` + `load_app_config(path, cls)` replace the config
   block every app re-typed (the template's went from ~70 lines to 12);
@@ -676,7 +712,7 @@ Reporters are credited in [SECURITY.md](SECURITY.md#reporters).
   by default, template moved to `opennvr_app_sdk/templates/app`
   (`scripts/create_opennvr_app.py` is now a wrapper that keeps in-tree
   examples on the editable SDK). Additive; server `api_version` stays
-  1.2. Tag `sdk-v0.5.0` to release.
+  1.2.
 - **The out-of-tree developer path works end to end.** A paid,
   `license_key` app was built in its own repository on nothing but the
   PyPI wheel (`docs/EXTERNAL_APP_WALKTHROUGH.md`); the platform surface

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite --config vite.config.ts",

--- a/kai-c/main.py
+++ b/kai-c/main.py
@@ -65,7 +65,7 @@ logger = logging.getLogger("kai-c")
 # on the same tag as the core server, so it reports the same version. This is the
 # *release* version, not the AI Adapter Contract version (that's v1, negotiated
 # per adapter via /capabilities).
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 
 # ============================================================

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2026 OpenNVR
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Single source of the SDK version (pyproject mirrors it)."""
-__version__ = "0.7.0"
+__version__ = "0.5.0"

--- a/sdk/opennvr-app-sdk/pyproject.toml
+++ b/sdk/opennvr-app-sdk/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "opennvr-app-sdk"
-version = "0.7.0"
+version = "0.5.0"
 description = "Shared SDK for OpenNVR monitoring apps: §11.5 alert dispatch, zone geometry, keyed TTL state, app manifests, and the Detector / FrameApp base loops."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server/main.py
+++ b/server/main.py
@@ -98,7 +98,7 @@ from services.mediamtx_admin_service import MediaMtxAdminService as _MtxAdmin
 # The OpenNVR release this build is cut from. Surfaced in /health and in the
 # OpenAPI schema, and quoted in bug reports (see SECURITY.md) — so it tracks the
 # git tag, not the API shape. Bump it in the release commit.
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 # FFmpeg-based RTSP proxy and recorder removed
 


### PR DESCRIPTION
Platform and adapter images move to 0.1.5, continuing the 0.1.x line (0.1.4 -> 0.1.5). Each component stays versioned by what consumes it rather than by a shared number: opennvr-app-sdk ships 0.5.0 (its own line, the first publish since 0.4.0), opennvr-adapter-sdk is unchanged at 1.2.0, and the app contract keeps its own api_version.

The app SDK is renumbered on main from 0.7.0 to 0.5.0 so the published sequence is unbroken: PyPI has only 0.4.0, so 0.5.0 is the next number on that line, and 0.5.0/0.6.0/0.7.0 were never released — everything they accumulated ships here under one version. Nothing depends on the old number: every example and the scaffold template pin the SDK unversioned through a local path, and the server's MIN_SDK_VERSION is 0.2.0.

Version strings: server/main.py, kai-c/main.py, app/package.json (and the root entry in package-lock, not the deep-is/imurmurhash deps that happen to sit at 0.1.4), the SDK's _version.py and pyproject.

Pins: .env.example moves CORE_TAG and ADAPTER_TAG to 0.1.5. These reference images that the release tags build, so release-pins stays red until ai-adapter v0.1.5 and this repo's v0.1.5 have published — the same ordering 0.1.4 had.

Changelog: [Unreleased] becomes [0.1.5] with the upgrade note and a summary of the four themes (per-app credentials and enforced egress, the App Catalog as a product surface, the camera-agent on Pipecat 1.8 with Smart Turn v3, and the security sweep). Three entries written while the SDK was deliberately untagged are reworded — it ships.

Suites green: SDK 298, kai-c 207, server 1376.