### PR TITLE
fix(overlay): draw only what was detected this frame, not coasting tr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Live overlay drew coasting tracks.** Phantom boxes piled up on a
+  moving scene — dozens of stale outlines on sky and hedges — while the
+  vehicle actually in shot went unboxed. Tier-0's tracker keeps an
+  unmatched track alive at its last box for up to `coast_ttl_seconds`
+  (five minutes) so a visit survives a skipped frame; that is right for
+  presence and wrong to draw. Each published track now carries
+  `matched` — detected in *this* frame — and the overlay bridge drops
+  the rest. `misses == 0` would not have worked: a track coasting
+  because its region was skipped never counts a miss, which is exactly
+  the phantom case. Additive on the bus; an older producer without the
+  field keeps drawing.
+
 ### Added
 
 - **Bounding boxes on the live view.** Tracked objects are outlined over

--- a/detect-pipeline/detect_pipeline/bus.py
+++ b/detect-pipeline/detect_pipeline/bus.py
@@ -65,6 +65,10 @@ def build_payload(camera_id: str, result: FrameResult, frame) -> dict:
                 # a best-frame crop is retained + fetchable for this track (a
                 # consumer can pull it instead of grabbing an arbitrary live frame)
                 "best": getattr(t, "best_crop", None) is not None,
+                # Detected in THIS frame, or coasting at its last box?
+                # Additive (EVENT_CONTRACTS.md); a live overlay draws only
+                # matched tracks, presence consumers use both.
+                "matched": bool(getattr(t, "matched_now", True)),
             }
             for t in result.tracks
         ],

--- a/detect-pipeline/detect_pipeline/tracking.py
+++ b/detect-pipeline/detect_pipeline/tracking.py
@@ -101,6 +101,13 @@ class Track:
     # Monotonic timestamp of the last positive match (set at spawn and on
     # every match) — the coast-TTL expiry anchor.
     last_matched: float = 0.0
+    # True for exactly the update() in which this track was matched to a
+    # detection (or spawned from one); False while it COASTS. Not the same
+    # as ``misses == 0``: a track coasting unscanned never counts a miss,
+    # so misses cannot tell "seen this frame" from "not looked for". The
+    # bus ships this so a live overlay draws only what was actually
+    # detected — a coasting track at its last box read as a phantom.
+    matched_now: bool = field(default=False, compare=False)
     # BGR crop of the best frame, retained only when the tracker is fed pixels
     # (the Tier-1 gate dispatches THIS on escalation — see gate/dispatch, PR B #10).
     best_crop: object | None = field(default=None, repr=False, compare=False)
@@ -258,6 +265,9 @@ class Tracker:
         # behavior: every unmatched track counts a miss.
         cfg = self.config
         now = self._clock()
+        # Every track starts this update unmatched; _match/_spawn set it.
+        for tr in self._tracks:
+            tr.matched_now = False
         # This frame's scene memo. Stamped here, cleared before the return:
         # the encode is shared by every track that peaks on this frame, and
         # the frame reference never outlives the call.
@@ -344,6 +354,7 @@ class Tracker:
         tr.hits += 1
         tr.age += 1
         tr.misses = 0
+        tr.matched_now = True
         tr.last_matched = now if now is not None else self._clock()
         if not tr.confirmed and tr.hits >= self.config.initialized():
             tr.confirmed = True
@@ -357,6 +368,7 @@ class Tracker:
             score=det.score,
             stationary_threshold=self.config.stationary_threshold,
             last_matched=now if now is not None else self._clock(),
+            matched_now=True,
         )
         tr.confirmed = self.config.initialized() <= 1
         self._update_best(tr, det, bgr)

--- a/detect-pipeline/test/test_bus_payload.py
+++ b/detect-pipeline/test/test_bus_payload.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 OpenNVR
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""build_payload ships `matched` per track (EVENT_CONTRACTS.md).
+
+A live overlay draws only matched tracks; presence consumers use both.
+Additive: nothing else in the payload moves.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from detect_pipeline.bus import SCHEMA, build_payload
+from detect_pipeline.pipeline import FrameResult
+from detect_pipeline.tracking import Track
+
+
+def _frame():
+    return SimpleNamespace(seq=7, ts=123.0, width=1920, height=1080)
+
+
+def test_matched_rides_on_every_track():
+    live = Track(id=1, label="car", box=(10, 10, 110, 110), score=0.9, matched_now=True)
+    ghost = Track(id=2, label="car", box=(500, 20, 600, 120), score=0.8, matched_now=False)
+    result = FrameResult(tracks=[live, ghost])
+    p = build_payload("cam3", result, _frame())
+    assert p["schema"] == SCHEMA
+    by_id = {t["id"]: t for t in p["tracks"]}
+    assert by_id[1]["matched"] is True
+    assert by_id[2]["matched"] is False
+    # The rest of the track shape is untouched.
+    assert by_id[2]["box"] == [500, 20, 600, 120] and by_id[2]["score"] == 0.8
+
+
+def test_matched_defaults_true_for_a_track_without_the_flag():
+    """A track object that predates the field entirely must not read as
+    coasting — that would make an older producer's frames go dark.
+    (A dataclass instance can't lose a class-defaulted attribute, so the
+    stand-in is a plain object with no such attribute at all.)"""
+    t = SimpleNamespace(id=1, label="car", box=(0, 0, 10, 10), score=0.5,
+                        stationary=False)
+    p = build_payload("cam3", FrameResult(tracks=[t]), _frame())
+    assert p["tracks"][0]["matched"] is True
+
+
+def test_a_fresh_track_object_defaults_to_coasting_until_matched():
+    """The dataclass default is False on purpose: a Track nobody has
+    matched yet is not 'seen this frame'. Only _spawn/_match set True."""
+    t = Track(id=1, label="car", box=(0, 0, 10, 10), score=0.5)
+    p = build_payload("cam3", FrameResult(tracks=[t]), _frame())
+    assert p["tracks"][0]["matched"] is False

