### PR TITLE
feat(live): bounding boxes with label and score over the live view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Bounding boxes on the live view.** Tracked objects are outlined over
+  the video with their label, confidence and track id, one colour per
+  class, drawn client-side on a canvas over the player — the stream is
+  untouched and the recording stays clean. Toggled with a **Boxes**
+  button in the Live View toolbar (off by default; remembered per
+  browser). Live only. Behind it, Tier-0's per-frame tracks now reach
+  the browser at all: a new `tier0_track_consumer` bridges the NATS
+  `opennvr.inference.tier0.<cam>.completed` subject onto the in-process
+  bus as a `tracks` WebSocket event with boxes normalized to 0..1, and
+  those events are subject to the same per-camera entitlement as the
+  video. One shared socket serves every tile on the page.
+
+### Added
+
 - **App SDK: the `App` facade — apps in one function.** Writing a first
   app required knowing about NATS subjects, inference envelopes,
   normalized bboxes, alert dispatchers and keyed TTL state before

--- a/app/src/components/VideoPlayer/DetectionOverlay.tsx
+++ b/app/src/components/VideoPlayer/DetectionOverlay.tsx
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 OpenNVR
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Bounding boxes, labels and scores drawn over the live video.
+//
+// Client-side on a <canvas>, not burned into the stream. Frigate's
+// "debug" view and ZoneMinder's zmeventnotification draw server-side into
+// a second MJPEG stream — that costs a re-encode per viewer and a second
+// stream per camera, and it means the clean recording and the annotated
+// live view are different pixels. Scrypted, Shinobi, UniFi Protect and
+// Blue Iris all overlay client-side, which is what a WebRTC/HLS
+// architecture wants: one stream, boxes as data, drawn where they are
+// looked at. It also makes the toggle free — no boxes means no canvas
+// work and no socket.
+//
+// The canvas fills the player's "feed box", which VideoPlayer sizes to
+// the stream's DISPLAY aspect and fills edge to edge with the video. So
+// the canvas rectangle IS the video rectangle and normalized 0..1 boxes
+// map straight onto it — no letterbox arithmetic, and an anamorphic
+// stream that VideoPlayer un-squishes carries its boxes with it.
+
+import { useEffect, useRef } from 'react'
+import { subscribeDetections, type OverlayFrame, type OverlayTrack } from '../../lib/detectionFeed'
+
+export interface DetectionOverlayProps {
+  cameraId: number
+  /** Drop a frame's boxes after this long without a newer one, so a
+   *  camera whose detector paused does not show a stale box forever.
+   *  Tier-0 publishes ~5 fps; two seconds covers a hiccup, not a stop. */
+  staleMs?: number
+}
+
+// One hue per label, stable across frames so a "person" is always the
+// same colour and the eye can follow it. Unlisted labels hash to a hue.
+const LABEL_HUES: Record<string, number> = {
+  person: 205, car: 30, truck: 45, bus: 45, motorcycle: 15, bicycle: 160,
+  dog: 290, cat: 290, bird: 120, license_plate: 60, plate: 60, face: 330,
+}
+function hueFor(label: string): number {
+  if (label in LABEL_HUES) return LABEL_HUES[label]
+  let h = 0
+  for (let i = 0; i < label.length; i++) h = (h * 31 + label.charCodeAt(i)) % 360
+  return h
+}
+
+export function DetectionOverlay({ cameraId, staleMs = 2000 }: DetectionOverlayProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const frameRef = useRef<OverlayFrame | null>(null)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    // Size the backing store to the element's CSS size × devicePixelRatio,
+    // so lines are crisp on HiDPI and never smeared by CSS scaling.
+    const fit = () => {
+      const dpr = window.devicePixelRatio || 1
+      const w = Math.max(1, Math.round(canvas.clientWidth * dpr))
+      const h = Math.max(1, Math.round(canvas.clientHeight * dpr))
+      if (canvas.width !== w || canvas.height !== h) { canvas.width = w; canvas.height = h }
+    }
+    const ro = new ResizeObserver(fit)
+    ro.observe(canvas)
+    fit()
+
+    const draw = () => {
+      rafRef.current = null
+      fit()
+      const W = canvas.width, H = canvas.height
+      ctx.clearRect(0, 0, W, H)
+      const frame = frameRef.current
+      if (!frame || Date.now() - frame.receivedAt > staleMs) return
+
+      const dpr = window.devicePixelRatio || 1
+      const lw = Math.max(1.5, 2 * dpr)
+      const fontPx = Math.max(10, Math.round(12 * dpr))
+      ctx.font = `600 ${fontPx}px system-ui, -apple-system, sans-serif`
+      ctx.textBaseline = 'top'
+      ctx.lineJoin = 'round'
+
+      for (const t of frame.tracks) drawTrack(ctx, t, W, H, lw, fontPx, frame.calibrating)
+    }
+    const requestDraw = () => { if (rafRef.current == null) rafRef.current = requestAnimationFrame(draw) }
+
+    const unsubscribe = subscribeDetections(cameraId, (frame) => {
+      frameRef.current = frame
+      requestDraw()
+    })
+    // Expire stale boxes even when no new frame arrives to trigger a draw.
+    const sweep = window.setInterval(() => {
+      const f = frameRef.current
+      if (f && Date.now() - f.receivedAt > staleMs) { frameRef.current = null; requestDraw() }
+    }, 500)
+
+    return () => {
+      unsubscribe()
+      window.clearInterval(sweep)
+      ro.disconnect()
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+    }
+  }, [cameraId, staleMs])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 w-full h-full pointer-events-none"
+      aria-hidden="true"
+      data-testid="detection-overlay"
+    />
+  )
+}
+
+function drawTrack(
+  ctx: CanvasRenderingContext2D, t: OverlayTrack,
+  W: number, H: number, lw: number, fontPx: number, calibrating: boolean,
+) {
+  const [nx, ny, nw, nh] = t.box
+  const x = nx * W, y = ny * H, w = nw * W, h = nh * H
+  if (!(w > 0 && h > 0)) return
+  const hue = hueFor(t.label)
+  // Calibrating = the tracker is still settling; draw it, but say so.
+  const alpha = calibrating ? 0.55 : 1
+
+  // Box: a dark halo under the coloured stroke keeps it legible on both
+  // bright sky and dark tarmac, the two backgrounds a camera sees most.
+  ctx.lineWidth = lw + 2
+  ctx.strokeStyle = `rgba(0,0,0,${0.55 * alpha})`
+  ctx.strokeRect(x, y, w, h)
+  ctx.lineWidth = lw
+  ctx.strokeStyle = `hsla(${hue}, 85%, 60%, ${alpha})`
+  ctx.strokeRect(x, y, w, h)
+
+  // Label chip: "person 91%" (+ id when the tracker has one). Sits above
+  // the box, or inside its top edge when the box touches the frame top.
+  const idPart = t.id != null ? ` #${t.id}` : ''
+  const text = `${t.label}${idPart} ${Math.round(t.score * 100)}%`
+  const padX = Math.round(fontPx * 0.45), padY = Math.round(fontPx * 0.25)
+  const tw = ctx.measureText(text).width
+  const chipW = tw + padX * 2, chipH = fontPx + padY * 2
+  const chipX = Math.min(Math.max(0, x), W - chipW)
+  const above = y - chipH >= 0
+  const chipY = above ? y - chipH : y
+  ctx.fillStyle = `hsla(${hue}, 85%, 45%, ${0.92 * alpha})`
+  ctx.fillRect(chipX, chipY, chipW, chipH)
+  ctx.fillStyle = `rgba(255,255,255,${alpha})`
+  ctx.fillText(text, chipX + padX, chipY + padY)
+}

