### PR TITLE
Feat/overlay controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   those events are subject to the same per-camera entitlement as the
   video. One shared socket serves every tile on the page.
 
+  Three controls, at three grains. **Viewer:** the Boxes button, per
+  browser. **Site:** `DETECTION_OVERLAY_ENABLED` (default on) gates the
+  bridge for every consumer at once and is logged with the boot posture.
+  **Per app:** apps can publish `overlay.boxes.v1` (SDK
+  `publish_overlay`) — plate outlines, zones — and the catalog shows an
+  Overlay switch for apps that declare it, off by default; the bridge
+  forwards an app's boxes only when that switch is on. The camera-agent
+  demo draws the same boxes over its own player (Boxes button on the
+  camera screen), relayed by the agent from the bus and filtered by the
+  session's camera scope.
+
 ### Added
 
 - **App SDK: the `App` facade — apps in one function.** Writing a first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,13 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Overlay switch for apps that declare it, off by default; the bridge
   forwards an app's boxes only when that switch is on. The camera-agent
   demo draws the same boxes over its own player (Boxes button on the
-  camera screen), relayed by the agent from the bus and filtered by the
-  session's camera scope.
+  camera screen): the agent consumes core's `/events/ws` as a platform
+  service — so the site switch, each app's permission and the box maths
+  are decided in exactly one place — and re-scopes every frame to the
+  viewer's own cameras before it reaches the page. `POST
+  /events/ws-ticket` now mints an unscoped *service* ticket for the
+  `INTERNAL_API_KEY`; user tickets are unchanged and an app key is
+  refused.
 
 ### Added
 

--- a/app/src/lib/detectionFeed.ts
+++ b/app/src/lib/detectionFeed.ts
@@ -128,8 +128,10 @@ async function connect() {
   if (totalListeners() === 0) { connecting = false; return }
 
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-  // task filter keeps everything the overlay does not draw off the wire.
-  const url = `${proto}://${window.location.host}/api/v1/events/ws?ticket=${encodeURIComponent(ticket)}&task=tier0`
+  // task filter keeps everything the overlay does not draw off the wire:
+  // tier0 = the platform detector, overlay = boxes an app asked to draw
+  // (forwarded only for apps the operator switched on in the catalog).
+  const url = `${proto}://${window.location.host}/api/v1/events/ws?ticket=${encodeURIComponent(ticket)}&task=tier0&task=overlay`
   const sock = new WebSocket(url)
   ws = sock
   connecting = false