--- a/detect-pipeline/test/test_tracking.py
+++ b/detect-pipeline/test/test_tracking.py
@@ -281,3 +281,48 @@ def test_plate_candidates_stay_box_sized_with_scene_retention_on(monkeypatch):
     assert ring is not None
     for cand in ring.ranked():
         assert cand.crop.shape[:2] != frame.shape[:2], "candidate is the whole frame"
+
+
+# ─── matched_now: detected this frame vs coasting ───────────────────────
+#
+# Reported against the live overlay: phantom boxes piling up on a moving
+# scene while the real vehicle went unboxed. The tracker keeps an
+# unmatched track alive at its last box (coasting) — correct for visit
+# continuity, wrong to DRAW. These pin the per-update flag the bus ships
+# so a renderer can tell the two apart.
+
+
+def test_spawn_and_match_set_matched_now():
+    tk = Tracker(FRAME, _cfg(min_initialized=1))
+    (tr,) = tk.update([Detection("car", (100, 100, 200, 200), 0.9)])
+    assert tr.matched_now is True                      # spawned from a detection
+    (tr,) = tk.update([Detection("car", (102, 101, 202, 201), 0.9)])
+    assert tr.matched_now is True                      # matched again
+
+
+def test_a_coasting_track_is_not_matched_now():
+    tk = Tracker(FRAME, _cfg(min_initialized=1))
+    tk.update([Detection("car", (100, 100, 200, 200), 0.9)])
+    (tr,) = tk.update([])                              # confirmed track survives a miss
+    assert tr.matched_now is False
+    assert tr.misses == 1
+
+
+def test_unscanned_coasting_is_not_matched_now_even_with_zero_misses():
+    """THE case that rules out `misses == 0` as the signal: a track whose
+    region was skipped this frame coasts WITHOUT counting a miss, so on
+    misses alone it looks identical to one detected this frame."""
+    tk = Tracker(FRAME, _cfg(min_initialized=1))
+    tk.update([Detection("car", (100, 100, 200, 200), 0.9)])
+    # Scanned a region nowhere near the track → the tracker coasts it.
+    (tr,) = tk.update([], scanned_regions=[(1000, 1000, 1100, 1100)])
+    assert tr.misses == 0
+    assert tr.matched_now is False
+
+
+def test_matched_now_resets_every_update():
+    tk = Tracker(FRAME, _cfg(min_initialized=1))
+    tk.update([Detection("car", (100, 100, 200, 200), 0.9)])
+    tk.update([])
+    (tr,) = tk.update([Detection("car", (101, 101, 201, 201), 0.9)])
+    assert tr.matched_now is True                      # back once re-detected

--- a/docs/EVENT_CONTRACTS.md
+++ b/docs/EVENT_CONTRACTS.md
@@ -126,7 +126,7 @@ consumers.
 |---|---|---|
 | `frame` | object | `{w, h}` in pixels — lets consumers normalise boxes. |
 | `calibrating` | bool | Tier-0 still calibrating; treat tracks as provisional. |
-| `tracks` | array | Same track shape as `opennvr.tier0.v1` (`id`, `label`, `conf`, `bbox`, motion fields). Normative source: `detect_pipeline/bus.py::build_payload`. |
+| `tracks` | array | Same track shape as `opennvr.tier0.v1` (`id`, `label`, `conf`, `bbox`, motion fields). Normative source: `detect_pipeline/bus.py::build_payload`. Each track also carries `matched` (bool): true when the object was detected in *this* frame, false when the track is **coasting** — kept alive at its last box (up to `coast_ttl_seconds`) because the tracker did not see it leave. Consumers rendering a live picture should draw only `matched` tracks; consumers reasoning about presence (visits, occupancy) want both. Additive: absent means matched. |
 
 ### `overlay.boxes.v1`
 