--- a/app/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/app/src/components/VideoPlayer/VideoPlayer.tsx
@@ -32,6 +32,7 @@ import { displayAspect, isStretched, snapshotSize } from '../../lib/aspect'
 import type { AspectOverride } from '../../lib/aspect'
 import { useVideoSize } from '../../hooks/useVideoAspect'
 import { VideoControls } from './VideoControls'
+import { DetectionOverlay } from './DetectionOverlay'
 import { AlertCircle } from 'lucide-react'
 
 export type VideoPlayerMode = 'live' | 'playback'
@@ -81,6 +82,11 @@ export interface VideoPlayerProps {
   /** Operator's per-camera display-aspect override ('auto' | 'native' | 'W:H').
       Absent or 'auto' runs the detection in lib/aspect.ts (issue #354). */
   displayAspectOverride?: AspectOverride | null
+  /** Core camera id — needed to subscribe this tile to its live tracks. */
+  cameraId?: number | null
+  /** Draw Tier-0 bounding boxes with label + score over the video.
+      Live mode only; costs nothing when false (no canvas, no socket). */
+  showDetections?: boolean
 }
 
 export interface VideoPlayerHandle {
@@ -115,6 +121,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       ptzActive = false,
       overlay,
       displayAspectOverride,
+      cameraId = null,
+      showDetections = false,
     },
     ref
   ) {
@@ -1080,6 +1088,14 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           crossOrigin="anonymous"
           preload={mode === 'playback' ? 'metadata' : 'auto'}
         />
+
+        {/* Detection overlay — INSIDE the feed box so its rectangle is the
+            video's rectangle and normalized boxes need no letterbox math.
+            Below the loading/error overlays in the tree, so those still
+            cover it. Live only: recordings carry no live tracks. */}
+        {mode === 'live' && showDetections && cameraId != null && (
+          <DetectionOverlay cameraId={cameraId} />
+        )}
 
         {/* Loading / reconnecting overlay */}
         {(isLoading || isReconnecting) && (

--- a/app/src/lib/detectionFeed.ts
+++ b/app/src/lib/detectionFeed.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 OpenNVR
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// ONE WebSocket for every detection overlay on the page.
+//
+// Each live tile could open its own /events/ws filtered to its camera,
+// but a 3×3 grid would then hold nine sockets and nine tickets for what
+// is one stream of events. Instead this opens a single unfiltered socket
+// — the server scopes it to the cameras the user is entitled to, per
+// event, so "unfiltered" never means "everything on the site" — and fans
+// the frames out to whichever overlays asked for that camera_id.
+//
+// Lifecycle follows demand: the socket opens when the first overlay
+// subscribes and closes when the last one leaves, so a page with the
+// overlay switched off costs nothing. Reconnects with backoff on drop; a
+// fresh single-use ticket is fetched on every (re)connect, same as
+// useCameraStatus, so the JWT never lands in a URL.
+
+import { apiService } from './apiService'
+
+export interface OverlayTrack {
+  id: number | string | null
+  label: string
+  score: number
+  /** Normalized [x, y, w, h] in 0..1 of the frame. */
+  box: [number, number, number, number]
+  stationary?: boolean
+}
+
+export interface OverlayFrame {
+  cameraId: number
+  /** Wall-clock ms when this frame arrived here (not the producer's stamp). */
+  receivedAt: number
+  calibrating: boolean
+  tracks: OverlayTrack[]
+}
+
+type Listener = (frame: OverlayFrame) => void
+
+const listeners = new Map<number, Set<Listener>>()
+let ws: WebSocket | null = null
+let connecting = false
+let closedByDemand = false
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let reconnectAttempt = 0
+
+function totalListeners(): number {
+  let n = 0
+  for (const set of listeners.values()) n += set.size
+  return n
+}
+
+/** Accepts both the Tier-0 bridge shape (`tracks[].box` as [x,y,w,h]) and
+ *  the adapter contract's detection shape (`detections[].bbox` as
+ *  {x,y,w,h}), so a BYOM model's live results draw too. */
+function toFrame(evt: any): OverlayFrame | null {
+  const cameraId = Number(evt?.camera_id)
+  if (!Number.isFinite(cameraId)) return null
+  const p = evt?.payload ?? {}
+  const out: OverlayTrack[] = []
+
+  if (evt.event_type === 'tracks' && Array.isArray(p.tracks)) {
+    for (const t of p.tracks) {
+      const b = t?.box
+      if (!Array.isArray(b) || b.length !== 4) continue
+      out.push({
+        id: t.id ?? null,
+        label: String(t.label ?? 'object'),
+        score: Number(t.score) || 0,
+        box: [Number(b[0]), Number(b[1]), Number(b[2]), Number(b[3])],
+        stationary: Boolean(t.stationary),
+      })
+    }
+  } else if (evt.event_type === 'inference_result' && Array.isArray(p.detections)) {
+    for (const d of p.detections) {
+      const bb = d?.bbox
+      let box: [number, number, number, number] | null = null
+      if (bb && typeof bb === 'object' && !Array.isArray(bb)) {
+        box = [Number(bb.x), Number(bb.y), Number(bb.w), Number(bb.h)]
+      } else if (Array.isArray(bb) && bb.length === 4) {
+        box = [Number(bb[0]), Number(bb[1]), Number(bb[2]), Number(bb[3])]
+      }
+      if (!box || box.some((v) => !Number.isFinite(v))) continue
+      // Pixel-space boxes (any coordinate > 1) need the frame size; drop
+      // them if it is absent rather than draw a box 1920 units wide.
+      if (Math.max(...box) > 1) {
+        const fw = Number(p.frame_dimensions?.w), fh = Number(p.frame_dimensions?.h)
+        if (!(fw > 0 && fh > 0)) continue
+        box = [box[0] / fw, box[1] / fh, box[2] / fw, box[3] / fh]
+      }
+      out.push({
+        id: d.track_id ?? null,
+        label: String(d.label ?? 'object'),
+        score: Number(d.confidence) || 0,
+        box,
+      })
+    }
+  } else {
+    return null
+  }
+  if (!out.length) return null
+  return { cameraId, receivedAt: Date.now(), calibrating: Boolean(p.calibrating), tracks: out }
+}
+
+function scheduleReconnect() {
+  if (closedByDemand || reconnectTimer) return
+  const delay = Math.min(30_000, 1000 * 2 ** Math.min(reconnectAttempt, 5))
+  reconnectAttempt += 1
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    if (totalListeners() > 0) void connect()
+  }, delay)
+}
+
+async function connect() {
+  if (ws || connecting) return
+  connecting = true
+  closedByDemand = false
+  let ticket: string
+  try {
+    const res = await apiService.createEventsWsTicket()
+    ticket = res.data.ticket
+  } catch {
+    connecting = false
+    scheduleReconnect()
+    return
+  }
+  if (totalListeners() === 0) { connecting = false; return }
+
+  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
+  // task filter keeps everything the overlay does not draw off the wire.
+  const url = `${proto}://${window.location.host}/api/v1/events/ws?ticket=${encodeURIComponent(ticket)}&task=tier0`
+  const sock = new WebSocket(url)
+  ws = sock
+  connecting = false
+
+  sock.onopen = () => { reconnectAttempt = 0 }
+  sock.onmessage = (msg) => {
+    let evt: any
+    try { evt = JSON.parse(msg.data) } catch { return }
+    const frame = toFrame(evt)
+    if (!frame) return
+    const set = listeners.get(frame.cameraId)
+    if (!set) return
+    for (const fn of set) { try { fn(frame) } catch { /* one bad listener must not stop the rest */ } }
+  }
+  sock.onclose = () => {
+    if (ws === sock) ws = null
+    if (!closedByDemand && totalListeners() > 0) scheduleReconnect()
+  }
+}
+
+function disconnect() {
+  closedByDemand = true
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+  const sock = ws
+  ws = null
+  if (sock) { sock.onclose = null; sock.close() }
+}
+
+/** Subscribe to live frames for one camera. Returns the unsubscribe. */
+export function subscribeDetections(cameraId: number, fn: Listener): () => void {
+  let set = listeners.get(cameraId)
+  if (!set) { set = new Set(); listeners.set(cameraId, set) }
+  set.add(fn)
+  void connect()
+  return () => {
+    const s = listeners.get(cameraId)
+    if (s) { s.delete(fn); if (s.size === 0) listeners.delete(cameraId) }
+    if (totalListeners() === 0) disconnect()
+  }
+}
+
+/** Test seam: feed a raw WS event through the same parser the socket uses. */
+export const _parseForTests = toFrame

--- a/app/src/views/LiveView.tsx
+++ b/app/src/views/LiveView.tsx
@@ -27,7 +27,7 @@ import { useFullscreen } from '../hooks/useFullscreen'
 import { useClickOutside } from '../hooks/useClickOutside'
 import { usePermissions } from '../hooks/usePermissions'
 import { useCameraStatus } from '../hooks/useCameraStatus'
-import { Camera, Maximize, Play, Settings, Save, Image as ImageIcon, Book, HardDrive, Power, X, Grid, Move, Square, Plus, Minus, ChevronDown, ChevronUp, Video, Search, AlertCircle, Expand, Scan } from 'lucide-react'
+import { Camera, Maximize, Play, Settings, Save, Image as ImageIcon, Book, HardDrive, Power, X, Grid, Move, Square, Plus, Minus, ChevronDown, ChevronUp, Video, Search, AlertCircle, Expand, Scan, ScanEye } from 'lucide-react'
 import { 
   DndContext, 
   DragOverlay, 
@@ -230,6 +230,23 @@ export function LiveView() {
   const toggleFillMode = () => setFillMode(prev => {
     const next = !prev
     try { localStorage.setItem('liveview-grid-mode', next ? 'fill' : 'fit') } catch { /* private mode */ }
+    return next
+  })
+
+  // Detection overlay: boxes + label + score from Tier-0, drawn over every
+  // live tile. Per-browser preference like the grid mode — an operator at
+  // the wall wants a clean picture; the one debugging a zone wants boxes.
+  // Off by default: the picture is the product, the boxes are a tool.
+  const [showDetections, setShowDetections] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem('liveview-detections') === 'on'
+    } catch {
+      return false
+    }
+  })
+  const toggleDetections = () => setShowDetections(prev => {
+    const next = !prev
+    try { localStorage.setItem('liveview-detections', next ? 'on' : 'off') } catch { /* private mode */ }
     return next
   })
 