--- a/app/src/services/appsService.ts
+++ b/app/src/services/appsService.ts
@@ -39,6 +39,9 @@ export const appsService = {
   getAppEgress: (id: string) => api.get(`/api/v1/apps/${id}/egress`),
   setAppEgress: (id: string, allow: string[]) =>
     api.put(`/api/v1/apps/${id}/egress`, { allow }),
+  // May this app's overlay.boxes.v1 be drawn over the live video? (superuser)
+  setAppOverlay: (id: string, enabled: boolean) =>
+    api.put(`/api/v1/apps/${id}/overlay`, { enabled }),
   disableApp: (id: string) => api.post(`/api/v1/apps/${id}/disable`),
   updateAppConfig: (id: string, config: Record<string, any>) =>
     api.put(`/api/v1/apps/${id}/config`, config),

--- a/app/src/views/AppCatalog.tsx
+++ b/app/src/views/AppCatalog.tsx
@@ -86,6 +86,8 @@ export type AppManifest = {
   // ("{host}" in it is replaced with the browser's hostname).
   ui_mode?: 'internal' | 'external'
   ui_url?: string
+  // App publishes overlay.boxes.v1 — the catalog shows an Overlay switch.
+  overlay?: boolean
   // Store listing (the Details section): long-form description
   // (blank-line-separated paragraphs), authorship, and the concrete
   // jobs the app solves.
@@ -232,6 +234,8 @@ export type RegisteredApp = {
   config?: Record<string, any> | null
   entitlement?: Entitlement | null
   egress?: AppEgress | null
+  /** Operator allowed this app's overlay.boxes.v1 to draw over live video. */
+  overlay_enabled?: boolean
 }
 
 // GET /apps/{id}/egress — apps live on an internal network and leave it
@@ -1380,6 +1384,49 @@ function LicensePanel({ app, isAdmin }: { app: RegisteredApp; isAdmin: boolean }
   )
 }
 
+/** Per-app permission to draw on the live video. Shown only for apps
+ *  whose manifest declares `overlay`; off by default because an app
+ *  painting on every operator's screen is a privilege, not a default. */
+function OverlayPanel({ app, isAdmin }: { app: RegisteredApp; isAdmin: boolean }) {
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useSnackbar()
+  const on = Boolean(app.overlay_enabled)
+  const set = useMutation({
+    mutationFn: (enabled: boolean) => apiService.setAppOverlay(app.id, enabled),
+    onSuccess: (_d, enabled) => {
+      queryClient.invalidateQueries({ queryKey: ['apps'] })
+      showSuccess(enabled
+        ? `${app.name} may now draw boxes over the live view (turn on "Boxes" in Live View to see them)`
+        : `${app.name} no longer draws over the live view`)
+    },
+    onError: (e) => showError(extractApiError(e, 'Could not change the overlay setting.')),
+  })
+  return (
+    <div className="rounded border border-[var(--border)] p-2 space-y-1 text-xs">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="font-medium text-[var(--text)]">Overlay</span>
+        <Badge variant={on ? 'success' : 'neutral'}>{on ? 'draws on live view' : 'not drawn'}</Badge>
+        {isAdmin && (
+          <Button
+            variant="outline"
+            className="ml-auto"
+            onClick={() => set.mutate(!on)}
+            disabled={set.isPending}
+            aria-pressed={on}
+          >
+            {on ? 'Stop drawing' : 'Allow drawing'}
+          </Button>
+        )}
+      </div>
+      <p className="text-[var(--text-dim)] leading-relaxed">
+        This app publishes boxes it wants shown over the live video — plate
+        outlines, zones. They appear only if you allow it here <em>and</em> an
+        operator has Boxes on in Live View. The app keeps running either way.
+      </p>
+    </div>
+  )
+}
+
 function NetworkPanel({ app, isAdmin }: { app: RegisteredApp; isAdmin: boolean }) {
   const queryClient = useQueryClient()
   const { showSuccess, showError } = useSnackbar()
@@ -1621,6 +1668,8 @@ function AppCard({ app, caps, tier0, skill, onConfigure }: { app: RegisteredApp;
         )}
 
         <NetworkPanel app={app} isAdmin={isAdmin} />
+
+        {app.manifest?.overlay && <OverlayPanel app={app} isAdmin={isAdmin} />}
 
         {/* RFC-0002 Phase 1: the skill this app provides, as the platform
             registry sees it — same derivation the agent's panel renders,

--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -128,6 +128,28 @@ consumers.
 | `calibrating` | bool | Tier-0 still calibrating; treat tracks as provisional. |
 | `tracks` | array | Same track shape as `opennvr.tier0.v1` (`id`, `label`, `conf`, `bbox`, motion fields). Normative source: `detect_pipeline/bus.py::build_payload`. |
 
+### `overlay.boxes.v1`
+
+Subject: `opennvr.events.overlay.boxes.v1.<camera_id>`
+Producer: any app (SDK `OverlayBoxes` / `DomainEventPublisher.publish_overlay`).
+
+Boxes an app wants drawn over the operator's live video — plate
+localisations, zones, anything with a rectangle. Core forwards them to
+the browser (`/events/ws`, `task=overlay`) **only for apps the operator
+has switched on in the App Catalog** (`installed_apps.overlay_enabled`,
+off by default); otherwise the event is published and ignored, so an
+app may call `publish_overlay` unconditionally. Whether a given screen
+draws them is that viewer's own toggle. Core never draws an app's
+boxes for a camera the viewer may not watch.
+
+`payload`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `boxes` | array | Required. `{label, box: [x, y, w, h], score?, id?}`; `box` normalized to 0..1 of the frame. |
+| `frame` | `{w, h}` \| absent | Optional. If `box` is in pixels, ship the frame size and core normalizes. Pixel boxes without it are dropped. |
+| `seq` | int \| absent | Optional producer sequence. |
+
 ### `visit.recorded.v1`
 
 Subject: `opennvr.events.visit.recorded.v1.<camera_id>`

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -85,7 +85,7 @@ from context import (
     camera_scope,
     reset_camera_scope,
     run_app_alert_subscriber,
-    run_tier0_track_subscriber,
+    run_core_tracks_subscriber,
     run_event_subscriber,
     scoped_cameras,
     set_camera_scope,
@@ -5006,23 +5006,38 @@ class CameraAgentRuntime:
                 "(opennvr.alerts.app.>)",
                 self.cfg.nats_inference_url,
             )
-            # Live detection overlay for the demo's own player: Tier-0's
-            # tracks, read off the same bus, pushed to the page over the
-            # /updates socket it already holds. Read/draw only.
-            self._tier0_track_task = asyncio.create_task(
-                run_tier0_track_subscriber(
-                    nats_url=self.cfg.nats_inference_url,
-                    nats_token=self.cfg.nats_inference_token,
-                    stop_event=self._stop_event,
-                    on_tracks=self._relay_tracks,
-                ),
-                name="camera-agent-tier0-track-subscriber",
-            )
         else:
             logger.info(
                 "camera-agent: NATS not configured; recent_events and "
                 "recent_app_alerts tools will always report 'no events'"
             )
+
+        # Live detection overlay for the demo's own player. Fed from
+        # CORE's /events/ws, not from the bus: core's bridge is where the
+        # site switch, each app's overlay permission and the box maths are
+        # decided, and the agent must not re-derive any of that. Reads as a
+        # platform service (INTERNAL_API_KEY → unscoped ticket) and
+        # re-scopes every frame per viewer before it reaches a page — see
+        # _tracks_push_visible. Read/draw only.
+        if self.cfg.opennvr_api_url:
+            import os as _os
+
+            _core_key = (
+                self.cfg.opennvr_api_key
+                or self.cfg.kaic_api_key
+                or _os.environ.get("INTERNAL_API_KEY", "")
+            )
+            self._core_tracks_task = asyncio.create_task(
+                run_core_tracks_subscriber(
+                    base_url=self.cfg.opennvr_api_url,
+                    api_key=_core_key,
+                    stop_event=self._stop_event,
+                    on_tracks=self._relay_tracks,
+                ),
+                name="camera-agent-core-tracks-subscriber",
+            )
+            logger.info("camera-agent: overlay tracks subscriber started on %s",
+                        self.cfg.opennvr_api_url)
 
         # Pre-warm the LLM in the background so the FIRST real question
         # doesn't pay the ~80s cold-load (Ollama loads the model into RAM
@@ -5667,6 +5682,21 @@ def agent_manifest(cfg: Any | None = None) -> dict[str, Any]:
         ui_mode="external",
         ui_url=agent_ui_url(cfg),
     ).to_dict()
+
+
+def _tracks_push_visible(pushed: Any) -> bool:
+    """May THIS session's socket receive ``pushed``?
+
+    A tracks push names a camera; it is honoured against the session's
+    per-camera scope exactly as the HTTP gate would honour a request, so
+    a viewer never receives boxes for a camera they may not watch. This
+    is the re-scoping the unscoped service ticket to core relies on.
+    Everything else on the socket is site-wide status and passes."""
+    tr = pushed.get("tracks") if isinstance(pushed, dict) else None
+    if not isinstance(tr, dict):
+        return True
+    scope = camera_scope()
+    return scope is None or tr.get("camera") in scope
 
 
 def build_app(runtime: CameraAgentRuntime) -> FastAPI:
@@ -6973,15 +7003,8 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 except asyncio.TimeoutError:
                     pushed = None
                 if pushed is not None:
-                    # A tracks push names a camera; honour this session's
-                    # per-camera scope exactly as the HTTP gate would, so
-                    # a viewer never receives boxes for a camera they may
-                    # not watch. Everything else is site-wide status.
-                    tr = pushed.get("tracks") if isinstance(pushed, dict) else None
-                    if isinstance(tr, dict):
-                        scope = camera_scope()
-                        if scope is not None and tr.get("camera") not in scope:
-                            continue
+                    if not _tracks_push_visible(pushed):
+                        continue
                     await websocket.send_text(json.dumps(pushed, default=str))
                     continue
                 alarms = runtime.alarms.list()

--- a/examples/camera-agent/camera_agent.py
+++ b/examples/camera-agent/camera_agent.py
@@ -85,6 +85,7 @@ from context import (
     camera_scope,
     reset_camera_scope,
     run_app_alert_subscriber,
+    run_tier0_track_subscriber,
     run_event_subscriber,
     scoped_cameras,
     set_camera_scope,
@@ -3533,6 +3534,17 @@ class CameraAgentRuntime:
     def unsubscribe_updates(self, q: "asyncio.Queue") -> None:
         self._update_subscribers.discard(q)
 
+    def _relay_tracks(self, core_camera_id: int, frame: dict[str, Any]) -> None:
+        """Tier-0 tracks for core camera N → the agent camera that maps to
+        it, pushed to the demo as {"tracks": {camera, ...}}. Dropped when
+        no configured camera claims that core id — boxes for a camera this
+        agent does not know are not this agent's to show."""
+        cam = next((c.camera_id for c in self.cfg.cameras
+                    if getattr(c, "opennvr_camera_id", None) == core_camera_id), None)
+        if cam is None:
+            return
+        self.publish_update({"tracks": {"camera": cam, **frame}})
+
     def publish_update(self, payload: dict[str, Any]) -> None:
         for q in list(self._update_subscribers):
             try:
@@ -4993,6 +5005,18 @@ class CameraAgentRuntime:
                 "camera-agent: app-alert subscriber started on %s "
                 "(opennvr.alerts.app.>)",
                 self.cfg.nats_inference_url,
+            )
+            # Live detection overlay for the demo's own player: Tier-0's
+            # tracks, read off the same bus, pushed to the page over the
+            # /updates socket it already holds. Read/draw only.
+            self._tier0_track_task = asyncio.create_task(
+                run_tier0_track_subscriber(
+                    nats_url=self.cfg.nats_inference_url,
+                    nats_token=self.cfg.nats_inference_token,
+                    stop_event=self._stop_event,
+                    on_tracks=self._relay_tracks,
+                ),
+                name="camera-agent-tier0-track-subscriber",
             )
         else:
             logger.info(
@@ -6949,6 +6973,15 @@ def build_app(runtime: CameraAgentRuntime) -> FastAPI:
                 except asyncio.TimeoutError:
                     pushed = None
                 if pushed is not None:
+                    # A tracks push names a camera; honour this session's
+                    # per-camera scope exactly as the HTTP gate would, so
+                    # a viewer never receives boxes for a camera they may
+                    # not watch. Everything else is site-wide status.
+                    tr = pushed.get("tracks") if isinstance(pushed, dict) else None
+                    if isinstance(tr, dict):
+                        scope = camera_scope()
+                        if scope is not None and tr.get("camera") not in scope:
+                            continue
                     await websocket.send_text(json.dumps(pushed, default=str))
                     continue
                 alarms = runtime.alarms.list()

--- a/examples/camera-agent/context.py
+++ b/examples/camera-agent/context.py
@@ -23,6 +23,7 @@ LLM turn don't trip each other up.
 from __future__ import annotations
 
 import asyncio
+import re
 import json
 import logging
 import time
@@ -759,6 +760,129 @@ def _summarise_event(payload: dict[str, Any]) -> str:
 
 
 # ── App alert relay (subscriber + parser) ──────────────────────────
+
+
+TIER0_TRACK_SUBJECT = "opennvr.inference.tier0.*.completed"
+
+
+def _normalize_track_box(box, frame_w, frame_h):
+    """``[x1,y1,x2,y2]`` (pixels, or already 0..1) → ``[x,y,w,h]`` in 0..1,
+    or None. A local twin of core's tier0_track_consumer.normalize_box —
+    the agent cannot import core, and the maths must agree."""
+    try:
+        x1, y1, x2, y2 = (float(v) for v in box)
+    except (TypeError, ValueError):
+        return None
+    if any(v != v for v in (x1, y1, x2, y2)):
+        return None
+    if max(x1, y1, x2, y2) > 1.0:
+        try:
+            fw, fh = float(frame_w), float(frame_h)
+        except (TypeError, ValueError):
+            return None
+        if fw <= 0 or fh <= 0:
+            return None
+        x1, x2, y1, y2 = x1 / fw, x2 / fw, y1 / fh, y2 / fh
+    x1, x2 = sorted((x1, x2)); y1, y2 = sorted((y1, y2))
+    c = lambda v: min(1.0, max(0.0, v))  # noqa: E731
+    x1, y1, x2, y2 = c(x1), c(y1), c(x2), c(y2)
+    if x2 - x1 <= 0 or y2 - y1 <= 0:
+        return None
+    return [round(x1, 4), round(y1, 4), round(x2 - x1, 4), round(y2 - y1, 4)]
+
+
+def tier0_tracks_for_overlay(payload: dict, *, min_score: float = 0.25) -> dict | None:
+    """The demo's overlay frame for one Tier-0 payload, or None when
+    nothing is drawable. Pure; tested without a bus."""
+    frame = payload.get("frame") or {}
+    fw, fh = frame.get("w"), frame.get("h")
+    out = []
+    for t in payload.get("tracks") or []:
+        if not isinstance(t, dict):
+            continue
+        try:
+            score = float(t.get("score", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if score < min_score:
+            continue
+        box = _normalize_track_box(t.get("box"), fw, fh)
+        if box is None:
+            continue
+        out.append({"id": t.get("id"), "label": str(t.get("label") or "object"),
+                    "score": round(score, 3), "box": box})
+    if not out:
+        return None
+    return {"calibrating": bool(payload.get("calibrating", False)), "tracks": out}
+
+
+async def run_tier0_track_subscriber(
+    *,
+    nats_url: str,
+    nats_token: str | None,
+    stop_event: asyncio.Event,
+    on_tracks,   # callback(core_camera_id: int, frame: dict) — the demo push
+) -> None:
+    """Subscribe to Tier-0's per-frame tracks so the demo can draw boxes
+    over its own player. READ-ONLY, like the app-alert subscriber: the
+    agent draws what the platform detected, it never runs detection.
+    The subject carries ``cam<N>``; N is core's camera id, and the
+    callback maps it to the agent's camera. Same connect/backoff shape as
+    run_app_alert_subscriber; nats-py missing → quietly no overlay."""
+    try:
+        import nats  # type: ignore
+    except ImportError:
+        logger.warning("nats-py not installed; no live detection overlay")
+        await stop_event.wait()
+        return
+    while not stop_event.is_set():
+        try:
+            options: dict[str, Any] = {"servers": [nats_url]}
+            if nats_token:
+                options["token"] = nats_token
+            nc = await nats.connect(**options)
+        except Exception as exc:
+            logger.warning("tier0 track subscriber: connect failed (%s); retrying in 5s", exc)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                continue
+            return
+        try:
+            async def _handler(msg) -> None:  # noqa: ANN001
+                try:
+                    payload = json.loads(msg.data.decode("utf-8"))
+                    parts = str(msg.subject).split(".")
+                    handle = parts[3] if len(parts) >= 5 else ""
+                    m = re.match(r"^cam-?(\d+)$", handle, re.IGNORECASE)
+                    if not m:
+                        return
+                    frame = tier0_tracks_for_overlay(payload)
+                    if frame is None:
+                        return
+                    on_tracks(int(m.group(1)), frame)
+                except Exception:
+                    logger.debug("tier0 track subscriber: dropping payload", exc_info=True)
+
+            sub = await nc.subscribe(TIER0_TRACK_SUBJECT, cb=_handler)
+            logger.info("tier0 track subscriber: subscribed to %s", TIER0_TRACK_SUBJECT)
+            await stop_event.wait()
+            try:
+                await sub.unsubscribe()
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.warning("tier0 track subscriber: subscription error (%s); reconnecting", exc)
+        finally:
+            try:
+                await nc.drain()
+            except Exception:
+                pass
+        if not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                pass
 
 
 async def run_app_alert_subscriber(

--- a/examples/camera-agent/context.py
+++ b/examples/camera-agent/context.py
@@ -762,127 +762,97 @@ def _summarise_event(payload: dict[str, Any]) -> str:
 # ── App alert relay (subscriber + parser) ──────────────────────────
 
 
-TIER0_TRACK_SUBJECT = "opennvr.inference.tier0.*.completed"
+def core_tracks_frame(event: Any) -> tuple[int, dict] | None:
+    """One `tracks` event off core's /events/ws → ``(core_camera_id, frame)``
+    for the demo, or None. Pure, so it is tested without a socket.
 
-
-def _normalize_track_box(box, frame_w, frame_h):
-    """``[x1,y1,x2,y2]`` (pixels, or already 0..1) → ``[x,y,w,h]`` in 0..1,
-    or None. A local twin of core's tier0_track_consumer.normalize_box —
-    the agent cannot import core, and the maths must agree."""
-    try:
-        x1, y1, x2, y2 = (float(v) for v in box)
-    except (TypeError, ValueError):
+    Core has already done the work — the site switch, the per-app
+    permission, the box normalisation — so this only validates shape:
+    the right event type, an integer camera id, at least one track."""
+    if not isinstance(event, dict) or event.get("event_type") != "tracks":
         return None
-    if any(v != v for v in (x1, y1, x2, y2)):
+    cam = event.get("camera_id")
+    if isinstance(cam, bool) or not isinstance(cam, int):
         return None
-    if max(x1, y1, x2, y2) > 1.0:
-        try:
-            fw, fh = float(frame_w), float(frame_h)
-        except (TypeError, ValueError):
-            return None
-        if fw <= 0 or fh <= 0:
-            return None
-        x1, x2, y1, y2 = x1 / fw, x2 / fw, y1 / fh, y2 / fh
-    x1, x2 = sorted((x1, x2)); y1, y2 = sorted((y1, y2))
-    c = lambda v: min(1.0, max(0.0, v))  # noqa: E731
-    x1, y1, x2, y2 = c(x1), c(y1), c(x2), c(y2)
-    if x2 - x1 <= 0 or y2 - y1 <= 0:
+    p = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+    tracks = [t for t in (p.get("tracks") or []) if isinstance(t, dict)]
+    if not tracks:
         return None
-    return [round(x1, 4), round(y1, 4), round(x2 - x1, 4), round(y2 - y1, 4)]
+    frame: dict[str, Any] = {"calibrating": bool(p.get("calibrating", False)),
+                             "tracks": tracks}
+    if p.get("source"):
+        frame["source"] = str(p["source"])
+    return cam, frame
 
 
-def tier0_tracks_for_overlay(payload: dict, *, min_score: float = 0.25) -> dict | None:
-    """The demo's overlay frame for one Tier-0 payload, or None when
-    nothing is drawable. Pure; tested without a bus."""
-    frame = payload.get("frame") or {}
-    fw, fh = frame.get("w"), frame.get("h")
-    out = []
-    for t in payload.get("tracks") or []:
-        if not isinstance(t, dict):
-            continue
-        try:
-            score = float(t.get("score", 0.0))
-        except (TypeError, ValueError):
-            continue
-        if score < min_score:
-            continue
-        box = _normalize_track_box(t.get("box"), fw, fh)
-        if box is None:
-            continue
-        out.append({"id": t.get("id"), "label": str(t.get("label") or "object"),
-                    "score": round(score, 3), "box": box})
-    if not out:
-        return None
-    return {"calibrating": bool(payload.get("calibrating", False)), "tracks": out}
-
-
-async def run_tier0_track_subscriber(
+async def run_core_tracks_subscriber(
     *,
-    nats_url: str,
-    nats_token: str | None,
+    base_url: str,
+    api_key: str,
     stop_event: asyncio.Event,
     on_tracks,   # callback(core_camera_id: int, frame: dict) — the demo push
 ) -> None:
-    """Subscribe to Tier-0's per-frame tracks so the demo can draw boxes
-    over its own player. READ-ONLY, like the app-alert subscriber: the
-    agent draws what the platform detected, it never runs detection.
-    The subject carries ``cam<N>``; N is core's camera id, and the
-    callback maps it to the agent's camera. Same connect/backoff shape as
-    run_app_alert_subscriber; nats-py missing → quietly no overlay."""
+    """Consume core's overlay tracks over its /events/ws and hand each
+    frame to ``on_tracks``. ONE source of truth: core's bridge decides
+    what is drawable (DETECTION_OVERLAY_ENABLED, each app's overlay
+    permission, the box maths) and this only relays it — the agent
+    never re-derives any of that from the bus.
+
+    Authenticates with the deployment's INTERNAL_API_KEY, which core
+    turns into an unscoped SERVICE ticket; the agent applies its own
+    per-viewer camera scope before anything reaches a page (see the
+    /updates handler). Backs off on failure; a ticket is single-use and
+    30 s, so a fresh one is minted on every (re)connect. `websockets`
+    missing → quietly no overlay, like nats-py for the alert relay.
+    """
     try:
-        import nats  # type: ignore
+        import websockets  # type: ignore
     except ImportError:
-        logger.warning("nats-py not installed; no live detection overlay")
+        logger.warning("websockets not installed; no live detection overlay")
         await stop_event.wait()
         return
+    import httpx
+
+    base = base_url.rstrip("/")
+    ws_base = re.sub(r"^http", "ws", base, count=1)
+    backoff = 2.0
     while not stop_event.is_set():
         try:
-            options: dict[str, Any] = {"servers": [nats_url]}
-            if nats_token:
-                options["token"] = nats_token
-            nc = await nats.connect(**options)
+            async with httpx.AsyncClient(timeout=5.0, trust_env=False) as hc:
+                r = await hc.post(f"{base}/api/v1/events/ws-ticket",
+                                  headers={"X-Internal-Api-Key": api_key})
+                r.raise_for_status()
+                ticket = r.json()["ticket"]
+            url = (f"{ws_base}/api/v1/events/ws?ticket={ticket}"
+                   f"&task=tier0&task=overlay")
+            async with websockets.connect(url, max_queue=64) as ws:
+                logger.info("core tracks subscriber: connected to %s/api/v1/events/ws", base)
+                backoff = 2.0
+                while not stop_event.is_set():
+                    try:
+                        raw = await asyncio.wait_for(ws.recv(), timeout=5.0)
+                    except asyncio.TimeoutError:
+                        continue
+                    try:
+                        parsed = core_tracks_frame(json.loads(raw))
+                    except Exception:
+                        continue
+                    if parsed is None:
+                        continue
+                    cam, frame = parsed
+                    try:
+                        on_tracks(cam, frame)
+                    except Exception:
+                        logger.debug("core tracks subscriber: on_tracks raised", exc_info=True)
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
-            logger.warning("tier0 track subscriber: connect failed (%s); retrying in 5s", exc)
-            try:
-                await asyncio.wait_for(stop_event.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
-                continue
-            return
+            logger.warning("core tracks subscriber: %s; retrying in %.0fs", exc, backoff)
         try:
-            async def _handler(msg) -> None:  # noqa: ANN001
-                try:
-                    payload = json.loads(msg.data.decode("utf-8"))
-                    parts = str(msg.subject).split(".")
-                    handle = parts[3] if len(parts) >= 5 else ""
-                    m = re.match(r"^cam-?(\d+)$", handle, re.IGNORECASE)
-                    if not m:
-                        return
-                    frame = tier0_tracks_for_overlay(payload)
-                    if frame is None:
-                        return
-                    on_tracks(int(m.group(1)), frame)
-                except Exception:
-                    logger.debug("tier0 track subscriber: dropping payload", exc_info=True)
-
-            sub = await nc.subscribe(TIER0_TRACK_SUBJECT, cb=_handler)
-            logger.info("tier0 track subscriber: subscribed to %s", TIER0_TRACK_SUBJECT)
-            await stop_event.wait()
-            try:
-                await sub.unsubscribe()
-            except Exception:
-                pass
-        except Exception as exc:
-            logger.warning("tier0 track subscriber: subscription error (%s); reconnecting", exc)
-        finally:
-            try:
-                await nc.drain()
-            except Exception:
-                pass
-        if not stop_event.is_set():
-            try:
-                await asyncio.wait_for(stop_event.wait(), timeout=2.0)
-            except asyncio.TimeoutError:
-                pass
+            await asyncio.wait_for(stop_event.wait(), timeout=backoff)
+        except asyncio.TimeoutError:
+            pass
+        backoff = min(backoff * 2, 30.0)
 
 
 async def run_app_alert_subscriber(

--- a/examples/camera-agent/demo/index.html
+++ b/examples/camera-agent/demo/index.html
@@ -501,6 +501,13 @@
     .rec-seg:hover,.rec-seg.on{border-color:var(--accent); color:var(--accent);}
     .rec-note{font-size:0.7rem; color:var(--faint); padding:0.3rem 0;}
     .player video{display:block; width:100%; aspect-ratio:16/9; max-height:44vh; object-fit:contain; background:#000;}
+    /* Detection boxes: a canvas over the whole player; the JS maps boxes
+       onto the video's CONTENT rect (object-fit:contain letterboxes), so
+       a box lands on the object, not on the black bar. */
+    .player canvas.boxes{position:absolute; inset:0; width:100%; height:100%; pointer-events:none; display:none;}
+    .player canvas.boxes.on{display:block;}
+    .player .boxbtn{right:2.6rem;}
+    .player .boxbtn.on{color:var(--accent); border-color:var(--accent);}
 
     /* ── events feed ─────────────────────────────────────────────────── */
     .evt{display:flex; align-items:flex-start; gap:0.45rem; padding:0.4rem 0.5rem; background:var(--glass2);
@@ -681,10 +688,12 @@
             <div class="player" id="camPlayer" title="Click the picture to pin this exact frame into the chat">
               <img id="camImg" alt="camera view" hidden>
               <video id="camVideo" controls playsinline hidden></video>
+              <canvas id="camBoxes" class="boxes" aria-hidden="true"></canvas>
               <div id="camNoFrame" class="empty-note" hidden>No frame — camera off or unreachable.</div>
               <span class="ovl" id="camTs"></span>
               <span class="modepill" id="camMode"><span class="mdot"></span><span id="camModeText">LIVE</span></span>
               <button class="fsbtn" id="camFs" type="button" title="Full screen" aria-label="Full screen">⛶</button>
+              <button class="fsbtn boxbtn" id="camBoxesBtn" type="button" title="Boxes: outline tracked objects with label and confidence" aria-label="Toggle detection boxes" aria-pressed="false">▣</button>
             </div>
             <div class="transport">
               <button class="pbtn" id="camPlay" title="Play / pause">⏸</button>
@@ -1702,6 +1711,51 @@
     let _viewGen=0;
     let _playback=false;   // a recorded segment is in the player
     let _pc=null, _whepResource=null;   // live WebRTC (WHEP) session
+    // ── Detection boxes over the camera screen's player ──────────────
+    // Same design as OpenNVR's Live View overlay: boxes arrive as data
+    // (Tier-0 tracks, relayed by the agent over /updates), drawn on a
+    // canvas over the video, never burned into the stream. Per-browser
+    // toggle, OFF by default — the picture is the product.
+    let _boxesOn=false; try{ _boxesOn=localStorage.getItem("agent.boxes")==="on"; }catch{}
+    let _lastTracks=null, _boxRaf=null;
+    const BOX_STALE_MS=2000;
+    const LABEL_HUES={person:205,car:30,truck:45,bus:45,motorcycle:15,bicycle:160,dog:290,cat:290,bird:120,license_plate:60,plate:60,face:330};
+    function hueFor(l){ if(l in LABEL_HUES) return LABEL_HUES[l]; let h=0; for(const ch of l) h=(h*31+ch.charCodeAt(0))%360; return h; }
+    function setBoxes(on){ _boxesOn=!!on; try{ localStorage.setItem("agent.boxes",on?"on":"off"); }catch{}
+      const b=$("camBoxesBtn"), c=$("camBoxes");
+      if(b){ b.classList.toggle("on",_boxesOn); b.setAttribute("aria-pressed",_boxesOn?"true":"false"); }
+      if(c){ c.classList.toggle("on",_boxesOn); if(!_boxesOn){ const x=c.getContext("2d"); x&&x.clearRect(0,0,c.width,c.height); } }
+      if(_boxesOn) drawBoxes(); }
+    function onTracks(t){ if(!t||!window._camScreenCam||t.camera!==window._camScreenCam) return;
+      _lastTracks={...t, at:Date.now()}; if(_boxesOn) requestBoxes(); }
+    function requestBoxes(){ if(_boxRaf==null) _boxRaf=requestAnimationFrame(()=>{ _boxRaf=null; drawBoxes(); }); }
+    /* The video is object-fit:contain inside a 16:9 element, so the frame
+       may be letterboxed. Compute the content rect from the coded size so
+       normalized boxes land on the object, not the bars. */
+    function videoContentRect(v,cw,ch){
+      const vw=v.videoWidth, vh=v.videoHeight; if(!vw||!vh) return {x:0,y:0,w:cw,h:ch};
+      const s=Math.min(cw/vw, ch/vh), w=vw*s, h=vh*s; return {x:(cw-w)/2, y:(ch-h)/2, w, h}; }
+    function drawBoxes(){ const c=$("camBoxes"), v=$("camVideo"); if(!c||!_boxesOn) return;
+      const dpr=window.devicePixelRatio||1, cw=c.clientWidth, ch=c.clientHeight;
+      if(!cw||!ch) return;
+      const W=Math.round(cw*dpr), H=Math.round(ch*dpr); if(c.width!==W||c.height!==H){ c.width=W; c.height=H; }
+      const x=c.getContext("2d"); x.clearRect(0,0,W,H);
+      const t=_lastTracks; if(!t || Date.now()-t.at>BOX_STALE_MS || v.hidden) return;
+      const r=videoContentRect(v,W,H), lw=Math.max(1.5,2*dpr), fpx=Math.max(10,Math.round(12*dpr));
+      x.font=`600 ${fpx}px system-ui,-apple-system,sans-serif`; x.textBaseline="top"; x.lineJoin="round";
+      const a=t.calibrating?0.55:1;
+      for(const tr of t.tracks||[]){ const [nx,ny,nw,nh]=tr.box||[]; if(!(nw>0&&nh>0)) continue;
+        const bx=r.x+nx*r.w, by=r.y+ny*r.h, bw=nw*r.w, bh=nh*r.h, hue=hueFor(tr.label||"object");
+        x.lineWidth=lw+2; x.strokeStyle=`rgba(0,0,0,${0.55*a})`; x.strokeRect(bx,by,bw,bh);
+        x.lineWidth=lw; x.strokeStyle=`hsla(${hue},85%,60%,${a})`; x.strokeRect(bx,by,bw,bh);
+        const txt=`${tr.label||"object"}${tr.id!=null?" #"+tr.id:""} ${Math.round((tr.score||0)*100)}%`;
+        const px=Math.round(fpx*0.45), py=Math.round(fpx*0.25), tw=x.measureText(txt).width, cwid=tw+px*2, chh=fpx+py*2;
+        const cx=Math.min(Math.max(0,bx),W-cwid), cy=by-chh>=0?by-chh:by;
+        x.fillStyle=`hsla(${hue},85%,45%,${0.92*a})`; x.fillRect(cx,cy,cwid,chh);
+        x.fillStyle=`rgba(255,255,255,${a})`; x.fillText(txt,cx+px,cy+py); } }
+    setInterval(()=>{ if(_boxesOn&&_lastTracks&&Date.now()-_lastTracks.at>BOX_STALE_MS){ _lastTracks=null; requestBoxes(); } },500);
+    (function(){ const b=$("camBoxesBtn"); if(b) b.addEventListener("click",e=>{ e.stopPropagation(); setBoxes(!_boxesOn); }); setBoxes(_boxesOn); })();
+
     function openCamScreen(cam,push=true){
       if(window._camScreenCam===cam) return;   // already here — no dup history
       window._camScreenCam=cam; _tl=null;      // stale timeline never drives the new camera
@@ -1716,7 +1770,7 @@
       const sr=$("suggestRow"); if(sr) sr.hidden=true;
       addMsg("Focused on "+cam+" — talk or type below, everything is scoped to this camera. ‹ Back returns to all cameras.","sys"); }
     function closeCamScreen(push=true){
-      window._camScreenCam=null;
+      window._camScreenCam=null; _lastTracks=null; requestBoxes();
       const inp=$("askInput"); if(inp) inp.placeholder="Type a question, e.g. how many people on cam1?";
       renderSuggestions();   // chips return on the all-cameras screen
       if(_liveTimer){clearInterval(_liveTimer);_liveTimer=null;}
@@ -2625,6 +2679,7 @@
       _updWs=ws;
       ws.onmessage=(ev)=>{ let d; try{ d=JSON.parse(ev.data); }catch{ return; }
         _updLive=true; _updBackoff=1500;
+        if(d.tracks) onTracks(d.tracks);
         if(d.working) onWorking(d.working);
         if(d.tasks) pollTasks(d.tasks);
         if(d.monitors) pollMonitors(d.monitors);

--- a/examples/camera-agent/pyproject.toml
+++ b/examples/camera-agent/pyproject.toml
@@ -24,6 +24,10 @@ dependencies = [
     "uvicorn>=0.27,<1.0",
     "PyYAML>=6.0,<7.0",
     "nats-py>=2.6",
+    # Core's /events/ws for the live detection overlay. Already pulled in
+    # transitively by pipecat and the App SDK; pinned here so the overlay
+    # cannot silently stop working if either of them drops it.
+    "websockets>=12,<18",
     "Pillow>=10.0",
     # App SDK convergence (app-sdk-spec §07): create_monitor's count/
     # crossing watches instantiate SDK detectors (the occupancy-counting

--- a/examples/camera-agent/tests/test_core_tracks_feed.py
+++ b/examples/camera-agent/tests/test_core_tracks_feed.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The demo's detection overlay is fed from core's /events/ws, not NATS.
+
+Core decides what is drawable; the agent relays and re-scopes. These
+pin the relay: the parser accepts exactly core's `tracks` shape, the
+runtime maps core's integer camera id to the agent's camera by
+opennvr_camera_id, and a viewer never receives a camera outside their
+scope.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from camera_agent import AppConfig, CameraAgentRuntime
+from context import CameraSpec, core_tracks_frame, set_camera_scope
+
+
+# ─── parser ─────────────────────────────────────────────────────────────
+
+
+def _ev(**over):
+    base = {"event_type": "tracks", "camera_id": 3, "task": "tier0",
+            "payload": {"calibrating": False,
+                        "tracks": [{"id": 5, "label": "person", "score": 0.9,
+                                    "box": [0.1, 0.1, 0.4, 0.4]}]}}
+    base.update(over)
+    return base
+
+
+def test_parses_a_core_tracks_event():
+    cam, frame = core_tracks_frame(_ev())
+    assert cam == 3
+    assert frame["calibrating"] is False
+    assert frame["tracks"][0]["box"] == [0.1, 0.1, 0.4, 0.4]
+    assert "source" not in frame
+
+
+def test_app_boxes_carry_their_source():
+    e = _ev(task="overlay")
+    e["payload"]["source"] = "app:license-plate-recognition"
+    _, frame = core_tracks_frame(e)
+    assert frame["source"] == "app:license-plate-recognition"
+
+
+def test_other_event_types_are_ignored():
+    assert core_tracks_frame(_ev(event_type="inference_result")) is None
+    assert core_tracks_frame(_ev(event_type="camera_status")) is None
+    assert core_tracks_frame({"event_type": "subscribed", "filters": {}}) is None
+
+
+def test_camera_id_must_be_an_integer():
+    assert core_tracks_frame(_ev(camera_id="cam3")) is None
+    assert core_tracks_frame(_ev(camera_id=None)) is None
+    assert core_tracks_frame(_ev(camera_id=True)) is None
+
+
+def test_empty_or_malformed_tracks_are_dropped():
+    e = _ev(); e["payload"]["tracks"] = []
+    assert core_tracks_frame(e) is None
+    e = _ev(); e["payload"]["tracks"] = ["junk", None]
+    assert core_tracks_frame(e) is None
+    assert core_tracks_frame("not a dict") is None
+
+
+def test_the_agent_does_not_re_normalize():
+    """Boxes come out exactly as core sent them — the maths lives in one
+    place now. A pixel-looking box is passed through untouched too;
+    core would never send one, and the agent must not guess."""
+    e = _ev(); e["payload"]["tracks"][0]["box"] = [192, 108, 960, 540]
+    _, frame = core_tracks_frame(e)
+    assert frame["tracks"][0]["box"] == [192, 108, 960, 540]
+
+
+# ─── relay + scope ──────────────────────────────────────────────────────
+
+
+def _runtime():
+    cfg = AppConfig(
+        kaic_url="http://k", kaic_api_key="x", system_prompt="t",
+        cameras=[
+            CameraSpec(camera_id="front-door", frame_url="http://x/1.jpg", role="f",
+                       opennvr_camera_id=3),
+            CameraSpec(camera_id="garage", frame_url="http://x/2.jpg", role="g",
+                       opennvr_camera_id=7),
+        ],
+    )
+    return CameraAgentRuntime(cfg)
+
+
+def test_relay_maps_core_id_to_the_agent_camera():
+    rt = _runtime()
+    q = rt.subscribe_updates()
+    rt._relay_tracks(3, {"calibrating": False, "tracks": [{"label": "person", "box": [0, 0, 1, 1]}]})
+    pushed = q.get_nowait()
+    assert pushed["tracks"]["camera"] == "front-door"
+    assert pushed["tracks"]["tracks"][0]["label"] == "person"
+
+
+def test_relay_drops_cameras_this_agent_does_not_know():
+    rt = _runtime()
+    q = rt.subscribe_updates()
+    rt._relay_tracks(99, {"calibrating": False, "tracks": [{"label": "x", "box": [0, 0, 1, 1]}]})
+    assert q.empty()
+
+
+def test_updates_socket_filters_tracks_by_the_viewers_scope():
+    """The re-scoping the service ticket relies on. The /updates handler
+    drops a tracks push whose camera is outside the session's scope; this
+    exercises the same predicate the handler uses."""
+    from camera_agent import _tracks_push_visible
+
+    set_camera_scope({"front-door"})
+    try:
+        assert _tracks_push_visible({"tracks": {"camera": "front-door"}}) is True
+        assert _tracks_push_visible({"tracks": {"camera": "garage"}}) is False
+        assert _tracks_push_visible({"working": "x"}) is True        # not a tracks push
+    finally:
+        set_camera_scope(None)
+    assert _tracks_push_visible({"tracks": {"camera": "garage"}}) is True   # unscoped session

--- a/sdk/opennvr-app-sdk/docs_src/reference/events.md
+++ b/sdk/opennvr-app-sdk/docs_src/reference/events.md
@@ -36,6 +36,8 @@ runs, free to consume.
 
 ::: opennvr_app_sdk.OccupancyFootfall
 
+::: opennvr_app_sdk.OverlayBoxes
+
 ::: opennvr_app_sdk.Tier0Snapshot
 
 ::: opennvr_app_sdk.snapshot_from_event

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/__init__.py
@@ -99,7 +99,7 @@ from .domain_subscriber import (
 )
 from .egress import connect_via_proxy, proxy_address
 from .event_types import (
-    EVENT_TYPES, AccessDecided, DetectionObserved, OccupancyChanged, OccupancyFootfall,
+    EVENT_TYPES, AccessDecided, DetectionObserved, OccupancyChanged, OccupancyFootfall, OverlayBoxes,
     OccupancyHeatmap, PlateRecognized, TypedPayload, VisitRecorded, typed_payload,
 )
 from .tier0 import (
@@ -235,6 +235,7 @@ EVENTS: tuple[str, ...] = (
     "OccupancyChanged",
     "OccupancyHeatmap",
     "OccupancyFootfall",
+    "OverlayBoxes",
     "Tier0Snapshot",
     "snapshot_from_event",
     "tier0_to_detections",

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_events.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/domain_events.py
@@ -116,5 +116,20 @@ class DomainEventPublisher:
         return self.publish(type(payload).SCHEMA, camera_id=camera_id,
                             payload=payload.to_payload(), correlation_id=correlation_id)
 
+    def publish_overlay(self, camera_id: str, boxes: list[dict[str, Any]], *,
+                        frame: dict[str, int] | None = None,
+                        seq: int | None = None) -> bool:
+        """Ask core to draw ``boxes`` over ``camera_id``'s live video.
+
+        Sugar over ``publish_typed(OverlayBoxes(...))``. Drawn only if the
+        operator enabled this app's overlay in the App Catalog; otherwise
+        the event is published and ignored, so an app can call this
+        unconditionally. Never raises on bus trouble."""
+        from .event_types import OverlayBoxes
+
+        return self.publish_typed(
+            OverlayBoxes(boxes=list(boxes), frame=frame, seq=seq),
+            camera_id=camera_id)
+
     def close(self) -> None:
         self._channel.close()

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/event_types.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/event_types.py
@@ -194,6 +194,27 @@ class OccupancyHeatmap(TypedPayload):
 
 
 @dataclass(frozen=True)
+class OverlayBoxes(TypedPayload):
+    """``overlay.boxes.v1`` — boxes an app wants drawn over the live video.
+
+    ``boxes`` entries are ``{"label", "box": [x, y, w, h], "score"?, "id"?}``
+    with ``box`` normalized to 0..1 of the frame — an app never knows the
+    resolution the operator is watching at, and core draws over streams
+    of every size. Send ``frame: {w, h}`` if your boxes are in pixels and
+    core will normalize; send nothing drawable and nothing is drawn.
+
+    Whether it IS drawn is the operator's call, per app, in the App
+    Catalog (off by default). Publishing costs nothing when it is off.
+    """
+
+    SCHEMA: ClassVar[str] = "overlay.boxes.v1"
+    REQUIRED: ClassVar[tuple[str, ...]] = ("boxes",)
+    boxes: list[dict[str, Any]] = field(default_factory=list)
+    frame: dict[str, int] | None = None
+    seq: int | None = None
+
+
+@dataclass(frozen=True)
 class OccupancyFootfall(TypedPayload):
     """``occupancy.footfall.v1`` — entries, exits and finished stays since the last publish."""
 
@@ -213,7 +234,7 @@ class OccupancyFootfall(TypedPayload):
 EVENT_TYPES: dict[str, type[TypedPayload]] = {
     cls.SCHEMA: cls for cls in (
         DetectionObserved, VisitRecorded, PlateRecognized, AccessDecided,
-        OccupancyChanged, OccupancyHeatmap, OccupancyFootfall,
+        OccupancyChanged, OccupancyHeatmap, OccupancyFootfall, OverlayBoxes,
     )
 }
 

--- a/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
+++ b/sdk/opennvr-app-sdk/opennvr_app_sdk/manifest.py
@@ -235,6 +235,11 @@ class AppManifest:
     # this app's GET /state payload. Empty ⇒ the catalog shows raw
     # state JSON as before.
     state_schema: list[StateView] = field(default_factory=list)
+    # Declares that this app publishes overlay.boxes.v1 (boxes to draw
+    # over the live video). Informational: the catalog shows an Overlay
+    # switch for apps that declare it. The switch, not the flag, decides
+    # whether anything is drawn — that is the operator's, per app.
+    overlay: bool = False
     # Declarative operator actions (optional) — verbs the catalog can
     # invoke on the app's contract surface via the server's JWT-only
     # proxy. Empty ⇒ no Actions section renders.
@@ -326,6 +331,7 @@ class AppManifest:
             "emits": [a.to_dict() for a in self.emits],
             "state_schema": [v.to_dict() for v in self.state_schema],
             "actions": [a.to_dict() for a in self.actions],
+            "overlay": bool(self.overlay),
             "has_ui": bool(self.has_ui),
             "ui_mode": self.ui_mode,
             "ui_url": self.ui_url,

--- a/sdk/opennvr-app-sdk/tests/test_event_types.py
+++ b/sdk/opennvr-app-sdk/tests/test_event_types.py
@@ -10,7 +10,7 @@ import pytest
 
 from opennvr_app_sdk import (
     EVENT_TYPES, AccessDecided, DetectionObserved, OccupancyChanged, OccupancyFootfall,
-    OccupancyHeatmap, PlateRecognized, VisitRecorded, typed_payload,
+    OccupancyHeatmap, OverlayBoxes, PlateRecognized, VisitRecorded, typed_payload,
 )
 from opennvr_app_sdk.domain_events import DomainEventPublisher
 from opennvr_app_sdk.domain_subscriber import parse_domain_event
@@ -32,6 +32,8 @@ def test_every_v1_contract_is_typed_and_round_trips():
                            "period_seconds": 60, "labels": ["person"]},
         OccupancyFootfall: {"entries": 3, "exits": 1, "dwell_count": 2, "dwell_seconds": 41.5,
                             "dwell_max_seconds": 30.0, "period_seconds": 60, "labels": ["person"]},
+        OverlayBoxes: {"boxes": [{"label": "plate", "box": [0.1, 0.2, 0.3, 0.1], "score": 0.9}],
+                       "frame": {"w": 1920, "h": 1080}, "seq": 4},
     }
     assert set(EVENT_TYPES) == {c.SCHEMA for c in samples}
     for cls, payload in samples.items():

--- a/sdk/opennvr-app-sdk/tests/test_overlay_boxes.py
+++ b/sdk/opennvr-app-sdk/tests/test_overlay_boxes.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""overlay.boxes.v1 — the typed payload and the publisher sugar."""
+from opennvr_app_sdk.event_types import EVENT_TYPES, OverlayBoxes, typed_payload
+from opennvr_app_sdk.domain_events import DomainEventPublisher
+
+
+def test_schema_is_registered():
+    assert EVENT_TYPES["overlay.boxes.v1"] is OverlayBoxes
+
+
+def test_round_trip_keeps_boxes_and_extra():
+    p = OverlayBoxes(boxes=[{"label": "plate", "box": [0.1, 0.2, 0.3, 0.1]}],
+                     frame={"w": 1920, "h": 1080}, seq=4)
+    wire = p.to_payload()
+    back = typed_payload("overlay.boxes.v1", {**wire, "vendor_note": "x"})
+    assert isinstance(back, OverlayBoxes)
+    assert back.boxes == p.boxes and back.frame == p.frame and back.seq == 4
+    assert back.extra == {"vendor_note": "x"}
+
+
+def test_boxes_is_required():
+    assert typed_payload("overlay.boxes.v1", {"frame": {"w": 1, "h": 1}}) is None
+
+
+def test_publish_overlay_publishes_the_typed_event(monkeypatch):
+    sent = []
+    pub = DomainEventPublisher.__new__(DomainEventPublisher)
+    pub._producer = "app:anpr"
+    class _Ch:
+        def publish_json(self, subject, envelope):
+            sent.append((subject, envelope)); return True
+    pub._channel = _Ch()
+    ok = pub.publish_overlay("cam3", [{"label": "plate", "box": [0, 0, 0.5, 0.5]}],
+                             frame={"w": 100, "h": 100}, seq=1)
+    assert ok is True
+    subject, env = sent[0]
+    assert subject == "opennvr.events.overlay.boxes.v1.cam3"
+    assert env["payload"]["boxes"][0]["label"] == "plate"
+    assert env["payload"]["frame"] == {"w": 100, "h": 100}

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -344,6 +344,14 @@ class Settings(BaseSettings):
     # when on, the web app never runs Docker: it writes a desired-state row and
     # a separate reconciler applies it. See docs/APPS_INSTALL.md.
     apps_install_enabled: bool = False
+    # Live detection overlay: bridge Tier-0 tracks (and any app that
+    # publishes overlay.boxes.v1) onto the WebSocket so the UI can draw
+    # boxes over the video. ON by default — the picture is unchanged
+    # either way, this only decides whether the DATA flows. Off silences
+    # it for every consumer at once: the Live View, the agent, the API.
+    # Whether a given screen DRAWS it is a per-viewer choice on that
+    # screen. Audit-logged at boot with the rest of the posture.
+    detection_overlay_enabled: bool = True
 
     # Self-service sign-up (``POST /auth/register`` → a viewer account).
     # Off by default: an NVR's users are created by its administrator

--- a/server/main.py
+++ b/server/main.py
@@ -120,7 +120,8 @@ async def lifespan(app: FastAPI):
         posture = current_posture()
         main_logger.info(
             f"Boot policy: deployment_mode={posture['deployment_mode']} "
-            f"ai_sovereignty={posture['ai_sovereignty']}"
+            f"ai_sovereignty={posture['ai_sovereignty']} "
+            f"detection_overlay={'on' if settings.detection_overlay_enabled else 'OFF'}"
         )
         audit_boot_posture()
         # Warn loudly if the retired ALLOW_REMOTE_MEDIAMTX env var is still set

--- a/server/migrations/versions/e8a1b2c3d4f5_add_installed_apps_overlay_enabled.py
+++ b/server/migrations/versions/e8a1b2c3d4f5_add_installed_apps_overlay_enabled.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""installed_apps.overlay_enabled — may this app draw on the live video?
+
+Apps can publish ``overlay.boxes.v1`` (plate boxes from ANPR, zones
+from occupancy). Whether those boxes are DRAWN over the operator's live
+view is the operator's call, per app, off by default: an app painting
+on the screen is a privilege granted in the catalog, not a side effect
+of being installed.
+
+Revision ID: e8a1b2c3d4f5
+Revises: d7f1c4b820ae
+Create Date: 2026-09-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e8a1b2c3d4f5"
+down_revision = "d7f1c4b820ae"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("installed_apps") as batch:
+        batch.add_column(
+            sa.Column(
+                "overlay_enabled",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("installed_apps") as batch:
+        batch.drop_column("overlay_enabled")

--- a/server/models.py
+++ b/server/models.py
@@ -1131,6 +1131,10 @@ class InstalledApp(Base):
     manifest_json = Column(JSON, nullable=False)
     config_json = Column(JSON, nullable=False, default=dict)
     enabled = Column(Boolean, default=False, nullable=False)
+    # Operator opt-in: may this app's overlay.boxes.v1 events be drawn
+    # over the live video? Off by default — an app drawing on the
+    # operator's screen is a privilege the operator grants, per app.
+    overlay_enabled = Column(Boolean, default=False, nullable=False, server_default="0")
     # registered | ok | unreachable
     status = Column(String(20), nullable=False, default="registered")
     last_seen = Column(DateTime(timezone=True), nullable=True)

--- a/server/routers/apps.py
+++ b/server/routers/apps.py
@@ -667,6 +667,7 @@ def _serialize_app(row: InstalledApp) -> dict[str, Any]:
         # Network: what the listing declared, what the operator allowed,
         # what the proxy refused — services/app_egress.py.
         "egress": egress_view(row),
+        "overlay_enabled": bool(getattr(row, "overlay_enabled", False)),
     }
 
 
@@ -941,6 +942,30 @@ def _registry_info() -> dict[str, Any]:
     if settings.nats_apps_url:
         info["bus"] = {"url": settings.nats_apps_url, "auth": "app_key"}
     return info
+
+
+class OverlayToggle(BaseModel):
+    enabled: bool
+
+
+@router.put("/{app_id}/overlay")
+async def set_app_overlay(
+    app_id: str,
+    payload: OverlayToggle,
+    current_user: User = Depends(get_current_superuser),
+    db: Session = Depends(get_db),
+):
+    """Allow (or stop allowing) this app's ``overlay.boxes.v1`` events to
+    be drawn over the live video. Superuser: an app painting on every
+    operator's screen is a site decision. The app itself is untouched —
+    it keeps publishing; the bridge just stops forwarding."""
+    row = _get_app_or_404(db, app_id)
+    row.overlay_enabled = bool(payload.enabled)
+    db.commit()
+    logger.info("app overlay %s: %s by %s",
+                "enabled" if payload.enabled else "disabled",
+                app_id, current_user.username)
+    return _serialize_app(row)
 
 
 @router.post("/{app_id}/enable")

--- a/server/routers/events.py
+++ b/server/routers/events.py
@@ -49,13 +49,14 @@ import secrets
 import time
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect, status
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
 from sqlalchemy.orm import Session
 
 from core.auth import get_current_active_user
 from core.database import get_db
 from core.logging_config import main_logger
 from models import User
+from routers.apps import get_read_principal
 from services.camera_scope import visible_camera_ids
 from services.event_bus_service import get_event_bus
 
@@ -74,7 +75,32 @@ router = APIRouter()
 # multiple workers, move this to a shared store (e.g. Redis).
 # ---------------------------------------------------------------------------
 _WS_TICKET_TTL_SECONDS = 30
-_ws_tickets: dict[str, tuple[str, float]] = {}  # ticket -> (username, expires_at)
+# ticket -> (username | None, expires_at). None = a platform SERVICE
+# identity (the deployment's INTERNAL_API_KEY): no user row, no camera
+# scope. Minted for trusted in-stack consumers — the camera agent relays
+# core's overlay tracks to its own viewers and scopes them itself.
+_ws_tickets: dict[str, tuple[str | None, float]] = {}
+
+
+class ServiceIdentity:
+    """The WS-side stand-in for a service ticket. Shaped like the two
+    User attributes the stream reads (``username`` for the log line,
+    ``is_active`` for the gate) so the handler needs no isinstance
+    branching beyond the scope decision."""
+
+    username = "service:internal"
+    is_active = True
+    is_superuser = True   # unrestricted scope, same as a superuser
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<ServiceIdentity>"
+
+
+SERVICE = ServiceIdentity()
+
+#: Sentinel distinguishing "ticket found, it is a service ticket" from
+#: "no such ticket" — both would otherwise be None.
+_SERVICE_TICKET = object()
 
 
 def _prune_ws_tickets(now: float) -> None:
@@ -82,7 +108,8 @@ def _prune_ws_tickets(now: float) -> None:
         _ws_tickets.pop(tok, None)
 
 
-def _mint_ws_ticket(username: str) -> tuple[str, int]:
+def _mint_ws_ticket(username: str | None) -> tuple[str, int]:
+    """``username=None`` mints a SERVICE ticket."""
     now = time.time()
     _prune_ws_tickets(now)
     ticket = secrets.token_urlsafe(32)
@@ -90,43 +117,86 @@ def _mint_ws_ticket(username: str) -> tuple[str, int]:
     return ticket, _WS_TICKET_TTL_SECONDS
 
 
-def _consume_ws_ticket(ticket: str) -> str | None:
-    """Validate and *consume* a ticket (single use); return its username or None."""
+def _consume_ws_ticket(ticket: str):
+    """Validate and *consume* a ticket (single use).
+
+    Returns the username for a user ticket, ``_SERVICE_TICKET`` for a
+    service ticket, or ``None`` when the ticket is unknown or expired —
+    three outcomes, because a service ticket has no username and must
+    not be mistaken for a missing one.
+    """
     entry = _ws_tickets.pop(ticket, None)  # pop() => cannot be replayed
     if entry is None:
         return None
     username, expires_at = entry
     if expires_at <= time.time():
         return None
-    return username
+    return _SERVICE_TICKET if username is None else username
 
 
 @router.post("/events/ws-ticket")
-async def create_ws_ticket(current_user: User = Depends(get_current_active_user)):
+async def create_ws_ticket(principal=Depends(get_read_principal)):
     """Mint a short-lived, single-use ticket for opening the events WebSocket.
 
-    The client (which cannot set an Authorization header on a WebSocket) calls
-    this authenticated endpoint, then opens ``/events/ws?ticket=<ticket>``.
+    A browser cannot set an Authorization header on a WebSocket, so it
+    calls this authenticated endpoint first, then opens
+    ``/events/ws?ticket=<ticket>``.
+
+    Three credentials are accepted, and they yield different tickets:
+
+    * a user JWT → a ticket bound to that user; the stream is scoped to
+      the cameras they may see (``visible_camera_ids``);
+    * the deployment's ``INTERNAL_API_KEY`` → a SERVICE ticket, unscoped.
+      For trusted in-stack consumers only: the camera agent relays core's
+      overlay tracks to its own viewers and applies its own per-viewer
+      scope, the same way it does for everything else it shows;
+    * an app key → refused (403). An installed app is not a platform
+      service; its own view of the bus is what the SDK gives it.
     """
-    ticket, ttl = _mint_ws_ticket(current_user.username)
-    return {"ticket": ticket, "expires_in": ttl}
+    from services.app_keys import AppPrincipal
+
+    if isinstance(principal, AppPrincipal):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="An app key cannot open the site-wide event stream",
+        )
+    if principal is None:
+        ticket, ttl = _mint_ws_ticket(None)
+        return {"ticket": ticket, "expires_in": ttl, "kind": "service"}
+    ticket, ttl = _mint_ws_ticket(principal.username)
+    return {"ticket": ticket, "expires_in": ttl, "kind": "user"}
 
 
-def _authenticate_ws(ticket: str | None, db: Session) -> User | None:
+def _authenticate_ws(ticket: str | None, db: Session) -> User | ServiceIdentity | None:
     """Authenticate a WS handshake using a single-use ticket.
 
     We deliberately do NOT raise here — the caller closes the socket with a
-    proper code so the client sees a clean rejection.
+    proper code so the client sees a clean rejection. A service ticket
+    yields ``SERVICE`` without touching the users table.
     """
     if not ticket:
         return None
-    username = _consume_ws_ticket(ticket)
-    if not username:
+    subject = _consume_ws_ticket(ticket)
+    if subject is None:
         return None
-    user = db.query(User).filter(User.username == username).first()
+    if subject is _SERVICE_TICKET:
+        return SERVICE
+    user = db.query(User).filter(User.username == subject).first()
     if user is None or not user.is_active:
         return None
     return user
+
+
+def _ws_scope_for(principal, db: Session) -> set[int] | None:
+    """Cameras this socket may receive events for; ``None`` = unrestricted.
+
+    Factored out so the decision is testable on its own: a service
+    identity is unrestricted (it re-scopes downstream), a user gets
+    exactly ``visible_camera_ids`` — a superuser's ``None`` included.
+    """
+    if principal is SERVICE:
+        return None
+    return visible_camera_ids(db, principal)
 
 
 @router.websocket("/events/ws")
@@ -194,7 +264,7 @@ async def events_stream(
         # against a detached instance works only for as long as its
         # attributes happen to still be loaded. Not a gamble worth taking
         # on an authorization path.
-        allowed = visible_camera_ids(db, user) if user is not None else set()
+        allowed = _ws_scope_for(user, db) if user is not None else set()
     finally:
         # Mirror FastAPI's get_db teardown without relying on Depends here
         # (WebSocket routes can't use Depends() for request-scoped DB sessions

--- a/server/services/event_bus_service.py
+++ b/server/services/event_bus_service.py
@@ -247,6 +247,7 @@ async def publish_tracks(
     *,
     camera_id: int,
     payload: dict[str, Any],
+    task: str = "tier0",
 ) -> None:
     """Publish one frame's worth of Tier-0 tracks (normalized boxes, see
     services/tier0_track_consumer.py) for live overlays. Carries a
@@ -256,7 +257,9 @@ async def publish_tracks(
     await get_event_bus().publish({
         "event_type": EVENT_TRACKS,
         "camera_id": camera_id,
-        "task": "tier0",
+        # "tier0" for the platform detector, "overlay" for an app's boxes —
+        # the WS task filter lets a client take either or both.
+        "task": task,
         "payload": payload,
     })
 

--- a/server/services/tier0_track_consumer.py
+++ b/server/services/tier0_track_consumer.py
@@ -35,6 +35,16 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 SUBJECT = "opennvr.inference.tier0.*.completed"
+#: Apps publish their own boxes here (SDK OverlayBoxes / overlay.boxes.v1):
+#: ANPR's plate localisations, occupancy's zones. Same wire shape out —
+#: the browser draws one kind of thing — but forwarded ONLY for apps the
+#: operator switched on in the catalog (installed_apps.overlay_enabled).
+APP_SUBJECT = "opennvr.events.overlay.boxes.v1.>"
+#: How long a "may this app draw?" answer is trusted before the DB is
+#: asked again. Overlay frames arrive many times a second; the toggle
+#: changes a few times a year.
+_APP_ALLOW_TTL_S = 15.0
+_app_allow_cache: dict[str, tuple[float, bool]] = {}
 
 #: Reconnect cadence after a connect/subscribe failure — one warning a
 #: minute for a down bus, not a hot loop.
@@ -148,11 +158,111 @@ async def _handle_message(msg) -> None:
                 "tier0 track consumer: dropped payload #%d (%s)", _dropped, exc)
 
 
+def _app_may_draw(app_id: str, now: float | None = None) -> bool:
+    """installed_apps.overlay_enabled for ``app_id``, cached briefly. A
+    missing row, a DB error, or a blank id all answer False — an app
+    draws only when the operator demonstrably said so."""
+    import time as _time
+
+    key = str(app_id or "").strip().lower()
+    if not key:
+        return False
+    now = _time.monotonic() if now is None else now
+    hit = _app_allow_cache.get(key)
+    if hit and now - hit[0] < _APP_ALLOW_TTL_S:
+        return hit[1]
+    allowed = False
+    try:
+        from core.database import SessionLocal
+        from models import InstalledApp
+
+        db = SessionLocal()
+        try:
+            row = db.query(InstalledApp.overlay_enabled, InstalledApp.enabled).filter(
+                InstalledApp.id == key).first()
+            allowed = bool(row and row[0] and row[1])
+        finally:
+            db.close()
+    except Exception:  # noqa: BLE001
+        logger.debug("overlay: could not read overlay_enabled for %s", key,
+                     exc_info=True)
+        allowed = False
+    _app_allow_cache[key] = (now, allowed)
+    return allowed
+
+
+def _invalidate_app_allow_cache() -> None:
+    _app_allow_cache.clear()
+
+
+def _xywh_to_xyxy(box: Any) -> list[float] | None:
+    """``[x, y, w, h]`` → ``[x1, y1, x2, y2]`` in the same units; None if
+    it is not four numbers. Width/height ≤ 0 stays and is rejected by
+    normalize_box as zero-area."""
+    try:
+        x, y, w, h = (float(v) for v in box)
+    except (TypeError, ValueError):
+        return None
+    return [x, y, x + w, y + h]
+
+
+async def _handle_app_message(msg) -> None:
+    """An app's overlay.boxes.v1 envelope → the same `tracks` event the
+    Tier-0 path emits, tagged with its source, if the operator allowed
+    that app to draw. Boxes arrive already normalized per the contract;
+    normalize_box still runs so a pixel-space slip is caught, not drawn."""
+    global _dropped
+    try:
+        env = json.loads(msg.data)
+        if not isinstance(env, dict):
+            raise ValueError("envelope is not an object")
+        payload = env.get("payload") if isinstance(env.get("payload"), dict) else env
+        app_id = str(env.get("producer") or payload.get("app_id") or "").strip()
+        # Producer id may arrive as "app:<id>" from the SDK envelope.
+        if app_id.startswith("app:"):
+            app_id = app_id[4:]
+        if not _app_may_draw(app_id):
+            return
+        from services.camera_scope import camera_id_from_handle
+
+        camera_id = camera_id_from_handle(env.get("camera_id") or payload.get("camera_id"))
+        if camera_id is None:
+            parts = str(getattr(msg, "subject", "")).split(".")
+            camera_id = camera_id_from_handle(parts[-1]) if parts else None
+        if camera_id is None:
+            raise ValueError("unmappable camera_id")
+        raw = {"frame": payload.get("frame") or {},
+               "calibrating": False,
+               "seq": payload.get("seq"), "wall_ts": env.get("ts") or payload.get("wall_ts"),
+               # The app contract is [x, y, w, h]; Tier-0's is [x1, y1, x2, y2]
+               # and normalize_box speaks the latter. Convert here — feeding
+               # xywh straight in silently produced boxes of the wrong size.
+               "tracks": [{"id": b.get("id"), "label": b.get("label"),
+                           "score": b.get("score", 1.0),
+                           "box": _xywh_to_xyxy(b.get("box"))}
+                          for b in (payload.get("boxes") or []) if isinstance(b, dict)]}
+        out = to_overlay_payload(raw, min_score=0.0)
+        if out is None:
+            return
+        out["source"] = f"app:{app_id}"
+        from services.event_bus_service import publish_tracks
+
+        await publish_tracks(camera_id=camera_id, payload=out, task="overlay")
+    except Exception as exc:  # noqa: BLE001
+        _dropped += 1
+        if _dropped in (1, 10, 100) or _dropped % 1000 == 0:
+            logger.warning("overlay consumer: dropped app payload #%d (%s)", _dropped, exc)
+
+
 async def run_consumer_loop() -> None:
     """Subscribe to Tier-0 completions for the process lifetime. Returns
     immediately when no NATS URL is configured; retries slowly otherwise."""
     from core.config import settings
 
+    if not bool(getattr(settings, "detection_overlay_enabled", True)):
+        logger.info("detection overlay disabled by DETECTION_OVERLAY_ENABLED "
+                    "— no track data will reach any consumer")
+        return
     url = (getattr(settings, "nats_url", "") or "").strip()
     if not url:
         logger.info("tier0 track consumer disabled (no NATS_URL) — "
@@ -167,16 +277,20 @@ async def run_consumer_loop() -> None:
     token = (getattr(settings, "internal_api_key", "") or "").strip() or None
 
     while True:
-        client = sub = None
+        client = sub = app_sub = None
         try:
             client = await nats.connect(url, connect_timeout=5, token=token)
             sub = await client.subscribe(SUBJECT, cb=_handle_message)
-            logger.info("tier0 track consumer subscribed to %s", SUBJECT)
+            app_sub = await client.subscribe(APP_SUBJECT, cb=_handle_app_message)
+            logger.info("tier0 track consumer subscribed to %s and %s",
+                        SUBJECT, APP_SUBJECT)
             await asyncio.Event().wait()
         except asyncio.CancelledError:
+            await _teardown(app_sub, None)
             await _teardown(sub, client)
             raise
         except Exception as exc:  # noqa: BLE001
+            await _teardown(app_sub, None)
             await _teardown(sub, client)
             logger.warning(
                 "tier0 track consumer: connect/subscribe failed (%s); "

--- a/server/tests/test_event_ws_service_ticket.py
+++ b/server/tests/test_event_ws_service_ticket.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 OpenNVR
+# Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+"""Service tickets for /events/ws — and proof that user tickets are
+unchanged by their existence.
+
+The camera agent consumes core's overlay tracks over this socket (one
+source of truth for the site switch, the per-app permission and the
+box maths) and re-scopes them per viewer itself. It authenticates with
+the deployment's INTERNAL_API_KEY, which mints an UNSCOPED ticket.
+Everything a user ticket did before — bound to a row, active only,
+scoped to visible cameras, single use, expiring — must still hold, and
+an app key must not be able to open the site-wide stream at all.
+"""
+import os
+import sys
+import time
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost/x")
+os.environ.setdefault("CREDENTIAL_ENCRYPTION_KEY", Fernet.generate_key().decode())
+os.environ.setdefault("INTERNAL_API_KEY", "x" * 48)
+os.environ.setdefault("SECRET_KEY", "s" * 64)
+os.environ.setdefault("MEDIAMTX_SECRET", "m" * 48)
+
+from core.database import Base  # noqa: E402
+from models import Role, User  # noqa: E402
+# `routers/__init__` re-exports the ROUTER under the name `events`, so
+# `from routers import events` would hand back an APIRouter; take the
+# module itself.
+import importlib  # noqa: E402
+
+ev = importlib.import_module("routers.events")
+from routers.apps import get_read_principal  # noqa: E402
+from services.app_keys import AppPrincipal  # noqa: E402
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://")
+    # Every table, not a subset: _ws_scope_for walks cameras and
+    # camera_permissions, and users.role_id is NOT NULL.
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    role = Role(name="viewer")
+    s.add(role)
+    s.commit()
+    s.info["role_id"] = role.id
+    yield s
+    s.close()
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_tickets():
+    ev._ws_tickets.clear()
+    yield
+    ev._ws_tickets.clear()
+
+
+def _user(db, name="alice", active=True, superuser=False):
+    u = User(username=name, email=f"{name}@x", hashed_password="h",
+             is_active=active, is_superuser=superuser,
+             role_id=db.info["role_id"])
+    db.add(u)
+    db.commit()
+    return u
+
+
+# ─── tickets ────────────────────────────────────────────────────────────
+
+
+def test_user_ticket_resolves_to_the_user_row(db):
+    _user(db, "alice")
+    t, _ = ev._mint_ws_ticket("alice")
+    who = ev._authenticate_ws(t, db)
+    assert isinstance(who, User) and who.username == "alice"
+
+
+def test_service_ticket_resolves_without_a_user_row(db):
+    t, _ = ev._mint_ws_ticket(None)
+    assert ev._authenticate_ws(t, db) is ev.SERVICE
+
+
+def test_service_ticket_is_not_mistaken_for_a_missing_one(db):
+    """The consume step has THREE outcomes now; the service one must not
+    collapse into 'unknown ticket'."""
+    t, _ = ev._mint_ws_ticket(None)
+    assert ev._consume_ws_ticket(t) is ev._SERVICE_TICKET
+    assert ev._consume_ws_ticket(t) is None          # single use, like before
+    assert ev._consume_ws_ticket("nope") is None
+
+
+def test_tickets_are_single_use_and_expire(db):
+    _user(db, "alice")
+    t, _ = ev._mint_ws_ticket("alice")
+    assert ev._authenticate_ws(t, db) is not None
+    assert ev._authenticate_ws(t, db) is None        # replay refused
+    t2, _ = ev._mint_ws_ticket(None)
+    ev._ws_tickets[t2] = (None, time.time() - 1)     # force expiry
+    assert ev._authenticate_ws(t2, db) is None
+
+
+def test_inactive_user_ticket_is_refused(db):
+    _user(db, "bob", active=False)
+    t, _ = ev._mint_ws_ticket("bob")
+    assert ev._authenticate_ws(t, db) is None
+
+
+def test_unknown_username_ticket_is_refused(db):
+    t, _ = ev._mint_ws_ticket("ghost")
+    assert ev._authenticate_ws(t, db) is None
+
+
+# ─── scope ──────────────────────────────────────────────────────────────
+
+
+def test_service_is_unrestricted_but_a_user_is_scoped(db):
+    """The whole point, and the whole risk: the service identity gets
+    None (everything), an ordinary user gets exactly their cameras."""
+    alice = _user(db, "alice")
+    assert ev._ws_scope_for(ev.SERVICE, db) is None
+    scoped = ev._ws_scope_for(alice, db)
+    assert scoped == set()        # no cameras owned or granted → nothing
+
+
+def test_superuser_stays_unrestricted(db):
+    root = _user(db, "root", superuser=True)
+    assert ev._ws_scope_for(root, db) is None
+
+
+# ─── the mint endpoint ──────────────────────────────────────────────────
+
+
+def _client(principal_factory):
+    app = FastAPI()
+    app.include_router(ev.router)
+    app.dependency_overrides[get_read_principal] = principal_factory
+    return TestClient(app)
+
+
+def test_user_jwt_mints_a_user_ticket(db):
+    _user(db, "alice")
+    c = _client(lambda: SimpleNamespace(username="alice"))
+    body = c.post("/events/ws-ticket").json()
+    assert body["kind"] == "user"
+    assert ev._authenticate_ws(body["ticket"], db).username == "alice"
+
+
+def test_internal_key_mints_a_service_ticket(db):
+    c = _client(lambda: None)                      # None = service identity
+    body = c.post("/events/ws-ticket").json()
+    assert body["kind"] == "service"
+    assert ev._authenticate_ws(body["ticket"], db) is ev.SERVICE
+
+
+def test_app_key_cannot_mint_a_ticket_at_all():
+    """An installed app is not a platform service. Its view of the bus is
+    what the SDK gives it, not the operator's site-wide stream."""
+    c = _client(lambda: AppPrincipal(app_id="loitering-detection"))
+    r = c.post("/events/ws-ticket")
+    assert r.status_code == 403
+    assert ev._ws_tickets == {}
+
+
+def test_response_shape_is_backward_compatible(db):
+    """Existing browser clients read `ticket` and `expires_in`; `kind` is
+    additive."""
+    _user(db, "alice")
+    c = _client(lambda: SimpleNamespace(username="alice"))
+    body = c.post("/events/ws-ticket").json()
+    assert {"ticket", "expires_in"} <= set(body)
+    assert body["expires_in"] == ev._WS_TICKET_TTL_SECONDS

--- a/server/tests/test_tier0_track_consumer.py
+++ b/server/tests/test_tier0_track_consumer.py
@@ -186,3 +186,131 @@ def test_tracks_events_are_subject_to_camera_entitlement():
                       allowed_camera_ids=frozenset({1}))
     assert sub.matches({"event_type": "tracks", "camera_id": 1}) is True
     assert sub.matches({"event_type": "tracks", "camera_id": 3}) is False
+
+
+# ─── app overlay path + site switch ─────────────────────────────────────
+
+
+def _app_msg(app="license-plate-recognition", cam="cam3", boxes=None, producer=None):
+    env = {"schema": "overlay.boxes.v1", "camera_id": cam,
+           "producer": producer if producer is not None else f"app:{app}",
+           "ts": 1.0,
+           "payload": {"boxes": boxes if boxes is not None else
+                       [{"label": "plate", "box": [0.2, 0.3, 0.1, 0.05], "score": 0.9}]}}
+    return SimpleNamespace(subject=f"opennvr.events.overlay.boxes.v1.{cam}",
+                           data=json.dumps(env).encode())
+
+
+def _run_app(msg, monkeypatch, *, allowed):
+    bus = _Bus()
+    from services import event_bus_service
+    monkeypatch.setattr(event_bus_service, "get_event_bus", lambda: bus)
+    monkeypatch.setattr(tc, "_app_may_draw", lambda app_id, now=None: allowed)
+    asyncio.run(tc._handle_app_message(msg))
+    return bus.published
+
+
+def test_app_boxes_are_forwarded_when_the_operator_allowed_it(monkeypatch):
+    out = _run_app(_app_msg(), monkeypatch, allowed=True)
+    assert len(out) == 1
+    ev = out[0]
+    assert ev["event_type"] == "tracks" and ev["task"] == "overlay"
+    assert ev["camera_id"] == 3
+    assert ev["payload"]["source"] == "app:license-plate-recognition"
+    assert ev["payload"]["tracks"][0]["box"] == [0.2, 0.3, 0.1, 0.05]
+    assert ev["payload"]["tracks"][0]["label"] == "plate"
+
+
+def test_app_boxes_are_dropped_when_not_allowed(monkeypatch):
+    """The whole point of the per-app switch: publishing is free, DRAWING
+    is a privilege the operator grants."""
+    assert _run_app(_app_msg(), monkeypatch, allowed=False) == []
+
+
+def test_app_pixel_boxes_use_the_shipped_frame_size(monkeypatch):
+    env = json.loads(_app_msg().data)
+    env["payload"] = {"frame": {"w": 1000, "h": 500},
+                      "boxes": [{"label": "zone", "box": [100, 50, 300, 150]}]}
+    msg = SimpleNamespace(subject="opennvr.events.overlay.boxes.v1.cam3",
+                          data=json.dumps(env).encode())
+    out = _run_app(msg, monkeypatch, allowed=True)
+    # [x=100, y=50, w=300, h=150] of a 1000×500 frame — xywh, per contract.
+    assert out[0]["payload"]["tracks"][0]["box"] == [0.1, 0.1, 0.3, 0.3]
+
+
+def test_xywh_to_xyxy():
+    assert tc._xywh_to_xyxy([0.2, 0.3, 0.1, 0.05]) == [0.2, 0.3, pytest.approx(0.3), pytest.approx(0.35)]
+    assert tc._xywh_to_xyxy([1, 2, 3]) is None
+    assert tc._xywh_to_xyxy(None) is None
+
+
+def test_app_box_without_score_is_drawn():
+    """An app's zone has no confidence; the score filter must not eat it."""
+    raw = {"frame": {}, "tracks": [{"label": "zone", "box": [0, 0, 0.5, 0.5]}]}
+    out = tc.to_overlay_payload(raw, min_score=0.0)
+    assert out and out["tracks"][0]["score"] == 0.0
+
+
+def test_producer_prefix_is_stripped_for_the_lookup(monkeypatch):
+    seen = []
+    def _may(app_id, now=None):
+        seen.append(app_id); return True
+    bus = _Bus()
+    from services import event_bus_service
+    monkeypatch.setattr(event_bus_service, "get_event_bus", lambda: bus)
+    monkeypatch.setattr(tc, "_app_may_draw", _may)
+    asyncio.run(tc._handle_app_message(_app_msg(producer="app:smart-doorbell")))
+    assert seen == ["smart-doorbell"]
+
+
+def test_app_allow_cache_reads_db_once_per_ttl(monkeypatch):
+    """Overlay frames arrive many times a second; the DB must not."""
+    calls = []
+    class _Q:
+        def __init__(self, v): self.v = v
+        def filter(self, *a, **k): return self
+        def first(self): calls.append(1); return self.v
+    class _DB:
+        def query(self, *a): return _Q((True, True))
+        def close(self): pass
+    import types
+    fake_core = types.SimpleNamespace(SessionLocal=lambda: _DB())
+    monkeypatch.setitem(sys.modules, "core.database", fake_core)
+    monkeypatch.setitem(sys.modules, "models",
+                        types.SimpleNamespace(InstalledApp=types.SimpleNamespace(
+                            overlay_enabled="o", enabled="e", id="i")))
+    tc._invalidate_app_allow_cache()
+    assert tc._app_may_draw("x", now=100.0) is True
+    assert tc._app_may_draw("x", now=105.0) is True    # cached
+    assert tc._app_may_draw("x", now=100.0 + tc._APP_ALLOW_TTL_S + 1) is True  # refreshed
+    assert len(calls) == 2
+
+
+def test_site_switch_off_disables_the_bridge(monkeypatch):
+    """DETECTION_OVERLAY_ENABLED=false must return before touching NATS.
+    core.config.settings is a full pydantic Settings() that needs every
+    site secret to construct, so the consumer's lazy `from core.config
+    import settings` is served a stand-in here."""
+    import types
+    fake = types.SimpleNamespace(
+        settings=types.SimpleNamespace(detection_overlay_enabled=False,
+                                       nats_url="nats://would-connect",
+                                       internal_api_key="k"))
+    monkeypatch.setitem(sys.modules, "core.config", fake)
+    # A nats import would prove the gate was skipped; make it explode.
+    monkeypatch.setitem(sys.modules, "nats", None)
+    asyncio.run(tc.run_consumer_loop())   # returns; no ImportError raised
+
+
+def test_site_switch_on_reaches_the_nats_import(monkeypatch):
+    """The inverse: with the switch on and a URL set, the loop proceeds to
+    `import nats` — which we make fail so the loop returns cleanly. Pins
+    that the gate is the switch, not something else short-circuiting."""
+    import types
+    fake = types.SimpleNamespace(
+        settings=types.SimpleNamespace(detection_overlay_enabled=True,
+                                       nats_url="nats://would-connect",
+                                       internal_api_key="k"))
+    monkeypatch.setitem(sys.modules, "core.config", fake)
+    monkeypatch.setitem(sys.modules, "nats", None)   # import → ImportError → return
+    asyncio.run(tc.run_consumer_loop())


### PR DESCRIPTION
<h2 aria-level="5" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Follows #464, which put Tier-0 bounding boxes on the Live View. This answers "and everywhere else?" at the three grains that question actually has, and makes core the single place that decides what is drawable.</p><h2 aria-level="5" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Three controls</h2>
Grain | Control | Default | Who
-- | -- | -- | --
Viewer | Boxes button (Live View; camera-agent camera screen) | off | per browser
Site | DETECTION_OVERLAY_ENABLED | on | operator, env
Per app | Overlay switch on the app's catalog card | off | superuser

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Response is additive (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">kind</code>); <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ticket</code> and <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">expires_in</code> are unchanged. The scope decision is factored into <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_ws_scope_for</code> and the agent's per-viewer check into <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_tracks_push_visible</code>, so both are tested predicates rather than paragraphs in handlers.</p><h2 aria-level="5" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Caught by tests before shipping</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The app contract is <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[x, y, w, h]</code>; Tier-0's is <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[x1, y1, x2, y2]</code>. The first cut fed one through the other's normalizer and silently produced boxes of the wrong size. A dedicated converter now sits between them, pixel-space case pinned.</p><h2 aria-level="5" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Deploy notes</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;"><strong>Run the migration</strong><span> </span>— adds<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">installed_apps.overlay_enabled</code><span> </span>(single alembic head confirmed).</li><li style="unicode-bidi: plaintext;"><strong>Agent cameras need<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">opennvr_camera_id</code></strong><span> </span>set; that's how core's<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">cam3</code><span> </span>maps to the agent's camera. Without it the agent draws nothing for that camera.</li><li style="unicode-bidi: plaintext;">The agent's<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INTERNAL_API_KEY</code><span> </span>must match core's, or the tracks subscriber will loop on "retrying".</li><li style="unicode-bidi: plaintext;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">examples/camera-agent/uv.lock</code><span> </span>is stale against the new<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">websockets</code><span> </span>pin (already satisfied transitively via pipecat and the SDK). Run<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uv lock</code><span> </span>before merge.</li><li style="unicode-bidi: plaintext;">No app publishes overlay boxes yet — ANPR's plate localisations are the obvious first.</li></ul><h2 aria-level="5" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="unicode-bidi: plaintext;">Core bridge: 33 tests. Core WS tickets: 19 (user bound/active/scoped/single-use/expiring, service unscoped, superuser unrestricted, app key 403, shape backward-compatible).</li><li style="unicode-bidi: plaintext;">Server<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">event|ws|ticket|apps|bus|consumer|tier0</code><span> </span>suites: identical to<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">main</code><span> </span>— 7 pre-existing failures both sides, none new.</li><li style="unicode-bidi: plaintext;">SDK suite: identical to<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">main</code><span> </span>by test name after regenerating the reference page.</li><li style="unicode-bidi: plaintext;">Agent: 81 (9 new — parser accepts only core's shape and does<span> </span><em>not</em><span> </span>re-normalize; relay maps by<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">opennvr_camera_id</code>; the scope predicate).</li><li style="unicode-bidi: plaintext;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tsc</code><span> </span>+<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">vite build</code><span> </span>clean; demo inline JS passes<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">node --check</code>; no circular import between the two routers.</li></ul>