--- a/server/services/tier0_track_consumer.py
+++ b/server/services/tier0_track_consumer.py
@@ -102,6 +102,17 @@ def to_overlay_payload(
     for t in raw.get("tracks") or []:
         if not isinstance(t, dict):
             continue
+        # COASTING tracks are not drawn. The tracker keeps an unmatched
+        # track alive for up to coast_ttl_seconds (five minutes by
+        # default) at its last box — right for visit continuity and
+        # best-frame retention, wrong for a live overlay, where it reads
+        # as a phantom sitting on the sky while the real vehicle goes
+        # unboxed. Tier-0 marks each track `matched` for the frame it was
+        # actually detected in; absent (an older producer) is taken as
+        # matched so a bus without the field keeps drawing rather than
+        # going dark.
+        if t.get("matched") is False:
+            continue
         try:
             score = float(t.get("score", 0.0))
         except (TypeError, ValueError):

--- a/server/tests/test_tier0_track_consumer.py
+++ b/server/tests/test_tier0_track_consumer.py
@@ -97,6 +97,37 @@ def test_nothing_drawable_returns_none():
     assert tc.to_overlay_payload(_raw([{"id": 1, "label": "x", "score": 0.01, "box": [0, 0, 9, 9]}])) is None
 
 
+def test_coasting_tracks_are_not_drawn():
+    """Reported: phantom boxes pile up on a moving scene while the real
+    vehicle goes unboxed. The tracker coasts an unmatched track for up
+    to five minutes at its last position; the overlay must draw only what
+    was detected THIS frame."""
+    out = tc.to_overlay_payload(_raw([
+        {"id": 1, "label": "car", "score": 0.9, "box": [0, 0, 100, 100], "matched": True},
+        {"id": 2, "label": "car", "score": 0.9, "box": [0, 0, 100, 100], "matched": False},
+        {"id": 3, "label": "car", "score": 0.9, "box": [0, 0, 100, 100], "matched": False},
+    ]))
+    assert [t["id"] for t in out["tracks"]] == [1]
+
+
+def test_a_frame_of_only_coasting_tracks_publishes_nothing():
+    """A calibrating or detect-skipped frame returns every track unmatched.
+    That must be 'nothing to draw', not 'draw last known positions'."""
+    out = tc.to_overlay_payload(_raw([
+        {"id": 1, "label": "car", "score": 0.9, "box": [0, 0, 100, 100], "matched": False},
+    ]))
+    assert out is None
+
+
+def test_missing_matched_field_is_treated_as_matched():
+    """Additive-only contract: a producer that predates `matched` keeps
+    drawing. Going dark on an older Tier-0 would be a regression."""
+    out = tc.to_overlay_payload(_raw([
+        {"id": 1, "label": "car", "score": 0.9, "box": [0, 0, 100, 100]},
+    ]))
+    assert out and [t["id"] for t in out["tracks"]] == [1]
+
+
 def test_non_dict_tracks_are_skipped_not_fatal():
     out = tc.to_overlay_payload(_raw([
         "junk", None, 42,


### PR DESCRIPTION
…acks

Reported by a tester: phantom boxes pile up on the live view while the real vehicle goes unboxed. The screenshot shows it exactly — track ids #900 through #975 on screen at once over a moving dashcam scene, boxes parked on sky and hedges, and the one car actually in shot (plate readable) with no tight box.

Tier-0's tracker COASTS: an unmatched track stays alive at its last box for up to coast_ttl_seconds (five minutes by default) because a skipped frame is not evidence the object left. That is correct for visit continuity and best-frame retention, and it is exactly wrong to draw — on a moving scene every vehicle that passes leaves a ghost, and build_payload shipped all of them with no way to tell fresh from stale. The 2 s staleness on the client could not help: the producer re-sent the ghosts every frame.

The obvious signal is wrong. `misses == 0` does NOT mean "seen this frame": a track coasting because its region was skipped this frame never counts a miss at all — the stationary-gating contract — so on misses alone it is indistinguishable from a track detected a moment ago. That is the phantom case precisely.

So the tracker sets a per-update boolean. Track.matched_now is reset to False for every track at the top of update(), set True by _match() and by _spawn(), and shipped by build_payload as `matched` — additive on the bus (EVENT_CONTRACTS.md), and the field the test for it documents as "a live overlay draws only matched tracks; presence consumers use both". compare=False, so no existing Track equality changes. Core's overlay bridge drops tracks with matched=False; a producer without the field is taken as matched, so an older Tier-0 keeps drawing rather than going dark.

Nothing about coasting itself changes. Visits, occupancy, plate attempts and best frames see the same tracks they always did.

Tests: the tracker flag through spawn, match, a counted miss, a reset, and — the one that rules out misses — an unscanned coast with misses == 0 and matched_now False. build_payload ships it and defaults a flagless object to matched. The bridge drops coasting tracks, publishes nothing for an all-coasting frame, and treats a missing field as matched. detect-pipeline: 439 passed, 0 failed (main: 0 failed); core bridge 36; server event/bus/tier0 suites identical to main; SDK tier0→detections unaffected.