@@ -490,6 +507,8 @@ export function LiveView() {
           onToggleFullscreen={toggleFs}
           fillMode={fillMode}
           onToggleFillMode={toggleFillMode}
+          showDetections={showDetections}
+          onToggleDetections={toggleDetections}
         />
       </header>
 
@@ -540,6 +559,7 @@ export function LiveView() {
                       onCameraAdded={loadCameras}
                       isDragging={activeDragId === `tile-${i}`}
                       canManage={canManageCameras}
+                      showDetections={showDetections}
                     />
                   </DraggableTile>
                 </DroppableTile>
@@ -659,7 +679,8 @@ function Tile({
   onCameraSelected,
   onCameraAdded,
   isDragging = false,
-  canManage = false
+  canManage = false,
+  showDetections = false,
 }: { 
   index: number
   availableCameras: Array<{id: number, name: string, live_online?: boolean | null, display_aspect_ratio?: AspectOverride | null}>
@@ -667,6 +688,7 @@ function Tile({
   onCameraSelected?: (cameraId: number) => void
   onCameraAdded?: () => void
   isDragging?: boolean
+  showDetections?: boolean
   canManage?: boolean
 }) {
   const [cameraId, setCameraId] = useState<number | null>(null)
@@ -797,6 +819,8 @@ function Tile({
               muted
               onSnapshot={handleSnapshot}
               displayAspectOverride={assignedCamera?.display_aspect_ratio}
+              cameraId={cameraId}
+              showDetections={showDetections}
               onTogglePtz={() => setPtzOpen((s) => !s)}
               ptzActive={ptzOpen}
               overlay={ptzOpen && cameraId ? (
@@ -898,6 +922,8 @@ function ToolbarContents({
   dropUp = false,
   fillMode,
   onToggleFillMode,
+  showDetections,
+  onToggleDetections,
   showFitToggle = true,
 }: {
   currentLayout: string
@@ -909,6 +935,8 @@ function ToolbarContents({
   dropUp?: boolean
   fillMode?: boolean
   onToggleFillMode?: () => void
+  showDetections?: boolean
+  onToggleDetections?: () => void
   showFitToggle?: boolean
 }) {
   const [layoutDropdownOpen, setLayoutDropdownOpen] = useState(false)
@@ -978,6 +1006,21 @@ function ToolbarContents({
           >
             {fillMode ? <Expand size={14} /> : <Scan size={14} />}
             <span className="hidden sm:inline">{fillMode ? 'Fill' : 'Fit'}</span>
+          </button>
+        )}
+        {/* Detection boxes on/off — same visual grammar as Fit/Fill: lit
+            when on. Reads "Boxes", not "AI", because that is what it does. */}
+        {onToggleDetections && (
+          <button
+            className={`px-2 py-1 border inline-flex items-center gap-1 ${showDetections ? 'bg-[var(--accent)]/80 border-[var(--accent)]' : 'bg-[var(--panel-2)] border-[var(--border)]'}`}
+            onClick={onToggleDetections}
+            aria-pressed={showDetections}
+            title={showDetections
+              ? 'Boxes on: tracked objects are outlined with label and confidence'
+              : 'Boxes off: show bounding boxes for tracked objects (label + confidence)'}
+          >
+            <ScanEye size={14} />
+            <span className="hidden sm:inline">Boxes</span>
           </button>
         )}
         <button className="px-2 py-1 bg-[var(--panel-2)] border border-[var(--border)] inline-flex items-center gap-1" onClick={onToggleFullscreen} title="Fullscreen">

--- a/server/main.py
+++ b/server/main.py
@@ -624,6 +624,21 @@ async def lifespan(app: FastAPI):
     spawn_background(background_occupancy_event_consumer(),
                      name="occupancy-event-consumer")
 
+    # Live detection overlay: bridge Tier-0 tracks (NATS) onto the
+    # in-process bus so /events/ws can stream normalized boxes to the
+    # browser. Same best-effort posture: no bus → no overlay, never a
+    # failed boot.
+    async def background_tier0_track_consumer():
+        async def _loop():
+            from services.tier0_track_consumer import run_consumer_loop
+
+            await run_consumer_loop()
+
+        await run_consumer_forever("Tier-0 track consumer", _loop)
+
+    spawn_background(background_tier0_track_consumer(),
+                     name="tier0-track-consumer")
+
     # Operator alert inbox: consume opennvr.alerts.> (the SDK apps'
     # NatsAlertChannel) into app_alerts so the UI bell can ring and
     # acknowledge. Same best-effort posture — no bus, no inbox, no crash.

--- a/server/routers/events.py
+++ b/server/routers/events.py
@@ -150,6 +150,28 @@ async def events_stream(
             "payload": { ...adapter response... }
         }
 
+    Live Tier-0 tracks for the detection overlay arrive as their own type
+    (bridged from NATS by services/tier0_track_consumer.py), boxes already
+    normalized to 0..1 of the frame so the client needs no resolution::
+
+        {
+            "event_type": "tracks",
+            "camera_id": 3,
+            "task": "tier0",
+            "payload": {
+                "schema": "opennvr.overlay.tracks.v1",
+                "calibrating": false,
+                "frame": {"w": 1920, "h": 1080},
+                "tracks": [
+                    {"id": 5, "label": "person", "score": 0.91,
+                     "box": [0.1, 0.1, 0.4, 0.4], "stationary": false}
+                ]
+            }
+        }
+
+    Filter with ``task=tier0`` to receive only these. They are subject to
+    the same per-camera entitlement as every other event on this socket.
+
     The server also sends two control frames:
       * ``{"event_type": "subscribed", "filters": {...}}`` on accept
       * ``{"event_type": "lagged", "dropped": N}`` when the client was too

--- a/server/services/event_bus_service.py
+++ b/server/services/event_bus_service.py
@@ -59,6 +59,11 @@ EVENT_INFERENCE_ERROR = "inference_error"
 EVENT_CAMERA_EVENT = "camera_event"
 EVENT_CAMERA_STATUS = "camera_status"
 EVENT_SYSTEM_ALERT = "system_alert"
+# Live Tier-0 tracks for the detection overlay. Its own type, not
+# inference_result: that type is keyed on model_id and drives the
+# AI Detection Results table, and 5 fps of tracker output per camera
+# would flood it. Consumers that want boxes opt in by name.
+EVENT_TRACKS = "tracks"
 
 # Reasonable default for a single slow WebSocket client. Bumping this trades
 # memory for tolerance of bursty traffic.
@@ -234,6 +239,24 @@ async def publish_inference_result(
         "camera_id": camera_id,
         "model_id": model_id,
         "task": task,
+        "payload": payload,
+    })
+
+
+async def publish_tracks(
+    *,
+    camera_id: int,
+    payload: dict[str, Any],
+) -> None:
+    """Publish one frame's worth of Tier-0 tracks (normalized boxes, see
+    services/tier0_track_consumer.py) for live overlays. Carries a
+    camera_id, so it is subject to the per-camera entitlement the bus
+    enforces — a viewer never receives boxes for a camera they cannot
+    see, exactly as with the video itself."""
+    await get_event_bus().publish({
+        "event_type": EVENT_TRACKS,
+        "camera_id": camera_id,
+        "task": "tier0",
         "payload": payload,
     })
 

--- a/server/services/tier0_track_consumer.py
+++ b/server/services/tier0_track_consumer.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Bridge Tier-0 tracks from the NATS bus to the in-process event bus.
+
+Tier-0 (``detect-pipeline``) runs YOLO + ByteTrack on every camera and
+publishes each frame's tracks to ``opennvr.inference.tier0.<cam>.completed``
+(``opennvr.tier0.v1``). Until this consumer existed nothing carried those
+tracks to the browser: the only NATS→bus bridge was the BYOM inference
+path, so the live view had detections happening behind it and no way to
+draw them. This is the missing hop — it is what puts bounding boxes on
+the video.
+
+It does three things and nothing else:
+
+* maps the bus camera handle (``"cam3"``) to core's integer id, because
+  the WebSocket entitlement check is a set of ints and an unmapped
+  event would be dropped for every scoped user;
+* normalizes the pixel-space ``[x1, y1, x2, y2]`` boxes into
+  ``[x, y, w, h]`` in 0..1, using the frame size the producer ships —
+  the overlay must not care what resolution the detector ran at;
+* republishes on the in-process bus as ``event_type="tracks"``, which
+  the WebSocket streams to entitled subscribers.
+
+Best-effort like its siblings: no NATS URL, no nats-py, or a down
+broker degrades to "no overlay", never to a crashed process. Payloads
+that fail to parse are counted and dropped, not raised.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SUBJECT = "opennvr.inference.tier0.*.completed"
+
+#: Reconnect cadence after a connect/subscribe failure — one warning a
+#: minute for a down bus, not a hot loop.
+_RETRY_SECONDS = 60.0
+
+#: Below this the tracker is guessing; the overlay would just flicker.
+DEFAULT_MIN_SCORE = 0.25
+
+_dropped = 0
+
+
+def normalize_box(box: Any, frame_w: Any, frame_h: Any) -> list[float] | None:
+    """``[x1, y1, x2, y2]`` (pixels, or already 0..1) → ``[x, y, w, h]`` in
+    0..1, clamped. ``None`` when it cannot be made sense of.
+
+    Tier-0 boxes are pixels of the frame it ran on (bus.py ships
+    ``frame.w/h`` precisely so consumers can do this). A box whose every
+    coordinate is already ≤ 1 is taken as normalized — a producer that
+    normalized upstream must not be squashed into the corner by dividing
+    again.
+    """
+    try:
+        x1, y1, x2, y2 = (float(v) for v in box)
+    except (TypeError, ValueError):
+        return None
+    if not all(v == v for v in (x1, y1, x2, y2)):   # NaN
+        return None
+    if max(x1, y1, x2, y2) > 1.0:
+        try:
+            fw, fh = float(frame_w), float(frame_h)
+        except (TypeError, ValueError):
+            return None
+        if fw <= 0 or fh <= 0:
+            return None
+        x1, x2 = x1 / fw, x2 / fw
+        y1, y2 = y1 / fh, y2 / fh
+    x1, x2 = sorted((x1, x2))
+    y1, y2 = sorted((y1, y2))
+    clamp = lambda v: min(1.0, max(0.0, v))  # noqa: E731
+    x1, y1, x2, y2 = clamp(x1), clamp(y1), clamp(x2), clamp(y2)
+    w, h = x2 - x1, y2 - y1
+    if w <= 0 or h <= 0:
+        return None
+    return [round(x1, 4), round(y1, 4), round(w, 4), round(h, 4)]
+
+
+def to_overlay_payload(
+    raw: dict[str, Any], *, min_score: float = DEFAULT_MIN_SCORE
+) -> dict[str, Any] | None:
+    """The browser-facing payload for one Tier-0 frame, or ``None`` when
+    nothing drawable survives. Pure, so it is testable without a bus."""
+    frame = raw.get("frame") or {}
+    fw, fh = frame.get("w"), frame.get("h")
+    tracks_out: list[dict[str, Any]] = []
+    for t in raw.get("tracks") or []:
+        if not isinstance(t, dict):
+            continue
+        try:
+            score = float(t.get("score", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if score < min_score:
+            continue
+        box = normalize_box(t.get("box"), fw, fh)
+        if box is None:
+            continue
+        tracks_out.append({
+            "id": t.get("id"),
+            "label": str(t.get("label") or "object"),
+            "score": round(score, 3),
+            "box": box,
+            "stationary": bool(t.get("stationary", False)),
+        })
+    if not tracks_out:
+        return None
+    return {
+        "schema": "opennvr.overlay.tracks.v1",
+        "seq": raw.get("seq"),
+        "wall_ts": raw.get("wall_ts"),
+        "calibrating": bool(raw.get("calibrating", False)),
+        "frame": {"w": fw, "h": fh},
+        "tracks": tracks_out,
+    }
+
+
+async def _handle_message(msg) -> None:
+    global _dropped
+    try:
+        raw = json.loads(msg.data)
+        if not isinstance(raw, dict):
+            raise ValueError("payload is not an object")
+        from services.camera_scope import camera_id_from_handle
+
+        camera_id = camera_id_from_handle(raw.get("camera_id"))
+        if camera_id is None:
+            # Also try the subject — opennvr.inference.tier0.<cam>.completed
+            parts = str(getattr(msg, "subject", "")).split(".")
+            camera_id = camera_id_from_handle(parts[3]) if len(parts) >= 5 else None
+        if camera_id is None:
+            raise ValueError(f"unmappable camera_id {raw.get('camera_id')!r}")
+        payload = to_overlay_payload(raw)
+        if payload is None:
+            return   # nothing drawable this frame; not an error
+        from services.event_bus_service import publish_tracks
+
+        await publish_tracks(camera_id=camera_id, payload=payload)
+    except Exception as exc:  # noqa: BLE001
+        _dropped += 1
+        if _dropped in (1, 10, 100) or _dropped % 1000 == 0:
+            logger.warning(
+                "tier0 track consumer: dropped payload #%d (%s)", _dropped, exc)
+
+
+async def run_consumer_loop() -> None:
+    """Subscribe to Tier-0 completions for the process lifetime. Returns
+    immediately when no NATS URL is configured; retries slowly otherwise."""
+    from core.config import settings
+
+    url = (getattr(settings, "nats_url", "") or "").strip()
+    if not url:
+        logger.info("tier0 track consumer disabled (no NATS_URL) — "
+                    "no live detection overlay")
+        return
+    try:
+        import nats
+    except ImportError:
+        logger.warning("tier0 track consumer disabled: nats-py not installed")
+        return
+
+    token = (getattr(settings, "internal_api_key", "") or "").strip() or None
+
+    while True:
+        client = sub = None
+        try:
+            client = await nats.connect(url, connect_timeout=5, token=token)
+            sub = await client.subscribe(SUBJECT, cb=_handle_message)
+            logger.info("tier0 track consumer subscribed to %s", SUBJECT)
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await _teardown(sub, client)
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await _teardown(sub, client)
+            logger.warning(
+                "tier0 track consumer: connect/subscribe failed (%s); "
+                "retrying in %.0fs", exc, _RETRY_SECONDS)
+            await asyncio.sleep(_RETRY_SECONDS)
+
+
+async def _teardown(sub, client) -> None:
+    try:
+        if sub is not None:
+            await sub.unsubscribe()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if client is not None:
+            await client.drain()
+    except Exception:  # noqa: BLE001
+        pass

--- a/server/tests/test_tier0_track_consumer.py
+++ b/server/tests/test_tier0_track_consumer.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""The Tier-0 → event-bus bridge behind the live detection overlay.
+
+The overlay draws whatever this produces, so the contract is pinned:
+boxes come out as normalized [x, y, w, h] regardless of the detector's
+resolution, the camera handle is mapped to core's integer id (the
+entitlement check is a set of ints), and junk is dropped rather than
+raised.
+"""
+import asyncio
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from cryptography.fernet import Fernet
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+from services import tier0_track_consumer as tc  # noqa: E402
+
+
+# ─── normalize_box ──────────────────────────────────────────────────────
+
+
+def test_pixel_box_is_normalized_by_frame_size():
+    assert tc.normalize_box([192, 108, 960, 540], 1920, 1080) == [0.1, 0.1, 0.4, 0.4]
+
+
+def test_already_normalized_box_is_not_divided_again():
+    """A producer that normalized upstream must not be squashed into the
+    top-left corner by a second division."""
+    assert tc.normalize_box([0.1, 0.1, 0.5, 0.5], 1920, 1080) == [0.1, 0.1, 0.4, 0.4]
+
+
+def test_box_is_clamped_to_the_frame():
+    assert tc.normalize_box([-50, -50, 2000, 1200], 1920, 1080) == [0.0, 0.0, 1.0, 1.0]
+
+
+def test_inverted_corners_are_sorted():
+    assert tc.normalize_box([960, 540, 192, 108], 1920, 1080) == [0.1, 0.1, 0.4, 0.4]
+
+
+@pytest.mark.parametrize("box", [None, "x", [1, 2, 3], [1, 2, 3, "a"], [float("nan")] * 4])
+def test_junk_boxes_are_none(box):
+    assert tc.normalize_box(box, 1920, 1080) is None
+
+
+def test_zero_area_box_is_none():
+    assert tc.normalize_box([10, 10, 10, 50], 1920, 1080) is None
+
+
+def test_pixel_box_without_frame_size_is_none():
+    """Cannot normalize pixels without knowing the frame; refusing beats
+    drawing a box 1920 units wide."""
+    assert tc.normalize_box([100, 100, 200, 200], None, None) is None
+    assert tc.normalize_box([100, 100, 200, 200], 0, 0) is None
+
+
+# ─── to_overlay_payload ─────────────────────────────────────────────────
+
+
+def _raw(tracks, *, w=1920, h=1080, calibrating=False):
+    return {"schema": "opennvr.tier0.v1", "camera_id": "cam3", "seq": 7,
+            "wall_ts": 1.0, "frame": {"w": w, "h": h},
+            "calibrating": calibrating, "tracks": tracks}
+
+
+def test_payload_shape_is_the_overlay_contract():
+    out = tc.to_overlay_payload(_raw([
+        {"id": 5, "label": "person", "score": 0.91, "box": [192, 108, 960, 540],
+         "stationary": False, "best": True},
+    ]))
+    assert out == {
+        "schema": "opennvr.overlay.tracks.v1", "seq": 7, "wall_ts": 1.0,
+        "calibrating": False, "frame": {"w": 1920, "h": 1080},
+        "tracks": [{"id": 5, "label": "person", "score": 0.91,
+                    "box": [0.1, 0.1, 0.4, 0.4], "stationary": False}],
+    }
+
+
+def test_low_score_tracks_are_filtered():
+    out = tc.to_overlay_payload(_raw([
+        {"id": 1, "label": "person", "score": 0.1, "box": [0, 0, 100, 100]},
+        {"id": 2, "label": "car", "score": 0.9, "box": [0, 0, 100, 100]},
+    ]))
+    assert [t["id"] for t in out["tracks"]] == [2]
+
+
+def test_nothing_drawable_returns_none():
+    assert tc.to_overlay_payload(_raw([])) is None
+    assert tc.to_overlay_payload(_raw([{"id": 1, "label": "x", "score": 0.9, "box": None}])) is None
+    assert tc.to_overlay_payload(_raw([{"id": 1, "label": "x", "score": 0.01, "box": [0, 0, 9, 9]}])) is None
+
+
+def test_non_dict_tracks_are_skipped_not_fatal():
+    out = tc.to_overlay_payload(_raw([
+        "junk", None, 42,
+        {"id": 1, "label": "person", "score": 0.9, "box": [0, 0, 100, 100]},
+    ]))
+    assert len(out["tracks"]) == 1
+
+
+def test_missing_label_becomes_object():
+    out = tc.to_overlay_payload(_raw([{"id": 1, "score": 0.9, "box": [0, 0, 100, 100]}]))
+    assert out["tracks"][0]["label"] == "object"
+
+
+# ─── _handle_message: mapping + republish ───────────────────────────────
+
+
+class _Bus:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, event):
+        self.published.append(event)
+
+
+def _run(msg, monkeypatch):
+    bus = _Bus()
+    from services import event_bus_service
+    monkeypatch.setattr(event_bus_service, "get_event_bus", lambda: bus)
+    asyncio.run(tc._handle_message(msg))
+    return bus.published
+
+
+def test_camera_handle_is_mapped_to_the_integer_id(monkeypatch):
+    """The entitlement check on the WebSocket is a set of ints; an event
+    keyed "cam3" would be dropped for every scoped user."""
+    msg = SimpleNamespace(
+        subject="opennvr.inference.tier0.cam3.completed",
+        data=json.dumps(_raw([{"id": 1, "label": "person", "score": 0.9,
+                               "box": [0, 0, 100, 100]}])).encode())
+    out = _run(msg, monkeypatch)
+    assert len(out) == 1
+    ev = out[0]
+    assert ev["event_type"] == "tracks"
+    assert ev["camera_id"] == 3 and isinstance(ev["camera_id"], int)
+    assert ev["task"] == "tier0"
+    assert ev["payload"]["tracks"][0]["box"] == [0.0, 0.0, 0.0521, 0.0926]
+
+
+def test_camera_id_falls_back_to_the_subject(monkeypatch):
+    raw = _raw([{"id": 1, "label": "person", "score": 0.9, "box": [0, 0, 100, 100]}])
+    raw["camera_id"] = "front-door"   # a name, not a handle
+    msg = SimpleNamespace(subject="opennvr.inference.tier0.cam7.completed",
+                          data=json.dumps(raw).encode())
+    out = _run(msg, monkeypatch)
+    assert out and out[0]["camera_id"] == 7
+
+
+def test_unmappable_camera_is_dropped_not_raised(monkeypatch):
+    raw = _raw([{"id": 1, "label": "person", "score": 0.9, "box": [0, 0, 100, 100]}])
+    raw["camera_id"] = "front-door"
+    msg = SimpleNamespace(subject="weird", data=json.dumps(raw).encode())
+    assert _run(msg, monkeypatch) == []
+
+
+def test_empty_frames_publish_nothing(monkeypatch):
+    """5 fps of empty results must not become 5 fps of empty events."""
+    msg = SimpleNamespace(subject="opennvr.inference.tier0.cam3.completed",
+                          data=json.dumps(_raw([])).encode())
+    assert _run(msg, monkeypatch) == []
+
+
+@pytest.mark.parametrize("data", [b"not json", b"[1,2,3]", b"null"])
+def test_garbage_is_dropped_not_raised(monkeypatch, data):
+    msg = SimpleNamespace(subject="opennvr.inference.tier0.cam3.completed", data=data)
+    assert _run(msg, monkeypatch) == []
+
+
+# ─── the bus itself gates tracks per camera ─────────────────────────────
+
+
+def test_tracks_events_are_subject_to_camera_entitlement():
+    """The WS fix from the S9S disclosure applies here too: a viewer
+    scoped to camera 1 must not receive camera 3's boxes any more than
+    its video."""
+    from services.event_bus_service import _Subscriber
+    sub = _Subscriber(queue_size=4, camera_id=None, tasks=None,
+                      allowed_camera_ids=frozenset({1}))
+    assert sub.matches({"event_type": "tracks", "camera_id": 1}) is True
+    assert sub.matches({"event_type": "tracks", "camera_id": 3}) is False


### PR DESCRIPTION
Reported: OpenNVR draws no boxes on tracked objects. It could not — the detections were happening, but nothing carried them to the browser. Tier-0 (YOLO + ByteTrack, every camera, ~5 fps) publishes each frame's tracks to NATS, and core's only NATS→WebSocket bridge was the BYOM inference path. The live view had a detector running behind it and no way to see it.

WHAT THE COMPETITION DOES, and why this follows the client-side camp. Frigate and ZoneMinder burn boxes into a second, server-rendered MJPEG "debug" stream: a re-encode per viewer, a second stream per camera, and the annotated picture and the clean recording are different pixels. Scrypted, Shinobi, UniFi Protect and Blue Iris overlay client-side on a canvas over the player, from a live event feed. WebRTC/HLS through MediaMTX wants the second design: one stream, boxes as data, drawn where they are looked at — and a toggle that costs nothing when off, because off means no canvas and no socket.

THREE PIECES.

services/tier0_track_consumer.py is the missing bridge. It subscribes to opennvr.inference.tier0.*.completed, maps the bus camera handle ("cam3") to core's integer id — the WebSocket entitlement is a set of ints, so an unmapped event would be dropped for every scoped user — normalizes the pixel-space [x1,y1,x2,y2] boxes to [x,y,w,h] in 0..1 using the frame size the producer ships, and republishes as a `tracks` event. Empty frames publish nothing; junk is counted and dropped, never raised. Best-effort like its siblings: no NATS, no overlay, never a failed boot. 24 tests, including that a box already normalized upstream is not divided again and that `tracks` events obey the per-camera gate from the S9S fix.

lib/detectionFeed.ts is one WebSocket for every overlay on the page. A 3×3 grid would otherwise hold nine sockets and nine tickets for one stream of events. It opens unfiltered — the server scopes it per event to the user's cameras, so unfiltered never means the whole site — fans frames out by camera_id, opens on the first subscriber and closes on the last, and reconnects with backoff on a fresh single-use ticket. It parses the adapter contract's {x,y,w,h} detection shape too, so a BYOM model's live results draw as well. 12 parser cases.

components/VideoPlayer/DetectionOverlay.tsx draws. It sits inside the player's feed box, which VideoPlayer already sizes to the stream's DISPLAY aspect and fills edge to edge — so the canvas rectangle IS the video rectangle, normalized boxes map straight on, and an anamorphic stream the player un-squishes carries its boxes with it. One hue per label so the eye can follow a class; a dark halo under the stroke for legibility on sky and tarmac alike; "person #5 91%" chips; DPR-aware backing store; boxes expire after 2 s without a newer frame so a paused detector does not leave a stale outline; a calibrating tracker draws at half opacity. Survives fullscreen because VideoPlayer fullscreens its container, not the raw <video>.

The toggle is a "Boxes" button in the Live View toolbar beside Fit/Fill, persisted per browser like the grid mode. Off by default: the picture is the product, the boxes are a tool.

NOT in this change: the camera-agent's own demo player. It is a different origin, and core's CORS is an operator allowlist, so the demo cannot fetch a ticket from the browser. The agent is already a NATS consumer; the right shape is a small tracks feed of its own on the agent, drawn over its WHEP player. Follows as its own PR.

tsc and vite build clean; server suites for events/bus/consumers identical to main (7 pre-existing failures both sides, none new).